### PR TITLE
Move heartbeat obligation to EVERY MESSAGE block

### DIFF
--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -2,7 +2,7 @@
 
 > **Always:** Pass ALL rule files to subagents. Use phase decomposition (A/B/C). Timestamp every message. Monitor subagent health. Report failures immediately.
 > **Ask first:** Respawning a failed subagent — tell the user what happened first.
-> **Never:** Summarize rules for subagents. Fire-and-forget subagents. Let a stalled PR go unreported. Skip timestamps.
+> **Never:** Summarize rules for subagents. Fire-and-forget subagents. Let a stalled PR go unreported. Skip timestamps. Go >5 minutes without a user-visible message. Report a PR as "awaiting review" for >5 minutes without a Phase B agent running.
 
 When spawning subagents via the Task tool, **always pass the FULL contents of ALL rule files into the subagent's prompt.** Subagents do not automatically inherit CLAUDE.md or `.claude/rules/` context — they only see what you put in their prompt.
 
@@ -83,6 +83,8 @@ The user has no visibility into subagent failures. If a subagent runs out of tok
 The user should never have to discover a stalled PR by checking GitHub manually.
 
 ### User Heartbeat (MANDATORY for parent agents)
+
+> **Core obligation is in CLAUDE.md item #3.** This section has the detailed rules. The 5-minute max silence is a non-negotiable behavior that applies to EVERY message — see the EVERY MESSAGE block.
 
 The user must never go more than **5 minutes** without a status message. This is separate from subagent polling — it's about keeping the user informed.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ These apply to EVERY message the parent agent sends to the user. No exceptions, 
 
 1. **Timestamp prefix.** Every message starts with Eastern time: `Mon Mar 16 02:34 AM ET`. Get via: `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`. NEVER estimate, calculate, or mentally derive timestamps — always run the `date` command. This includes elapsed time: do not count poll cycles or steps to estimate minutes passed. If you need elapsed time, compare two `date` outputs. This is the FIRST thing in every message — before status updates, before questions, before summaries.
 2. **Active monitoring declaration.** If you are monitoring background agents, state how many and which PRs at the end of every message. Example: "Monitoring: PR #618 (Phase B), PR #620 (Phase B), PR #623 (Phase C) — next poll in ~60s."
+3. **5-minute heartbeat.** The user must never go more than 5 minutes without a status message. When you run `date` for the timestamp, check how long it has been since your last message to the user. If >5 minutes, your FIRST action must be a status update — before any tool call. Include: what you are currently doing, what is pending (open PRs, active agents), and any blocked items. See `subagent-orchestration.md` "User Heartbeat" for detailed rules. **Never go silent for >5 minutes — not while doing substantive work, not while polling, not after compaction.**
 
 If you have just resumed from context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `subagent-orchestration.md`) and report it WITH a timestamp.
 


### PR DESCRIPTION
## Summary

- Adds 5-minute heartbeat as item #3 in the EVERY MESSAGE block of CLAUDE.md
- Adds explicit anti-patterns to the Never block in subagent-orchestration.md: going >5 min silent, reporting PRs as "awaiting review" without Phase B running
- Adds cross-reference from the User Heartbeat section to the EVERY MESSAGE block

**Root cause:** The heartbeat rule was in subagent-orchestration.md but degraded over long sessions after context compaction and during multi-step operations. Moving it to the EVERY MESSAGE block gives it the same non-negotiable priority as the timestamp rule.

Closes #16

## Test plan

- [ ] EVERY MESSAGE block in CLAUDE.md has a 3rd item for heartbeat/status obligation
- [ ] Rule specifies 5-minute max silence and what to include in the heartbeat
- [ ] subagent-orchestration.md Never block updated with the explicit anti-patterns
- [ ] Existing heartbeat section in subagent-orchestration.md cross-references the EVERY MESSAGE block
- [ ] No duplicate/redundant content — CLAUDE.md has the obligation, subagent-orchestration.md has the details

🤖 Generated with [Claude Code](https://claude.com/claude-code)