### PR TITLE
Add /prioritize skill for ranking backlog issues by business goal impact

### DIFF
--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -1,8 +1,8 @@
 # Subagent Context
 
-> **Always:** Pass ALL rule files to subagents. Use phase decomposition (A/B/C). Timestamp every message. Monitor subagent health. Report failures immediately.
-> **Ask first:** Respawning a failed subagent — tell the user what happened first.
-> **Never:** Summarize rules for subagents. Fire-and-forget subagents. Let a stalled PR go unreported. Skip timestamps. Go >5 minutes without a user-visible message. Report a PR as "awaiting review" for >5 minutes without a Phase B agent running.
+> **Always:** Pass ALL rule files to subagents. Use phase decomposition (A/B/C). Timestamp every message. Monitor subagent health. Report failures immediately. Enter monitor mode when subagents are active.
+> **Ask first:** Respawning a failed subagent — tell the user what happened first. Breaking monitor mode for explicit user requests — warn about paused monitoring first.
+> **Never:** Summarize rules for subagents. Fire-and-forget subagents. Let a stalled PR go unreported. Skip timestamps. Go >5 minutes without a user-visible message. Report a PR as "awaiting review" for >5 minutes without a Phase B agent running. Do substantive work (coding, issue creation, file editing) while subagents are active.
 
 When spawning subagents via the Task tool, **always pass the FULL contents of ALL rule files into the subagent's prompt.** Subagents do not automatically inherit CLAUDE.md or `.claude/rules/` context — they only see what you put in their prompt.
 
@@ -84,7 +84,10 @@ This applies to ALL messages — status updates, failure reports, success report
 The user has no visibility into subagent failures. If a subagent runs out of tokens or times out, the parent agent is the only one who knows — and if the parent doesn't report it, the user won't discover the failure until they manually check GitHub 15-20 minutes later. **This is unacceptable.**
 
 **Monitoring rules for parent agents:**
-1. **Poll subagent status every ~60 seconds.** When running subagents in the background, check their status regularly. Do not fire-and-forget. If you are also doing other work (fixing code, managing PRs), this obligation does NOT pause. Either: (a) delegate the fix work to a subagent so you can keep polling, or (b) send the user a status message BEFORE starting the fix work, explaining what you're doing and that monitoring is temporarily paused.
+
+> **Monitor mode prerequisite:** The ~60s polling obligation below is enforceable precisely because Dedicated Monitor Mode (see below) prohibits the parent from doing competing substantive work. If you have active subagents, you are in monitor mode — polling is your primary job, not a side task.
+
+1. **Poll subagent status every ~60 seconds.** When running subagents in the background, check their status regularly. Do not fire-and-forget. Monitor mode ensures you have no competing work — polling is your only responsibility.
 2. **Report failures immediately.** If a subagent exits with an error, times out, or returns without completing its task, tell the user right away. Include:
    - Which PR / issue the subagent was working on
    - What phase it was in (A/B/C)
@@ -105,12 +108,15 @@ The user should never have to discover a stalled PR by checking GitHub manually.
 
 The user must never go more than **5 minutes** without a status message. This is separate from subagent polling — it's about keeping the user informed.
 
+> **Monitor mode makes this easy.** When in Dedicated Monitor Mode (see below), heartbeats are one of your few permitted activities. There is no competing work to displace them — if you miss a heartbeat while in monitor mode, something is fundamentally wrong with your loop.
+
 **Rules:**
-1. **Before entering any multi-step operation** (fixing code, reading multiple files, running a sequence of commands), send a brief status message first: "16:03 ET — Fixing 2 CR findings on PR #620. Other PRs (#618, #619, #621, #622) are waiting for review. Will update in ~3 min."
-2. **After completing any multi-step operation**, immediately send a status update — don't start the next operation first.
-3. **If you're blocked waiting** (e.g., polling), use that wait time to compose a dashboard message to the user.
-4. **Never batch status updates.** Don't wait until everything is done to report. Report incrementally: "PR #620 fix pushed. Now checking PR #618 status."
-5. **Time your silences.** If your last message to the user was >5 minutes ago by wall clock, your next tool call must be a status message, not another background operation.
+1. **In monitor mode**, heartbeats are part of your core loop: poll subagent status → compose status message → send to user → wait → repeat. There is no "multi-step operation" competing for attention.
+2. **Outside monitor mode** (no active subagents), send a brief status message before entering any multi-step operation: "16:03 ET — Fixing 2 CR findings on PR #620. Will update in ~3 min."
+3. **After completing any multi-step operation**, immediately send a status update — don't start the next operation first.
+4. **If you're blocked waiting** (e.g., polling), use that wait time to compose a dashboard message to the user.
+5. **Never batch status updates.** Don't wait until everything is done to report. Report incrementally: "PR #620 fix pushed. Now checking PR #618 status."
+6. **Time your silences.** If your last message to the user was >5 minutes ago by wall clock, your next tool call must be a status message, not another background operation.
 
 ### Heartbeat Enforcement (Automatic)
 
@@ -119,6 +125,54 @@ The 5-minute heartbeat rule is enforced by a PostToolUse hook (`silence-detector
 **How it works:** Stop hook (`silence-detector-ack.sh`) touches `/tmp/claude-heartbeat-$CLAUDE_SESSION_ID` after each response. PostToolUse hook (`silence-detector.sh`) checks mtime after tool calls; if >5 min elapsed, injects warning via `additionalContext`.
 
 **When you see the warning:** Stop what you are doing and send a status message to the user immediately. Include a timestamp (run `date` command), what you're currently doing, what's pending, and any blockers. Then resume your work — the next tool call will check again and the warning will be gone (because the Stop hook touched the file after your status message).
+
+### Dedicated Monitor Mode (MANDATORY for parent agents)
+
+When one or more subagents are active, the parent agent enters **monitor mode**. In monitor mode, the parent's sole responsibility is orchestration — not substantive work. This prevents monitoring obligations (heartbeats, Phase B launches, failure detection) from being displaced by coding or other heavy tasks.
+
+**Entry condition:** Monitor mode activates whenever `active_agents` in `session-state.json` is non-empty, or when you have spawned any subagent that has not yet completed or failed.
+
+**Exit condition:** Monitor mode deactivates when ALL of the following are true:
+- All subagents have completed or failed (no active agents)
+- No PRs are awaiting review (no pending Phase B/C launches)
+- All phase transitions have been executed (no Phase A completions waiting for Phase B launch)
+
+**Permitted activities in monitor mode (exhaustive list):**
+- Poll subagent status (~60s cycle)
+- Send heartbeat/status messages to the user
+- Launch next-phase agents (Phase A → B → C transitions)
+- Verify subagent outputs (check pushes, check replies)
+- Read `session-state.json` and update it
+- Reconstruct state after context compaction
+- Respond to user questions about status or progress
+- Write checkpoint state to `session-state.json`
+
+**Prohibited activities in monitor mode (substantive work):**
+- Writing or editing code/files directly
+- Creating GitHub issues or PRs
+- Reading/analyzing source files for non-monitoring purposes
+- Running local CR reviews
+- Any multi-step operation that takes >60 seconds and could displace a poll cycle
+- Fixing code yourself instead of delegating to a subagent
+
+> **The core principle:** If it can be delegated to a subagent, it MUST be delegated. The parent's job is to orchestrate, not to execute.
+
+**Exception: Explicit user request.** If the user explicitly asks the parent to perform substantive work while subagents are active, the parent MAY do so — but must first warn:
+
+> "I have N active subagent(s) monitoring PR(s) #X, #Y. Monitoring will pause while I work on this. Heartbeats and phase transitions may be delayed until I finish."
+
+After completing the user-requested work, immediately re-enter monitor mode:
+1. Check all subagent statuses (some may have completed or failed while you were working)
+2. Execute any pending phase transitions
+3. Send a status update to the user
+4. Resume the normal monitoring loop
+
+**How to delegate instead of doing it yourself:**
+
+When you identify work that needs doing (e.g., a new issue to create, code to fix, a file to update) while in monitor mode:
+1. Spawn a subagent with the task
+2. Add it to `active_agents` in `session-state.json`
+3. Continue monitoring — the new subagent is now part of your monitoring set
 
 ### Post-Compaction Recovery (MANDATORY)
 

--- a/.claude/skills/prioritize/SKILL.md
+++ b/.claude/skills/prioritize/SKILL.md
@@ -53,10 +53,10 @@ If an engineer username was provided, understand their current workload and rece
 
 ```bash
 # Recent merged PRs — shows what they've been working on
-gh pr list --author $USERNAME --state merged --limit 20 --json number,title,mergedAt,additions,deletions
+gh pr list --author $USERNAME --state merged --limit 20 --json number,title,mergedAt,additions,deletions,files
 
 # Currently open PRs — shows what they're actively doing RIGHT NOW
-gh pr list --author $USERNAME --state open --json number,title,createdAt,additions,deletions
+gh pr list --author $USERNAME --state open --json number,title,createdAt,additions,deletions,files
 
 # Issues currently assigned to them
 gh issue list --state open --assignee $USERNAME --json number,title,labels,createdAt
@@ -76,7 +76,7 @@ For every open issue, assess:
 1. **Goal alignment (primary signal):** How directly does completing this issue advance the stated business goal? Score on a 4-point scale:
    - **Critical:** Directly unblocks or achieves the goal. Without this, the goal cannot be met.
    - **High:** Significant enabler — completing this materially accelerates progress toward the goal.
-   - **Medium:** Supporting work — useful but not on the critical path. Could be deferred without derailing the goal.
+   - **Medium:** Supporting work — useful but not on the critical path; it can be deferred without derailing the goal.
    - **Low:** Tangential — nice to have, or addresses a different goal entirely.
 
 2. **Leverage (secondary signal):** Does this issue unblock other high-value issues? An issue that unblocks 3 Critical issues is itself Critical, even if its direct goal alignment is Medium.
@@ -182,7 +182,7 @@ Limit to 3-5 actions. Each action should be specific enough to act on immediatel
 - **1-2 lines per issue maximum** in the tiered list. Save detail for the next actions section.
 - **Flag dependencies inline** with the issue they affect (e.g., `Blocked by: #35`). Do not create a separate dependency section — keep it scannable.
 - **"Stop doing" is sensitive.** Only include it when the misalignment is clear and the alternative is materially better. Do not flag Medium work as "stop doing" unless Critical work is available.
-- **Do not list every issue.** If 80 of 100 issues are Low/tangential, say "68 additional issues are Low priority relative to this goal" rather than listing them all.
+- **Do not list every issue.** If 80 of 100 issues are Low/tangential, say "68 additional issues are Low-priority relative to this goal" rather than listing them all.
 - **Total output should be scannable in under 2 minutes.** An engineering manager should be able to read this and know what to assign.
 - **Do not mention the scoring process.** The output should read as a confident recommendation, not a methodology explanation.
 - **If no engineer was specified**, skip the "Stop doing" section and the role filtering. Rank all issues for any engineer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ These apply to EVERY message the parent agent sends to the user. No exceptions, 
 1. **Timestamp prefix.** Every message starts with Eastern time: `Mon Mar 16 02:34 AM ET`. Get via: `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`. NEVER estimate, calculate, or mentally derive timestamps — always run the `date` command. This includes elapsed time: do not count poll cycles or steps to estimate minutes passed. If you need elapsed time, compare two `date` outputs. This is the FIRST thing in every message — before status updates, before questions, before summaries.
 2. **Active monitoring declaration.** If you are monitoring background agents, state how many and which PRs at the end of every message. Example: "Monitoring: PR #618 (Phase B), PR #620 (Phase B), PR #623 (Phase C) — next poll in ~60s."
 3. **5-minute heartbeat.** The user must never go more than 5 minutes without a status message. When you run `date` for the timestamp, check how long it has been since your last message to the user. If >5 minutes, your FIRST action must be a status update — before any tool call. Include: what you are currently doing, what is pending (open PRs, active agents), and any blocked items. See `subagent-orchestration.md` "User Heartbeat" for detailed rules. **Never go silent for >5 minutes — not while doing substantive work, not while polling, not after compaction.**
+4. **Dedicated monitor mode.** If you have active subagents, you are in **monitor mode**: your ONLY job is polling subagent status, sending heartbeats, and launching next-phase agents. Do NOT do substantive work (coding, issue creation, file editing) — delegate it to a subagent instead. If the user explicitly asks you to do something, warn that monitoring will pause, do the work, then re-enter monitor mode. See `subagent-orchestration.md` "Dedicated Monitor Mode" for the full rules, permitted/prohibited activities, and exit conditions.
 
 If you have just resumed from context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `subagent-orchestration.md`) and report it WITH a timestamp.
 
@@ -75,7 +76,7 @@ Detailed workflow rules are split into topic-specific files in `.claude/rules/`:
 | `cr-local-review.md` | Local CodeRabbit CLI review loop (primary review workflow) |
 | `cr-github-review.md` | GitHub CR polling, rate limits, fast-path detection, thread resolution, completion criteria |
 | `greptile.md` | Greptile peer reviewer + CR fallback + self-review fallback |
-| `subagent-orchestration.md` | Task decomposition (phases A/B/C), health monitoring, timestamps, subagent quick-reference |
+| `subagent-orchestration.md` | Task decomposition (phases A/B/C), dedicated monitor mode, health monitoring, timestamps, subagent quick-reference |
 | `work-log.md` | Auto-update daily work log on issue create, PR open, PR merge |
 | `safety.md` | Destructive command prohibitions, .env protection, subagent safety warnings |
 | `repo-bootstrap.md` | Auto-provision required GitHub Actions workflows on first touch |


### PR DESCRIPTION
## Summary

- New `/prioritize` slash command that scans a repo's open issue backlog and produces a ranked priority list of what a specific engineer should work on next
- Ordered by impact on a stated business goal, filtered by engineer role/skill constraints
- Follows the established skill pattern (standup skill) with YAML frontmatter and structured Markdown body

Closes #24

## Test plan

- [ ] Skill file created at `.claude/skills/prioritize/SKILL.md`
- [ ] Reads open issue bodies (not just titles) to understand ticket scope
- [ ] Filters/ranks by stated business goal
- [ ] Accounts for engineer role/skill constraints
- [ ] Output includes tiered priority list with rationale per ticket
- [ ] Identifies dependencies between tickets
- [ ] Includes "stop doing" recommendations when relevant
- [ ] Suggests concrete next actions in priority order
- [ ] Skill symlinked to `~/.claude/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automation that ranks open issues against a stated business goal, with optional engineer-specific filtering, dependency mapping, and concise prioritized next actions.

* **Documentation**
  * Added documentation for the new issue-prioritization skill.
  * Updated orchestration rules to introduce a “dedicated monitor mode” for subagent activity, clarifying allowed/prohibited monitor tasks and an exception workflow when the user requests substantive work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->