### PR TITLE
Add /pm-clean skill — detect stale issues, suggest closures

### DIFF
--- a/.claude/skills/pm-clean/SKILL.md
+++ b/.claude/skills/pm-clean/SKILL.md
@@ -42,9 +42,9 @@ gh issue list --state closed --limit 200 --json number,title,body,closedAt,state
 For each merged PR from Step 2, scan the PR body AND branch name for closure keywords referencing open issues:
 
 **In the PR body**, search for these patterns (case-insensitive):
-- `Closes #N`, `Close #N`
-- `Fixes #N`, `Fix #N`
-- `Resolves #N`, `Resolve #N`
+- `Closes #N`, `Close #N`, `Closed #N`
+- `Fixes #N`, `Fix #N`, `Fixed #N`
+- `Resolves #N`, `Resolve #N`, `Resolved #N`
 
 Extract each referenced issue number `N`. If `N` matches an open issue from Step 1, flag it:
 - **Category:** `solved-by-pr`
@@ -70,7 +70,7 @@ For each open issue from Step 1, check for recent activity:
 
    Also check if any open PR references this issue (substitute the issue number into the regex):
    ```bash
-   gh pr list --state open --json number,title,body --jq '.[] | select(.body | test("(?i)(closes|fixes|resolves)\\s+#42"))'
+   gh pr list --state open --json number,title,body --jq '.[] | select(.body | test("(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\\s+#42"))'
    ```
 
 3. **Commit-reference check (for candidates only):** Verify whether recent commits reference the issue number in their messages:

--- a/.claude/skills/pm-clean/SKILL.md
+++ b/.claude/skills/pm-clean/SKILL.md
@@ -6,8 +6,8 @@ argument-hint: "[days] (optional — inactivity threshold, default 30)"
 
 Scan the repo's open issues for staleness and present closure recommendations. Parse `$ARGUMENTS`:
 
-- If `$ARGUMENTS` is a number, use it as the inactivity threshold in days (default: 30).
-- If empty, use 30 days.
+- If `$ARGUMENTS` is a number, use it as the inactivity threshold in days.
+- If empty or non-numeric, default to 30 days (warn if non-numeric: "Invalid argument '{value}', defaulting to 30 days").
 
 ## Step 1: Gather open issues
 
@@ -63,6 +63,8 @@ For each open issue from Step 1, check for recent activity:
    gh api "repos/{owner}/{repo}/issues/42/comments" --jq '[.[] | .created_at] | sort | last'
    ```
    If the most recent comment is older than the threshold (or there are no comments), the issue is still a candidate.
+
+   If the jq result is `null` (empty comments array), treat it as "no recent comments" — the issue remains a candidate.
 
    Also check if any open PR references this issue (substitute the issue number into the regex):
    ```bash

--- a/.claude/skills/pm-clean/SKILL.md
+++ b/.claude/skills/pm-clean/SKILL.md
@@ -6,8 +6,10 @@ argument-hint: "[days] (optional — inactivity threshold, default 30)"
 
 Scan the repo's open issues for staleness and present closure recommendations. Parse `$ARGUMENTS`:
 
-- If `$ARGUMENTS` is a number, use it as the inactivity threshold in days.
-- If empty or non-numeric, default to 30 days (warn if non-numeric: "Invalid argument '{value}', defaulting to 30 days").
+- If `$ARGUMENTS` is a positive number, use it as the inactivity threshold in days.
+- If empty, non-numeric, or non-positive (zero or negative), default to 30 days:
+  - Warn if non-numeric: "Invalid argument '{value}', defaulting to 30 days"
+  - Warn if non-positive: "Threshold must be positive, defaulting to 30 days"
 
 ## Step 1: Gather open issues
 
@@ -49,7 +51,7 @@ Extract each referenced issue number `N`. If `N` matches an open issue from Step
 - **Rationale:** "PR #M (`title`) merged on `date` references `Closes #N` but issue remains open."
 
 **In the branch name**, search for patterns like `issue-42-` or `42-` at the start. If the branch name contains a number matching an open issue and the PR merged successfully, flag it as a weaker signal:
-- Only flag if the PR title or body shares at least 2 significant keywords with the open issue's title (after lowercasing and removing stopwords like "add", "fix", "update", "the"). This avoids false positives from coincidental branch numbering.
+- Only flag if the PR title or body shares at least 2 significant keywords with the open issue's title (after lowercasing and removing common stopwords: articles, prepositions, and generic action verbs like "add", "fix", "update", "change", "remove"). A "significant keyword" is any remaining token with 4+ characters. This avoids false positives from coincidental branch numbering.
 
 ## Step 5: Detect inactive issues
 
@@ -83,20 +85,24 @@ For each open issue from Step 1, check for recent activity:
 
 For each open issue from Step 1 (that wasn't already flagged in Steps 4-5), check if the issue's context has been overtaken by recent changes:
 
-1. **Extract file references** from the issue body — look for paths like `src/foo.ts`, `lib/bar.py`, function names, or component names.
+1. **Extract file references** from the issue body:
+   - Match file paths with extensions (e.g., `src/foo.ts`, `lib/bar.py`) using pattern `[a-zA-Z0-9_/.-]+\.[a-z]{2,4}`
+   - Extract capitalized identifiers in backticks or code blocks (likely function/component names)
+   - Exclude common generic terms (e.g., "utils", "helper", "handler", "index") that would produce false positives
 
 2. **For issues with file references**, check if those files have been substantially changed since the issue was created. Replace `ISSUE_CREATED_DATE` with the issue's `createdAt` value (ISO date, e.g., `2026-01-15`) and `path/to/file` with the actual file path:
    ```bash
    git log --since="2026-01-15" --oneline -- "src/utils/parser.ts"
    ```
-   If the file has 5+ commits since the issue was created, it's a superseded candidate.
+   If the file has 3+ commits since the issue was created, it's a superseded candidate. (Threshold is deliberately low — the "strong evidence" rule in step 4 still requires corroboration.)
 
 3. **For issues referencing features or behaviors**, check if the described feature was added or removed by scanning recent commit messages. Replace `KEYWORD` with a key term extracted from the issue (e.g., a feature name or component):
    ```bash
    git log --since="2026-01-15" --oneline --grep="dark mode"
    ```
+   Flag if 3+ commits match the keyword.
 
-4. **Only flag if the evidence is strong** — multiple commits touching the referenced files/features. A single commit is not enough (it might be an unrelated refactor).
+4. **Only flag if the evidence is strong** — require both file-path matches AND keyword matches, or 5+ commits on a single referenced file. A single commit is not enough (it might be an unrelated refactor).
    - **Category:** `superseded`
    - **Rationale:** "Files referenced in this issue (`path`) have been modified in N commits since the issue was created. The described behavior may already be addressed."
 
@@ -104,9 +110,9 @@ For each open issue from Step 1 (that wasn't already flagged in Steps 4-5), chec
 
 Compare each open issue's title and body against closed issues from Step 3:
 
-1. **Title similarity:** Normalize titles (lowercase, strip punctuation, remove common words like "add", "fix", "update", "the", "a"). If two titles share 3+ significant words, they're a candidate pair.
+1. **Title similarity:** Normalize titles (lowercase, strip punctuation, remove common English stopwords and generic action verbs). A "significant word" is any remaining token with 4+ characters. If two titles share 3+ significant words, they're a candidate pair.
 
-2. **Body keyword overlap:** Extract key terms from both issue bodies (ignoring markdown formatting, code blocks, and boilerplate). If 5+ significant terms overlap, strengthen the duplicate signal.
+2. **Body keyword overlap:** Extract key terms from both issue bodies (ignoring Markdown formatting, code blocks, and boilerplate). Apply the same significance filter (4+ chars, not a stopword). If 5+ significant terms overlap, strengthen the duplicate signal.
 
 3. **Only flag if the closed issue was resolved** (not closed as "not planned"):
    - **Category:** `potential-duplicate`
@@ -183,7 +189,7 @@ Which issues should I close? (List numbers, category names, or "all")
 - **Be conservative with "superseded" and "duplicate" flags.** False positives waste the user's time reviewing issues that shouldn't be closed. Only flag when evidence is clear.
 - **Include rationale for every recommendation.** The user should be able to evaluate each suggestion without reading the full issue.
 - **Handle large backlogs gracefully.** If there are 100+ open issues, batch the API calls and use the performance limits described in Step 5. Report how many issues were fully analyzed vs. skimmed.
-- **Respect issue labels.** If an issue has labels like `pinned`, `do-not-close`, `long-term`, or `epic`, skip it in the inactive and superseded checks. Still check it for solved-by-PR (since that's a factual signal, not a judgment call).
+- **Respect issue labels.** If an issue has labels like `pinned`, `do-not-close`, `long-term`, or `epic`, skip it in the inactive, superseded, and duplicate checks. Still check it for solved-by-PR (since that's a factual signal, not a judgment call).
 - **When the user confirms closures**, close each issue with a comment:
   ```bash
   # Replace 42 with the actual issue number and customize the rationale

--- a/.claude/skills/pm-clean/SKILL.md
+++ b/.claude/skills/pm-clean/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: pm-clean
+description: Scan open issues for staleness and suggest closures. Detects issues solved by merged PRs, no-activity issues (30+ days), superseded issues, and potential duplicates of already-closed issues. Presents recommendations for user confirmation — never auto-closes. Triggers on "pm-clean", "stale issues", "clean backlog", "close stale".
+argument-hint: "[days] (optional — inactivity threshold, default 30)"
+---
+
+Scan the repo's open issues for staleness and present closure recommendations. Parse `$ARGUMENTS`:
+
+- If `$ARGUMENTS` is a number, use it as the inactivity threshold in days (default: 30).
+- If empty, use 30 days.
+
+## Step 1: Gather open issues
+
+Fetch all open issues:
+
+```bash
+gh issue list --state open --limit 500 --json number,title,labels,assignees,createdAt,updatedAt,body
+```
+
+Store the result. If the list is empty, report "No open issues found — backlog is clean." and stop.
+
+Record the total count for the summary.
+
+## Step 2: Gather recently merged PRs
+
+Fetch merged PRs to cross-reference closure keywords:
+
+```bash
+gh pr list --state merged --limit 200 --json number,title,body,mergedAt,headRefName
+```
+
+## Step 3: Gather recently closed issues (for duplicate detection)
+
+```bash
+gh issue list --state closed --limit 200 --json number,title,body,closedAt,stateReason
+```
+
+## Step 4: Detect issues solved by merged PRs
+
+For each merged PR from Step 2, scan the PR body AND branch name for closure keywords referencing open issues:
+
+**In the PR body**, search for these patterns (case-insensitive):
+- `Closes #N`, `Close #N`
+- `Fixes #N`, `Fix #N`
+- `Resolves #N`, `Resolve #N`
+
+Extract each referenced issue number `N`. If `N` matches an open issue from Step 1, flag it:
+- **Category:** `solved-by-pr`
+- **Rationale:** "PR #M (`title`) merged on `date` references `Closes #N` but issue remains open."
+
+**In the branch name**, search for patterns like `issue-N-` or `N-` at the start. If the branch name contains a number matching an open issue and the PR merged successfully, flag it as a weaker signal:
+- Only flag if the PR title or body also references the issue's topic (to avoid false positives from coincidental numbering).
+
+## Step 5: Detect inactive issues
+
+For each open issue from Step 1, check for recent activity:
+
+1. **Last update check:** Compare `updatedAt` against the inactivity threshold. If `updatedAt` is older than the threshold, the issue is a candidate.
+
+2. **Comment check (for candidates only):** For issues that pass the updatedAt filter, verify by checking comments:
+   ```bash
+   gh api "repos/{owner}/{repo}/issues/{N}/comments" --jq 'length'
+   ```
+   Also check if any open PR references this issue:
+   ```bash
+   gh pr list --state open --json number,title,body --jq '.[] | select(.body | test("(?i)(closes|fixes|resolves)\\s+#N"))'
+   ```
+   Replace `N` with the issue number.
+
+3. **If no comments in the threshold period AND no open PR references the issue**, flag it:
+   - **Category:** `inactive`
+   - **Rationale:** "No activity for X days (last updated: `date`). No open PRs reference this issue."
+
+4. **If the issue has comments but all are older than the threshold**, still flag but note the last comment date.
+
+**Performance note for large backlogs:** If there are more than 50 inactive candidates after the `updatedAt` filter, limit the per-issue API calls (comment check + PR reference check) to the 50 oldest issues. Note the remaining count: "N additional inactive issues not fully checked — run again with a shorter threshold to review them."
+
+## Step 6: Detect superseded issues
+
+For each open issue from Step 1 (that wasn't already flagged in Steps 4-5), check if the issue's context has been overtaken by recent changes:
+
+1. **Extract file references** from the issue body — look for paths like `src/foo.ts`, `lib/bar.py`, function names, or component names.
+
+2. **For issues with file references**, check if those files have been substantially changed since the issue was created:
+   ```bash
+   git log --since="ISSUE_CREATED_DATE" --oneline -- "path/to/file"
+   ```
+   If the file has 5+ commits since the issue was created, it's a superseded candidate.
+
+3. **For issues referencing features or behaviors**, check if the described feature was added or removed by scanning recent commit messages:
+   ```bash
+   git log --since="ISSUE_CREATED_DATE" --oneline --grep="KEYWORD"
+   ```
+
+4. **Only flag if the evidence is strong** — multiple commits touching the referenced files/features. A single commit is not enough (it might be an unrelated refactor).
+   - **Category:** `superseded`
+   - **Rationale:** "Files referenced in this issue (`path`) have been modified in N commits since the issue was created. The described behavior may already be addressed."
+
+## Step 7: Detect potential duplicates
+
+Compare each open issue's title and body against closed issues from Step 3:
+
+1. **Title similarity:** Normalize titles (lowercase, strip punctuation, remove common words like "add", "fix", "update", "the", "a"). If two titles share 3+ significant words, they're a candidate pair.
+
+2. **Body keyword overlap:** Extract key terms from both issue bodies (ignoring markdown formatting, code blocks, and boilerplate). If 5+ significant terms overlap, strengthen the duplicate signal.
+
+3. **Only flag if the closed issue was resolved** (not closed as "not planned"):
+   - **Category:** `potential-duplicate`
+   - **Rationale:** "Similar to closed #M (`title`, closed `date`). Shared keywords: `word1, word2, word3`."
+
+4. **Do not flag issues that reference each other** — if an open issue says "follow-up to #M" or "related to #M", it's intentionally separate, not a duplicate.
+
+## Step 8: Present recommendations
+
+Group all flagged issues by category and present them in a scannable format.
+
+### Output structure
+
+```
+## Backlog Cleanup Recommendations
+
+Scanned N open issues. Found M candidates for closure.
+
+### Solved by Merged PR (K issues)
+
+These issues appear to have been resolved by merged PRs but were not auto-closed:
+
+| Issue | PR | Merged | Recommendation |
+|-------|-----|--------|----------------|
+| #N — Title | PR #M | date | Close — PR body contains `Closes #N` |
+
+### Inactive (K issues, threshold: X days)
+
+No activity (comments, PR references, or updates) in X+ days:
+
+| Issue | Last Activity | Age | Recommendation |
+|-------|--------------|-----|----------------|
+| #N — Title | date | X days | Close with comment or reassign |
+
+### Superseded (K issues)
+
+Referenced files/features have been substantially modified since issue creation:
+
+| Issue | Evidence | Recommendation |
+|-------|----------|----------------|
+| #N — Title | N commits to `path` since creation | Verify resolved, then close |
+
+### Potential Duplicates (K pairs)
+
+Open issues that may duplicate already-closed issues:
+
+| Open Issue | Similar Closed Issue | Shared Keywords |
+|-----------|---------------------|-----------------|
+| #N — Title | #M — Title (closed date) | word1, word2, word3 |
+```
+
+If a category has no flagged issues, omit that section entirely.
+
+If no issues were flagged across all categories, report: "Backlog is clean — no stale or duplicate issues detected."
+
+### Closing section
+
+After the recommendations table:
+
+```
+## Next Steps
+
+To close recommended issues, confirm which ones to close. I can:
+1. Close specific issues with a comment explaining why
+2. Close all issues in a category (e.g., all "Solved by Merged PR")
+3. Skip — leave the backlog as-is
+
+Which issues should I close? (List numbers, category names, or "all")
+```
+
+## Rules
+
+- **NEVER auto-close issues.** Always present recommendations and wait for user confirmation.
+- **Be conservative with "superseded" and "duplicate" flags.** False positives waste the user's time reviewing issues that shouldn't be closed. Only flag when evidence is clear.
+- **Include rationale for every recommendation.** The user should be able to evaluate each suggestion without reading the full issue.
+- **Handle large backlogs gracefully.** If there are 100+ open issues, batch the API calls and use the performance limits described in Step 5. Report how many issues were fully analyzed vs. skimmed.
+- **Respect issue labels.** If an issue has labels like `pinned`, `do-not-close`, `long-term`, or `epic`, skip it in the inactive and superseded checks. Still check it for solved-by-PR (since that's a factual signal, not a judgment call).
+- **When the user confirms closures**, close each issue with a comment:
+  ```bash
+  gh issue close N --comment "Closing: [rationale from the recommendation]. Identified by backlog cleanup scan."
+  ```

--- a/.claude/skills/pm-clean/SKILL.md
+++ b/.claude/skills/pm-clean/SKILL.md
@@ -68,9 +68,9 @@ For each open issue from Step 1, check for recent activity:
 
    If the jq result is `null` (empty comments array), treat it as "no recent comments" — the issue remains a candidate.
 
-   Also check if any open PR references this issue (substitute the issue number into the regex):
+   Also check if any open PR references this issue (title or body; substitute the issue number). Use null-coalescing to handle PRs with empty bodies:
    ```bash
-   gh pr list --state open --json number,title,body --jq '.[] | select(.body | test("(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\\s+#42"))'
+   gh pr list --state open --json number,title,body --jq '.[] | select(((.title // "") + " " + (.body // "")) | test("(?i)(#42\\b|close[sd]?\\s+#42|fix(e[sd])?\\s+#42|resolve[sd]?\\s+#42)"))'
    ```
 
 3. **Commit-reference check (for candidates only):** Verify whether recent commits reference the issue number in their messages:

--- a/.claude/skills/pm-clean/SKILL.md
+++ b/.claude/skills/pm-clean/SKILL.md
@@ -48,8 +48,8 @@ Extract each referenced issue number `N`. If `N` matches an open issue from Step
 - **Category:** `solved-by-pr`
 - **Rationale:** "PR #M (`title`) merged on `date` references `Closes #N` but issue remains open."
 
-**In the branch name**, search for patterns like `issue-N-` or `N-` at the start. If the branch name contains a number matching an open issue and the PR merged successfully, flag it as a weaker signal:
-- Only flag if the PR title or body also references the issue's topic (to avoid false positives from coincidental numbering).
+**In the branch name**, search for patterns like `issue-42-` or `42-` at the start. If the branch name contains a number matching an open issue and the PR merged successfully, flag it as a weaker signal:
+- Only flag if the PR title or body shares at least 2 significant keywords with the open issue's title (after lowercasing and removing stopwords like "add", "fix", "update", "the"). This avoids false positives from coincidental branch numbering.
 
 ## Step 5: Detect inactive issues
 
@@ -57,15 +57,17 @@ For each open issue from Step 1, check for recent activity:
 
 1. **Last update check:** Compare `updatedAt` against the inactivity threshold. If `updatedAt` is older than the threshold, the issue is a candidate.
 
-2. **Comment check (for candidates only):** For issues that pass the updatedAt filter, verify by checking comments:
+2. **Comment check (for candidates only):** For issues that pass the updatedAt filter, verify by fetching comment timestamps. Replace `{owner}`, `{repo}`, and the issue number with actual values:
    ```bash
-   gh api "repos/{owner}/{repo}/issues/{N}/comments" --jq 'length'
+   # Example for issue #42 — check if any comments fall within the threshold
+   gh api "repos/{owner}/{repo}/issues/42/comments" --jq '[.[] | .created_at] | sort | last'
    ```
-   Also check if any open PR references this issue:
+   If the most recent comment is older than the threshold (or there are no comments), the issue is still a candidate.
+
+   Also check if any open PR references this issue (substitute the issue number into the regex):
    ```bash
-   gh pr list --state open --json number,title,body --jq '.[] | select(.body | test("(?i)(closes|fixes|resolves)\\s+#N"))'
+   gh pr list --state open --json number,title,body --jq '.[] | select(.body | test("(?i)(closes|fixes|resolves)\\s+#42"))'
    ```
-   Replace `N` with the issue number.
 
 3. **If no comments in the threshold period AND no open PR references the issue**, flag it:
    - **Category:** `inactive`
@@ -81,15 +83,15 @@ For each open issue from Step 1 (that wasn't already flagged in Steps 4-5), chec
 
 1. **Extract file references** from the issue body — look for paths like `src/foo.ts`, `lib/bar.py`, function names, or component names.
 
-2. **For issues with file references**, check if those files have been substantially changed since the issue was created:
+2. **For issues with file references**, check if those files have been substantially changed since the issue was created. Replace `ISSUE_CREATED_DATE` with the issue's `createdAt` value (ISO date, e.g., `2026-01-15`) and `path/to/file` with the actual file path:
    ```bash
-   git log --since="ISSUE_CREATED_DATE" --oneline -- "path/to/file"
+   git log --since="2026-01-15" --oneline -- "src/utils/parser.ts"
    ```
    If the file has 5+ commits since the issue was created, it's a superseded candidate.
 
-3. **For issues referencing features or behaviors**, check if the described feature was added or removed by scanning recent commit messages:
+3. **For issues referencing features or behaviors**, check if the described feature was added or removed by scanning recent commit messages. Replace `KEYWORD` with a key term extracted from the issue (e.g., a feature name or component):
    ```bash
-   git log --since="ISSUE_CREATED_DATE" --oneline --grep="KEYWORD"
+   git log --since="2026-01-15" --oneline --grep="dark mode"
    ```
 
 4. **Only flag if the evidence is strong** — multiple commits touching the referenced files/features. A single commit is not enough (it might be an unrelated refactor).
@@ -182,5 +184,6 @@ Which issues should I close? (List numbers, category names, or "all")
 - **Respect issue labels.** If an issue has labels like `pinned`, `do-not-close`, `long-term`, or `epic`, skip it in the inactive and superseded checks. Still check it for solved-by-PR (since that's a factual signal, not a judgment call).
 - **When the user confirms closures**, close each issue with a comment:
   ```bash
-  gh issue close N --comment "Closing: [rationale from the recommendation]. Identified by backlog cleanup scan."
+  # Replace 42 with the actual issue number and customize the rationale
+  gh issue close 42 --comment "Closing: [rationale from the recommendation]. Identified by backlog cleanup scan."
   ```

--- a/.claude/skills/pm-clean/SKILL.md
+++ b/.claude/skills/pm-clean/SKILL.md
@@ -73,11 +73,18 @@ For each open issue from Step 1, check for recent activity:
    gh pr list --state open --json number,title,body --jq '.[] | select(.body | test("(?i)(closes|fixes|resolves)\\s+#42"))'
    ```
 
-3. **If no comments in the threshold period AND no open PR references the issue**, flag it:
-   - **Category:** `inactive`
-   - **Rationale:** "No activity for X days (last updated: `date`). No open PRs reference this issue."
+3. **Commit-reference check (for candidates only):** Verify whether recent commits reference the issue number in their messages:
+   ```bash
+   # Example for issue #42 — check for commits mentioning #42 in the threshold period
+   git log --since="THRESHOLD_DATE" --oneline --grep="#42"
+   ```
+   If any commits match, treat as recent activity and do not flag as inactive.
 
-4. **If the issue has comments but all are older than the threshold**, still flag but note the last comment date.
+4. **If no comments in the threshold period AND no open PR references the issue AND no recent commit references**, flag it:
+   - **Category:** `inactive`
+   - **Rationale:** "No activity for X days (last updated: `date`). No recent comments, PR references, or commit references."
+
+5. **If the issue has comments but all are older than the threshold**, still flag but note the last comment date.
 
 **Performance note for large backlogs:** If there are more than 50 inactive candidates after the `updatedAt` filter, limit the per-issue API calls (comment check + PR reference check) to the 50 oldest issues. Note the remaining count: "N additional inactive issues not fully checked — run again with a shorter threshold to review them."
 


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/pm-clean/SKILL.md` — a new skill that scans open issues for staleness and presents closure recommendations
- Detects 4 categories: solved by merged PR, inactive (30+ days default), superseded by recent changes, potential duplicates of closed issues
- Never auto-closes — presents a table of recommendations and waits for user confirmation

Closes #88

## Test plan
- [x] Detects issues that should have been auto-closed by merged PRs
- [x] Flags issues with no activity in 30+ days
- [x] Identifies issues superseded by recent changes
- [x] Does NOT auto-close — presents suggestions for user confirmation
- [x] Handles repos with no stale issues gracefully (empty result)
- [x] Works with large backlogs (100+ open issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pm-clean skill to scan and categorize the GitHub backlog and generate user-confirmed closure recommendations
  * Detects issues resolved by merged PRs, inactive issues, superseded items, and potential duplicates
  * Customizable inactivity threshold (default 30 days) with input validation and sensible fallback
  * Limits expensive checks for performance and reports when backlog is clean

* **Documentation**
  * Added public skill documentation and usage hints (optional days argument)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->