### PR TITLE
Simplify review merge gate: CR-first with G as fallback, sticky G assignment

### DIFF
--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -3,7 +3,7 @@
 
 > **Always:** Poll all 3 endpoints + check-runs every cycle. Use `per_page=100`. Filter by `coderabbitai[bot]`. Batch fixes into one commit. Reply to every thread. Resolve threads via GraphQL.
 > **Ask first:** Merging — always ask the user.
-> **Never:** Poll only 1-2 endpoints. Use bare `coderabbitai` without `[bot]`. Push per-finding. Trigger `@coderabbitai full review` more than twice/hour. Skip waiting for Greptile's 5-minute timeout when it's triggered. Merge without all 3 required clean reviews.
+> **Never:** Poll only 1-2 endpoints. Use bare `coderabbitai` without `[bot]`. Push per-finding. Trigger `@coderabbitai full review` more than twice/hour. Trigger Greptile proactively (only on CR failure). Merge without meeting the merge gate (2 clean CR or 1 clean G).
 
 > **This is the fallback review workflow.** It runs after you push and create a PR. If the local review loop was thorough, CR should find few or no issues here. But edge cases exist (e.g., CI-only context, cross-file interactions the local review missed), so always let this loop run.
 
@@ -41,17 +41,18 @@ After pushing a commit to a PR, automatically enter the CR review loop:
     --jq '.[] | select(.context | test("CodeRabbit"; "i")) | {context, state, description}'
   ```
   - **Completion signal:** `status: "completed"` with `conclusion: "success"` = review done (visible as "CodeRabbit — Review completed" in the PR's CI checks box). This is the definitive signal, especially for clean passes.
-  - **Fast-path rate limit detection:** If EITHER endpoint shows rate limiting — check-run has `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit status has `state: "failure"`/`state: "error"` with `description` containing "rate limit" — **trigger Greptile IMMEDIATELY.** Do not wait 8 minutes. This catches rate limits within ~60-120 seconds of pushing.
+  - **Fast-path rate limit detection:** If EITHER endpoint shows rate limiting — check-run has `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit status has `state: "failure"`/`state: "error"` with `description` containing "rate limit" — **trigger Greptile IMMEDIATELY.** Do not wait 7 minutes. This catches rate limits within ~60-120 seconds of pushing. **Once Greptile is triggered for a PR, that PR stays on Greptile for all subsequent review cycles — do not fall back to CR.**
   - **Do NOT confuse the ack with completion.** The "Actions performed — Full review triggered" issue comment means CR **started** reviewing — it does NOT mean the review is finished. The CI check "CodeRabbit — Review completed" is what signals actual completion.
 - **CR's GitHub username is `coderabbitai[bot]` (with the `[bot]` suffix).** Always filter by `.user.login == "coderabbitai[bot]"` — NOT bare `coderabbitai`. Using the wrong username will silently miss all CR comments.
 - Track the **highest comment ID** seen so far across all three endpoints. Any comment from `coderabbitai[bot]` with an ID greater than the watermark is a new finding that needs attention.
 - If CR responds, process immediately
-- **Hard timeout: 8 minutes.** If CR has not delivered a review after 8 minutes of polling, stop waiting and trigger **Greptile**. Do NOT keep polling — it wastes tokens and risks session timeout.
+- **Hard timeout: 7 minutes.** If CR has not delivered a review after 7 minutes of polling, stop waiting and trigger **Greptile**. Do NOT keep polling — it wastes tokens and risks session timeout. **Once Greptile is triggered, that PR stays on Greptile permanently — do not switch back to CR.**
 
 ### Timeout & Fallback — Two Trigger Paths to Greptile
 
 - **Fast path (~1-2 min):** The check-runs or commit statuses API shows "Review rate limit exceeded" -> trigger Greptile immediately on that poll cycle. Do not wait.
-- **Slow path (8 min):** No rate-limit signal visible, but CR has not delivered review content after 8 minutes -> trigger Greptile. The distinction between "rate-limited" and "slow" is irrelevant at this point — the action is the same.
+- **Slow path (7 min):** No rate-limit signal visible, but CR has not delivered review content after 7 minutes -> trigger Greptile. The distinction between "rate-limited" and "slow" is irrelevant at this point — the action is the same.
+- **Sticky Greptile assignment:** Once either trigger path fires for a PR, that PR stays on Greptile permanently (see `greptile.md` "Sticky Assignment" for full details). Do not switch back to CR.
 - **If Greptile also fails** (5-minute timeout with no response): fall back to **self-review**.
 - Tell the user which fallback was used and why.
 
@@ -111,28 +112,31 @@ GitHub does not auto-resolve PR review comments when the fix touches different l
 
 ### Completion
 
-**Step 1 — Confirm reviews are clean (3 clean reviews required):**
+**Step 1 — Confirm reviews are clean (merge gate):**
 
-Merge requires ALL of these:
-1. 1 clean Greptile review (no findings from `greptile-apps[bot]`)
-2. 2 clean CR reviews (no findings from `coderabbitai[bot]`) — the second is the confirmation pass, and the final review before merge must always be CR
+> Canonical merge-gate definition is in `greptile.md` "Detecting a Clean Greptile Pass". Repeated here for subagent self-containment.
 
-If Greptile is unavailable (timeout), perform a self-review for risk reduction and report the blocker to the user, but do NOT count self-review toward merge readiness. The required clean passes remain: 1 Greptile + 2 CR.
+The merge gate depends on which reviewer owns the PR:
 
+**CR-only path** (Greptile was never triggered for this PR):
+- 2 clean CR reviews required. The second is a confirmation pass — CR's completion signal is unreliable (it may mark the check as "completed" but post findings minutes later), so a second clean pass is needed.
 - If CR responds with no findings after a round of fixes, post `@coderabbitai full review` one more time to confirm.
+- **After 2 failed re-triggers on the same SHA**, stop and tell the user. Do not loop forever.
+
+**Greptile path** (Greptile was triggered at any point for this PR):
+- 1 clean Greptile review = merge-ready. Greptile's CI check accurately reflects its review state, so no confirmation pass is needed.
+- After fixing Greptile findings, trigger `@greptileai` again and poll for the next review. Stay on Greptile — do not switch back to CR.
+
+**If both CR and Greptile are down** (CR rate-limited/timed out + Greptile 5-min timeout): perform a self-review for risk reduction. A clean self-review does NOT satisfy the merge gate — report the blocker to the user.
+
 - **How to detect a clean CR pass:** After triggering `@coderabbitai full review`, watch for these signals in order:
   1. **Ack (review started):** CR posts an issue comment (on `issues/{N}/comments`) with "Actions performed — Full review triggered." This means CR **started** the review — it is NOT a completion signal.
   2. **Completion (review finished):** The commit status check for CodeRabbit shows `status: "completed"` with `conclusion: "success"` (visible as "CodeRabbit — Review completed" in the PR's CI checks). This is the **definitive completion signal**.
-  3. **Clean = completed + no new findings:** Once the CI check shows completed, check all three comment endpoints for any new findings posted after the ack. If there are none, the review is a clean pass. You do NOT need to keep polling to the 8-minute timeout once the CI check is green and no findings appeared.
-- After a clean Greptile pass, re-trigger CR to get the required CR clean passes:
-  - **If you pushed new code since the last CR attempt** (new SHA): CR auto-triggers on push. Enter the normal polling loop immediately — do NOT wait 15 minutes. The new SHA has fresh check-runs; the old rate-limit message is irrelevant.
-  - **If you're re-requesting review on the SAME SHA** (no new push): Wait 15 minutes before triggering `@coderabbitai full review`. Re-reviewing the same SHA while rate-limited will just fail again.
-  - **After 2 failed re-triggers on the same SHA**, stop and tell the user. Do not loop forever.
-- If Greptile timed out and you performed self-review, report blocker status to the user and stop merge-readiness progression until a clean Greptile review is obtained.
-- Once the 3-review requirement is met, proceed immediately to Step 2.
+  3. **Clean = completed + no new findings:** Once the CI check shows completed, check all three comment endpoints for any new findings posted after the ack. If there are none, the review is a clean pass. You do NOT need to keep polling to the 7-minute timeout once the CI check is green and no findings appeared.
+- Once the merge gate is met, proceed immediately to Step 2.
 
 **Step 2 — Verify every Test Plan checkbox (MANDATORY — do NOT skip):**
-> This is the **immediate next step** after CR is clean. Do not ask the user about merging until this is done.
+> This is the **immediate next step** after the merge gate is met. Do not ask the user about merging until this is done.
 >
 > 1. Fetch the PR body via `gh pr view N --json body`
 > 2. Parse **every** checkbox in the **Test plan** section of the PR description
@@ -146,5 +150,5 @@ If Greptile is unavailable (timeout), perform a self-review for risk reduction a
 > Skipping this step is a **blocking failure** — the user should never see unchecked AC boxes when asked about merge.
 
 **Step 3 — Ask the user about merging:**
-- Ask the user: "CR is clean, all AC verified and checked off. Want me to squash and merge and delete the branch, or do you want to review the diff yourself first?"
+- Ask the user: "Reviews are clean, all AC verified and checked off. Want me to squash and merge and delete the branch, or do you want to review the diff yourself first?"
 - Always use **squash and merge** (never regular merge or rebase)

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -3,7 +3,7 @@
 
 > **Always:** Poll all 3 endpoints + check-runs every cycle. Use `per_page=100`. Filter by `coderabbitai[bot]`. Batch fixes into one commit. Reply to every thread. Resolve threads via GraphQL.
 > **Ask first:** Merging — always ask the user.
-> **Never:** Poll only 1-2 endpoints. Use bare `coderabbitai` without `[bot]`. Push per-finding. Trigger `@coderabbitai full review` more than twice/hour. Trigger Greptile proactively (only on CR failure). Merge without meeting the merge gate (2 clean CR or 1 clean G).
+> **Never:** Poll only 1-2 endpoints. Use bare `coderabbitai` without `[bot]`. Push per-finding. Trigger `@coderabbitai full review` more than twice per PR per hour. Trigger Greptile proactively (only on CR failure). Merge without meeting the merge gate (2 clean CR or 1 clean G).
 
 > **This is the fallback review workflow.** It runs after you push and create a PR. If the local review loop was thorough, CR should find few or no issues here. But edge cases exist (e.g., CI-only context, cross-file interactions the local review missed), so always let this loop run.
 
@@ -41,12 +41,12 @@ After pushing a commit to a PR, automatically enter the CR review loop:
     --jq '.[] | select(.context | test("CodeRabbit"; "i")) | {context, state, description}'
   ```
   - **Completion signal:** `status: "completed"` with `conclusion: "success"` = review done (visible as "CodeRabbit — Review completed" in the PR's CI checks box). This is the definitive signal, especially for clean passes.
-  - **Fast-path rate limit detection:** If EITHER endpoint shows rate limiting — check-run has `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit status has `state: "failure"`/`state: "error"` with `description` containing "rate limit" — **trigger Greptile IMMEDIATELY.** Do not wait 7 minutes. This catches rate limits within ~60-120 seconds of pushing. **Once Greptile is triggered for a PR, that PR stays on Greptile for all subsequent review cycles — do not fall back to CR.**
+  - **Fast-path rate limit detection:** If EITHER endpoint shows rate limiting — check-run has `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit status has `state: "failure"`/`state: "error"` with `description` containing "rate limit" — **trigger Greptile IMMEDIATELY.** Do not wait 7 minutes. This catches rate limits within ~60-120 seconds of pushing. Sticky assignment applies (see below).
   - **Do NOT confuse the ack with completion.** The "Actions performed — Full review triggered" issue comment means CR **started** reviewing — it does NOT mean the review is finished. The CI check "CodeRabbit — Review completed" is what signals actual completion.
 - **CR's GitHub username is `coderabbitai[bot]` (with the `[bot]` suffix).** Always filter by `.user.login == "coderabbitai[bot]"` — NOT bare `coderabbitai`. Using the wrong username will silently miss all CR comments.
 - Track the **highest comment ID** seen so far across all three endpoints. Any comment from `coderabbitai[bot]` with an ID greater than the watermark is a new finding that needs attention.
 - If CR responds, process immediately
-- **Hard timeout: 7 minutes.** If CR has not delivered a review after 7 minutes of polling, stop waiting and trigger **Greptile**. Do NOT keep polling — it wastes tokens and risks session timeout. **Once Greptile is triggered, that PR stays on Greptile permanently — do not switch back to CR.**
+- **Hard timeout: 7 minutes.** If CR has not delivered a review after 7 minutes of polling, stop waiting and trigger **Greptile**. Do NOT keep polling — it wastes tokens and risks session timeout. Sticky assignment applies (see below).
 
 ### Timeout & Fallback — Two Trigger Paths to Greptile
 

--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -79,7 +79,7 @@ A Greptile review is **clean** when:
 - `greptile-apps[bot]` posted a review or summary with no actionable findings, OR
 - 👍 completion signal appeared with no inline comments or review findings
 
-**A clean Greptile pass = merge-ready** for that PR (no further CR review needed). Greptile's CI check accurately reflects its review state, so no confirmation pass is required. This differs from CR, which needs 2 clean passes due to unreliable completion signals.
+**A clean Greptile pass = merge-ready** for that PR (no further CR review needed). No confirmation pass is required on the Greptile path.
 
 ## Self-Review Fallback
 

--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -1,10 +1,10 @@
-# Greptile — Peer Reviewer & CodeRabbit Fallback
+# Greptile — CodeRabbit Fallback Reviewer
 
-> **Always:** Trigger Greptile on every PR alongside CR. Poll for response. Reply to every thread. Fix all valid findings.
+> **Always:** Poll for response after triggering. Reply to every thread. Fix all valid findings. Stay on G once triggered for a PR.
 > **Ask first:** Never — fix findings autonomously.
-> **Never:** Skip Greptile on a PR. Merge without a clean Greptile pass. Ignore Greptile findings because "CR already reviewed."
+> **Never:** Trigger Greptile proactively on a PR where CR hasn't failed yet. Ignore Greptile findings. Switch a PR back to CR after Greptile has been triggered.
 
-Greptile is an AI code reviewer that runs as a **peer** alongside CodeRabbit on every PR. It also serves as the fallback when CR is rate-limited.
+Greptile is an AI code reviewer used as a **fallback** when CodeRabbit is rate-limited or unresponsive. It is trusted equally with CR in terms of review quality. The differences are cost ($1/review beyond the included 50/month quota) and completion-signal reliability — Greptile's signals are accurate, while CR's are not.
 
 ## Greptile Basics
 
@@ -21,23 +21,19 @@ Greptile is an AI code reviewer that runs as a **peer** alongside CodeRabbit on 
 
 ## When to Trigger Greptile
 
-### On every PR (peer review mode)
+**Greptile is fallback-only.** Never trigger it proactively alongside CR. It is only triggered when CR fails for a specific PR:
 
-After pushing code and creating/updating a PR, trigger BOTH reviewers:
+1. **CR rate limit detected (fast-path):** Check-runs or commit statuses show rate limiting → trigger Greptile immediately.
+2. **CR timeout (slow-path):** CR has not delivered a review within 7 minutes of push → trigger Greptile.
 
-1. CR auto-triggers on push (or use `@coderabbitai full review`)
-2. Comment `@greptileai` on the PR to trigger Greptile
+### Sticky Assignment
 
-Both run in parallel — there is no conflict. Process findings from whichever responds first.
+**Once Greptile is triggered for a PR, that PR stays on Greptile for all remaining review cycles.** Do not switch back to CR. Rationale: if CR was slow or rate-limited once for this PR, it will likely be slow again, and switching back just wastes more time.
 
-### As CR fallback (rate-limit recovery)
-
-When CR is rate-limited (detected via fast-path check-run signal or 8-minute timeout):
-
-1. Greptile should already be running (triggered in step above)
-2. If Greptile was not yet triggered, comment `@greptileai` immediately
-3. Process Greptile findings while waiting for CR to recover
-4. After fixing + pushing, CR auto-triggers on the new SHA — enter normal polling
+This means:
+- After fixing Greptile findings, trigger `@greptileai` again (not `@coderabbitai full review`)
+- Ignore any late CR reviews that arrive after Greptile has taken ownership
+- The merge gate for this PR is now 1 clean Greptile review (see below)
 
 ## Polling for Greptile Response
 
@@ -74,6 +70,7 @@ Same protocol as CR findings:
    - Issue comments: `gh api repos/{owner}/{repo}/issues/{N}/comments -f body="@greptileai Fixed: <summary>"`
 5. Resolve threads via GraphQL (same as CR threads)
 6. Use 👍/👎 reactions on Greptile comments to provide feedback
+7. **Trigger `@greptileai` again** to request the next review (stay on Greptile — do not switch to CR)
 
 ## Detecting a Clean Greptile Pass
 
@@ -82,7 +79,7 @@ A Greptile review is **clean** when:
 - `greptile-apps[bot]` posted a review or summary with no actionable findings, OR
 - 👍 completion signal appeared with no inline comments or review findings
 
-A clean Greptile pass counts as 1 of the 3 required reviews for merge readiness.
+**A clean Greptile pass = merge-ready** for that PR (no further CR review needed). Greptile's CI check accurately reflects its review state, so no confirmation pass is required. This differs from CR, which needs 2 clean passes due to unreliable completion signals.
 
 ## Self-Review Fallback
 
@@ -90,5 +87,5 @@ If BOTH CR and Greptile are unavailable (CR rate-limited + Greptile timeout):
 
 1. Perform a self-review of the full diff (`git diff main...HEAD`)
 2. Check for: bugs, security issues, error handling, types, naming, edge cases
-3. A clean self-review does NOT satisfy the 3-review merge requirement
+3. A clean self-review does NOT satisfy the merge gate
 4. Tell the user both reviewers are down and what was left unreviewed

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -139,8 +139,8 @@ When running a long monitoring session with multiple PRs, write a status checkpo
   "last_updated": "2026-03-16T16:00:00Z",
   "monitoring_active": true,
   "prs": {
-    "618": {"phase": "B", "round": 2, "head_sha": "7b2cfbf", "reviewer": "cr", "reviews_clean": ["cr_round_1"], "needs": "cr_round_2_clean"},
-    "620": {"phase": "B", "round": 1, "head_sha": "d0e4fef", "reviewer": "g", "reviews_clean": [], "needs": "fix_and_push"}
+    "618": {"phase": "B", "head_sha": "7b2cfbf", "reviewer": "cr", "needs": "cr_confirmation_pass"},
+    "620": {"phase": "B", "head_sha": "d0e4fef", "reviewer": "g", "needs": "fix_and_push"}
   },
   "cr_quota": {"reviews_used": 5, "window_start": "2026-03-16T15:00:00Z"},
   "active_agents": [

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -29,13 +29,15 @@ Subagents have a hardcoded **32K output token limit** that cannot be configured 
 - **EXIT after push — do not enter polling loop**
 
 **Phase B: Review Loop** (lighter — incremental)
-- Poll for new CR review (fast-path + 8-minute slow-path Greptile trigger)
-- If CR/Greptile posts new findings: fix, commit, push, reply (same as Phase A but smaller scope)
-- If clean pass: trigger one more `@coderabbitai full review` for confirmation
+- If this PR is on CR: poll for CR review (fast-path + 7-minute slow-path Greptile trigger). If Greptile is triggered, the PR switches to Greptile permanently.
+- If this PR is already on Greptile: skip CR polling, trigger `@greptileai` and poll for Greptile response directly.
+- If reviewer posts new findings: fix, commit, push, reply (same as Phase A but smaller scope)
+- If clean pass on CR: trigger one more `@coderabbitai full review` for confirmation (2 clean CR passes needed)
+- If clean pass on Greptile: merge-ready (1 clean Greptile pass is sufficient)
 - **EXIT after confirming clean or after fixing one round**
 
 **Phase C: Merge Prep** (lightest)
-- Verify merge gate is satisfied: 1 clean Greptile review + 2 clean CR reviews (final review must be CR)
+- Verify merge gate is satisfied: if PR is on Greptile, 1 clean G review. If CR-only, 2 clean CR reviews.
 - Read PR body, verify all acceptance criteria against final code
 - Check off all boxes
 - Report ready for merge
@@ -44,7 +46,7 @@ Subagents have a hardcoded **32K output token limit** that cannot be configured 
 - Parent agent launches Phase A subagents (can run in parallel across different PRs)
 - **When Phase A completes, parent MUST launch Phase B immediately** — see "Phase A Completion Protocol" below
 - When Phase B reports clean, parent launches Phase C
-- **No hard limit on parallel Phase B PRs.** CR rate limiting is handled by the Greptile fallback for interim feedback, but merge readiness still requires the full gate: 1 clean Greptile + 2 clean CR passes.
+- **No hard limit on parallel Phase B PRs.** CR rate limiting is handled by the Greptile fallback. Each PR tracks its own reviewer assignment: CR-only PRs need 2 clean CR passes; Greptile PRs need 1 clean G pass.
 - **Track CR quota.** Maintain a running count of CR reviews consumed this hour. Increment when: pushing to a PR with CR configured (auto-review), or posting `@coderabbitai full review`. If count reaches 7 in the current hour, expect Greptile to be the primary reviewer for remaining PRs until the window resets.
 - Use judgment on small PRs: if CR only found 1-2 findings, a single subagent may handle the full lifecycle without hitting token limits
 
@@ -137,8 +139,8 @@ When running a long monitoring session with multiple PRs, write a status checkpo
   "last_updated": "2026-03-16T16:00:00Z",
   "monitoring_active": true,
   "prs": {
-    "618": {"phase": "B", "round": 2, "head_sha": "7b2cfbf", "reviews_clean": ["greptile", "cr_round_1"], "needs": "cr_round_2_clean"},
-    "620": {"phase": "B", "round": 1, "head_sha": "d0e4fef", "reviews_clean": [], "needs": "fix_and_push"}
+    "618": {"phase": "B", "round": 2, "head_sha": "7b2cfbf", "reviewer": "cr", "reviews_clean": ["cr_round_1"], "needs": "cr_round_2_clean"},
+    "620": {"phase": "B", "round": 1, "head_sha": "d0e4fef", "reviewer": "g", "reviews_clean": [], "needs": "fix_and_push"}
   },
   "cr_quota": {"reviews_used": 5, "window_start": "2026-03-16T15:00:00Z"},
   "active_agents": [
@@ -165,7 +167,10 @@ BEFORE triggering `@coderabbitai full review` or entering the polling loop:
 4. Only request a new review after all prior findings are addressed
 Skipping this step wastes a review cycle and burns CR quota.
 
-### Step 1: Wait for CR review (fast-path check every cycle, 8-min slow-path max)
+### Step 1: Check if PR is already on Greptile
+If this PR has already switched to Greptile (check session-state `reviewer` field), skip CR polling entirely — go directly to Step 3 and trigger `@greptileai`.
+
+### Step 1b: Wait for CR review (only if PR is still on CR)
 - Poll every 60s on all 3 endpoints (per_page=100):
   - `repos/{owner}/{repo}/pulls/{N}/reviews?per_page=100`
   - `repos/{owner}/{repo}/pulls/{N}/comments?per_page=100`
@@ -176,11 +181,12 @@ Skipping this step wastes a review cycle and burns CR quota.
   If check shows "rate limit" in output.title with conclusion "failure" -> Greptile IMMEDIATELY.
   If check-runs empty, also check: `gh api "repos/{owner}/{repo}/commits/{SHA}/statuses"`
 
-### Step 2: After 8 minutes with no review -> trigger Greptile (NO EXCEPTIONS)
-If 8 minutes pass and CR has not delivered review content, trigger Greptile.
+### Step 2: After 7 minutes with no review -> trigger Greptile (NO EXCEPTIONS)
+If 7 minutes pass and CR has not delivered review content, trigger Greptile.
 It does NOT matter whether you see an explicit rate-limit signal.
 The "Actions performed" ack means CR STARTED — it is NOT a review.
-If you see the ack but no review within 8 minutes, CR failed to deliver.
+If you see the ack but no review within 7 minutes, CR failed to deliver.
+**Once Greptile is triggered, this PR stays on Greptile permanently.**
 
 ### Step 3: Trigger Greptile (if not already running)
 1. Post: `gh pr comment <PR_NUMBER> --body "@greptileai"`
@@ -193,24 +199,19 @@ If you see the ack but no review within 8 minutes, CR failed to deliver.
    - Issue comments: `gh api repos/{owner}/{repo}/issues/{N}/comments -f body="@greptileai Fixed: <summary>"`
    Pushing code does NOT resolve threads — you MUST post explicit replies.
 
-### After Greptile fix+push: CR gets a fresh chance automatically
-Pushing creates a new SHA with clean check-runs. CR auto-triggers on push.
-Do NOT wait 15 minutes. Enter the normal polling loop on the new SHA.
-The 15-min wait only applies to `@coderabbitai full review` on the SAME SHA.
+### After Greptile fix+push: stay on Greptile
+Once a PR is on Greptile, it stays on Greptile. After pushing fixes, trigger `@greptileai` again.
+Do NOT switch back to CR or enter the CR polling loop.
 
 ### Greptile clean detection
 greptile-apps[bot] posts a review/summary with no actionable findings = clean pass.
 Also watch for 👍 completion signal with no inline comments.
 Check-run name: TBD — update after first Greptile review on this repo.
 
-### Step 4: Get 3 clean reviews for merge readiness
-Merge requires ALL of these:
-1. 1 clean Greptile review (no findings from greptile-apps[bot])
-2. 2 clean CR reviews (no findings from coderabbitai[bot]) — the second is the confirmation pass, and the final review before merge must always be CR
+### Step 4: Merge gate
+The merge gate depends on which reviewer owns the PR:
+- **CR-only** (Greptile never triggered): 2 clean CR reviews required (confirmation pass needed due to unreliable signals)
+- **Greptile** (triggered at any point): 1 clean Greptile review = merge-ready
 
-If Greptile is unavailable (timeout), perform self-review for risk reduction and report the blocker, but do NOT count self-review toward merge readiness. Required gate remains 1 Greptile + 2 CR.
-
-After a Greptile pass (or after self-review used only for risk reduction while reporting a blocker), the next CR step depends on whether you pushed new code:
-1. **New commit pushed** (e.g., Greptile fixes) -> CR auto-triggers on the new SHA. Enter polling immediately — no wait needed.
-2. **Same SHA, manual re-trigger only** -> Wait 15 min, then `@coderabbitai full review`. If still rate-limited, tell user and stop.
+If BOTH reviewers are down (CR rate-limited + Greptile timeout), perform self-review for risk reduction and report the blocker. Self-review does NOT satisfy the merge gate.
 ```

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -46,7 +46,7 @@ Subagents have a hardcoded **32K output token limit** that cannot be configured 
 - Parent agent launches Phase A subagents (can run in parallel across different PRs)
 - **When Phase A completes, parent MUST launch Phase B immediately** — see "Phase A Completion Protocol" below
 - When Phase B reports clean, parent launches Phase C
-- **No hard limit on parallel Phase B PRs.** CR rate limiting is handled by the Greptile fallback. Each PR tracks its own reviewer assignment: CR-only PRs need 2 clean CR passes; Greptile PRs need 1 clean G pass.
+- **Soft limit on parallel Phase B PRs:** aim for 3-4 active CR-polled PRs at once to reduce CR throttling and unnecessary Greptile fallback cost. Each PR tracks its own reviewer assignment: CR-only PRs need 2 clean CR passes; Greptile PRs need 1 clean G pass.
 - **Track CR quota.** Maintain a running count of CR reviews consumed this hour. Increment when: pushing to a PR with CR configured (auto-review), or posting `@coderabbitai full review`. If count reaches 7 in the current hour, expect Greptile to be the primary reviewer for remaining PRs until the window resets.
 - Use judgment on small PRs: if CR only found 1-2 findings, a single subagent may handle the full lifecycle without hitting token limits
 


### PR DESCRIPTION
## Summary
- Greptile becomes fallback-only (never triggered proactively on every PR), saving ~$1/review
- Once Greptile is triggered for a PR (via rate limit or 7-min timeout), that PR stays on Greptile permanently (sticky assignment) — no bouncing back to CR
- Merge gate simplified: 2 clean CR reviews (CR-only path) OR 1 clean Greptile review (G path), replacing the old "3 reviews required (1 G + 2 CR)" gate
- CR timeout reduced from 8 min to 7 min across all rule files
- Session-state schema now tracks which reviewer (`cr` or `g`) owns each PR

## Test plan
- [x] G is never triggered on a PR unless CR hits rate limit or 7-min timeout
- [x] Once G is triggered for a PR, all subsequent reviews for that PR use G (no fallback to CR)
- [x] Merge gate: 2 clean CR reviews if CR-only path; 1 clean G review if G was triggered
- [x] Timeout is 7 minutes (not 8) in all references across all rule files
- [x] Old "3 reviews required (1 G + 2 CR)" gate is fully removed from all files
- [x] Local CR CLI review loop is unchanged
- [x] Self-review fallback still exists for when both CR and G are down
- [x] Subagent quick-reference block and Phase B/C descriptions reflect the new logic
- [x] Session-state schema tracks which reviewer (CR or G) "owns" each PR

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Greptile is now a fallback reviewer: triggered on CR rate-limit or after a 7-minute timeout, stays assigned for the PR (late CR reviews ignored; no switching back).
  * CR full-review requests capped at >2 per PR/hour; Greptile proactively runs only when CR fails or is rate-limited.
  * Reviewer-keyed merge gate: CR-only needs 2 clean CR passes (second confirms); Greptile-owned needs 1 clean Greptile pass; clean self-review no longer counts.
  * Updated user prompts and parallelism guidance (~3–4 active polled PRs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->