### PR TITLE
Document worktree-symlink re-prompting and add auto-repair hook

### DIFF
--- a/.claude/hooks/trust-flag-repair.sh
+++ b/.claude/hooks/trust-flag-repair.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Trust flag auto-repair — Stop hook (fires after each agent response)
+# Repairs all trust flags in ~/.claude.json so worktree-created project entries
+# don't trigger re-prompting on subsequent operations.
+# See .claude/rules/trust-dialog-fix.md for details.
+
+# Consume stdin (required by hook protocol)
+cat > /dev/null
+
+python3 -c "
+import json, os, sys
+
+path = os.path.expanduser('~/.claude.json')
+try:
+    with open(path) as f:
+        data = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    sys.exit(0)
+
+projects = data.get('projects')
+if not isinstance(projects, dict):
+    sys.exit(0)
+
+flags = ['hasTrustDialogAccepted', 'hasClaudeMdExternalIncludesApproved', 'hasClaudeMdExternalIncludesWarningShown']
+changed = False
+for proj in projects.values():
+    if not isinstance(proj, dict):
+        continue
+    for flag in flags:
+        if not proj.get(flag):
+            proj[flag] = True
+            changed = True
+
+if changed:
+    with open(path, 'w') as f:
+        json.dump(data, f, indent=2)
+" 2>/dev/null
+
+exit 0

--- a/.claude/hooks/trust-flag-repair.sh
+++ b/.claude/hooks/trust-flag-repair.sh
@@ -32,8 +32,17 @@ for proj in projects.values():
             changed = True
 
 if changed:
-    with open(path, 'w') as f:
-        json.dump(data, f, indent=2)
+    import tempfile
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try: os.unlink(tmp)
+        except OSError: pass
 " 2>/dev/null
 
 exit 0

--- a/.claude/hooks/trust-flag-repair.sh
+++ b/.claude/hooks/trust-flag-repair.sh
@@ -17,6 +17,9 @@ try:
 except (FileNotFoundError, json.JSONDecodeError):
     sys.exit(0)
 
+if not isinstance(data, dict):
+    sys.exit(0)
+
 projects = data.get('projects')
 if not isinstance(projects, dict):
     sys.exit(0)

--- a/.claude/rules/trust-dialog-fix.md
+++ b/.claude/rules/trust-dialog-fix.md
@@ -115,12 +115,29 @@ else:
 "
 ```
 
+## Worktree Root Cause
+
+Every worktree gets its own absolute path (e.g., `/Users/you/repo/.claude/worktrees/my-worktree/`), and Claude Code registers this as a separate project in `~/.claude.json`. New project entries start with all trust flags set to `false`, triggering the trust dialog and external includes approval prompts.
+
+This is especially problematic for the `claude-code-config` repo because it is the global config source — `~/.claude/CLAUDE.md` and `~/.claude/rules` are symlinks pointing **into** this repo. From a worktree's perspective, those symlinks resolve to paths outside the worktree directory, so Claude Code treats them as "external includes." Other repos using worktrees don't have this problem because their global symlinks don't point back into themselves.
+
+See the README troubleshooting section (Cause 3) for the full topology explanation and upstream issue links.
+
+**Recommended mitigation:** The `trust-flag-repair.sh` Stop hook (see "Automatic Hook" below) repairs flags after every agent response, preventing re-prompting on subsequent operations within a session.
+
 ## When to Run
 
 - **Symptom:** Claude Code prompts you to trust a project or approve external includes when it shouldn't (bypass permissions is already enabled).
 - **After deleting `~/.claude.json`:** Claude Code recreates it with `false` defaults. Run the repair script after the file is recreated.
 - **After cloning/moving a project:** A new project entry in `~/.claude.json` starts with `false` flags.
 
-## Automatic Hook (Optional)
+## Automatic Hook
 
-If this issue recurs frequently, add an automatic hook in `global-settings.json` to auto-repair the flags. This is not included by default because the issue is intermittent and the manual fix is fast. Create a hook script and register it under `Stop` or `PostToolUse` (these are the supported hook arrays).
+The `trust-flag-repair.sh` script runs as a `Stop` hook after every agent response. It repairs all trust flags across all projects in `~/.claude.json`, preventing re-prompting on subsequent operations within a session.
+
+- **Script:** `.claude/hooks/trust-flag-repair.sh`
+- **Registered in:** `global-settings.json` under `hooks.Stop`
+- **Behavior:** Idempotent — safe to run repeatedly. Exits silently when all flags are already set. Handles missing `~/.claude.json` gracefully.
+- **Limitation:** Cannot prevent the initial trust prompt when a brand-new worktree is created for the first time (the project entry doesn't exist yet). The hook repairs it after the first response, so subsequent operations in that session won't re-prompt.
+
+The manual repair scripts above remain useful for debugging and one-off fixes (e.g., after deleting `~/.claude.json`).

--- a/.claude/rules/trust-dialog-fix.md
+++ b/.claude/rules/trust-dialog-fix.md
@@ -121,9 +121,7 @@ Every worktree gets its own absolute path (e.g., `/Users/you/repo/.claude/worktr
 
 This is especially problematic for the `claude-code-config` repo because it is the global config source — `~/.claude/CLAUDE.md` and `~/.claude/rules` are symlinks pointing **into** this repo. From a worktree's perspective, those symlinks resolve to paths outside the worktree directory, so Claude Code treats them as "external includes." Other repos using worktrees don't have this problem because their global symlinks don't point back into themselves.
 
-See the README troubleshooting section (Cause 3) for the full topology explanation and upstream issue links.
-
-**Recommended mitigation:** The `trust-flag-repair.sh` Stop hook (see "Automatic Hook" below) repairs flags after every agent response, preventing re-prompting on subsequent operations within a session.
+See the README troubleshooting section (Cause 3) for the full topology explanation and upstream issue links. The `trust-flag-repair.sh` Stop hook (see "Automatic Hook" below) mitigates this automatically.
 
 ## When to Run
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sed -i 's|/path/to/claude-code-config|'"$(pwd)"'|g' ~/.claude/settings.json
 
 This file configures:
 - **Permissions** — Broad allow rules so Claude operates autonomously without prompting for every tool call.
-- **Hooks** — Three shell scripts that run automatically during sessions (see below).
+- **Hooks** — Shell scripts that run automatically during sessions (see below).
 - **Environment variables** — Model preferences and experimental flags.
 - **Plugin marketplaces** — Access to official Claude plugins.
 
@@ -327,7 +327,7 @@ The config is plain Markdown. Edit to match your workflow:
 
 ### Claude Code keeps asking for permission even with bypass enabled
 
-This is the most common issue. You've set `"allow": ["*"]` in `~/.claude/settings.json`, but Claude Code still prompts you to approve edits, bash commands, or the trust dialog. There are two independent causes — fix both.
+This is the most common issue. You've set `"allow": ["*"]` in `~/.claude/settings.json`, but Claude Code still prompts you to approve edits, bash commands, or the trust dialog. There are three independent causes — fix all that apply.
 
 **Cause 1: A project-level `.claude/settings.json` exists in the repo.**
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Claude Code loads project-level `CLAUDE.md` first, then falls back to `~/.claude
 | Script | Trigger | Purpose |
 |--------|---------|---------|
 | `silence-detector-ack.sh` | Stop (after each response) | Touches a heartbeat file so the detector knows the agent is alive |
+| `trust-flag-repair.sh` | Stop (after each response) | Auto-repairs trust flags in `~/.claude.json` to prevent re-prompting |
 | `silence-detector.sh` | PostToolUse (after every tool call) | Checks if the agent has been silent >5 minutes; injects a warning |
 | `post-merge-pull.sh` | PostToolUse on Bash | Auto-pulls main after squash merges to keep local main in sync |
 
@@ -397,6 +398,24 @@ else:
 ```
 
 You'll need to re-run this after creating new worktrees. See `.claude/rules/trust-dialog-fix.md` for more details and a single-project variant.
+
+**Cause 3: Worktree-symlink topology (this repo only).**
+
+> This cause is specific to `claude-code-config` itself. Other repos using worktrees are not affected.
+
+This repo is the source of truth for global Claude Code config — `~/.claude/CLAUDE.md` and `~/.claude/rules` are symlinks pointing **into** this repo. When Claude Code runs in a worktree of this repo, the symlinks resolve to the root repo's files (e.g., `/Users/you/claude-code-config/CLAUDE.md`), which is **outside** the worktree directory (e.g., `/Users/you/claude-code-config/.claude/worktrees/my-worktree/`). Claude Code sees these as "external includes" and creates a new project entry in `~/.claude.json` with all trust flags set to `false`, triggering the trust dialog and external includes approval prompts.
+
+Other repos don't have this problem because their worktrees only *consume* the global symlinks — there's no path collision. This repo is unique because the global symlinks point back *into* it.
+
+Note: `--dangerously-skip-permissions` does **not** bypass trust dialogs — they are a separate security boundary.
+
+**Upstream issues tracking this:**
+- [anthropics/claude-code#34437](https://github.com/anthropics/claude-code/issues/34437) — Worktrees should share parent repo's project directory
+- [anthropics/claude-code#23109](https://github.com/anthropics/claude-code/issues/23109) — Feature request: trusted workspace patterns
+- [anthropics/claude-code#28506](https://github.com/anthropics/claude-code/issues/28506) — `--dangerously-skip-permissions` doesn't bypass workspace trust
+- [anthropics/claude-code#9113](https://github.com/anthropics/claude-code/issues/9113) — Pre-configured `~/.claude.json` flags not respected
+
+**Mitigation:** A `Stop` hook (`trust-flag-repair.sh`) automatically repairs all trust flags after every agent response. This prevents re-prompting on subsequent operations within a session, but cannot prevent the initial prompt when creating a brand-new worktree for the first time. For manual repair, use the script under Cause 2 above or see `.claude/rules/trust-dialog-fix.md`.
 
 ## Contributing
 

--- a/global-settings.json
+++ b/global-settings.json
@@ -26,6 +26,11 @@
             "type": "command",
             "command": "/path/to/claude-code-config/.claude/hooks/silence-detector-ack.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/trust-flag-repair.sh",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Adds **Cause 3** to README troubleshooting: documents the worktree-symlink topology unique to this repo where global symlinks (`~/.claude/CLAUDE.md`, `~/.claude/rules`) point INTO the config repo, causing "external includes" re-prompting in every new worktree
- Adds **Worktree Root Cause** section to `trust-dialog-fix.md` explaining the root cause chain (worktree → new project entry → false flags)
- Creates **`trust-flag-repair.sh`** Stop hook that auto-repairs all trust flags in `~/.claude.json` after every agent response (atomic write, idempotent, silent on success)
- Registers the hook in `global-settings.json` alongside existing Stop hooks
- Links to 4 upstream Claude Code issues tracking the underlying platform fix

Closes #99

## Test plan
- [x] README troubleshooting section documents worktree external includes re-prompting
- [x] Explanation covers why this only affects this specific repo
- [x] Links to upstream Claude Code issues for tracking
- [x] Manual workaround is clearly documented
- [x] Auto-repair hook is implemented with rationale documented
.claude.json/- [x] Hook script is idempotent and handles missing ~/.claude.json/.claude.json
- [x] Hook uses atomic write to prevent corruption
- [x] Hook is registered in global-settings.json Stop array
- [x] trust-dialog-fix.md Automatic Hook section updated from advisory to implemented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic trust-flag repair that runs after each response and an accompanying stop-hook entry in global settings.

* **Documentation**
  * Updated hooks description and expanded troubleshooting with a new cause, mitigation guidance, and links to upstream issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->