### PR TITLE
Add global branch protection check to repo bootstrap

### DIFF
--- a/.claude/rules/repo-bootstrap.md
+++ b/.claude/rules/repo-bootstrap.md
@@ -67,8 +67,8 @@ gh api "repos/{owner}/{repo}/branches/main/protection/required_status_checks" 2>
 2. **Ask the user:** "This repo's `main` branch has no required status checks — PRs can merge with failing CI. Found checks: `lint`, `test`, `build`. Want me to enable branch protection requiring these to pass?"
 3. **If approved:**
    - Read existing protection via `gh api repos/{owner}/{repo}/branches/main/protection` (may 404).
-   - PUT to the same endpoint with `required_status_checks.contexts` set to the discovered check names and `strict: false` (or `true` for low-activity repos).
-   - Preserve `required_pull_request_reviews`, `restrictions`, and `enforce_admins` from the read; default to `null`/`false` if no prior protection exists.
+   - PUT to the same endpoint with `required_status_checks.contexts` set to the discovered check names and `strict: true` (prevents merging stale branches).
+   - Preserve all existing protection settings from the read response (merge in the updated `required_status_checks` only). If no prior protection exists (404), use sensible defaults (`enforce_admins: false`, others `null`).
 4. **If declined:** move on. Do not ask again in the same session.
 
 ### Rules


### PR DESCRIPTION
## Summary
- Adds a new "Branch Protection — Required Status Checks" section to `.claude/rules/repo-bootstrap.md`
- At session start, the agent checks if the repo's `main` branch has required status checks configured via `gh api`
- If missing, discovers CI check names and asks the user before applying branch protection
- Preserves existing protection rules (required reviews, restrictions, admin enforcement) when adding status checks

Closes #114

## Context
PR #837 in `LocalMovers-dot-com/license_manager` was merged while CI lint was failing because `main` had no required status checks configured. This broke CI for all subsequent PRs. While our agent-level rules (`/merge`, `/wrap`) already block merges on failing CI, this adds the missing **GitHub platform-level** enforcement as a global session-start check.

## Test plan
- [x] `repo-bootstrap.md` has a new section "2. Branch Protection — Required Status Checks" under "Session Start: Required Configuration Checks"
- [x] The check uses `gh api repos/{owner}/{repo}/branches/main/protection/required_status_checks` to detect missing protection
- [x] Three outcomes are handled: 200 (configured), 404 (not configured), 403 (no permission)
- [x] Remediation requires user confirmation before modifying branch protection
- [x] Remediation preserves existing `required_pull_request_reviews`, `restrictions`, and `enforce_admins` from current settings
- [x] Existing CLAUDE.md CI enforcement rules are unchanged
- [x] `\/merge` and `/wrap` skills are unchanged (already enforce CI checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded bootstrap docs to validate both workflow presence and main branch protection during setup
  * Clarified that missing workflow files are added idempotently without altering existing files
  * Added guidance for discovering required status checks and a user-confirmed remediation flow to enable them
  * Emphasized preserving existing branch protection and requiring explicit user confirmation for any changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->