### PR TITLE
Add slash commands: /merge, /check-acceptance-criteria, /status, /lessons

### DIFF
--- a/.claude/skills/check-acceptance-criteria/SKILL.md
+++ b/.claude/skills/check-acceptance-criteria/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: check-acceptance-criteria
+description: Verify all Test Plan checkboxes in a PR against the actual code, check off passing items, and report any failures.
+disable-model-invocation: true
+argument-hint: "[PR number, default: current branch's PR]"
+---
+
+Verify acceptance criteria for PR $ARGUMENTS (or the current branch's PR if no argument given).
+
+## Steps
+
+### Step 1: Identify the PR
+
+If an argument was provided, use it as the PR number. Otherwise, detect from the current branch:
+
+```bash
+gh pr view --json number,title,body --jq '{number, title, body}'
+```
+
+If no PR exists, stop and tell the user.
+
+### Step 2: Parse the Test Plan section
+
+Extract the PR body and find the **Test plan** section (may also be labeled "Test Plan", "Acceptance Criteria", or "## Test plan").
+
+Parse every checkbox line (`- [ ]` or `- [x]`). If there is no Test Plan section, warn the user: "No Test Plan section found in PR body. Nothing to verify."
+
+### Step 3: Verify each criterion
+
+For each checkbox item:
+
+1. **Read the criterion carefully** — understand what it's asserting
+2. **Identify the relevant source files** — which files need to be checked to verify this criterion
+3. **Read those files** and confirm the criterion is satisfied by the current code
+4. **Record the result** — pass or fail, with a brief explanation
+
+Some criteria may not be verifiable from code alone (e.g., "renders correctly in browser", "performance is acceptable"). For these, note: "Requires manual testing — cannot verify from code."
+
+### Step 4: Update the PR body
+
+For each passing criterion, check it off by editing the PR body:
+
+```bash
+# Fetch current body, replace checkboxes, update
+current_body="$(gh pr view N --json body --jq .body)"
+# Replace specific - [ ] lines with - [x] for passing items
+gh pr edit N --body "$updated_body"
+```
+
+Only check off items that are verified. Never check off items that failed or require manual testing.
+
+### Step 5: Report results
+
+Output a summary:
+- Total criteria: N
+- Passed (checked off): N
+- Failed: N (list each with explanation)
+- Requires manual testing: N (list each)
+
+If all items pass, say: "All acceptance criteria verified and checked off. PR is ready for merge."
+If any fail, say: "N acceptance criteria failed — fix before merging." and list the failures.

--- a/.claude/skills/lessons/SKILL.md
+++ b/.claude/skills/lessons/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: lessons
+description: Summarize lessons learned from the current session — what went wrong, what patterns emerged, what to remember. Saves actionable insights to memory.
+disable-model-invocation: true
+---
+
+Reflect on the current session and extract reusable lessons before the thread is closed.
+
+## Steps
+
+### Step 1: Review the session
+
+Look back at what happened in this session:
+- What was the task? What was accomplished?
+- What went wrong or was harder than expected?
+- What patterns emerged (good or bad)?
+- Were there any surprises — tools behaving unexpectedly, edge cases hit, workflow friction?
+- Did any workarounds get used that should be codified?
+- Were there any bugs, regressions, or close calls?
+
+### Step 2: Categorize lessons
+
+For each lesson identified, determine:
+
+1. **Type** — which memory category fits best:
+   - **feedback** — corrections to Claude's approach that should persist (e.g., "don't mock the DB", "always check X before Y")
+   - **project** — facts about the project that affect future decisions (e.g., "module X is fragile when Y changes", "legal requires Z")
+   - **user** — things learned about the user's preferences or expertise
+
+2. **Actionability** — is this something that should change future behavior, or just an observation? Only save actionable lessons.
+
+3. **Novelty** — is this already covered by existing memory? Check `MEMORY.md` before creating duplicates. If an existing memory should be updated, update it instead of creating a new one.
+
+### Step 3: Save to memory
+
+For each actionable, novel lesson:
+
+1. Write a memory file to `~/.claude/projects/{project}/memory/` with proper frontmatter:
+   ```markdown
+   ---
+   name: <descriptive_name>
+   description: <one-line description for relevance matching>
+   type: <feedback|project|user>
+   ---
+
+   <lesson content>
+
+   **Why:** <what happened that surfaced this lesson>
+   **How to apply:** <when and where this should change behavior>
+   ```
+
+2. Add a pointer to `MEMORY.md`
+
+### Step 4: Output summary
+
+Present the lessons to the user in a concise format:
+
+```
+## Session Lessons
+
+### Saved to memory:
+1. **<lesson title>** — <one-line summary> (saved as <type>)
+2. ...
+
+### Observations (not saved):
+- <things noted but not actionable enough to persist>
+```
+
+If the session was straightforward with nothing notable, say so: "Clean session — no new lessons to capture."
+
+## Guidelines
+
+- **Quality over quantity.** 1-3 strong lessons are better than 7 weak ones.
+- **Be specific.** "CR sometimes re-raises findings when line numbers shift" is useful. "Code review can be tricky" is not.
+- **Include the why.** A lesson without context is hard to apply later.
+- **Don't repeat what's in the rules.** If something is already documented in `.claude/rules/`, it's not a lesson — it's a known procedure.
+- **Don't log task completion as a lesson.** "We merged PR #40" is not a lesson. "Merging after a rebase requires waiting for a new CR cycle" is.

--- a/.claude/skills/lessons/SKILL.md
+++ b/.claude/skills/lessons/SKILL.md
@@ -35,7 +35,7 @@ For each lesson identified, determine:
 
 For each actionable, novel lesson:
 
-1. Write a memory file to `~/.claude/projects/{project}/memory/` with proper frontmatter:
+1. Write a memory file to `~/.claude/projects/{project}/memory/` with proper frontmatter. Derive the filename by slugifying the `name` field (lowercase, spaces to hyphens, e.g., `feedback_no_git_clean.md`):
    ```markdown
    ---
    name: <descriptive_name>
@@ -49,7 +49,7 @@ For each actionable, novel lesson:
    **How to apply:** <when and where this should change behavior>
    ```
 
-2. Add a pointer to `MEMORY.md` as a single bullet: `- [filename.md](filename.md) — one-line description`
+2. Add a pointer to `MEMORY.md` (the memory index at `~/.claude/projects/{project}/memory/MEMORY.md`) as a single bullet: `- [filename.md](filename.md) — one-line description`. If updating an existing memory, update the existing pointer instead of adding a duplicate.
 
 ### Step 4: Output summary
 

--- a/.claude/skills/lessons/SKILL.md
+++ b/.claude/skills/lessons/SKILL.md
@@ -49,7 +49,7 @@ For each actionable, novel lesson:
    **How to apply:** <when and where this should change behavior>
    ```
 
-2. Add a pointer to `MEMORY.md`
+2. Add a pointer to `MEMORY.md` as a single bullet: `- [filename.md](filename.md) — one-line description`
 
 ### Step 4: Output summary
 

--- a/.claude/skills/lessons/SKILL.md
+++ b/.claude/skills/lessons/SKILL.md
@@ -35,7 +35,7 @@ For each lesson identified, determine:
 
 For each actionable, novel lesson:
 
-1. Write a memory file to `~/.claude/projects/{project}/memory/` with proper frontmatter. Derive the filename by slugifying the `name` field (lowercase, spaces to hyphens, e.g., `feedback_no_git_clean.md`):
+1. Write a memory file to `~/.claude/projects/{project}/memory/` with proper frontmatter. Derive the filename by slugifying the `name` field (lowercase, spaces/hyphens to underscores, prefixed by type, e.g., `feedback_no_git_clean.md`):
    ```markdown
    ---
    name: <descriptive_name>

--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: merge
+description: Squash merge the current PR, delete the branch, log to work-log, and clean up. Verifies merge gate and acceptance criteria before merging.
+disable-model-invocation: true
+---
+
+Squash merge the current PR. This is the "we're done here" command.
+
+## Steps
+
+### Step 1: Identify the PR
+
+```bash
+gh pr view --json number,title,headRefName,body,state --jq '{number, title, headRefName, body, state}'
+```
+
+If no PR exists on the current branch, stop and tell the user: "No PR found for the current branch. Push and create a PR first."
+
+If the PR is already merged or closed, stop and tell the user.
+
+### Step 2: Verify the merge gate
+
+Determine which reviewer owns this PR:
+
+1. **Check session-state** — read `~/.claude/session-state.json` and check the `reviewer` field for this PR number. If it says `"g"`, this PR is on Greptile.
+2. **If no session-state entry**, check the PR's review history to determine ownership:
+   ```bash
+   gh api "repos/{owner}/{repo}/pulls/{N}/reviews?per_page=100" --jq '.[].user.login'
+   gh api "repos/{owner}/{repo}/pulls/{N}/comments?per_page=100" --jq '.[].user.login'
+   gh api "repos/{owner}/{repo}/issues/{N}/comments?per_page=100" --jq '.[].user.login'
+   ```
+   - If `greptile-apps[bot]` has posted reviews/comments, this PR is on Greptile.
+   - Otherwise, it's on CR.
+
+**Merge gate check:**
+
+- **CR-only PR:** Need 2 clean CR reviews. Check the last 2 review objects from `coderabbitai[bot]` — both must have no actionable findings. Also verify the CodeRabbit check-run shows `conclusion: "success"`.
+- **Greptile PR:** Need 1 clean Greptile review. Check the last review from `greptile-apps[bot]` has no actionable findings.
+
+If the merge gate is NOT met, stop and tell the user exactly what's missing (e.g., "PR needs 1 more clean CR review" or "Greptile has unresolved findings").
+
+### Step 3: Verify acceptance criteria
+
+Before merging, run the acceptance criteria check inline:
+
+1. Fetch the PR body via `gh pr view N --json body`
+2. Parse every checkbox in the **Test plan** section
+3. For each item, read the relevant source files and verify the criterion is met
+4. Check off passing items by editing the PR body (replace `- [ ]` with `- [x]`)
+5. If ANY item fails, stop and tell the user which items failed and why. Do NOT merge with unchecked boxes.
+
+### Step 4: Squash merge
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+### Step 5: Log to work-log
+
+If a work-log directory exists (detected at session start per work-log.md rules):
+
+1. Determine the cycle count by reconstructing from PR history:
+   - Fetch all reviews on `pulls/{N}/reviews` and all commits on `pulls/{N}/commits`
+   - Count each review with actionable findings followed by a fix commit = 1 cycle
+2. Append a merge entry to today's session log:
+   ```
+   - {time} ET — PR #{N} merged (Issue #{M}): {1-line summary} [opened: {open_time}, merged: {merge_time}, cycles: {count}]
+   ```
+3. Get the linked issue number from the PR body (`Closes #N` pattern)
+
+### Step 6: Report completion
+
+Tell the user:
+- PR number and title
+- Merge SHA
+- Branch deleted
+- Work-log updated (if applicable)

--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -41,13 +41,7 @@ If the merge gate is NOT met, stop and tell the user exactly what's missing (e.g
 
 ### Step 3: Verify acceptance criteria
 
-Before merging, run the acceptance criteria check inline:
-
-1. Fetch the PR body via `gh pr view N --json body`
-2. Parse every checkbox in the **Test plan** section
-3. For each item, read the relevant source files and verify the criterion is met
-4. Check off passing items by editing the PR body (replace `- [ ]` with `- [x]`)
-5. If ANY item fails, stop and tell the user which items failed and why. Do NOT merge with unchecked boxes.
+Run the `/check-acceptance-criteria` skill logic for this PR. All Test Plan checkboxes must be checked off before proceeding. If any fail, stop and report — do NOT merge with unchecked boxes.
 
 ### Step 4: Squash merge
 
@@ -60,8 +54,17 @@ gh pr merge --squash --delete-branch
 If a work-log directory exists (detected at session start per work-log.md rules):
 
 1. Determine the cycle count by reconstructing from PR history:
-   - Fetch all reviews on `pulls/{N}/reviews` and all commits on `pulls/{N}/commits`
-   - Count each review with actionable findings followed by a fix commit = 1 cycle
+   ```bash
+   # Fetch reviews and commits
+   gh api "repos/{owner}/{repo}/pulls/{N}/reviews?per_page=100" \
+     --jq '[.[] | select(.user.login == "coderabbitai[bot]" or .user.login == "greptile-apps[bot]") | {state, submitted_at}]'
+   gh api "repos/{owner}/{repo}/pulls/{N}/commits?per_page=100" \
+     --jq '[.[] | {sha: .sha, date: .commit.committer.date}]'
+   ```
+   - For each review where `state == "CHANGES_REQUESTED"` (or has inline comments with actionable findings), check if any commit has `committed_date > review.submitted_at`
+   - If yes, that review-then-fix pair = 1 cycle. Multiple commits after a single review count as 1 cycle.
+   - Include reviews from both `coderabbitai[bot]` and `greptile-apps[bot]`
+   - Clean passes and confirmation reviews do not count
 2. Append a merge entry to today's session log:
    ```
    - {time} ET — PR #{N} merged (Issue #{M}): {1-line summary} [opened: {open_time}, merged: {merge_time}, cycles: {count}]

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: status
+description: Show a dashboard of all open PRs with review state, unresolved findings, and blockers.
+disable-model-invocation: true
+---
+
+Build a status dashboard of all open PRs in this repo.
+
+## Steps
+
+### Step 1: List open PRs
+
+```bash
+gh pr list --state open --json number,title,headRefName,updatedAt,author,additions,deletions --limit 50
+```
+
+If no open PRs, say "No open PRs." and stop.
+
+### Step 2: For each PR, gather review state
+
+For each open PR, fetch review data from all 3 endpoints:
+
+```bash
+# Reviews (approve/changes requested)
+gh api "repos/{owner}/{repo}/pulls/{N}/reviews?per_page=100" \
+  --jq '[.[] | select(.user.login == "coderabbitai[bot]" or .user.login == "greptile-apps[bot]") | {user: .user.login, state: .state, submitted: .submitted_at}] | last'
+
+# Inline comments (unresolved findings)
+gh api "repos/{owner}/{repo}/pulls/{N}/comments?per_page=100" \
+  --jq '[.[] | select(.user.login == "coderabbitai[bot]" or .user.login == "greptile-apps[bot]")] | length'
+
+# Issue comments (summary, ack)
+gh api "repos/{owner}/{repo}/issues/{N}/comments?per_page=100" \
+  --jq '[.[] | select(.user.login == "coderabbitai[bot]" or .user.login == "greptile-apps[bot]")] | length'
+```
+
+Also check the commit status:
+```bash
+SHA=$(gh pr view N --json commits --jq '.commits[-1].oid')
+gh api "repos/{owner}/{repo}/commits/$SHA/check-runs" \
+  --jq '.check_runs[] | select(.name == "CodeRabbit") | {status: .status, conclusion: .conclusion}'
+```
+
+### Step 3: Determine status for each PR
+
+Classify each PR into one of these states:
+- **Clean (merge-ready)** — merge gate satisfied (2 clean CR or 1 clean G)
+- **Has findings** — reviewer posted actionable comments that need fixing
+- **Review pending** — pushed but no review yet
+- **Rate-limited** — CR check shows rate limit failure
+
+Also note:
+- Which reviewer owns the PR (CR or Greptile)
+- Number of unresolved inline comments
+- Time since last update
+
+### Step 4: Check session-state
+
+If `~/.claude/session-state.json` exists, cross-reference it:
+- Active agents and what they're doing
+- Phase assignments (A/B/C)
+- CR quota usage this hour
+
+### Step 5: Format the dashboard
+
+Output a table like:
+
+```
+PR    | Title                          | Reviewer | State          | Findings | Updated
+------|--------------------------------|----------|----------------|----------|--------
+#40   | Add slash commands             | CR       | Review pending | 0        | 2 min ago
+#38   | Fix auth middleware            | Greptile | Has findings   | 3        | 15 min ago
+#35   | Add post-merge hook            | CR       | Clean          | 0        | 1 hr ago
+```
+
+Below the table, add:
+- **Blocked:** List any PRs that are blocked and why
+- **CR quota:** N/8 reviews used this hour (if session-state available)
+- **Active agents:** List any running agents and their tasks (if session-state available)

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -25,9 +25,9 @@ For each open PR, fetch review data from all 3 endpoints:
 gh api "repos/{owner}/{repo}/pulls/{N}/reviews?per_page=100" \
   --jq '[.[] | select(.user.login == "coderabbitai[bot]" or .user.login == "greptile-apps[bot]") | {user: .user.login, state: .state, submitted: .submitted_at}] | sort_by(.submitted) | if length == 0 then {} else last end'
 
-# Inline comments (unresolved findings)
-gh api "repos/{owner}/{repo}/pulls/{N}/comments?per_page=100" \
-  --jq '[.[] | select(.user.login == "coderabbitai[bot]" or .user.login == "greptile-apps[bot]")] | length'
+# Unresolved findings (use GraphQL to get only unresolved threads)
+gh api graphql -f query='query { repository(owner: "{owner}", name: "{repo}") { pullRequest(number: {N}) { reviewThreads(first: 100) { nodes { isResolved comments(first: 1) { nodes { author { login } } } } } } } }' \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
 
 # Issue comments (summary, ack)
 gh api "repos/{owner}/{repo}/issues/{N}/comments?per_page=100" \
@@ -66,11 +66,11 @@ If `~/.claude/session-state.json` exists, cross-reference it:
 Output a table like:
 
 ```
-PR    | Title                          | Reviewer | State          | Findings | Updated
-------|--------------------------------|----------|----------------|----------|--------
-#40   | Add slash commands             | CR       | Review pending | 0        | 2 min ago
-#38   | Fix auth middleware            | Greptile | Has findings   | 3        | 15 min ago
-#35   | Add post-merge hook            | CR       | Clean          | 0        | 1 hr ago
+PR    | Title                          | Reviewer | State          | Findings | HEAD SHA | Updated
+------|--------------------------------|----------|----------------|----------|----------|--------
+#40   | Add slash commands             | CR       | Review pending | 0        | 517690c  | 2 min ago
+#38   | Fix auth middleware            | Greptile | Has findings   | 3        | d0e4fef  | 15 min ago
+#35   | Add post-merge hook            | CR       | Clean          | 0        | 7b2cfbf  | 1 hr ago
 ```
 
 Below the table, add:

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -23,7 +23,7 @@ For each open PR, fetch review data from all 3 endpoints:
 ```bash
 # Reviews (approve/changes requested)
 gh api "repos/{owner}/{repo}/pulls/{N}/reviews?per_page=100" \
-  --jq '[.[] | select(.user.login == "coderabbitai[bot]" or .user.login == "greptile-apps[bot]") | {user: .user.login, state: .state, submitted: .submitted_at}] | last'
+  --jq '[.[] | select(.user.login == "coderabbitai[bot]" or .user.login == "greptile-apps[bot]") | {user: .user.login, state: .state, submitted: .submitted_at}] | if length == 0 then {} else last end'
 
 # Inline comments (unresolved findings)
 gh api "repos/{owner}/{repo}/pulls/{N}/comments?per_page=100" \

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -23,7 +23,7 @@ For each open PR, fetch review data from all 3 endpoints:
 ```bash
 # Reviews (approve/changes requested)
 gh api "repos/{owner}/{repo}/pulls/{N}/reviews?per_page=100" \
-  --jq '[.[] | select(.user.login == "coderabbitai[bot]" or .user.login == "greptile-apps[bot]") | {user: .user.login, state: .state, submitted: .submitted_at}] | if length == 0 then {} else last end'
+  --jq '[.[] | select(.user.login == "coderabbitai[bot]" or .user.login == "greptile-apps[bot]") | {user: .user.login, state: .state, submitted: .submitted_at}] | sort_by(.submitted) | if length == 0 then {} else last end'
 
 # Inline comments (unresolved findings)
 gh api "repos/{owner}/{repo}/pulls/{N}/comments?per_page=100" \


### PR DESCRIPTION
## Summary
- Adds 4 new slash command skills to `.claude/skills/`
- `/merge` — squash merge current PR with merge gate + AC verification + work-log logging
- `/check-acceptance-criteria` — verify Test Plan checkboxes against code and check them off
- `/status` — dashboard of all open PRs with review state, findings, blockers
- `/lessons` — extract session lessons and save to memory

Closes #40

## Test plan
- [x] Each skill has a `SKILL.md` in `.claude/skills/<name>/`
- [x] Each skill has correct frontmatter (`name`, `description`, `disable-model-invocation`)
- [x] `/merge` verifies merge gate and AC before merging
- [x] `/check-acceptance-criteria` parses Test Plan checkboxes and verifies against code
- [x] `/status` shows open PRs with review state and blockers
- [x] `/lessons` extracts insights and saves to memory
- [x] All 4 skills are functional via slash command invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR Test Plan verifier: parses Test Plan checkboxes, runs automated checks, marks verified items in the PR, and summarizes pass/fail/manual-test and merge-readiness.
  * Lesson capture & memory: extracts session lessons, categorizes/deduplicates them, saves actionable memories with metadata, and reports saved vs observed items.
  * Controlled merge automation: enforces review/CI gates, verifies criteria, performs squash-merge, and appends merge logs.
  * PR status dashboard: summarizes open PRs’ review state, findings, check-run status, and merge-readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->