### PR TITLE
Remove disable-model-invocation from all custom skills

### DIFF
--- a/.claude/skills/check-acceptance-criteria/SKILL.md
+++ b/.claude/skills/check-acceptance-criteria/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: check-acceptance-criteria
 description: Verify all Test Plan checkboxes in a PR against the actual code, check off passing items, and report any failures.
-disable-model-invocation: true
 argument-hint: "[PR number, default: current branch's PR]"
 ---
 

--- a/.claude/skills/continue/SKILL.md
+++ b/.claude/skills/continue/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: continue
 description: Resume an interrupted or stalled review workflow. Detects where the agent left off — local CR review, push, PR creation, review polling, CR/Greptile feedback processing, thread resolution, merge gate verification, or acceptance criteria — and continues from the next incomplete step automatically.
-disable-model-invocation: true
 ---
 
 Detect and resume the interrupted review workflow for the current branch.

--- a/.claude/skills/lessons/SKILL.md
+++ b/.claude/skills/lessons/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: lessons
 description: Summarize lessons learned from the current session — what went wrong, what patterns emerged, what to remember. Saves actionable insights to memory.
-disable-model-invocation: true
 ---
 
 Reflect on the current session and extract reusable lessons before the thread is closed.

--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: merge
 description: Squash merge the current PR, delete the branch, log to work-log, and clean up. Verifies merge gate and acceptance criteria before merging.
-disable-model-invocation: true
 ---
 
 Squash merge the current PR. This is the "we're done here" command.

--- a/.claude/skills/prioritize/SKILL.md
+++ b/.claude/skills/prioritize/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: prioritize
 description: Scan a repo's open issue backlog and produce a ranked priority list of what a specific engineer should work on next, ordered by impact on a stated business goal.
-disable-model-invocation: true
 argument-hint: "business goal | @username role-constraints | depth (e.g. \"increase scraping throughput | @auerbachb backend-python | 50\")"
 ---
 

--- a/.claude/skills/standup/SKILL.md
+++ b/.claude/skills/standup/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: standup
 description: Generate a daily standup summary of what was accomplished since the last standup, from a business logic perspective. Reads PR bodies to understand what changes actually enabled.
-disable-model-invocation: true
 argument-hint: [since-time, e.g. "yesterday at noon ET"]
 ---
 

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: status
 description: Show a dashboard of all open PRs with review state, unresolved findings, and blockers.
-disable-model-invocation: true
 ---
 
 Build a status dashboard of all open PRs in this repo.

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: wrap
 description: End-of-session command — verify no unresolved findings, squash merge, detect follow-ups, extract lessons, sync work-log, and clean up the worktree.
-disable-model-invocation: true
 ---
 
 Wrap up the current PR and session. This is the "we're done here" command that handles everything from final verification through worktree cleanup.


### PR DESCRIPTION
## Summary
- Removes `disable-model-invocation: true` from all 8 custom skill SKILL.md files
- This flag was preventing skills from appearing in the `/` autocomplete menu
- Skills still work when typed manually; this fix adds discoverability

Closes #79

## Test plan
- [ ] All 8 custom skills appear in `/` autocomplete in a new Claude Code session
- [ ] Skills still execute correctly when invoked via `/skillname`
- [ ] Claude does not auto-invoke skills inappropriately during normal conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration for multiple AI workflow skills to re-enable model invocation. The skills' visible behavior, instructions, and workflows remain unchanged; only the execution metadata that previously disabled model calls was removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->