### PR TITLE
Add global-settings.json: track ~/.claude/settings.json config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ cp global-settings.json ~/.claude/settings.json
 # Or symlink (auto-updates when you pull changes)
 ln -sfn /path/to/claude-code-config/CLAUDE.md ~/.claude/CLAUDE.md
 ln -sfn /path/to/claude-code-config/.claude/rules ~/.claude/rules
-# Note: global-settings.json must be COPIED (not symlinked) because
-# you need to replace placeholder paths with your actual paths
+# Note: global-settings.json must be copied, not symlinked (needs per-user path edits)
 ```
 
 ### Option 2: Per-project config

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ cp global-settings.json ~/.claude/settings.json
 # Or symlink (auto-updates when you pull changes)
 ln -sfn /path/to/claude-code-config/CLAUDE.md ~/.claude/CLAUDE.md
 ln -sfn /path/to/claude-code-config/.claude/rules ~/.claude/rules
-ln -sfn /path/to/claude-code-config/global-settings.json ~/.claude/settings.json
+# Note: global-settings.json must be COPIED (not symlinked) because
+# you need to replace placeholder paths with your actual paths
 ```
 
 ### Option 2: Per-project config

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The config is split into a root `CLAUDE.md` (~60 lines) and topic-specific rule 
 
 | File | What it does |
 |---|---|
-| **`global-settings.json`** | Global user settings (`~/.claude/settings.json`) — hooks, env vars, plugin marketplaces. Update absolute paths before copying. |
+| **`global-settings.json`** | Global user settings (`~/.claude/settings.json`) — hooks, env vars, plugin marketplaces. Copy first, then update absolute paths in the copied file. |
 | **`CLAUDE.md`** | Worktree policy, PR & issue workflow, branch naming, squash-merge, acceptance criteria |
 | **`.claude/rules/issue-planning.md`** | Issue creation flow, CR plan integration, 5-step planning flow |
 | **`.claude/rules/cr-local-review.md`** | Primary review workflow — runs CR locally via CLI before pushing, instant feedback, no PR noise |

--- a/README.md
+++ b/README.md
@@ -33,9 +33,14 @@ cp CLAUDE.md ~/.claude/CLAUDE.md
 mkdir -p ~/.claude/rules
 cp -R .claude/rules/. ~/.claude/rules/
 
+# Copy global settings (hooks, env vars, marketplace config)
+# Review and update absolute paths in the hooks section first
+cp global-settings.json ~/.claude/settings.json
+
 # Or symlink (auto-updates when you pull changes)
-ln -sfn /path/to/claude-code-coderabbit/CLAUDE.md ~/.claude/CLAUDE.md
-ln -sfn /path/to/claude-code-coderabbit/.claude/rules ~/.claude/rules
+ln -sfn /path/to/claude-code-config/CLAUDE.md ~/.claude/CLAUDE.md
+ln -sfn /path/to/claude-code-config/.claude/rules ~/.claude/rules
+ln -sfn /path/to/claude-code-config/global-settings.json ~/.claude/settings.json
 ```
 
 ### Option 2: Per-project config
@@ -66,6 +71,7 @@ The config is split into a root `CLAUDE.md` (~60 lines) and topic-specific rule 
 
 | File | What it does |
 |---|---|
+| **`global-settings.json`** | Global user settings (`~/.claude/settings.json`) — hooks, env vars, plugin marketplaces. Update absolute paths before copying. |
 | **`CLAUDE.md`** | Worktree policy, PR & issue workflow, branch naming, squash-merge, acceptance criteria |
 | **`.claude/rules/issue-planning.md`** | Issue creation flow, CR plan integration, 5-step planning flow |
 | **`.claude/rules/cr-local-review.md`** | Primary review workflow — runs CR locally via CLI before pushing, instant feedback, no PR noise |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cp -R .claude/rules/. ~/.claude/rules/
 
 # Copy global settings (hooks, env vars, marketplace config)
 cp global-settings.json ~/.claude/settings.json
-# Edit ~/.claude/settings.json and replace /absolute/path/to/your-repo/ with your actual paths
+# Edit ~/.claude/settings.json and replace /path/to/claude-code-config/ with your actual clone path
 
 # Or symlink (auto-updates when you pull changes)
 ln -sfn /path/to/claude-code-config/CLAUDE.md ~/.claude/CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ mkdir -p ~/.claude/rules
 cp -R .claude/rules/. ~/.claude/rules/
 
 # Copy global settings (hooks, env vars, marketplace config)
-# Review and update absolute paths in the hooks section first
 cp global-settings.json ~/.claude/settings.json
+# Edit ~/.claude/settings.json and replace /absolute/path/to/your-repo/ with your actual paths
 
 # Or symlink (auto-updates when you pull changes)
 ln -sfn /path/to/claude-code-config/CLAUDE.md ~/.claude/CLAUDE.md

--- a/global-settings.json
+++ b/global-settings.json
@@ -1,0 +1,47 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/absolute/path/to/your-repo/.claude/hooks/silence-detector-ack.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/absolute/path/to/your-repo/.claude/hooks/post-merge-pull.sh",
+            "timeout": 15
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/absolute/path/to/your-repo/.claude/hooks/silence-detector.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  },
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
+    }
+  }
+}

--- a/global-settings.json
+++ b/global-settings.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/your-repo/.claude/hooks/silence-detector-ack.sh",
+            "command": "/path/to/claude-code-config/.claude/hooks/silence-detector-ack.sh",
             "timeout": 5
           }
         ]
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/your-repo/.claude/hooks/post-merge-pull.sh",
+            "command": "/path/to/claude-code-config/.claude/hooks/post-merge-pull.sh",
             "timeout": 15
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/your-repo/.claude/hooks/silence-detector.sh",
+            "command": "/path/to/claude-code-config/.claude/hooks/silence-detector.sh",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary
- Adds `global-settings.json` — a sanitized reference copy of `~/.claude/settings.json` (hooks, env vars, plugin marketplaces)
- Absolute paths replaced with `/absolute/path/to/your-repo/` placeholders
- Updates README Quick Start with copy and symlink instructions
- Adds the file to the "What's in the config" table

Closes #56

## Test plan
- [x] `global-settings.json` exists at repo root with sanitized paths (no real absolute paths)
- [x] README Quick Start includes `cp global-settings.json ~/.claude/settings.json` instruction
- [x] README symlink section includes `ln -sfn` for `global-settings.json`
- [x] "What\'s in the config" table includes `global-settings.json` entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global settings configuration to enable an experimental agent flag, register an external plugin marketplace, and provide predefined execution hooks with timeouts for stop and post-tool-use flows.

* **Documentation**
  * Setup instructions updated to require copying the global settings into the user config (not symlinking), to update placeholder absolute paths, and to adjust the referenced base path for symlinked items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->