### PR TITLE
Raise gh issue list limits to 500 in PM skills, add truncation warnings

### DIFF
--- a/.claude/skills/pm-handoff/SKILL.md
+++ b/.claude/skills/pm-handoff/SKILL.md
@@ -80,7 +80,7 @@ You manage the backlog, track progress, write GitHub issues, and generate prompt
 {Leave empty with a placeholder: "No OKRs set. Use `/pm-okr set` to define objectives."}
 
 ## Workflow Rules
-1. Check repo state: `gh issue list --state open`, `gh pr list --state open`, `gh pr list --state merged --limit 10`
+1. Check repo state: `gh issue list --state open --limit 500`, `gh pr list --state open`, `gh pr list --state merged --limit 10`
 2. Identify what can run in parallel (no dependency conflicts)
 3. Write detailed prompts for each thread — each prompt should:
    - Reference the GitHub issue URL
@@ -124,7 +124,7 @@ Query current repo state:
 gh repo view --json nameWithOwner,description,url
 
 # Open issues
-gh issue list --state open --json number,title,labels,assignees,createdAt --limit 100
+gh issue list --state open --json number,title,labels,assignees,createdAt --limit 500
 
 # Open PRs
 gh pr list --state open --json number,title,headRefName,author,updatedAt,additions,deletions
@@ -132,6 +132,8 @@ gh pr list --state open --json number,title,headRefName,author,updatedAt,additio
 # Recent merges (last 20)
 gh pr list --state merged --limit 20 --json number,title,mergedAt,author
 ```
+
+**Truncation check:** If the returned issue count equals 500, warn: "Showing 500 issues — repo may have more. Results may be incomplete."
 
 If any command returns empty results, note that gracefully (e.g., "No open issues" rather than failing).
 

--- a/.claude/skills/pm-okr/SKILL.md
+++ b/.claude/skills/pm-okr/SKILL.md
@@ -46,8 +46,10 @@ If OKRs exist, display them formatted clearly with any progress indicators the u
 After displaying OKRs, fetch the open issue backlog and show which issues align with each key result:
 
 ```bash
-gh issue list --state open --json number,title,labels,body --limit 100
+gh issue list --state open --json number,title,labels,body --limit 500
 ```
+
+**Truncation check:** If the returned issue count equals 500, warn: "Showing 500 issues — repo may have more. Results may be incomplete."
 
 For each objective and key result, scan open issue titles, labels, and bodies to find alignment. Match by comparing key terms from the key result text against issue titles, labels, and body content. Only list issues with a clear keyword connection — do not force-match tangential issues.
 
@@ -88,8 +90,10 @@ gh pr list --state merged --search "merged:>$(date -v-30d '+%Y-%m-%d' 2>/dev/nul
 gh issue list --state closed --search "closed:>$(date -v-30d '+%Y-%m-%d' 2>/dev/null || date -d '30 days ago' '+%Y-%m-%d')" --json number,title --limit 50
 
 # Open issues (to see what's left)
-gh issue list --state open --json number,title,labels --limit 50
+gh issue list --state open --json number,title,labels --limit 500
 ```
+
+**Truncation check:** If the returned issue count equals 500, warn: "Showing 500 issues — repo may have more. Results may be incomplete."
 
 ### Step 3b: Identify themes
 

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -57,8 +57,10 @@ State files may be stale. Cross-reference with live data:
 ```bash
 gh pr list --state open --json number,title,headRefName,author,updatedAt
 gh pr list --state merged --limit 10 --json number,title,mergedAt
-gh issue list --state open --json number,title,labels,assignees --limit 100
+gh issue list --state open --json number,title,labels,assignees --limit 500
 ```
+
+**Truncation check:** If the returned issue count equals 500, warn: "Showing 500 issues — repo may have more. Results may be incomplete."
 
 - PRs that have merged since the handoff: mark as complete, remove from assignments.
 - Issues that have been closed: remove from backlog.
@@ -99,15 +101,17 @@ Extract the `## OKRs` section if present and non-placeholder. Set `OKR_MODE=true
 gh pr list --state merged --limit 20 --json number,title,mergedAt,author,body
 
 # Open issues — the backlog
-gh issue list --state open --json number,title,labels,assignees,createdAt,updatedAt --limit 100
+gh issue list --state open --json number,title,labels,assignees,createdAt,updatedAt --limit 500
 
 # Open PRs — detect in-flight work
 gh pr list --state open --json number,title,headRefName,author,updatedAt,additions,deletions
 ```
 
+**Truncation check:** If the returned issue count equals 500, warn: "Showing 500 issues — repo may have more. Results may be incomplete."
+
 ### 1B.3: Read issue bodies for top candidates
 
-Reading all 100 issue bodies is expensive. Use a two-pass approach:
+Reading all issue bodies is expensive. Use a two-pass approach:
 
 **Pass 1 — Quick scan:** From the issue list, identify the top ~20 candidates using fast signals:
 - Labels containing `bug`, `critical`, `P0`, `P1`, `urgent`, `blocked`


### PR DESCRIPTION
Closes #128

## Summary
- Raised all `gh issue list --state open` limits from 100 (or 50, or missing) to 500 across `pm`, `pm-handoff`, and `pm-okr` skills
- Added truncation detection warnings: when returned count equals 500, skills now emit "Showing 500 issues — repo may have more. Results may be incomplete."
- Fixed bare `gh issue list --state open` (no limit) in pm-handoff workflow rules template

## Test plan
- [x] All `gh issue list --state open` calls in PM skills use `--limit 500`
- [x] No `gh issue list` call exists without an explicit `--limit` parameter
- [x] When result count equals the limit, a truncation warning is emitted in the skill output
- [x] The `/pm-handoff` line 83 bare `gh issue list --state open` has an explicit limit
- [x] The `/pm-okr` line 91 limit is raised from 50 to 500
- [x] Skills already at 200-500 (`pm-clean`, `pm-sprint-plan`, `pm-sprint-review`, `pm-team-standup`, `pm-rate-team`) are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased the number of issues retrieved across PM workflows to better handle larger backlogs.
  * Added warnings when results may be incomplete due to hitting the retrieval limit.

* **Documentation**
  * Updated guidance and messaging to reflect the larger retrieval limit and the new truncation warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->