### PR TITLE
Harden Phase A→B transition with mandatory completion protocol

### DIFF
--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -53,7 +53,7 @@ Subagents have a hardcoded **32K output token limit** that cannot be configured 
 **WHEN** a subagent returns and reports a PR was created or updated, **THEN** execute this checklist immediately — before any other work:
 
 1. **Verify the push happened.** Run `gh pr view N --json commits --jq '.commits[-1].oid'` and confirm the SHA matches what the subagent reported. If the push didn't happen, the subagent silently failed — report to user.
-2. **Check if reviewers already posted findings.** Fetch all 3 comment endpoints for the PR. If CR or Greptile already posted findings (common if the review was fast), include those findings in the Phase B prompt.
+2. **Check if reviewers already posted findings.** Fetch all 3 comment endpoints for the PR (`per_page=100` on each). If CR or Greptile already posted findings (common if the review was fast), include those findings in the Phase B prompt.
 3. **Launch Phase B within 60 seconds.** This is the immediate next action — queue it ahead of any other work (creating issues, reading files, responding to unrelated questions). If you cannot launch within 60 seconds due to tool throttling, tell the user why and when you will launch, then automatically retry until Phase B is launched (do not wait for user action). Record the planned retry in `session-state.json`.
 4. **Update `session-state.json`.** Write the phase transition: PR moved from Phase A to Phase B, record the HEAD SHA, reset review state.
 5. **Report to user.** "Phase A complete for PR #N — fixes pushed (SHA `abc1234`). Phase B launched, polling for reviews."
@@ -125,7 +125,7 @@ Context compaction can happen at any time in long sessions. When it does, you lo
    ```
    Build a dashboard: PR number, HEAD SHA, last review state, last reviewer, pending action.
 3. **Check for stale background agents.** Any agents mentioned in the summary are likely dead (compaction killed their parent's awareness). Verify by checking if their expected outputs exist (commits pushed, comments posted).
-4. **Check Phase B coverage.** For every open PR, check `session-state.json` for a Phase B entry. If no Phase B record exists for a PR that has unprocessed review findings, launch Phase B immediately and record it in `session-state.json` — this is the most common post-compaction failure.
+4. **Check Phase B coverage.** For every open PR, check `~/.claude/session-state.json` for a Phase B entry. If no Phase B record exists for a PR that has unprocessed review findings, launch Phase B immediately and record it in `~/.claude/session-state.json` — this is the most common post-compaction failure.
 5. **Report to the user.** Post the reconstructed dashboard with a note: "Resuming after context compaction. Reconstructed state from GitHub. [N agents may need relaunching]."
 6. **Resume the monitoring loop.** Re-enter the polling cycle for any PRs still awaiting reviews.
 


### PR DESCRIPTION
## Summary

- Adds **Phase A Completion Protocol** — a mandatory WHEN/THEN checklist that fires when any subagent returns with a PR: verify push, check existing findings, launch Phase B within 60s, update checkpoint, report to user
- Makes Phase B launch the **highest-priority action** after Phase A — queued ahead of all other work
- Post-compaction recovery now **checks Phase B coverage** on all open PRs (step 4)
- Checkpoint writes required on **every phase transition** instead of periodic 10-minute intervals
- Strengthens the orchestration rules to cross-reference the new protocol

**Root cause:** Parent agents treated Phase A completion as "done" and passively monitored instead of actively launching Phase B. PRs sat "awaiting review" for hours with no Phase B agent processing feedback.

Closes #19

## Test plan

- [x] Phase A Completion Protocol exists as a numbered WHEN...THEN block
- [x] NEVER rule for stale PRs (>5 min awaiting review without Phase B) present in Never block
- [x] Phase B launch priority is explicit (immediate next action, ahead of other work)
- [x] Post-compaction recovery checks for Phase B on all open PRs (step 4)
- [x] session-state.json writes required on every phase transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Phase B now launches immediately when Phase A completes, ensuring quicker handoffs.
  * Introduced a mandatory Phase A completion protocol to verify findings, fold prior review context into Phase B, and report launch status.
  * Post-compaction recovery now checks and launches Phase B for open PRs with unprocessed findings.
  * Checkpointing changed to event-driven writes on phase transitions and key events for stronger state reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->