### PR TITLE
Fix polling blind spots: review ID watermark + CI health checks

### DIFF
--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -54,7 +54,7 @@ After pushing a commit to a PR, **automatically** enter the CR review loop. Do n
 
 ```bash
 gh api "repos/{owner}/{repo}/commits/{SHA}/check-runs?per_page=100" \
-  --jq '.check_runs[] | {name, status, conclusion}'
+  --jq '.check_runs[] | {id, name, status, conclusion, title: .output.title}'
 ```
 
 **Rules:**

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -319,7 +319,7 @@ Skipping this step wastes a review cycle and burns CR quota.
 
 ### Step 0b: Check ALL CI check-runs (MANDATORY — every poll cycle)
 Fetch ALL check-runs once per cycle (reuse this result in Step 1b for CR rate-limit detection):
-`gh api "repos/{owner}/{repo}/commits/{SHA}/check-runs?per_page=100" --jq '.check_runs[] | {name, status, conclusion}'`
+`gh api "repos/{owner}/{repo}/commits/{SHA}/check-runs?per_page=100" --jq '.check_runs[] | {id, name, status, conclusion, title: .output.title}'`
 If ANY check-run has a blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`):
 1. Read the failure output: `gh api "repos/{owner}/{repo}/check-runs/{ID}" --jq '.output.summary'`
 2. If test/lint/build failure -> fix code, commit, push BEFORE continuing review loop


### PR DESCRIPTION
## Summary
- Fixes review watermark tracking to use review IDs instead of inline comment IDs, preventing missed CR reviews when comment IDs are non-monotonic across reviews
- Adds mandatory CI Health Check subsection requiring all check-runs (test, lint, build, audit, gitleaks) be monitored every poll cycle — not just CodeRabbit
- Adds Step 0b to the subagent quick-reference for CI check-run monitoring

Closes #94

## Test plan
- [x] `cr-github-review.md` Polling section updated with review ID watermark guidance (replaces old comment ID watermark)
- [x] `cr-github-review.md` has new "CI Health Check" subsection in Polling section
- [x] `subagent-orchestration.md` quick-reference updated with Step 0b for CI checks
- [x] Changes are consistent across both project-local and global rule file copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Per-poll CI health check added: fetch all check-runs, treat specific conclusions as blocking, fetch failed check-run summaries, and report CI pass/fail to users.
  * CI failures now block merge regardless of review status and require targeted remediation (fix & push for code failures; record/retry for transient infra).
  * Polling watermarking clarified: track whole reviews and fetch all comments for new reviews; issue comments keep comment-ID watermarking.
  * Polling rate-limit logic now reuses cached check-run results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->