### PR TITLE
Fix dispatched threads using Sonnet instead of Opus

### DIFF
--- a/global-settings.json
+++ b/global-settings.json
@@ -12,8 +12,11 @@
       "mcp__*"
     ]
   },
+  "model": "opus",
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "ANTHROPIC_MODEL": "opus",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "opus"
   },
   "hooks": {
     "Stop": [


### PR DESCRIPTION
## Summary
- Updates `global-settings.json` (the tracked copy of `~/.claude/settings.json`) to reflect the model configuration fix already applied to the live settings
- Adds `"model": "opus"` top-level setting and `ANTHROPIC_MODEL`/`CLAUDE_CODE_SUBAGENT_MODEL` env vars to the `env` block
- These env vars ensure dispatched threads, scheduled tasks, and subagents all use Opus instead of defaulting to Sonnet

Closes #60

## Verification

**Live `~/.claude/settings.json`** already has these settings applied:
```json
"model": "opus",
"env": {
  "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
  "ANTHROPIC_MODEL": "opus",
  "CLAUDE_CODE_SUBAGENT_MODEL": "opus"
}
```

**`~/.zshrc`** also exports both vars as belt-and-suspenders:
```bash
export ANTHROPIC_MODEL=opus
export CLAUDE_CODE_SUBAGENT_MODEL=opus
```

**This PR** updates the tracked `global-settings.json` to match, so the repo accurately reflects the live configuration.

## Test plan
- [x] `~/.claude/settings.json` has `ANTHROPIC_MODEL=opus` and `CLAUDE_CODE_SUBAGENT_MODEL=opus` in `env` block
- [x] `~/.zshrc` has `export ANTHROPIC_MODEL=opus` and `export CLAUDE_CODE_SUBAGENT_MODEL=opus`
- [x] `global-settings.json` in repo matches the live settings structure
- [ ] After restarting Claude Code, new dispatched threads use Opus (not Sonnet) — requires manual verification
- [ ] Subagents spawned via Agent tool use Opus — requires manual verification
- [x] Interactive sessions continue to use Opus (this session is running on Opus 4.6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated system configuration to use the Opus model for AI-driven features.
  * Aligned internal AI environment settings so all agent components now run on the Opus model, ensuring consistent behavior across features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->