### PR TITLE
Fix work-log missed after context compaction

### DIFF
--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -116,7 +116,8 @@ Context compaction can happen at any time in long sessions. When it does, you lo
 **Immediate recovery protocol (do ALL of these before any other work):**
 
 1. **Timestamp your first message.** (See "EVERY MESSAGE" rules in CLAUDE.md.)
-2. **Reconstruct PR state from GitHub.** For every open PR in the summary:
+2. **Re-run session-start checklist.** Compaction wipes in-memory state like the work-log path. Re-run the work-log detection from `work-log.md` (search from the **main worktree root**, not the current worktree — see that file for details). Also re-check any other session-start obligations from rule files.
+3. **Reconstruct PR state from GitHub.** For every open PR in the summary:
    ```bash
    gh pr view N --json state,title,mergeStateStatus,commits
    gh api "repos/{owner}/{repo}/pulls/N/reviews?per_page=100"
@@ -124,10 +125,10 @@ Context compaction can happen at any time in long sessions. When it does, you lo
    gh api "repos/{owner}/{repo}/issues/N/comments?per_page=100"
    ```
    Build a dashboard: PR number, HEAD SHA, last review state, last reviewer, pending action.
-3. **Check for stale background agents.** Any agents mentioned in the summary are likely dead (compaction killed their parent's awareness). Verify by checking if their expected outputs exist (commits pushed, comments posted).
-4. **Check Phase B coverage.** For every open PR, check `~/.claude/session-state.json` for a Phase B entry. If no Phase B record exists for a PR that has unprocessed review findings, launch Phase B immediately and record it in `~/.claude/session-state.json` — this is the most common post-compaction failure.
-5. **Report to the user.** Post the reconstructed dashboard with a note: "Resuming after context compaction. Reconstructed state from GitHub. [N agents may need relaunching]."
-6. **Resume the monitoring loop.** Re-enter the polling cycle for any PRs still awaiting reviews.
+4. **Check for stale background agents.** Any agents mentioned in the summary are likely dead (compaction killed their parent's awareness). Verify by checking if their expected outputs exist (commits pushed, comments posted).
+5. **Check Phase B coverage.** For every open PR, check `~/.claude/session-state.json` for a Phase B entry. If no Phase B record exists for a PR that has unprocessed review findings, launch Phase B immediately and record it in `~/.claude/session-state.json` — this is the most common post-compaction failure.
+6. **Report to the user.** Post the reconstructed dashboard with a note: "Resuming after context compaction. Reconstructed state from GitHub. [N agents may need relaunching]."
+7. **Resume the monitoring loop.** Re-enter the polling cycle for any PRs still awaiting reviews.
 
 **Pre-compaction checkpointing (preventive):**
 
@@ -136,6 +137,8 @@ When running a long monitoring session with multiple PRs, write a status checkpo
 {
   "last_updated": "2026-03-16T16:00:00Z",
   "monitoring_active": true,
+  "root_repo": "/Users/user/repos/my-project",
+  "work_log_path": "docs/work-logs",
   "prs": {
     "618": {"phase": "B", "round": 2, "head_sha": "7b2cfbf", "reviews_clean": ["greptile", "cr_round_1"], "needs": "cr_round_2_clean"},
     "620": {"phase": "B", "round": 1, "head_sha": "d0e4fef", "reviews_clean": [], "needs": "fix_and_push"}

--- a/.claude/rules/work-log.md
+++ b/.claude/rules/work-log.md
@@ -8,10 +8,12 @@
 
 At the start of every session, before any code work:
 
-1. **Find existing `work-logs/` directories** by running this command from the repo root:
+1. **Find existing `work-logs/` directories** by searching the **main worktree root** (not the current worktree, which may lack shared directories). Get the main worktree path via:
    ```bash
-   find . -type d -name "work-logs" -not -path "./.git/*" -not -path "./.claude/*"
+   ROOT_REPO=$(git worktree list | head -1 | awk '{print $1}')
+   find "$ROOT_REPO" -type d -name "work-logs" -not -path "*/.git/*" -not -path "*/.claude/*"
    ```
+   If you are not in a worktree (i.e., working directly in the repo), `$ROOT_REPO` is just the repo root and the find command works the same way.
    **NEVER create a `work-logs/` directory.** Only use directories that already exist. If the find command returns nothing, this rule is a no-op — skip all logging for the session.
 2. **If one match is found:** Ask the user once to confirm: "I found a work log directory at `{path}`. I'll log issues, PRs, and merges there — sound good?" If the user already mentioned the work log or it's clear from context, skip the ask and just use it.
 3. **If multiple matches are found:** Prefer paths under `docs/` (e.g., `docs/work-logs/` over `work-logs/` at repo root) — a `docs/` location indicates intentional placement. If still ambiguous, ask the user to choose.

--- a/.claude/rules/work-log.md
+++ b/.claude/rules/work-log.md
@@ -11,7 +11,7 @@ At the start of every session, before any code work:
 1. **Find existing `work-logs/` directories** by searching the **main worktree root** (not the current worktree, which may lack shared directories). Get the main worktree path via:
 
    ```bash
-   ROOT_REPO=$(git worktree list | head -1 | awk '{print $1}')
+   ROOT_REPO=$(git worktree list --porcelain | awk '/^worktree /{sub(/^worktree /, ""); print; exit}')
    find "$ROOT_REPO" -type d -name "work-logs" -not -path "*/.git/*" -not -path "*/.claude/*"
    ```
 

--- a/.claude/rules/work-log.md
+++ b/.claude/rules/work-log.md
@@ -9,10 +9,12 @@
 At the start of every session, before any code work:
 
 1. **Find existing `work-logs/` directories** by searching the **main worktree root** (not the current worktree, which may lack shared directories). Get the main worktree path via:
+
    ```bash
    ROOT_REPO=$(git worktree list | head -1 | awk '{print $1}')
    find "$ROOT_REPO" -type d -name "work-logs" -not -path "*/.git/*" -not -path "*/.claude/*"
    ```
+
    If you are not in a worktree (i.e., working directly in the repo), `$ROOT_REPO` is just the repo root and the find command works the same way.
    **NEVER create a `work-logs/` directory.** Only use directories that already exist. If the find command returns nothing, this rule is a no-op — skip all logging for the session.
 2. **If one match is found:** Ask the user once to confirm: "I found a work log directory at `{path}`. I'll log issues, PRs, and merges there — sound good?" If the user already mentioned the work log or it's clear from context, skip the ask and just use it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Tell the user: "I'll create a worktree for isolated work." Then use the `EnterWo
 
 ### Branching & Merging
 - **NEVER work on `main` — not editing, not committing, not pushing.** All code changes happen in worktrees on feature branches. If you're not in a worktree, create one first. If `git branch --show-current` returns `main`, do not touch any files.
-- **Every change requires: GitHub issue -> feature branch -> PR -> squash merge.** No exceptions.
+- **Every change requires: GitHub issue -> feature branch -> PR -> squash merge.** No exceptions. This includes `.claude/rules/*.md` and `CLAUDE.md` — rule files are code and follow the same PR workflow.
 - Branch naming: `issue-N-short-description` (e.g. `issue-10-nav-welcome-header`).
 - Always **squash and merge** via `gh pr merge --squash --delete-branch`, then delete the branch.
 - **Never merge immediately after a rebase or force-push.** Even trivial conflict resolutions (e.g. a single import line) trigger a new CR review cycle. Always wait for CR to review the rebased commit and confirm no findings before merging. The safe flow is: resolve conflict -> force-push -> wait for CR -> confirm clean -> merge.


### PR DESCRIPTION
## Summary

- Post-compaction recovery protocol now re-runs session-start checklist (work-log detection, etc.) as step 2
- Work-log directory search uses `git worktree list --porcelain` to find the main worktree root (space-safe), not the current worktree directory
- `session-state.json` schema includes `root_repo` and `work_log_path` fields so these survive compaction
- CLAUDE.md clarifies that `.claude/rules/*.md` and `CLAUDE.md` are code changes subject to the full PR workflow

Closes #30

## Test plan

- [x] Post-compaction recovery protocol includes step 2: "Re-run session-start checklist" with work-log detection
- [x] Work-log `find` command uses porcelain-based `ROOT_REPO` parser (space-safe) instead of `.`
- [x] `session-state.json` schema example includes `root_repo` and `work_log_path` fields
- [x] CLAUDE.md "Branching & Merging" section states rule files follow the same PR workflow
- [x] Existing rule file content is preserved — changes are additive only

🤖 Generated with [Claude Code](https://claude.com/claude-code)