### PR TITLE
Add worktree log sync rule and PR lifecycle tracking

### DIFF
--- a/.claude/rules/work-log.md
+++ b/.claude/rules/work-log.md
@@ -56,7 +56,7 @@ This data measures PR throughput, average cycle time, and review friction — in
 
 **How to count cycles:** Increment the cycle counter each time any reviewer (bot or human) posts findings that result in a new fix commit. Clean passes and confirmation reviews do not count.
 
-**Determining the count at merge time:** If the cycle count wasn't tracked during the session (e.g., after context compaction or session handoff), reconstruct it from the PR's history: fetch all review objects on `pulls/{N}/reviews` and all commits on `pulls/{N}/commits`. Count each review that contains actionable findings (i.e., has inline comments or a body with specific fix requests) and is followed by at least one new commit before the next review or merge. Each such review-then-fix pair = 1 cycle. Reviews with no findings (clean passes) do not count.
+**Determining the count at merge time:** If the cycle count wasn't tracked during the session (e.g., after context compaction or session handoff), reconstruct it from the PR's history: fetch all review objects on `pulls/{N}/reviews` and all commits on `pulls/{N}/commits`. Count each review that is actionable (has inline comments, a body with specific fix requests, or `state: "CHANGES_REQUESTED"`) and is followed by at least one new commit before the next review or merge. Each such review-then-fix pair = 1 cycle. Reviews with no findings (clean passes) do not count.
 
 ### PR merge summaries
 
@@ -72,7 +72,7 @@ When working in a worktree, any edits to shared docs (session logs, work logs, c
 
 **Before pushing any PR or closing the work session, the agent must ensure one of the following:**
 
-1. **Commit the log file in the PR branch** — stage and commit the work-log file alongside the code changes so it merges with the PR.
+1. **Commit the shared doc in the PR branch** — stage and commit the affected shared doc(s) alongside the code changes so they merge with the PR.
 2. **Manually sync the log to the root repo** — if the log edits should not be part of the PR (e.g., the log lives in a different repo or on main), append only the missing Activity Log entries to the root repo's copy (do not replace the entire file), then commit separately.
 
 **Never assume a worktree-local edit to a shared doc will "make it back" on its own.** At task completion, verify the root repo's copy is current:


### PR DESCRIPTION
## Summary
- **Worktree log sync rule**: Agents must ensure shared doc edits (session logs, work logs) are synced back to root repo before task completion — prevents data stranding in worktrees
- **PR lifecycle tracking**: Every PR log entry now includes `opened`/`merged` timestamps and `review_cycles` count for throughput measurement
- Updated Activity Log format with bracketed lifecycle suffix

## Test plan
- [x] Worktree log sync rule added to `work-log.md`
- [x] PR lifecycle tracking rule added to `work-log.md` with `opened`, `merged`, `cycles` fields
- [x] Activity Log format updated with new bracketed lifecycle suffix
- [x] Existing rules preserved (append-only, coexistence with narrative content)
- [x] No changes to files outside `work-log.md`

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Always/Never rules: describe syncing worktree log edits back to the root, note when updates may remain in a worktree, and clarify work-log discovery at session start.
  * Expanded Daily Log conventions: add PR lifecycle suffixes for opened/merged entries and formalize lifecycle fields (opened, merged, review cycles) with guidance for counting/reconstructing cycles.
  * Added Worktree Log Sync, reconciliation, verification steps, and coexistence/append-only guidance for root logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->