### PR TITLE
Add /standup skill for daily standup summaries

### DIFF
--- a/.claude/skills/standup/SKILL.md
+++ b/.claude/skills/standup/SKILL.md
@@ -13,8 +13,9 @@ Generate a standup report summarizing what was accomplished since $ARGUMENTS (de
 
 2. **Convert the user's time reference to an ISO 8601 timestamp** with the correct UTC offset (handles EST/EDT automatically):
    ```bash
-   # Example: "yesterday at noon ET" → ISO 8601 with correct offset
+   # Example: "yesterday at noon ET" → ISO 8601 with colon offset (GitHub requires +HH:MM not +HHMM)
    SINCE_ISO=$(TZ='America/New_York' date -d 'yesterday 12:00' '+%Y-%m-%dT%H:%M:%S%z' 2>/dev/null || TZ='America/New_York' date -v-1d -v12H -v0M -v0S '+%Y-%m-%dT%H:%M:%S%z')
+   SINCE_ISO=$(printf '%s' "$SINCE_ISO" | sed -E 's/([+-][0-9]{2})([0-9]{2})$/\1:\2/')
    ```
    Adjust the date expression to match the user's time reference.
 


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/standup/SKILL.md` — a user-invocable `/standup` skill
- Queries GitHub for closed issues, merged PRs, and open PRs since a given time
- Generates a business-focused standup summary (<150 words) with scale metrics
- Uses dynamic TZ-aware ISO 8601 timestamps (handles EST/EDT correctly)
- Manual trigger only (`disable-model-invocation: true`)

Also installed as a global skill at `~/.claude/skills/standup/` so it works from any repo.

Closes #14

## Test plan

- [x] Skill file exists at `.claude/skills/standup/SKILL.md`
- [x] Skill is user-invocable via `/standup` with optional time argument
- [x] Skill has `disable-model-invocation: true` (manual trigger only)
- [x] Instructions specify GitHub CLI commands for data gathering
- [x] Output format includes accomplishments, in-progress work, and scale metrics
- [x] ISO 8601 timestamp uses dynamic TZ offset (not hardcoded `-05:00`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone "standup" skill that generates concise daily standup reports summarizing closed issues, merged PRs (with additions/deletions), and open PRs authored by you.
  * Accepts an optional "since-time" (eg. “yesterday at noon ET”) and converts natural-language times to an ISO 8601 cutoff with correct UTC offset.
  * Determines relevant repositories from your context; produces first-person, structured reports ("Since [time]", "In progress", "Scale"), ≤150 words, aggregated items, and optional "~lines changed".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->