### PR TITLE
Prevent PM skill from auto-spawning subagents

### DIFF
--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -89,6 +89,7 @@ You manage the backlog, track progress, write GitHub issues, and generate prompt
    - Include: "Follow the full issue planning flow: check issue comments for @coderabbitai plan, merge plans into issue body, then implement. Create a worktree, run local CR review before pushing, create the PR with `Closes #N`."
 4. When threads finish, verify PRs merged, then identify next batch
 5. Create new GitHub issues when gaps are identified
+6. **Do NOT spawn subagents or use the Agent tool to execute work.** Your job is to write prompts and present them to the user. The user will paste them into new Claude Code threads (web or CLI). Only use subagents if the user explicitly asks (e.g., "go ahead and run those", "spin up agents for those").
 
 ## Infrastructure
 {Auto-detected infrastructure from 2b}
@@ -149,6 +150,9 @@ You are the project manager for {repo URL} — {description}.
 
 ## Workflow
 {Workflow Rules section from config}
+
+## Execution Boundary
+Do NOT spawn subagents or use the Agent tool to execute work yourself. Write the prompt and present it to the user — they will paste it into a new Claude Code thread. Only use subagents if the user explicitly asks (e.g., "go ahead and run those", "spin up agents for those").
 
 ## What's Been Built
 {Infrastructure section from config}


### PR DESCRIPTION
## Summary
- Adds rule #6 to the `pm-config.md` template's Workflow Rules section: the PM writes prompts for the user to paste — it does not spawn subagents unless explicitly asked
- Adds an `## Execution Boundary` section to the assembled handoff prompt as a hardcoded safety net reinforcing the same constraint
- Both locations make clear the distinction: write the prompt and present it, do not execute via subagents

Closes #100

## Test plan
- [x] The `/pm` skill's handoff prompt includes an explicit instruction: do NOT spawn subagents or use the Agent tool to do work unless the user explicitly asks
- [x] The `pm-config.md` template's Workflow Rules section reinforces this: the PM generates prompts for the user to paste into new threads — it does not launch work itself
- [x] The generated prompt makes clear the distinction: "Write the prompt and present it to the user. Do not execute it yourself via subagents."
- [x] If the user says something like "go ahead and run those" or "spin up agents for those", THEN and only then should the PM use subagents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PM handoff guidance with a new "Execution Boundary" section that clarifies the PM should not spawn or auto-run subagents; instead, prompts should be prepared for users to paste into execution threads unless the user explicitly requests execution.

* **Chores**
  * Reinforced execution constraints across configuration and runtime prompt generation for PM handoffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->