### PR TITLE
Add .claude/rules/safety.md: protect .env and prohibit destructive commands

### DIFF
--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -1,0 +1,24 @@
+# Safety — Destructive Command Prohibitions
+
+> **Always:** Stay in your worktree directory. Treat `.env` files as untouchable. Warn subagents about these rules.
+> **Ask first:** Never — these are absolute prohibitions with no exceptions.
+> **Never:** Delete `.env` files. Run `git clean`. Run destructive commands in the root repo. Operate in the root repo directory.
+
+These rules exist because a thread accidentally deleted a repo's `.env` file by running destructive commands in the root repo directory instead of staying in its worktree. The user only caught it because the file happened to be open in their IDE.
+
+## Absolute Rules (no exceptions)
+
+1. **NEVER delete, overwrite, move, or modify `.env` files.** Not in root, not in worktrees, not anywhere, not in any repo. `.env` files contain secrets and credentials that cannot be recovered.
+2. **NEVER run `git clean` in ANY directory.** It removes untracked files — including `.env` files that are in `.gitignore`.
+3. **NEVER run destructive file commands in the root repo directory.** This includes `rm -rf`, `rm`, `git checkout .`, `git stash` (which can drop untracked files), and `git reset --hard`. All work happens in worktrees — the root repo stays untouched on `main`.
+4. **NEVER `cd` to the root repo and run file operations there.** Stay in your assigned worktree directory at all times. The only safe root-repo operations are read-only: `git worktree list`, `find` for locating directories, reading files.
+
+## Subagent Warning (MANDATORY)
+
+When spawning subagents, include this warning in the prompt:
+
+```
+SAFETY: Do NOT modify or delete .env files. Do NOT run git clean. Do NOT run destructive
+commands (rm -rf, git checkout ., git reset --hard) in the root repo directory. Stay in
+your worktree directory at all times.
+```

--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -18,7 +18,8 @@ Prevent accidental `.env` deletion and other destructive operations from the rep
 When spawning subagents, include this warning in the prompt:
 
 ```
-SAFETY: Do NOT modify or delete .env files. Do NOT run git clean. Do NOT run destructive
-commands (rm -rf, git checkout ., git reset --hard) in the root repo directory. Stay in
-your worktree directory at all times.
+SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo.
+Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm,
+git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your
+worktree directory at all times.
 ```

--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -4,7 +4,7 @@
 > **Ask first:** Never — these are absolute prohibitions with no exceptions.
 > **Never:** Delete `.env` files. Run `git clean`. Run destructive commands in the root repo. Operate in the root repo directory.
 
-These rules exist because a thread accidentally deleted a repo's `.env` file by running destructive commands in the root repo directory instead of staying in its worktree. The user only caught it because the file happened to be open in their IDE.
+Prevent accidental `.env` deletion and other destructive operations from the repo root. All work happens in worktrees.
 
 ## Absolute Rules (no exceptions)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,5 +69,6 @@ Detailed workflow rules are split into topic-specific files in `.claude/rules/`:
 | `greptile.md` | Greptile peer reviewer + CR fallback + self-review fallback |
 | `subagent-orchestration.md` | Task decomposition (phases A/B/C), health monitoring, timestamps, subagent quick-reference |
 | `work-log.md` | Auto-update daily work log on issue create, PR open, PR merge |
+| `safety.md` | Destructive command prohibitions, .env protection, subagent safety warnings |
 
 These files auto-load for the parent agent session. **Subagents do NOT auto-load these files.** See `subagent-orchestration.md` for how to pass rules to subagents.


### PR DESCRIPTION
## Summary
- Adds `.claude/rules/safety.md` with absolute prohibitions: never delete `.env`, never run `git clean`, never run destructive commands in the root repo, stay in worktrees
- Updates `CLAUDE.md` rule files table to reference `safety.md`
- Includes mandatory subagent warning text to embed in every subagent prompt

Closes #38

## Test plan
- [ ] `.claude/rules/safety.md` exists with Always/Ask first/Never header format
- [ ] `CLAUDE.md` rule files table includes `safety.md` entry
- [ ] Subagent warning block mirrors the absolute rules (all prohibited commands listed)
- [ ] Format matches existing rule files (3-line header, sections, code blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)