### PR TITLE
Auto-trigger Add GitHub Actions workflow for automatic issue planning plan on new issues via GitHub Actions

### DIFF
--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -10,12 +10,10 @@ When creating a new GitHub issue (whether the user asked for it or you identifie
 - Write the title, body, acceptance criteria, and any relevant context
 - Do NOT post it yet
 
-## 2. Create the issue and trigger CR plan
+## 2. Create the issue (CR plan is auto-triggered)
 - Post the issue via `gh issue create`
-- Immediately comment `@coderabbitai plan` on the new issue:
-  ```
-  gh issue comment N --body "@coderabbitai plan"
-  ```
+- **A GitHub Actions workflow (`.github/workflows/cr-plan-on-issue.yml`) automatically comments `@coderabbitai plan` on every new issue.** You do not need to manually trigger it. The workflow skips bot-created issues.
+- If you want to confirm the trigger fired, check the issue comments — but do not manually post `@coderabbitai plan` unless the workflow failed (visible in the Actions tab).
 - CR will analyze the issue and post an implementation plan with file recommendations, edge cases, and architectural considerations. This feedback is valuable — it catches gaps in the spec before any coding begins.
 
 ## 3. If starting work immediately

--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -11,6 +11,7 @@ When creating a new GitHub issue (whether the user asked for it or you identifie
 - Do NOT post it yet
 
 ## 2. Create the issue (CR plan is auto-triggered)
+
 - Post the issue via `gh issue create`
 - **A GitHub Actions workflow (`.github/workflows/cr-plan-on-issue.yml`) automatically comments `@coderabbitai plan` on every new issue.** You do not need to manually trigger it. The workflow skips bot-created issues.
 - If you want to confirm the trigger fired, check the issue comments — but do not manually post `@coderabbitai plan` unless the workflow failed (visible in the Actions tab).

--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -1,6 +1,6 @@
 # Issue Creation Flow
 
-> **Always:** Create a GitHub issue before any code work. Trigger `@coderabbitai plan` on every new issue. Merge CR's plan into the issue body.
+> **Always:** Create a GitHub issue before any code work. Ensure `@coderabbitai plan` runs on every new issue (automated via workflow). Merge CR's plan into the issue body.
 > **Ask first:** Never — issue creation and planning are autonomous.
 > **Never:** Skip the issue. Start coding without a plan. Post the plan as scattered comments instead of editing the issue body.
 

--- a/.claude/rules/repo-bootstrap.md
+++ b/.claude/rules/repo-bootstrap.md
@@ -1,0 +1,52 @@
+# Repo Bootstrap — Auto-Provision Workflows
+
+> **Always:** Check for required workflows at session start. Add missing ones before any code work.
+> **Ask first:** Never — bootstrapping is autonomous and non-destructive.
+> **Never:** Skip the check. Modify existing workflows that already exist.
+
+## Session Start: Check Required Workflows
+
+At the start of every session, after creating the worktree but before any code work, verify that the repo has the required GitHub Actions workflows. If any are missing, add them as part of the first PR or as a standalone commit on the feature branch.
+
+### Required Workflows
+
+#### 1. `cr-plan-on-issue.yml` — Auto-trigger CodeRabbit plan on new issues
+
+**Check:** Does `.github/workflows/cr-plan-on-issue.yml` exist?
+
+**If missing**, create it with this exact content:
+
+```yaml
+name: Trigger CodeRabbit Plan on New Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  trigger-cr-plan:
+    runs-on: ubuntu-latest
+    if: "!endsWith(github.event.issue.user.login, '[bot]')"
+    steps:
+      - name: Comment @coderabbitai plan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '@coderabbitai plan'
+            });
+```
+
+**How to add it:** Include it in the first PR you create in that repo. Add it alongside the feature changes — no separate PR needed for bootstrap files. If you're only doing planning (no PR yet), note it for the first PR.
+
+### Rules
+
+- **Only add missing workflows.** If the file already exists, do not modify it — even if the content differs. The repo owner may have customized it.
+- **Do not create a separate PR just for bootstrapping.** Bundle it with the first feature PR in that session.
+- **This check is idempotent.** Running it multiple times is safe — it only acts when the file is missing.

--- a/.claude/rules/repo-bootstrap.md
+++ b/.claude/rules/repo-bootstrap.md
@@ -14,7 +14,7 @@ At the start of every session, after creating the worktree but before any code w
 
 **Check:** Does `.github/workflows/cr-plan-on-issue.yml` exist?
 
-**If missing**, create it with this exact content:
+**If missing**, create it with this exact content (canonical source: `.github/workflows/cr-plan-on-issue.yml` — keep both in sync):
 
 ```yaml
 name: Trigger CodeRabbit Plan on New Issues

--- a/.claude/rules/repo-bootstrap.md
+++ b/.claude/rules/repo-bootstrap.md
@@ -43,10 +43,9 @@ jobs:
             });
 ```
 
-**How to add it:** Include it in the first PR you create in that repo. Add it alongside the feature changes — no separate PR needed for bootstrap files. If you're only doing planning (no PR yet), note it for the first PR.
+**How to add it:** Include it in your first feature PR in that repo — do not open a bootstrap-only PR. If you're only planning (no PR yet), note it for the first PR.
 
 ### Rules
 
 - **Only add missing workflows.** If the file already exists, do not modify it — even if the content differs. The repo owner may have customized it.
-- **Do not create a separate PR just for bootstrapping.** Bundle it with the first feature PR in that session.
 - **This check is idempotent.** Running it multiple times is safe — it only acts when the file is missing.

--- a/.claude/rules/repo-bootstrap.md
+++ b/.claude/rules/repo-bootstrap.md
@@ -2,7 +2,7 @@
 
 > **Always:** Check for required workflows at session start. Add missing ones before any code work.
 > **Ask first:** Never — bootstrapping is autonomous and non-destructive.
-> **Never:** Skip the check. Modify existing workflows that already exist.
+> **Never:** Skip the check. Modify workflows that already exist.
 
 ## Session Start: Check Required Workflows
 

--- a/.github/workflows/cr-plan-on-issue.yml
+++ b/.github/workflows/cr-plan-on-issue.yml
@@ -1,0 +1,24 @@
+name: Trigger CodeRabbit Plan on New Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  trigger-cr-plan:
+    runs-on: ubuntu-latest
+    if: "!endsWith(github.event.issue.user.login, '[bot]')"
+    steps:
+      - name: Comment @coderabbitai plan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '@coderabbitai plan'
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,5 +78,6 @@ Detailed workflow rules are split into topic-specific files in `.claude/rules/`:
 | `subagent-orchestration.md` | Task decomposition (phases A/B/C), health monitoring, timestamps, subagent quick-reference |
 | `work-log.md` | Auto-update daily work log on issue create, PR open, PR merge |
 | `safety.md` | Destructive command prohibitions, .env protection, subagent safety warnings |
+| `repo-bootstrap.md` | Auto-provision required GitHub Actions workflows on first touch |
 
 These files auto-load for the parent agent session. **Subagents do NOT auto-load these files.** See `subagent-orchestration.md` for how to pass rules to subagents.


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically comments `@coderabbitai plan` on every newly opened issue
- Updates `.claude/rules/issue-planning.md` to reflect that agents no longer need to manually trigger the plan
- Adds `.claude/rules/repo-bootstrap.md` — a session-start rule that auto-provisions required workflows into any repo Claude touches
- Skips bot-created issues (dependabot, renovate, etc.)

Closes #61

## Test plan
- [x] Workflow file exists at `.github/workflows/cr-plan-on-issue.yml`
- [x] Workflow triggers on `issues: [opened]` events
- [x] Workflow posts `@coderabbitai plan` as a comment on the new issue
- [x] Workflow skips bot-created issues (uses `endsWith` check on `[bot]` suffix)
- [x] Workflow uses minimal permissions (`issues: write` only)
- [x] Rule file updated to remove manual trigger instructions
- [x] `repo-bootstrap.md` rule file exists and contains the workflow template
- [x] `CLAUDE.md` rule files table includes `repo-bootstrap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)