### PR TITLE
Enhance /pm-prioritize and /pm-okr to be OKR-aware

### DIFF
--- a/.claude/skills/pm-okr/SKILL.md
+++ b/.claude/skills/pm-okr/SKILL.md
@@ -51,7 +51,7 @@ gh issue list --state open --json number,title,labels,body --limit 100
 
 For each objective and key result, scan open issue titles, labels, and bodies to find alignment. Match by comparing key terms from the key result text against issue titles, labels, and body content. Only list issues with a clear keyword connection — do not force-match tangential issues.
 
-Display a compact cross-reference below each key result:
+Display a compact cross-reference below each key result. Sort aligned issues by ascending issue number:
 
 ```
 O1: Launch MVP by April 15

--- a/.claude/skills/prioritize/SKILL.md
+++ b/.claude/skills/prioritize/SKILL.md
@@ -28,7 +28,7 @@ Check if `.claude/pm-config.md` exists and has a non-empty OKRs section:
 test -f .claude/pm-config.md && echo "CONFIG_EXISTS" || echo "NO_CONFIG"
 ```
 
-If the config exists, extract the `## OKRs` section content: from a line matching `^## OKRs` at column 1 through the line before the next `^## ` header (or EOF). When the section is empty, contains only the default placeholder ("No OKRs set"), or the config doesn't exist, set `OKR_MODE=false` and proceed with heuristic-only ranking.
+If the config exists, extract the `## OKRs` section content: from a line matching `^## OKRs` at column 1 through the line before the next `^## ` header (or EOF). When the section is empty, contains only a placeholder (any text starting with "No OKRs set"), or the config doesn't exist, set `OKR_MODE=false` and proceed with heuristic-only ranking.
 
 For sections containing objectives and key results, set `OKR_MODE=true` and parse the OKRs into a structured list. Expected format:
 


### PR DESCRIPTION
## Summary
- **`/pm-prioritize`**: Now reads OKRs from `.claude/pm-config.md` when available. Issues advancing a key result get a one-tier ranking boost. Business goal argument remains primary signal; OKRs supplement.
- **`/pm-okr show`**: Cross-references open issues against each key result, showing which issues align with each OKR.
- **`/pm-okr suggest`**: Now explicitly references both merged PRs and closed issues as evidence when assessing key result progress.

Backward compatible — existing pipe-delimited argument format preserved. When no OKRs exist, prioritize behaves identically to before.

Closes #89

## Test plan
- [x] `/pm-prioritize` ranks issues without OKRs using heuristics (existing behavior preserved)
- [x] `/pm-prioritize` changes ranking when OKRs are present in pm-config.md
- [x] Dependency-blocking issues rank higher than standalone issues
- [x] `/pm-okr` displays current OKRs from pm-config.md
- [x] `/pm-okr suggest` references both merged PRs and closed issues
- [x] `/pm-okr show` displays which open issues align with each key result
- [x] `/pm-okr` handles missing OKRs section (offers to create one)
- [x] Works with empty backlog (no open issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show cross-referenced open issues under each key result with aligned issue numbers sorted ascending, or a clear "No open issues to cross-reference." message when none exist.
  * Optional OKR-aware prioritization that boosts/reorders issues aligned to incomplete KRs, annotates matched advances (e.g., "Advances: O#/KR#"), and appends an OKR-loaded summary line when enabled.

* **Documentation**
  * Progress assessment and suggestion guidance updated to use both merged PRs and closed issues as evidence; examples and suggested outputs now include combined PR/issue citations and distinguish still-open items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->