### PR TITLE
Stop @mentioning Greptile in reply comments

### DIFF
--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -4,7 +4,7 @@
 > **Ask first:** Never — fix findings autonomously.
 > **Never:** Trigger Greptile proactively on a PR where CR hasn't failed yet. Ignore Greptile findings. Switch a PR back to CR after Greptile has been triggered. Include `@greptileai` in reply comments (triggers a paid re-review with no learning benefit).
 
-Greptile is an AI code reviewer used as a **fallback** when CR is rate-limited or unresponsive. Both tools' findings must be verified against code. Differences: cost ($1/review beyond 50/month quota) and completion-signal reliability (Greptile completion signals are accurate; CR completion signals require confirmation passes).
+Greptile is an AI code reviewer used as a **fallback** when CR is rate-limited or unresponsive. Both tools' findings must be verified against code. Differences: cost ($0.50-$1.00/review beyond 50/month quota) and completion-signal reliability (Greptile completion signals are accurate; CR completion signals require confirmation passes).
 
 ## Greptile Basics
 

--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -2,7 +2,7 @@
 
 > **Always:** Poll for response after triggering. Reply to every thread. Fix all valid findings. Classify by severity (P0/P1/P2). Only re-review for P0. Stay on G once triggered for a PR.
 > **Ask first:** Never — fix findings autonomously.
-> **Never:** Trigger Greptile proactively on a PR where CR hasn't failed yet. Ignore Greptile findings. Switch a PR back to CR after Greptile has been triggered.
+> **Never:** Trigger Greptile proactively on a PR where CR hasn't failed yet. Ignore Greptile findings. Switch a PR back to CR after Greptile has been triggered. Include `@greptileai` in reply comments (triggers a paid re-review with no learning benefit).
 
 Greptile is an AI code reviewer used as a **fallback** when CR is rate-limited or unresponsive. Both tools' findings must be verified against code. Differences: cost ($1/review beyond 50/month quota) and completion-signal reliability (Greptile completion signals are accurate; CR completion signals require confirmation passes).
 
@@ -75,9 +75,22 @@ Filter by `greptile-apps[bot]` (with `[bot]` suffix).
 
 ## Processing Greptile Findings
 
-Same protocol as CR: classify by severity (P0/P1/P2 — use Greptile badges only), verify against code, fix all valid findings in one commit, push once, reply to every thread, resolve via GraphQL. Use 👍/👎 reactions for feedback.
+Classify by severity (P0/P1/P2 — use Greptile badges only), verify against code, fix all valid findings in one commit, push once, reply to every thread, resolve via GraphQL. Use 👍/👎 reactions for feedback (this is Greptile's only learning mechanism).
 
-**Severity-gated re-review:** P0 present → re-trigger `@greptileai` after fix. P1/P2 only → merge-ready after fix push, no re-review needed.
+> **CRITICAL: Do NOT include `@greptileai` in reply comments.** Every `@greptileai` mention — even in a reply — triggers a new paid review ($0.50-$1.00). Greptile does not learn from text replies (unlike CR which has a knowledge base). Replies are purely for GitHub thread management and human readability.
+>
+> | | CodeRabbit | Greptile |
+> |--|-----------|----------|
+> | Reply format | Include `@coderabbitai` (teaches knowledge base) | **No @mention** — plain text only |
+> | Learns from replies | Yes | No — only from 👍/👎 reactions |
+> | @mention cost | Within hourly quota | $0.50-$1.00 per triggered review |
+
+**Reply format for Greptile threads:**
+- Inline comments: `gh api repos/{owner}/{repo}/pulls/comments/{id}/replies -f body="Fixed in \`SHA\`: <what changed>"`
+- Issue/PR-level comments: `gh pr comment N --body "Fixed in \`SHA\`: <what changed>"`
+- **Never** include `@greptileai` in reply bodies. The only valid use of `@greptileai` is posting a standalone comment to intentionally request a new review (P0 re-review trigger).
+
+**Severity-gated re-review:** P0 present → re-trigger `@greptileai` after fix (this is an intentional re-review request, not a reply). P1/P2 only → merge-ready after fix push, no re-review needed.
 
 ## Detecting a Merge-Ready Greptile Review
 

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -107,7 +107,7 @@ Subagents have a hardcoded **32K output token limit** that cannot be configured 
 - Read affected source files
 - Fix all valid findings + fix lint/CI failures
 - Commit all fixes in ONE commit, push once
-- Reply to all review comment threads
+- Reply to all review comment threads (for Greptile: plain text only — do not include `@greptileai`, every @mention triggers a paid re-review)
 - **Write handoff file** to `~/.claude/handoffs/pr-{N}-handoff.json` (see "Structured Handoff Files" section below) with all findings fixed, threads replied/resolved, files changed, and HEAD SHA. Include `findings_dismissed` for any findings verified as false positives (each entry: `{id, reason}`).
 - **EXIT after push — do not enter polling loop**
 

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -440,9 +440,11 @@ If you see the ack but no review within 7 minutes, CR failed to deliver.
 3. Timeout after 5 minutes (Greptile typically responds in 1-3 minutes)
 4. If no response, do a self-review instead
 5. Process Greptile findings same as CR: fix all valid findings in one commit, push once
-6. Reply to EVERY Greptile comment thread confirming the fix:
+6. Reply to EVERY Greptile comment thread confirming the fix using **plain text (no `@greptileai` mention)**:
    - Inline comments: `gh api repos/{owner}/{repo}/pulls/comments/{id}/replies -f body="Fixed in \`SHA\`: <what changed>"`
-   - Issue comments: `gh api repos/{owner}/{repo}/issues/{N}/comments -f body="@greptileai Fixed: <summary>"`
+   - Issue/PR-level comments: `gh pr comment N --body "Fixed in \`SHA\`: <what changed>"`
+   **Do NOT include `@greptileai` in replies** — every @mention triggers a new paid review ($0.50-$1.00).
+   Greptile does not learn from text replies (only from 👍/👎 reactions). Replies are for thread management only.
    Pushing code does NOT resolve threads — you MUST post explicit replies.
 
 ### After Greptile fix+push: severity-gated re-review


### PR DESCRIPTION
## Summary
- Removes `@greptileai` from all reply/acknowledgment comment instructions in `greptile.md` and `subagent-orchestration.md`
- Every `@greptileai` mention triggers a paid re-review ($0.50-$1.00) with no learning benefit — Greptile only learns from 👍/👎 reactions, not text replies
- `@greptileai` is now reserved exclusively for intentional re-review requests (P0 severity gate)
- Adds CR vs Greptile reply behavior comparison table for clarity

Closes #125

## Test plan
- [x] `greptile.md` "Processing Greptile Findings" section updated: replies to Greptile threads must NOT include `@greptileai`
- [x] `greptile.md` top-level Never block includes `@greptileai` reply prohibition
- [x] `subagent-orchestration.md` quick-reference Step 3 updated: Greptile reply examples use plain text (no @mention)
- [x] Only intentional re-review triggers (P0 severity gate) use `@greptileai`
- [x] Documentation note explains why Greptile replies differ from CR replies (cost + no learning)
- [x] No regression: CR reply behavior unchanged (still uses `@coderabbitai`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified interaction rules for the automated review tool: threaded replies must be plain text and must not include mentions of the tool; standalone mentions start a new paid review ($0.50–$1.00).
  * Added required plain-text reply templates for PR/issue/inline contexts (e.g., "Fixed in <SHA>: ...").
  * Emphasized that only 👍/👎 reactions count as learning signals and that explicit replies are required to resolve threads.
  * Added a CRITICAL disclaimer and a comparison summary of reply-format rules and learning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->