### PR TITLE
Rename /pm to /pm-handoff, create new /pm orchestrator

### DIFF
--- a/.claude/skills/pm-handoff/SKILL.md
+++ b/.claude/skills/pm-handoff/SKILL.md
@@ -234,10 +234,15 @@ Locate and read the memory index file:
 
 ```bash
 # Derive the project memory path from the repo root
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-# The memory path uses the absolute path with slashes replaced by dashes
-MEMORY_PATH="$HOME/.claude/projects/-$(echo "$REPO_ROOT" | sed 's|/|-|g')/memory/MEMORY.md"
-test -f "$MEMORY_PATH" && cat "$MEMORY_PATH" || echo "NO_MEMORY_INDEX"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if [ -z "$REPO_ROOT" ]; then
+  echo "NO_MEMORY_INDEX"
+else
+  # The memory path uses the absolute path with slashes replaced by dashes
+  REPO_SLUG="$(echo "$REPO_ROOT" | sed 's|/|-|g')"
+  MEMORY_PATH="$HOME/.claude/projects/-${REPO_SLUG}/memory/MEMORY.md"
+  test -f "$MEMORY_PATH" && cat "$MEMORY_PATH" || echo "NO_MEMORY_INDEX"
+fi
 ```
 
 If the memory index exists, include its entries as a "Lessons & Context" section:

--- a/.claude/skills/pm-handoff/SKILL.md
+++ b/.claude/skills/pm-handoff/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: pm-handoff
+description: Generate a PM handoff prompt for context-window turnover. Captures static config, live GitHub state, in-flight thread state, and memory summary into a self-contained prompt for a fresh PM thread. Bootstraps `.claude/pm-config.md` on first run. Triggers on "pm-handoff", "handoff", "context turnover", "new pm thread", "thread turnover".
+argument-hint: "[copy] (optional — copies output to clipboard via pbcopy)"
+---
+
+Generate a PM handoff prompt for starting or continuing a PM orchestration thread. This prompt is self-contained — paste it into a new Claude Code session (web or CLI) and the new thread becomes the project manager for this repo, with full awareness of what the previous PM thread was doing.
+
+Parse `$ARGUMENTS`:
+- If `$ARGUMENTS` contains "copy" or "clipboard", copy the final output to clipboard via `pbcopy` in addition to stdout.
+- If empty, output to stdout only.
+
+## Step 1: Detect mode (bootstrap vs. standard)
+
+Check if `.claude/pm-config.md` exists in the current repo:
+
+```bash
+test -f .claude/pm-config.md && echo "CONFIG_EXISTS" || echo "BOOTSTRAP"
+```
+
+- If **BOOTSTRAP**: proceed to Step 2 (create config from repo scan)
+- If **CONFIG_EXISTS**: skip to Step 3 (read existing config)
+
+## Step 2: Bootstrap — create pm-config.md from repo discovery
+
+Only runs on first invocation for a repo. Scan the repo to auto-generate `.claude/pm-config.md`.
+
+### 2a: Get repo identity
+
+```bash
+gh repo view --json nameWithOwner,description,url --jq '{name: .nameWithOwner, description: .description, url: .url}'
+```
+
+### 2b: Detect infrastructure
+
+Check for infrastructure signals by testing file/directory existence:
+
+| Signal file | Service |
+|-------------|---------|
+| `railway.toml` or `railway.json` | Railway |
+| `vercel.json` or `.vercel/` | Vercel |
+| `fly.toml` | Fly.io |
+| `render.yaml` | Render |
+| `docker-compose.yml` or `Dockerfile` | Docker |
+| `supabase/` or `supabase.json` | Supabase |
+| `.neon` or references to `neon.tech` in config | Neon DB |
+| `netlify.toml` | Netlify |
+| `package.json` | Node.js (extract key deps like Next.js, Express, React) |
+| `requirements.txt` or `pyproject.toml` or `Pipfile` | Python (extract key deps) |
+| `.env.example` | Environment variables (list key names, not values) |
+
+For each detected service, record it with a brief note on its role.
+
+### 2c: Map architecture
+
+Scan the directory structure (depth 2) and identify patterns:
+
+- **Entry points:** `main.py`, `app.py`, `index.ts`, `server.js`, etc.
+- **Standard directories:** `src/`, `lib/`, `app/`, `tests/`, `migrations/`, `.github/workflows/`, `frontend/`, `backend/`, `api/`, `web/`, `utils/`
+- **Database patterns:** `prisma/`, `drizzle/`, `alembic/`, `migrations/` (numbered SQL files)
+- **Test patterns:** `tests/`, `__tests__/`, `cypress/`, `playwright/`, `*.test.*`
+- **CI patterns:** `.github/workflows/` (list workflow names)
+- **Config files:** `.coderabbit.yaml`, `tsconfig.json`, `pyproject.toml`, etc.
+
+Record the directory layout and notable patterns.
+
+### 2d: Generate pm-config.md
+
+Write `.claude/pm-config.md` with this structure:
+
+```markdown
+# PM Config — {repo name}
+
+## Role
+You are the project manager for {repo URL} — {repo description}.
+
+You manage the backlog, track progress, write GitHub issues, and generate prompts for parallel cloud threads (Claude Code on the Web) to do the actual coding work. You do NOT write code yourself — you orchestrate.
+
+## OKRs
+{Leave empty with a placeholder: "No OKRs set. Use `/pm-okr set` to define objectives."}
+
+## Workflow Rules
+1. Check repo state: `gh issue list --state open`, `gh pr list --state open`, `gh pr list --state merged --limit 10`
+2. Identify what can run in parallel (no dependency conflicts)
+3. Write detailed prompts for each thread — each prompt should:
+   - Reference the GitHub issue URL
+   - Describe what exists in the codebase (relevant files, tables, patterns to reuse)
+   - State dependencies that are already met
+   - Include: "Follow the full issue planning flow: check issue comments for @coderabbitai plan, merge plans into issue body, then implement. Create a worktree, run local CR review before pushing, create the PR with `Closes #N`."
+4. When threads finish, verify PRs merged, then identify next batch
+5. Create new GitHub issues when gaps are identified
+6. **Do NOT spawn subagents or use the Agent tool to execute work.** Your job is to write prompts and present them to the user. The user will paste them into new Claude Code threads (web or CLI). Only use subagents if the user explicitly asks (e.g., "go ahead and run those", "spin up agents for those").
+
+## Infrastructure
+{Auto-detected infrastructure from 2b}
+
+## Architecture
+{Auto-detected architecture from 2c}
+
+## Dependency Rules
+- Always check what's open before suggesting parallel work
+- Never suggest threads that depend on each other
+- Prompts must be self-contained (the receiving thread has no prior context)
+
+## Team
+{Leave empty with placeholder: "No team members configured. Add GitHub usernames and roles here."}
+
+## Notes
+{Leave empty with placeholder: "Add repo-specific context the PM should always know."}
+```
+
+Tell the user the config was bootstrapped and they should review/customize the Role, OKRs, Team, and Notes sections.
+
+## Step 3: Read existing config
+
+Parse `.claude/pm-config.md` using line-anchored level-2 headers (`^## ` at column 1). For each header, capture content verbatim until the next `^## ` header (or EOF), then store by header name. Do not split on `## ` appearing mid-line in section bodies.
+
+## Step 4: Fetch live GitHub state
+
+Query current repo state:
+
+```bash
+# Repo identity
+gh repo view --json nameWithOwner,description,url
+
+# Open issues
+gh issue list --state open --json number,title,labels,assignees,createdAt --limit 100
+
+# Open PRs
+gh pr list --state open --json number,title,headRefName,author,updatedAt,additions,deletions
+
+# Recent merges (last 20)
+gh pr list --state merged --limit 20 --json number,title,mergedAt,author
+```
+
+If any command returns empty results, note that gracefully (e.g., "No open issues" rather than failing).
+
+## Step 5: Assemble the handoff prompt
+
+Combine static config with dynamic state into a single prompt. Structure:
+
+```
+You are the project manager for {repo URL} — {description}.
+
+You are continuing from a previous PM session. The state below reflects where the previous thread left off. **Verify GitHub state is current before acting on it** — issues may have been closed, PRs merged, or new work started since this handoff was generated.
+
+Use `/pm` to enter active orchestration mode once you've reviewed the state below.
+
+## Your Role
+{Role section from config}
+
+## OKRs
+{OKRs section from config, or "None set" if empty/placeholder}
+
+## Workflow
+{Workflow Rules section from config}
+
+## Execution Boundary
+Do NOT spawn subagents or use the Agent tool to execute work yourself. Write the prompt and present it to the user — they will paste it into a new Claude Code thread. Only use subagents if the user explicitly asks (e.g., "go ahead and run those", "spin up agents for those").
+
+## What's Been Built
+{Infrastructure section from config}
+{Architecture section from config}
+
+## Dependency Rules
+{Dependency Rules section from config}
+
+## Team
+{Team section from config, or omit if empty/placeholder}
+
+## In-Flight Work
+{From Step 5b — or "No in-flight work detected" if empty}
+
+## Lessons & Context
+{From Step 5c — or omit if no memory index found}
+
+## Current State
+{Format as actionable lists:}
+
+### Open Issues ({count})
+{List each: "- #N — Title [labels] (assigned: @user or unassigned)"}
+
+### Open PRs ({count})
+{List each: "- PR #N — Title (by @author, +adds/-dels)"}
+
+### Recently Merged ({count})
+{List each: "- PR #N — Title (merged {date} by @author)"}
+
+## Notes
+{Notes section from config, or omit if empty/placeholder}
+```
+
+### Step 5b: Capture in-flight thread state
+
+Scan for orchestration state files:
+
+```bash
+# Session state (high-level orchestration)
+test -f ~/.claude/session-state.json && cat ~/.claude/session-state.json || echo "NO_SESSION_STATE"
+
+# Per-PR handoff files
+ls ~/.claude/handoffs/pr-*-handoff.json 2>/dev/null || echo "NO_HANDOFF_FILES"
+```
+
+If `session-state.json` exists, extract and summarize:
+- Which PRs are tracked and in which phase (A/B/C)
+- Which reviewer owns each PR (CR or Greptile)
+- Any `needs` or `remaining_work` fields
+- Active agents (may be stale — note they need verification)
+
+If handoff files exist, for each one extract:
+- PR number, phase completed, reviewer, HEAD SHA
+- Files changed, findings fixed count
+- Notes field
+
+Format as a readable summary:
+
+```
+### In-Flight Work
+
+| PR | Issue | Phase | Reviewer | Status | Last SHA |
+|----|-------|-------|----------|--------|----------|
+| #88 | #42 | B (Review) | CR | Awaiting review | abc1234 |
+| #90 | #55 | A (Fix+Push) | — | Fixes pushed | def5678 |
+
+**Note:** Thread state may be stale. Verify PR status on GitHub before acting.
+```
+
+If no state files exist, output: "No in-flight work detected. Starting fresh."
+
+### Step 5c: Memory summary
+
+Locate and read the memory index file:
+
+```bash
+# Derive the project memory path from the repo root
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+# The memory path uses the absolute path with slashes replaced by dashes
+MEMORY_PATH="$HOME/.claude/projects/-$(echo "$REPO_ROOT" | sed 's|/|-|g')/memory/MEMORY.md"
+test -f "$MEMORY_PATH" && cat "$MEMORY_PATH" || echo "NO_MEMORY_INDEX"
+```
+
+If the memory index exists, include its entries as a "Lessons & Context" section:
+
+```
+## Lessons & Context
+These are key learnings from previous sessions (from memory index — not full details):
+
+{Each non-empty line from MEMORY.md as a bullet}
+```
+
+If no memory index exists, omit this section entirely.
+
+### Step 5d: Continuation header
+
+The assembled prompt (Step 5 above) already includes the continuation instructions at the top: "You are continuing from a previous PM session..." This tells the receiving thread to verify state before acting.
+
+## Step 6: Output
+
+1. Print the assembled prompt to stdout.
+2. If the `copy` argument was provided:
+   ```bash
+   echo "$PROMPT" | pbcopy 2>/dev/null && echo "--- Copied to clipboard ---" || echo "--- pbcopy not available — copy from above ---"
+   ```
+3. After the prompt, print a brief summary: "Generated PM handoff prompt for {repo}. {N} open issues, {M} open PRs, {K} recent merges, {J} in-flight PRs included."

--- a/.claude/skills/pm-handoff/SKILL.md
+++ b/.claude/skills/pm-handoff/SKILL.md
@@ -198,8 +198,15 @@ Scan for orchestration state files:
 # Session state (high-level orchestration)
 test -f ~/.claude/session-state.json && cat ~/.claude/session-state.json || echo "NO_SESSION_STATE"
 
-# Per-PR handoff files
-ls ~/.claude/handoffs/pr-*-handoff.json 2>/dev/null || echo "NO_HANDOFF_FILES"
+# Per-PR handoff files (emit valid JSON content per file)
+found_handoffs=false
+for f in ~/.claude/handoffs/pr-*-handoff.json; do
+  [ -f "$f" ] || continue
+  found_handoffs=true
+  echo "--- $f ---"
+  cat "$f"
+done
+$found_handoffs || echo "NO_HANDOFF_FILES"
 ```
 
 If `session-state.json` exists, extract and summarize:
@@ -239,7 +246,7 @@ if [ -z "$REPO_ROOT" ]; then
   echo "NO_MEMORY_INDEX"
 else
   # The memory path uses the absolute path with slashes replaced by dashes
-  REPO_SLUG="$(echo "$REPO_ROOT" | sed 's|/|-|g')"
+  REPO_SLUG="$(echo "$REPO_ROOT" | sed 's|^/||; s|/|-|g')"
   MEMORY_PATH="$HOME/.claude/projects/-${REPO_SLUG}/memory/MEMORY.md"
   test -f "$MEMORY_PATH" && cat "$MEMORY_PATH" || echo "NO_MEMORY_INDEX"
 fi

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -71,7 +71,7 @@ Show the user:
 2. Any issues that were in-progress but whose PRs are now missing or stale
 3. Remaining open issues not yet assigned
 
-Ask: "Here's where we left off. Want me to continue with the current assignments, or re-prioritize?"
+Proceed with current assignments by default. State: "Continuing with current assignments. Say 're-prioritize' to change strategy."
 
 Then proceed to **Step 3: Orchestration Loop**.
 
@@ -183,7 +183,7 @@ Based on {N} open issues, {M} recent merges, and {OKR status}:
 {If any suggested issues have dependency chains, note the order}
 ```
 
-Ask the user: "Which of these should we work on? Pick the issues (or adjust), and I'll generate coding thread prompts."
+Select the top-ranked batch by default and generate prompts immediately. State: "Generating prompts for the top issues below. Say 'adjust' to change the selection before pasting into threads."
 
 Then proceed to **Step 3: Orchestration Loop**.
 
@@ -219,8 +219,8 @@ Fix/implement issue #{N}: {title}
 
 ## Workflow
 1. Create a worktree for isolated work
-2. Read the issue and any CodeRabbit plan in the comments
-3. Merge plans into the issue body if not already done
+2. Read the issue body — this is the canonical implementation plan (includes merged CodeRabbit recommendations when available)
+3. Check issue comments only to detect any plan content not yet merged into the body — if found, merge it first
 4. Implement the changes
 5. Run local CodeRabbit review (`coderabbit review --prompt-only`) — fix all findings
 6. Two clean passes, then commit and push

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -34,8 +34,15 @@ If config exists, parse it using line-anchored `^## ` headers (same logic as `/p
 # Session-wide orchestration state
 test -f ~/.claude/session-state.json && cat ~/.claude/session-state.json || echo "NO_SESSION_STATE"
 
-# Per-PR handoff files
-ls ~/.claude/handoffs/pr-*-handoff.json 2>/dev/null && cat ~/.claude/handoffs/pr-*-handoff.json || echo "NO_HANDOFF_FILES"
+# Per-PR handoff files (iterate to emit valid JSON per file)
+found_handoffs=false
+for f in ~/.claude/handoffs/pr-*-handoff.json; do
+  [ -f "$f" ] || continue
+  found_handoffs=true
+  echo "--- $f ---"
+  cat "$f"
+done
+$found_handoffs || echo "NO_HANDOFF_FILES"
 ```
 
 Parse any found state into an assignments table:

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -1,190 +1,306 @@
 ---
 name: pm
-description: Generate a self-contained project manager handoff prompt for starting a new thread. Bootstraps a `.claude/pm-config.md` on first run, then combines static config with live GitHub state. Use this whenever you need to start a fresh PM thread, hand off project context to a new session, or generate an orchestration prompt for parallel cloud threads. Triggers on "pm", "project manager", "handoff prompt", "new thread", "thread turnover".
-argument-hint: "[copy] (optional — copies output to clipboard via pbcopy)"
+description: Active PM orchestrator — manages issue pipeline, tracks coding threads, suggests next work. Cold-starts from GitHub state or resumes from a /pm-handoff prompt. Triggers on "pm", "project manager", "orchestrate", "what should I work on".
+argument-hint: "[resume] (optional — 'resume' reads in-flight state from session files to continue a previous PM session)"
 ---
 
-Generate a PM handoff prompt for starting a new orchestration thread. This prompt is self-contained — paste it into a new Claude Code session (web or CLI) and the new thread becomes the project manager for this repo.
+Active PM orchestrator. Manages which issues are being worked on across coding threads, tracks progress, and suggests next work.
+
+**Two modes:**
+- **Cold start (default):** Scan GitHub state, suggest next 3-5 issues, enter orchestration loop.
+- **Resume:** Read in-flight state from session files and continue where the previous PM left off.
 
 Parse `$ARGUMENTS`:
-- If `$ARGUMENTS` contains "copy" or "clipboard", copy the final output to clipboard via `pbcopy` in addition to stdout.
-- If empty, output to stdout only.
+- If `$ARGUMENTS` contains "resume" or "handoff": enter Resume mode (Step 1A).
+- Otherwise: enter Cold Start mode (Step 1B).
 
-## Step 1: Detect mode (bootstrap vs. standard)
+---
 
-Check if `.claude/pm-config.md` exists in the current repo:
+## Step 1A: Resume mode
+
+Read existing orchestration state to continue where a previous PM thread left off.
+
+### 1A.1: Load pm-config.md
+
+```bash
+test -f .claude/pm-config.md && echo "CONFIG_EXISTS" || echo "NO_CONFIG"
+```
+
+If config exists, parse it using line-anchored `^## ` headers (same logic as `/pm-handoff` Step 3). If missing, tell the user to run `/pm-handoff` first to bootstrap the config.
+
+### 1A.2: Load in-flight state
+
+```bash
+# Session-wide orchestration state
+test -f ~/.claude/session-state.json && cat ~/.claude/session-state.json || echo "NO_SESSION_STATE"
+
+# Per-PR handoff files
+ls ~/.claude/handoffs/pr-*-handoff.json 2>/dev/null && cat ~/.claude/handoffs/pr-*-handoff.json || echo "NO_HANDOFF_FILES"
+```
+
+Parse any found state into an assignments table:
+
+| PR | Issue | Phase | Reviewer | Last SHA | Notes |
+|----|-------|-------|----------|----------|-------|
+
+### 1A.3: Verify against live GitHub
+
+State files may be stale. Cross-reference with live data:
+
+```bash
+gh pr list --state open --json number,title,headRefName,author,updatedAt
+gh pr list --state merged --limit 10 --json number,title,mergedAt
+gh issue list --state open --json number,title,labels,assignees --limit 100
+```
+
+- PRs that have merged since the handoff: mark as complete, remove from assignments.
+- Issues that have been closed: remove from backlog.
+- New PRs not in the state file: note them as untracked.
+
+### 1A.4: Present recovered state
+
+Show the user:
+1. Verified assignments table (corrected for merges/closures since handoff)
+2. Any issues that were in-progress but whose PRs are now missing or stale
+3. Remaining open issues not yet assigned
+
+Ask: "Here's where we left off. Want me to continue with the current assignments, or re-prioritize?"
+
+Then proceed to **Step 3: Orchestration Loop**.
+
+---
+
+## Step 1B: Cold start (default)
+
+No prior state — scan GitHub and suggest what to work on.
+
+### 1B.1: Load or bootstrap pm-config.md
 
 ```bash
 test -f .claude/pm-config.md && echo "CONFIG_EXISTS" || echo "BOOTSTRAP"
 ```
 
-- If **BOOTSTRAP**: proceed to Step 2 (create config from repo scan)
-- If **CONFIG_EXISTS**: skip to Step 3 (read existing config)
+- If **BOOTSTRAP**: Run the same bootstrap logic as `/pm-handoff` Step 2 (detect infrastructure, map architecture, generate pm-config.md). Then continue.
+- If **CONFIG_EXISTS**: Parse it using line-anchored `^## ` headers.
 
-## Step 2: Bootstrap — create pm-config.md from repo discovery
+Extract the `## OKRs` section if present and non-placeholder. Set `OKR_MODE=true` if OKRs exist.
 
-Only runs on first invocation for a repo. Scan the repo to auto-generate `.claude/pm-config.md`.
-
-### 2a: Get repo identity
+### 1B.2: Fetch GitHub state
 
 ```bash
-gh repo view --json nameWithOwner,description,url --jq '{name: .nameWithOwner, description: .description, url: .url}'
-```
+# Recent merged PRs — understand momentum and direction
+gh pr list --state merged --limit 20 --json number,title,mergedAt,author,body
 
-### 2b: Detect infrastructure
+# Open issues — the backlog
+gh issue list --state open --json number,title,labels,assignees,createdAt,updatedAt --limit 100
 
-Check for infrastructure signals by testing file/directory existence:
-
-| Signal file | Service |
-|-------------|---------|
-| `railway.toml` or `railway.json` | Railway |
-| `vercel.json` or `.vercel/` | Vercel |
-| `fly.toml` | Fly.io |
-| `render.yaml` | Render |
-| `docker-compose.yml` or `Dockerfile` | Docker |
-| `supabase/` or `supabase.json` | Supabase |
-| `.neon` or references to `neon.tech` in config | Neon DB |
-| `netlify.toml` | Netlify |
-| `package.json` | Node.js (extract key deps like Next.js, Express, React) |
-| `requirements.txt` or `pyproject.toml` or `Pipfile` | Python (extract key deps) |
-| `.env.example` | Environment variables (list key names, not values) |
-
-For each detected service, record it with a brief note on its role.
-
-### 2c: Map architecture
-
-Scan the directory structure (depth 2) and identify patterns:
-
-- **Entry points:** `main.py`, `app.py`, `index.ts`, `server.js`, etc.
-- **Standard directories:** `src/`, `lib/`, `app/`, `tests/`, `migrations/`, `.github/workflows/`, `frontend/`, `backend/`, `api/`, `web/`, `utils/`
-- **Database patterns:** `prisma/`, `drizzle/`, `alembic/`, `migrations/` (numbered SQL files)
-- **Test patterns:** `tests/`, `__tests__/`, `cypress/`, `playwright/`, `*.test.*`
-- **CI patterns:** `.github/workflows/` (list workflow names)
-- **Config files:** `.coderabbit.yaml`, `tsconfig.json`, `pyproject.toml`, etc.
-
-Record the directory layout and notable patterns.
-
-### 2d: Generate pm-config.md
-
-Write `.claude/pm-config.md` with this structure:
-
-```markdown
-# PM Config — {repo name}
-
-## Role
-You are the project manager for {repo URL} — {repo description}.
-
-You manage the backlog, track progress, write GitHub issues, and generate prompts for parallel cloud threads (Claude Code on the Web) to do the actual coding work. You do NOT write code yourself — you orchestrate.
-
-## OKRs
-{Leave empty with a placeholder: "No OKRs set. Use `/pm-okr set` to define objectives."}
-
-## Workflow Rules
-1. Check repo state: `gh issue list --state open`, `gh pr list --state open`, `gh pr list --state merged --limit 10`
-2. Identify what can run in parallel (no dependency conflicts)
-3. Write detailed prompts for each thread — each prompt should:
-   - Reference the GitHub issue URL
-   - Describe what exists in the codebase (relevant files, tables, patterns to reuse)
-   - State dependencies that are already met
-   - Include: "Follow the full issue planning flow: check issue comments for @coderabbitai plan, merge plans into issue body, then implement. Create a worktree, run local CR review before pushing, create the PR with `Closes #N`."
-4. When threads finish, verify PRs merged, then identify next batch
-5. Create new GitHub issues when gaps are identified
-6. **Do NOT spawn subagents or use the Agent tool to execute work.** Your job is to write prompts and present them to the user. The user will paste them into new Claude Code threads (web or CLI). Only use subagents if the user explicitly asks (e.g., "go ahead and run those", "spin up agents for those").
-
-## Infrastructure
-{Auto-detected infrastructure from 2b}
-
-## Architecture
-{Auto-detected architecture from 2c}
-
-## Dependency Rules
-- Always check what's open before suggesting parallel work
-- Never suggest threads that depend on each other
-- Prompts must be self-contained (the receiving thread has no prior context)
-
-## Team
-{Leave empty with placeholder: "No team members configured. Add GitHub usernames and roles here."}
-
-## Notes
-{Leave empty with placeholder: "Add repo-specific context the PM should always know."}
-```
-
-Tell the user the config was bootstrapped and they should review/customize the Role, OKRs, Team, and Notes sections.
-
-## Step 3: Read existing config
-
-Parse `.claude/pm-config.md` using line-anchored level-2 headers (`^## ` at column 1). For each header, capture content verbatim until the next `^## ` header (or EOF), then store by header name. Do not split on `## ` appearing mid-line in section bodies.
-
-## Step 4: Fetch live GitHub state
-
-Query current repo state:
-
-```bash
-# Repo identity
-gh repo view --json nameWithOwner,description,url
-
-# Open issues
-gh issue list --state open --json number,title,labels,assignees,createdAt --limit 100
-
-# Open PRs
+# Open PRs — detect in-flight work
 gh pr list --state open --json number,title,headRefName,author,updatedAt,additions,deletions
-
-# Recent merges (last 10)
-gh pr list --state merged --limit 10 --json number,title,mergedAt,author
 ```
 
-If any command returns empty results, note that gracefully (e.g., "No open issues" rather than failing).
+### 1B.3: Read issue bodies for top candidates
 
-## Step 5: Assemble the handoff prompt
+Reading all 100 issue bodies is expensive. Use a two-pass approach:
 
-Combine static config with dynamic state into a single prompt. Structure:
+**Pass 1 — Quick scan:** From the issue list, identify the top ~20 candidates using fast signals:
+- Labels containing `bug`, `critical`, `P0`, `P1`, `urgent`, `blocked`
+- Issues with no assignee (available for pickup)
+- Issues not already covered by an open PR (cross-reference PR branch names and bodies for `#N` references)
+- Most recently updated (active discussion = likely important)
+- Oldest unassigned (may be neglected but important)
+
+**Pass 2 — Deep read:** For the top ~20 candidates, fetch full bodies:
+
+```bash
+# For each candidate issue number:
+gh issue view $NUMBER --json body,title,labels,comments,assignees
+```
+
+Extract from each:
+- Scope and intent (what the issue actually asks for)
+- Dependency references: `blocked by #N`, `depends on #N`, `unblocks #N`
+- Complexity signals: number of acceptance criteria, files mentioned
+- Whether a PR is already in flight for this issue
+
+### 1B.4: Score and rank issues
+
+For each candidate, assess:
+
+1. **Priority signals (primary):**
+   - Labels: `P0`/`critical` > `P1`/`bug` > `P2`/`enhancement` > unlabeled
+   - Dependency leverage: issues that unblock 2+ other issues rank higher
+   - Age + activity: old unassigned issues with recent comments = neglected priority
+
+2. **OKR alignment (when `OKR_MODE=true`):**
+   - Issues that directly advance an incomplete key result get a one-tier boost
+   - Issues aligned with an objective broadly get a tiebreaker advantage
+   - Record which OKR(s) each issue aligns with
+
+3. **Recent momentum:**
+   - What areas of the codebase have recent merged PRs? Issues in the same area benefit from warm context.
+   - What themes appear in recent merges? Issues continuing that theme are cheaper to pick up.
+
+4. **Exclusions:**
+   - Skip issues that already have an open PR (someone is working on it)
+   - Skip issues assigned to someone else (unless stale > 14 days)
+   - Skip issues labeled `blocked`, `on-hold`, `wontfix`, `duplicate`
+
+### 1B.5: Present recommendations
+
+Output the top 3-5 issues as a ranked list:
 
 ```
-You are the project manager for {repo URL} — {description}.
+## Suggested Next Issues
 
-## Your Role
-{Role section from config}
+Based on {N} open issues, {M} recent merges, and {OKR status}:
 
-## OKRs
-{OKRs section from config, or "None set" if empty/placeholder}
+1. **#42 — {Title}** — {1-line rationale connecting to business value or OKR}
+   - Labels: {labels} | Age: {days} days | Unblocks: #50, #53
+
+2. **#38 — {Title}** — {rationale}
+   - Labels: {labels} | Age: {days} days | Blocked by: #35
+
+3. **#55 — {Title}** — {rationale}
+   - Labels: {labels} | Age: {days} days
+
+4. **#61 — {Title}** — {rationale}
+   - Labels: {labels} | Age: {days} days
+
+5. **#47 — {Title}** — {rationale}
+   - Labels: {labels} | Age: {days} days
+
+### Already In-Flight
+{List open PRs with their linked issues — these don't need new threads}
+
+### Dependency Note
+{If any suggested issues have dependency chains, note the order}
+```
+
+Ask the user: "Which of these should we work on? Pick the issues (or adjust), and I'll generate coding thread prompts."
+
+Then proceed to **Step 3: Orchestration Loop**.
+
+---
+
+## Step 2: (Reserved — both modes skip to Step 3)
+
+---
+
+## Step 3: Orchestration Loop
+
+This is the core PM behavior. Once the user confirms which issues to work on, enter the orchestration loop.
+
+### 3.1: Generate coding thread prompts
+
+For each selected issue, generate a self-contained prompt that can be pasted into a new Claude Code thread (web or CLI). Each prompt must include:
+
+```
+You are a coding agent working on {repo URL}.
+
+## Task
+Fix/implement issue #{N}: {title}
+{Full issue URL}
+
+## Issue Details
+{Issue body — paste the full body so the thread has context}
+
+## Relevant Codebase Context
+{Based on the issue body and recent PRs, describe:}
+- Key files likely involved (from issue body references, labels, or educated guess from architecture)
+- Patterns to reuse (from pm-config Architecture section)
+- Dependencies that are already met
 
 ## Workflow
-{Workflow Rules section from config}
+1. Create a worktree for isolated work
+2. Read the issue and any CodeRabbit plan in the comments
+3. Merge plans into the issue body if not already done
+4. Implement the changes
+5. Run local CodeRabbit review (`coderabbit review --prompt-only`) — fix all findings
+6. Two clean passes, then commit and push
+7. Create a PR with `Closes #{N}` in the body
+8. Include a Test Plan section with checkboxes for acceptance criteria
+9. Enter the review polling loop and fix any findings
 
-## Execution Boundary
-Do NOT spawn subagents or use the Agent tool to execute work yourself. Write the prompt and present it to the user — they will paste it into a new Claude Code thread. Only use subagents if the user explicitly asks (e.g., "go ahead and run those", "spin up agents for those").
-
-## What's Been Built
-{Infrastructure section from config}
-{Architecture section from config}
-
-## Dependency Rules
-{Dependency Rules section from config}
-
-## Team
-{Team section from config, or omit if empty/placeholder}
-
-## Current State
-{Format as actionable lists:}
-
-### Open Issues ({count})
-{List each: "- #N — Title [labels] (assigned: @user or unassigned)"}
-
-### Open PRs ({count})
-{List each: "- PR #N — Title (by @author, +adds/-dels)"}
-
-### Recently Merged ({count})
-{List each: "- PR #N — Title (merged {date} by @author)"}
-
-## Notes
-{Notes section from config, or omit if empty/placeholder}
+## Constraints
+- Do NOT work on main — use a worktree or feature branch
+- Do NOT modify .env files
+- Squash and merge when reviews are clean
 ```
 
-## Step 6: Output
+Present all prompts to the user. Do NOT spawn subagents or execute the prompts — present them for the user to paste into coding threads. Only spawn agents if the user explicitly asks (e.g., "go ahead and run those", "spin up agents for those").
 
-1. Print the assembled prompt to stdout.
-2. If the `copy` argument was provided:
-   ```bash
-   echo "$PROMPT" | pbcopy 2>/dev/null && echo "--- Copied to clipboard ---" || echo "--- pbcopy not available — copy from above ---"
-   ```
-3. After the prompt, print a brief summary: "Generated PM handoff prompt for {repo}. {N} open issues, {M} open PRs, {K} recent merges included."
+### 3.2: Track assignments
+
+Maintain a state table in the conversation. Update it as work progresses:
+
+```
+## Active Work
+
+| Issue | Thread | PR | Status | Last Update |
+|-------|--------|----|--------|-------------|
+| #42 | Prompt generated | — | Awaiting thread start | {timestamp} |
+| #38 | Active | PR #88 | In review | {timestamp} |
+| #55 | Active | PR #90 | Merged | {timestamp} |
+```
+
+### 3.3: Progress detection
+
+When the user asks "status", "what's next", or "update" — or periodically when it makes sense:
+
+```bash
+# Check for new/merged PRs
+gh pr list --state open --json number,title,headRefName,body
+gh pr list --state merged --limit 10 --json number,title,mergedAt,body
+
+# Check for closed issues
+gh issue list --state closed --limit 20 --json number,title,closedAt
+```
+
+Cross-reference with the assignments table:
+- Detect PRs that reference tracked issues (search PR body for `Closes #N`, `Fixes #N`)
+- Mark issues as "PR open" or "Merged" accordingly
+- Flag stale threads: if an issue was assigned > 30 minutes ago with no PR, note it
+
+Also accept user input: "thread for #42 is done", "PR #88 merged", "#55 is blocked".
+
+### 3.4: Suggest next batch
+
+When one or more threads finish (PRs merged, issues closed):
+
+1. Remove completed items from the assignments table
+2. Re-scan open issues (reuse 1B.2-1B.4 logic but lighter — only fetch new/changed issues)
+3. Suggest 1-3 new issues to fill the pipeline
+4. Generate prompts for the user's selected issues
+
+### 3.5: Handoff awareness
+
+When the conversation is getting long (many back-and-forth cycles, multiple batches of work completed), proactively suggest:
+
+> "This PM session has been running for a while. To preserve context for a fresh thread, run `/pm-handoff` — it will capture the current state, memory, and in-flight work into a prompt you can paste into a new PM session."
+
+---
+
+## Execution Boundary (CRITICAL)
+
+**This skill does NOT write code, create PRs, or spawn subagents.**
+
+The PM orchestrator's job is to:
+- Analyze the backlog and recommend what to work on
+- Generate self-contained prompts for coding threads
+- Track progress across threads
+- Suggest next work when threads finish
+
+The **user** decides when and where to paste the prompts. The user starts the coding threads. The PM tracks and coordinates.
+
+**Exception:** If the user explicitly says "go ahead and run those", "spin up agents", or "execute those prompts" — then and only then may you spawn subagents via the Agent tool to execute the coding thread prompts.
+
+---
+
+## Writing Rules
+
+- **Rationales must connect to business value.** "This is a bug" is not a rationale. "This bug blocks the checkout flow that drives 60% of revenue" is.
+- **1-2 lines per issue** in the suggestions list. Save detail for the coding thread prompts.
+- **Flag dependencies inline** with the issues they affect.
+- **Total suggestions should be scannable in under 1 minute.**
+- **Coding thread prompts should be complete and self-contained.** The receiving thread has zero prior context — give it everything it needs.
+- **Do not list every issue.** If 80 of 100 issues are low-priority, say "75 additional issues deferred" rather than listing them.


### PR DESCRIPTION
## Summary
- Renames existing `/pm` skill to `/pm-handoff` with enhanced context-window turnover support (in-flight thread state capture, memory summary, continuation instructions)
- Creates new `/pm` skill as an active orchestrator that manages the issue pipeline, tracks coding threads across sessions, and suggests next work
- `/pm` has two modes: cold start (scans GitHub, suggests 3-5 issues) and resume (reads session state to continue previous PM session)

Closes #112

## Test plan
- [x] `/pm-handoff` produces same output as old `/pm` plus memory summary, in-flight state, and continuation instructions
- [x] `/pm-handoff copy` copies to clipboard
- [x] `/pm` (cold start) scans GitHub and suggests 3-5 issues with rationales
- [x] `/pm resume` reads existing state and enters orchestration mode
- [x] Both skills appear in skill autocomplete
- [x] Old `/pm` handoff-only behavior is preserved in `/pm-handoff`
- [ ] Symlinks updated after merge (post-merge task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PM Handoff: generates a complete, copyable PM handoff prompt that merges repo config, live GitHub state, in-flight work summaries, and optional clipboard copying.
  * Active PM Orchestrator: manages issue/PR pipelines with resume/scan modes, ranks candidate issues, tracks progress, and generates coding-thread prompts and next-step assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->