### PR TITLE
Harden timestamp rule to prevent mental time estimation

### DIFF
--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -56,6 +56,8 @@ Subagents have a hardcoded **32K output token limit** that cannot be configured 
 
 Get the timestamp via: `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`
 
+NEVER estimate, calculate, or mentally derive timestamps — always run the `date` command. This includes elapsed time: do not count poll cycles or steps to estimate minutes passed. If you need elapsed time, compare two `date` outputs.
+
 This applies to ALL messages — status updates, failure reports, success reports, questions, summaries. No exceptions.
 
 > **Compaction-proof:** This obligation survives context compaction. If you are resuming from compaction and realize you haven't been timestamping, start immediately — do not wait for the next "natural" message. Your first post-compaction message must include a timestamp and an acknowledgment that monitoring is being re-established.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 These apply to EVERY message the parent agent sends to the user. No exceptions, no degradation over time, no skipping after context compaction.
 
-1. **Timestamp prefix.** Every message starts with Eastern time: `Mon Mar 16 02:34 AM ET`. Get via: `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`. This is the FIRST thing in every message — before status updates, before questions, before summaries.
+1. **Timestamp prefix.** Every message starts with Eastern time: `Mon Mar 16 02:34 AM ET`. Get via: `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`. NEVER estimate, calculate, or mentally derive timestamps — always run the `date` command. This includes elapsed time: do not count poll cycles or steps to estimate minutes passed. If you need elapsed time, compare two `date` outputs. This is the FIRST thing in every message — before status updates, before questions, before summaries.
 2. **Active monitoring declaration.** If you are monitoring background agents, state how many and which PRs at the end of every message. Example: "Monitoring: PR #618 (Phase B), PR #620 (Phase B), PR #623 (Phase C) — next poll in ~60s."
 
 If you have just resumed from context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `subagent-orchestration.md`) and report it WITH a timestamp.


### PR DESCRIPTION
## Summary
- Adds explicit prohibition against estimating/calculating timestamps mentally in CLAUDE.md and subagent-orchestration.md
- Agents must always run the `date` command — never derive timestamps from counting poll cycles or steps
- For elapsed time, agents must compare two `date` outputs
- Total word count: 8,469 (well within 10,000 limit)

Closes #10

## Test plan
- [ ] CLAUDE.md timestamp rule hardened with explicit prohibition against mental time estimation
- [ ] subagent-orchestration.md timestamp section updated with matching prohibition
- [ ] Total word count across all rule files remains under 10,000
- [ ] No other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Strengthened timestamp guidance: timestamps must be obtained via system date commands rather than estimated or mentally derived.
  * Clarified elapsed-time handling: compute elapsed time by comparing two timestamp outputs instead of counting cycles or steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->