### PR TITLE
Fix stale local main: add session-start pull + harden post-merge hook

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -6,7 +6,15 @@ This directory contains Claude Code [hooks](https://docs.anthropic.com/en/docs/c
 
 Automatically pulls `main` in the root repo after every successful `gh pr merge`. This keeps hardlinked rule files in `~/.claude/rules/` up to date without manual intervention.
 
-**How it works:** When Claude Code runs a Bash command matching `gh pr merge`, this hook detects success and runs `git pull origin main --ff-only` in the root repo (not the worktree).
+**How it works:** When Claude Code runs a Bash command matching `gh pr merge`, this hook detects success and runs `git pull origin main --ff-only` in the root repo (not the worktree). It uses three fallback strategies to locate the root repo:
+
+1. **`$cwd` from the hook input** — resolves the root via `git worktree list` (works when the worktree still exists)
+2. **Script path** — walks up from `.claude/hooks/` to find the parent repo (works even if the worktree is gone)
+3. **Repo name search** — extracts the repo name from `git remote` and searches common directories (`~/Documents/Develop`, `~/repos`, `~/projects`, `~/src`)
+
+If all strategies fail, a visible warning is printed to stderr instead of exiting silently.
+
+> **Note:** This hook is a safety net, not the primary mechanism. The primary mechanism is the session-start `git pull origin main --ff-only` rule in `CLAUDE.md`, which catches all missed pulls regardless of how a merge happened (web UI, other sessions, hook failures).
 
 ### Setup
 

--- a/.claude/hooks/post-merge-pull.sh
+++ b/.claude/hooks/post-merge-pull.sh
@@ -9,7 +9,7 @@
 #         "matcher": "Bash",
 #         "hooks": [{
 #           "type": "command",
-#           "command": "~/.claude/hooks/post-merge-pull.sh",
+#           "command": "/absolute/path/to/repo/.claude/hooks/post-merge-pull.sh",
 #           "timeout": 15
 #         }]
 #       }]

--- a/.claude/hooks/post-merge-pull.sh
+++ b/.claude/hooks/post-merge-pull.sh
@@ -9,7 +9,7 @@
 #         "matcher": "Bash",
 #         "hooks": [{
 #           "type": "command",
-#           "command": "<repo-root>/.claude/hooks/post-merge-pull.sh",
+#           "command": "~/.claude/hooks/post-merge-pull.sh",
 #           "timeout": 15
 #         }]
 #       }]
@@ -23,20 +23,55 @@ exit_code=$(echo "$input" | jq -r '.tool_response.exitCode // 1' 2>/dev/null)
 
 # Only act on successful gh pr merge commands
 if [[ "$command" == *"gh pr merge"* ]] && [[ "$exit_code" == "0" ]]; then
-  # Find the root repo (first entry from git worktree list)
-  cwd=$(echo "$input" | jq -r '.cwd')
-  if [[ -z "$cwd" || ! -d "$cwd" ]]; then
-    exit 0
-  fi
-  root_repo=$(git -C "$cwd" worktree list --porcelain 2>/dev/null \
-    | sed -n 's/^worktree //p' \
-    | head -n 1)
 
+  root_repo=""
+
+  # Strategy 1: Use $cwd to find root repo via git worktree list
+  cwd=$(echo "$input" | jq -r '.cwd')
+  if [[ -n "$cwd" && -d "$cwd" ]]; then
+    root_repo=$(git -C "$cwd" worktree list --porcelain 2>/dev/null \
+      | sed -n 's/^worktree //p' \
+      | head -n 1)
+  fi
+
+  # Strategy 2: Resolve this script's location to find the repo it lives in
+  if [[ -z "$root_repo" || ! -d "$root_repo/.git" ]]; then
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # Walk up from .claude/hooks/ to find the repo root
+    candidate="${script_dir%/.claude/hooks}"
+    if [[ "$candidate" != "$script_dir" && -d "$candidate/.git" ]]; then
+      root_repo=$(git -C "$candidate" worktree list --porcelain 2>/dev/null \
+        | sed -n 's/^worktree //p' \
+        | head -n 1)
+    fi
+  fi
+
+  # Strategy 3: Extract repo name from the gh command and search common locations
+  if [[ -z "$root_repo" || ! -d "$root_repo/.git" ]]; then
+    # gh pr merge often runs in a repo context — try to extract from git remote
+    # in the cwd (even if the dir exists but worktree list failed)
+    if [[ -n "$cwd" && -d "$cwd" ]]; then
+      repo_name=$(git -C "$cwd" remote get-url origin 2>/dev/null \
+        | sed 's|.*/||; s|\.git$||')
+      if [[ -n "$repo_name" ]]; then
+        for base in "$HOME/Documents/Develop" "$HOME/repos" "$HOME/projects" "$HOME/src"; do
+          if [[ -d "$base/$repo_name/.git" ]]; then
+            root_repo="$base/$repo_name"
+            break
+          fi
+        done
+      fi
+    fi
+  fi
+
+  # Pull if we found the root repo
   if [[ -n "$root_repo" && -d "$root_repo/.git" ]]; then
-    # Pull main in the root repo (not the worktree)
     if ! git -C "$root_repo" pull origin main --ff-only >/dev/null 2>&1; then
       printf 'post-merge-pull: fast-forward pull failed in %s\n' "$root_repo" >&2
     fi
+  else
+    # Visible warning instead of silent exit
+    printf 'post-merge-pull: could not find root repo (cwd=%s). Local main may be stale.\n' "$cwd" >&2
   fi
 fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,12 @@ If you have just resumed from context compaction, your FIRST action is to recons
 **At the start of every session, before doing anything else, sync local `main` and then create a worktree.**
 
 1. **Pull remote main into local main.** This ensures your worktree branches from the latest code — not a stale local `main` that missed merges from other sessions, the web UI, or hook failures.
+
    ```bash
    ROOT_REPO=$(git worktree list | head -1 | awk '{print $1}')
    git -C "$ROOT_REPO" pull origin main --ff-only
    ```
+
    If the pull fails (e.g., diverged history), tell the user — do not force-pull or reset.
 2. **Create a worktree.** Tell the user: "I'll create a worktree for isolated work." Then use the `EnterWorktree` tool (or ask the user to say "use a worktree"). This gives you your own working directory and branch — completely isolated from the root repo and from any other agents.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,15 @@ If you have just resumed from context compaction, your FIRST action is to recons
 
 ## ALWAYS USE A WORKTREE — READ THIS FIRST
 
-**At the start of every session, before doing anything else, create a worktree.**
+**At the start of every session, before doing anything else, sync local `main` and then create a worktree.**
 
-Tell the user: "I'll create a worktree for isolated work." Then use the `EnterWorktree` tool (or ask the user to say "use a worktree"). This gives you your own working directory and branch — completely isolated from the root repo and from any other agents.
+1. **Pull remote main into local main.** This ensures your worktree branches from the latest code — not a stale local `main` that missed merges from other sessions, the web UI, or hook failures.
+   ```bash
+   ROOT_REPO=$(git worktree list | head -1 | awk '{print $1}')
+   git -C "$ROOT_REPO" pull origin main --ff-only
+   ```
+   If the pull fails (e.g., diverged history), tell the user — do not force-pull or reset.
+2. **Create a worktree.** Tell the user: "I'll create a worktree for isolated work." Then use the `EnterWorktree` tool (or ask the user to say "use a worktree"). This gives you your own working directory and branch — completely isolated from the root repo and from any other agents.
 
 **Why this is mandatory:**
 - The root repo directory stays clean on `main`. You never touch it.


### PR DESCRIPTION
Closes #53

## Summary
- Adds a mandatory `git pull origin main --ff-only` step to the session-start checklist in CLAUDE.md (before worktree creation)
- Hardens `post-merge-pull.sh` with two fallback strategies when `$cwd` is missing/invalid, plus visible warnings on failure

## Why
Local `main` fell 2 commits behind remote after PRs #47 and #52 were merged. The post-merge hook silently failed because the worktree `$cwd` was gone by the time the hook ran. The session-start pull is the primary fix (catches ALL missed pulls); the hook hardening is defense-in-depth.

## Test plan
- [x] `CLAUDE.md` session-start section includes mandatory `git pull origin main --ff-only` step before worktree creation
- [x] `post-merge-pull.sh` has fallback strategy when `$cwd` is missing or invalid (Strategy 2: script path, Strategy 3: repo name search)
- [x] `post-merge-pull.sh` logs a visible warning on stderr when no root repo is found instead of silent exit
- [x] The rule and hook are consistent — both target the root repo's `main` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Require syncing local main with remote (fast-forward only) before creating worktrees; added explicit guidance for handling sync failures and clarified hook role as a safety net.

* **Bug Fixes**
  * Improved hook root-repo detection with multiple fallback strategies and replaced silent exit with a visible warning when the root can’t be resolved; automatic pulls run only when a valid repository is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->