### PR TITLE
Set CR review profile to assertive, sync standup skill

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,6 +2,7 @@
 # This repo contains Claude Code agent configuration files (not application code).
 
 reviews:
+  profile: assertive
   path_instructions:
     - path: "**/*"
       instructions: |


### PR DESCRIPTION
## Summary

- Sets `profile: assertive` in `.coderabbit.yaml` to match the user's CodeRabbit web dashboard setting
- Standup skill was already synced with the enhanced global version (includes PR body reading, business themes, closing synthesis)

Closes #25

## Test plan

- [x] `.coderabbit.yaml` has `profile: assertive` under `reviews:`
- [x] In-repo standup skill matches global version (verified via `diff` — identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration settings to apply assertive review profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->