### PR TITLE
Add .coderabbit.yaml with structural quality checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,7 @@ reviews:
     - path: "**/*"
       instructions: |
         This repository contains Claude Code agent configuration files — CLAUDE.md
-        and .claude/rules/*.md — not application code. These files are loaded into
+        and .claude/rules/**/*.md — not application code. These files are loaded into
         Claude's context window on every conversation turn, so token efficiency is
         critical. Reviews should focus on clarity, consistency, correctness of
         workflow instructions, and token efficiency rather than code-level concerns.
@@ -14,12 +14,12 @@ reviews:
     - path: "CLAUDE.md"
       instructions: |
         When reviewing changes to this file, check the following structural
-        quality criteria. These matter because CLAUDE.md and all .claude/rules/*.md
+        quality criteria. These matter because CLAUDE.md and all .claude/rules/**/*.md
         files are loaded into Claude's context window every turn — bloated or
         poorly structured rules waste tokens and degrade agent performance.
 
         1. TOKEN FOOTPRINT: Flag if the total word count across CLAUDE.md and all
-           .claude/rules/*.md files exceeds 10,000 words (~13K tokens, ~6.5% of
+           .claude/rules/**/*.md files exceeds 10,000 words (~13K tokens, ~6.5% of
            the 200K context window). Include the current total in your review.
         2. INFORMATION HIERARCHY: The most critical behaviors (timestamps,
            worktree requirements, never-do lists) must appear at the top of the
@@ -35,12 +35,12 @@ reviews:
     - path: ".claude/rules/**/*.md"
       instructions: |
         When reviewing changes to rule files, check the following structural
-        quality criteria. These matter because all .claude/rules/*.md files are
+        quality criteria. These matter because all .claude/rules/**/*.md files are
         loaded into Claude's context window every turn — bloated or poorly
         structured rules waste tokens and degrade agent performance.
 
         1. TOKEN FOOTPRINT: Flag if the total word count across CLAUDE.md and all
-           .claude/rules/*.md files exceeds 10,000 words (~13K tokens, ~6.5% of
+           .claude/rules/**/*.md files exceeds 10,000 words (~13K tokens, ~6.5% of
            the 200K context window). Include the current total in your review.
         2. INFORMATION HIERARCHY: The most critical behaviors should appear at the
            top of each file. Flag if high-priority rules are buried below less


### PR DESCRIPTION
## Summary
- Creates `.coderabbit.yaml` in repo root with CodeRabbit review configuration
- Adds `path_instructions` for `CLAUDE.md` and `.claude/rules/**` that enforce 4 structural quality checks on every edit: token footprint, information hierarchy, redundancy, and density
- Adds general `reviews.instructions` providing repo-level context (config files, not application code)
- Enables `knowledge_base.code_guidelines` so CR auto-detects rule files as reference

Closes #8

## Test plan
- [ ] `.coderabbit.yaml` created in repo root
- [ ] `path_instructions` for `CLAUDE.md` and `.claude/rules/*.md` with all 4 structural checks
- [ ] General `reviews.instructions` providing repo-level context
- [ ] `knowledge_base.code_guidelines` configured
- [ ] No changes to existing rule files in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a public configuration to establish automated review governance for agent-driven reviews.
  * Introduced path-based review instructions and per-file structural criteria (including Always / Ask First / Never guidance) to improve token efficiency, information hierarchy, and redundancy controls.
  * Enabled knowledge-base code-guideline validation with targeted file-pattern checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->