### PR TITLE
Enforce CI pass before merge + ban linter suppression comments

### DIFF
--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -42,13 +42,33 @@ If the merge gate is NOT met, stop and tell the user exactly what's missing (e.g
 
 Run the `/check-acceptance-criteria` skill logic for this PR. All Test Plan checkboxes must be checked off before proceeding. If any fail, stop and report — do NOT merge with unchecked boxes.
 
-### Step 4: Squash merge
+### Step 4: Verify CI passes (NON-NEGOTIABLE)
+
+Before merging, check ALL CI check-runs on the HEAD commit:
+
+```bash
+SHA=$(gh pr view <PR_NUMBER> --json commits --jq '.commits[-1].oid')
+gh api "repos/{owner}/{repo}/commits/$SHA/check-runs?per_page=100" \
+  --jq '.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required") | {name, conclusion}'
+```
+
+**If ANY check-run has a blocking conclusion: DO NOT MERGE.** Instead:
+1. Read the failure output: `gh api "repos/{owner}/{repo}/check-runs/{CHECK_RUN_ID}" --jq '.output.summary'`
+2. Fix the issue (lint errors, type errors, test failures, etc.)
+3. Commit, push, and wait for CI to re-run
+4. Re-verify all checks pass before proceeding
+
+**Never add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, or any suppression comment to work around CI.** Fix the actual code.
+
+If all checks pass, proceed to merge.
+
+### Step 5: Squash merge
 
 ```bash
 gh pr merge --squash --delete-branch
 ```
 
-### Step 5: Log to work-log
+### Step 6: Log to work-log
 
 If a work-log directory exists (detected at session start per work-log.md rules):
 
@@ -70,7 +90,7 @@ If a work-log directory exists (detected at session start per work-log.md rules)
    ```
 3. Get the linked issue number from the PR body (`Closes #N` pattern)
 
-### Step 6: Report completion
+### Step 7: Report completion
 
 Tell the user:
 - PR number and title

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -83,13 +83,31 @@ Before merging, verify the PR has not been rebased or force-pushed since the las
    ```
 2. If the SHA differs from what the merge gate was verified against, a rebase/force-push happened — **do NOT merge.** Wait for a fresh CR review on the new SHA before proceeding.
 
-### Step 2.4: Squash merge
+### Step 2.4: Verify CI passes (NON-NEGOTIABLE)
+
+Before merging, check ALL CI check-runs on the HEAD commit:
+
+```bash
+SHA=$(gh pr view <PR_NUMBER> --json commits --jq '.commits[-1].oid')
+gh api "repos/{owner}/{repo}/commits/$SHA/check-runs?per_page=100" \
+  --jq '.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required") | {name, conclusion}'
+```
+
+**If ANY check-run has a blocking conclusion: DO NOT MERGE.** Instead:
+1. Read the failure output: `gh api "repos/{owner}/{repo}/check-runs/{CHECK_RUN_ID}" --jq '.output.summary'`
+2. Fix the issue (lint errors, type errors, test failures, etc.)
+3. Commit, push, and wait for CI to re-run
+4. Re-verify all checks pass before proceeding
+
+**Never add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, or any suppression comment to work around CI.** Fix the actual code.
+
+### Step 2.5: Squash merge
 
 ```bash
 gh pr merge --squash --delete-branch
 ```
 
-### Step 2.4: Log to work-log
+### Step 2.6: Log to work-log
 
 If a work-log directory was detected at session start:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,36 @@ If you catch yourself composing a "should I...?" or "want me to...?" question ab
 - Acceptance criteria are verified via code review and manual testing after deploy, not automated test suites.
 - When verifying, read the relevant source files and confirm the logic satisfies each criterion.
 
+### CI Must Pass Before Merge (NON-NEGOTIABLE)
+
+Before running `gh pr merge` on ANY PR, check ALL CI check-runs:
+
+```bash
+SHA=$(gh pr view <PR_NUMBER> --json commits --jq '.commits[-1].oid')
+gh api "repos/{owner}/{repo}/commits/$SHA/check-runs?per_page=100" \
+  --jq '.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required") | {name, conclusion}'
+```
+
+**If ANY check-run has a blocking conclusion (`failure`, `timed_out`, `action_required`): DO NOT MERGE.** Instead:
+1. Read the failure output and fix the issue
+2. Commit, push, and wait for CI to re-run
+3. Only merge after ALL checks pass
+
+**Never disable linters, suppress warnings, or add eslint-disable comments to work around CI failures.** Fix the actual code errors. If lint errors exist in files you didn't touch, fix them anyway — they block the entire CI pipeline.
+
+This applies to ALL merge paths: manual `gh pr merge`, the `/merge` skill, the `/wrap` skill, and Phase C merge prep.
+
+### Never Suppress Linter Errors (NON-NEGOTIABLE)
+
+**NEVER add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or any linter suppression comment** to work around CI failures. These hide bugs instead of fixing them.
+
+When CI lint/typecheck fails:
+1. Read the error messages
+2. Fix the actual code — unused vars, missing types, incorrect imports, etc.
+3. If the error is in a file you didn't modify, fix it anyway — broken lint blocks the entire pipeline
+
+The only acceptable use of suppression comments is when the linter is provably wrong about a specific line AND you add a comment explaining why.
+
 ### Branching & Merging
 - **NEVER work on `main` — not editing, not committing, not pushing.** All code changes happen in worktrees on feature branches. If you're not in a worktree, create one first. If `git branch --show-current` returns `main`, do not touch any files.
 - **Every change requires: GitHub issue -> feature branch -> PR -> squash merge.** No exceptions. This includes `.claude/rules/*.md` and `CLAUDE.md` — rule files are code and follow the same PR workflow.


### PR DESCRIPTION
## Summary
- Adds non-negotiable "CI Must Pass Before Merge" rule to root `CLAUDE.md` requiring all check-runs to pass before any `gh pr merge`
- Adds "Never Suppress Linter Errors" rule banning `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa` as CI workarounds
- Adds CI verification step to `/merge` skill (new Step 4) before squash merge
- Adds CI verification step to `/wrap` skill (new Step 2.4) before squash merge

Closes #107

## Test plan
- [x] Root `CLAUDE.md` contains a "CI Must Pass Before Merge" rule that blocks `gh pr merge` when any check-run has a blocking conclusion
- [x] The rule covers all merge paths: `gh pr merge`, `/merge` skill, `/wrap` skill, Phase C merge prep
- [x] Root `CLAUDE.md` contains a "Never Suppress Linter Errors" rule banning `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa` as CI workarounds
- [x] The `/merge` skill checks CI status before executing the merge command
- [x] The `/wrap` skill checks CI status before executing the merge command
- [x] Existing `cr-github-review.md` CI Health Check section is consistent with the new merge-gate rule (no contradictions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a mandatory CI verification gate that blocks merges if any checks fail or time out.
  * Added explicit remediation steps: inspect failures, fix, push, wait for CI rerun, and re-verify before merging.
  * Prohibits using lint/typecheck suppression comments as a CI bypass; requires proper fixes and justification for rare exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->