### PR TITLE
Remove project-level .claude/settings.json — causes permission re-prompting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,0 @@
-{
-    "permissions": {
-        "allow": [
-            "*"
-        ]
-    }
-}

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ This is the most common issue. You've set `"allow": ["*"]` in `~/.claude/setting
 
 When a `.claude/settings.json` exists inside a repo (or worktree), Claude Code treats its permissions block as an **override** rather than merging it with `~/.claude/settings.json`. Even with `"allow": ["*"]` in both files, the project-level file's presence interferes with the global wildcard. Four other repos with no project-level settings file work fine on global settings alone — this repo was the only one that re-prompted, and removing the file fixed it.
 
-Related issues: [anthropics/claude-code#17017](https://github.com/anthropics/claude-code/issues/17017), [#13340](https://github.com/anthropics/claude-code/issues/13340), [#27139](https://github.com/anthropics/claude-code/issues/27139).
+Related issues: [anthropics/claude-code#17017](https://github.com/anthropics/claude-code/issues/17017), [anthropics/claude-code#13340](https://github.com/anthropics/claude-code/issues/13340), [anthropics/claude-code#27139](https://github.com/anthropics/claude-code/issues/27139).
 
 **Fix:** Delete any `.claude/settings.json` from your repos and rely exclusively on the global settings file (`~/.claude/settings.json`). Use `global-settings.json` from this repo as your template.
 

--- a/README.md
+++ b/README.md
@@ -344,7 +344,8 @@ find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/
 
 # Inspect each file — if it only contains permissions, it's safe to delete.
 # If it has hooks or env vars you want to keep, migrate those to ~/.claude/settings.json first.
-find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*" -exec cat {} +
+find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*" \
+  -exec sh -c 'echo "== $1 =="; cat "$1"' _ {} \;
 
 # After confirming the files only contain permissions:
 find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*" -delete

--- a/README.md
+++ b/README.md
@@ -339,16 +339,16 @@ Related issues: [anthropics/claude-code#17017](https://github.com/anthropics/cla
 **Fix:** Delete any `.claude/settings.json` from your repos and rely exclusively on the global settings file (`~/.claude/settings.json`). Use `global-settings.json` from this repo as your template.
 
 ```bash
-# Find project-level settings files
-find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*"
+# Find project-level settings files (use . from a repo root, or an absolute path)
+find . -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*"
 
 # Inspect each file — if it only contains permissions, it's safe to delete.
 # If it has hooks or env vars you want to keep, migrate those to ~/.claude/settings.json first.
-find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*" \
+find . -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*" \
   -exec sh -c 'echo "== $1 =="; cat "$1"' _ {} \;
 
 # After confirming the files only contain permissions:
-find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*" -delete
+find . -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*" -delete
 ```
 
 **Cause 2: Trust dialog flags reset on new worktrees.**

--- a/README.md
+++ b/README.md
@@ -339,9 +339,14 @@ Related issues: [anthropics/claude-code#17017](https://github.com/anthropics/cla
 **Fix:** Delete any `.claude/settings.json` from your repos and rely exclusively on the global settings file (`~/.claude/settings.json`). Use `global-settings.json` from this repo as your template.
 
 ```bash
-# Find and remove project-level settings files
+# Find project-level settings files
 find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*"
-# After confirming the list looks right:
+
+# Inspect each file — if it only contains permissions, it's safe to delete.
+# If it has hooks or env vars you want to keep, migrate those to ~/.claude/settings.json first.
+find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*" -exec cat {} +
+
+# After confirming the files only contain permissions:
 find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*" -delete
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ Claude Code loads project-level `CLAUDE.md` first, then falls back to `~/.claude
 |------|---------|
 | `CLAUDE.md` | Core instructions — worktree policy, PR workflow, branch naming, acceptance criteria |
 | `global-settings.json` | Global user settings — hooks, permissions, env vars, plugin marketplaces |
-| `.claude/settings.json` | Project-level permissions for this repo |
 | `.coderabbit.yaml` | CodeRabbit review configuration |
 
 ### Rule files (`.claude/rules/`)
@@ -329,29 +328,21 @@ The config is plain Markdown. Edit to match your workflow:
 
 This is the most common issue. You've set `"allow": ["*"]` in `~/.claude/settings.json`, but Claude Code still prompts you to approve edits, bash commands, or the trust dialog. There are two independent causes — fix both.
 
-**Cause 1: Project-level settings override your global wildcard.**
+**Cause 1: A project-level `.claude/settings.json` exists in the repo.**
 
-A `.claude/settings.json` inside the repo (or inside a worktree) takes precedence over `~/.claude/settings.json`. If the project-level file uses specific patterns like `Edit(*)` instead of `*`, certain operations (especially cross-worktree edits) won't match and will trigger prompts.
+> **Do not use project-level `.claude/settings.json` files for permissions.** This repo previously shipped one and it caused *more* re-prompting, not less.
 
-**Fix:** Ensure every `.claude/settings.json` in the repo and its worktrees uses the `*` wildcard. Note: if your worktrees live outside the repo directory (e.g., sibling directories), run the find command from a parent directory that contains all of them.
+When a `.claude/settings.json` exists inside a repo (or worktree), Claude Code treats its permissions block as an **override** rather than merging it with `~/.claude/settings.json`. Even with `"allow": ["*"]` in both files, the project-level file's presence interferes with the global wildcard. Four other repos with no project-level settings file work fine on global settings alone — this repo was the only one that re-prompted, and removing the file fixed it.
+
+Related issues: [anthropics/claude-code#17017](https://github.com/anthropics/claude-code/issues/17017), [#13340](https://github.com/anthropics/claude-code/issues/13340), [#27139](https://github.com/anthropics/claude-code/issues/27139).
+
+**Fix:** Delete any `.claude/settings.json` from your repos and rely exclusively on the global settings file (`~/.claude/settings.json`). Use `global-settings.json` from this repo as your template.
 
 ```bash
-# Find all project-level settings files (use a parent dir that covers worktrees too)
+# Find and remove project-level settings files
 find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*"
-
-# Update each one — merges the wildcard without wiping other settings
-find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*" -print0 \
-  | while IFS= read -r -d '' f; do
-      python3 - "$f" <<'PY'
-import json, sys
-p = sys.argv[1]
-with open(p) as fh:
-    data = json.load(fh)
-data.setdefault("permissions", {})["allow"] = ["*"]
-with open(p, "w") as fh:
-    json.dump(data, fh, indent=2)
-PY
-    done
+# After confirming the list looks right:
+find /path/to/your/repo -name "settings.json" -path "*/.claude/*" -not -path "*/.git/*" -delete
 ```
 
 **Cause 2: Trust dialog flags reset on new worktrees.**


### PR DESCRIPTION
## Summary

- Deletes `.claude/settings.json` from this repo — it causes more permission re-prompting than having no project-level settings at all
- Updates README to warn against project-level settings files and explain the root cause (Claude Code treats them as overrides, not merges)
- Directs users to rely on global `~/.claude/settings.json` instead

**Root cause:** When a `.claude/settings.json` exists in a repo, Claude Code treats its permissions block as an override rather than merging with `~/.claude/settings.json`. Even with `"allow": ["*"]` in both files, the project-level file interferes with the global wildcard. Four other repos without project-level settings work fine — this repo was the outlier.

Closes #92

## Test plan

- [x] `.claude/settings.json` is removed from the repo
- [x] README "What's included" table no longer lists `.claude/settings.json`
- [x] README Troubleshooting "Cause 1" explains why project-level settings should be avoided (not how to fix them)
- [x] README references upstream issues #17017, #13340, #27139
- [x] README directs users to global `~/.claude/settings.json` via `global-settings.json` template
- [x] Cleanup instructions include an inspection step before deleting files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting: clarified causes, added an explicit warning about project-level permission files acting as overrides, revised inspection and removal steps, and updated example commands and related links.

* **Chores**
  * Removed the repository's project-level permission configuration file to prevent unintended permission overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->