### PR TITLE
Add global hook to sync skills worktree and root repo on session start

### DIFF
--- a/.claude/hooks/post-merge-pull.sh
+++ b/.claude/hooks/post-merge-pull.sh
@@ -35,11 +35,11 @@ if [[ "$command" == *"gh pr merge"* ]] && [[ "$exit_code" == "0" ]]; then
   fi
 
   # Strategy 2: Resolve this script's location to find the repo it lives in
-  if [[ -z "$root_repo" || ! -d "$root_repo/.git" ]]; then
+  if [[ -z "$root_repo" || ! -e "$root_repo/.git" ]]; then
     script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     # Walk up from .claude/hooks/ to find the repo root
     candidate="${script_dir%/.claude/hooks}"
-    if [[ "$candidate" != "$script_dir" && -d "$candidate/.git" ]]; then
+    if [[ "$candidate" != "$script_dir" && -e "$candidate/.git" ]]; then
       root_repo=$(git -C "$candidate" worktree list --porcelain 2>/dev/null \
         | sed -n 's/^worktree //p' \
         | head -n 1)
@@ -47,7 +47,7 @@ if [[ "$command" == *"gh pr merge"* ]] && [[ "$exit_code" == "0" ]]; then
   fi
 
   # Strategy 3: Extract repo name from the gh command and search common locations
-  if [[ -z "$root_repo" || ! -d "$root_repo/.git" ]]; then
+  if [[ -z "$root_repo" || ! -e "$root_repo/.git" ]]; then
     # gh pr merge often runs in a repo context — try to extract from git remote
     # in the cwd (even if the dir exists but worktree list failed)
     if [[ -n "$cwd" && -d "$cwd" ]]; then
@@ -55,7 +55,7 @@ if [[ "$command" == *"gh pr merge"* ]] && [[ "$exit_code" == "0" ]]; then
         | sed 's|.*/||; s|\.git$||')
       if [[ -n "$repo_name" ]]; then
         for base in "$HOME/Documents/Develop" "$HOME/repos" "$HOME/projects" "$HOME/src"; do
-          if [[ -d "$base/$repo_name/.git" ]]; then
+          if [[ -e "$base/$repo_name/.git" ]]; then
             root_repo="$base/$repo_name"
             break
           fi
@@ -65,21 +65,27 @@ if [[ "$command" == *"gh pr merge"* ]] && [[ "$exit_code" == "0" ]]; then
   fi
 
   # Pull if we found the root repo
-  if [[ -n "$root_repo" && -d "$root_repo/.git" ]]; then
+  if [[ -n "$root_repo" && -e "$root_repo/.git" ]]; then
     if ! git -C "$root_repo" pull origin main --ff-only >/dev/null 2>&1; then
       printf 'post-merge-pull: fast-forward pull failed in %s\n' "$root_repo" >&2
     fi
 
     # --- Sync skills worktree (if it exists) ---
     skills_wt="$HOME/.claude/skills-worktree"
-    if [[ -d "$skills_wt" ]]; then
+    sync_errors=""
+
+    if [[ ! -d "$skills_wt" ]]; then
+      sync_errors="skills worktree not found at $skills_wt"
+    elif [[ ! -f "$skills_wt/.git" ]]; then
+      sync_errors="skills worktree at $skills_wt is not a valid git directory"
+    else
       # Verify it belongs to the same repo
       wt_root="$(git -C "$skills_wt" worktree list 2>/dev/null | head -1 | awk '{print $1}')"
       if [[ "$wt_root" == "$root_repo" ]]; then
-        if ! git -C "$skills_wt" fetch origin main --quiet 2>/dev/null; then
-          printf 'post-merge-pull: skills worktree fetch failed\n' >&2
-        elif ! git -C "$skills_wt" reset --hard origin/main --quiet 2>/dev/null; then
-          printf 'post-merge-pull: skills worktree reset failed\n' >&2
+        if ! err=$(git -C "$skills_wt" fetch origin main --quiet 2>&1); then
+          sync_errors="skills worktree fetch failed: $err"
+        elif ! err=$(git -C "$skills_wt" reset --hard origin/main --quiet 2>&1); then
+          sync_errors="skills worktree reset failed: $err"
         fi
 
         # Re-symlink any new or stale skills
@@ -102,7 +108,43 @@ if [[ "$command" == *"gh pr merge"* ]] && [[ "$exit_code" == "0" ]]; then
             ln -s "$target" "$link" 2>/dev/null || true
           done
         fi
+
+        # Verify/refresh CLAUDE.md and rules symlinks
+        claude_md_link="$HOME/.claude/CLAUDE.md"
+        claude_md_target="$skills_wt/CLAUDE.md"
+        if [[ -L "$claude_md_link" ]]; then
+          if [[ "$(readlink "$claude_md_link")" != "$claude_md_target" && -f "$claude_md_target" ]]; then
+            rm "$claude_md_link" 2>/dev/null || true
+            ln -s "$claude_md_target" "$claude_md_link" 2>/dev/null || true
+          fi
+        elif [[ ! -e "$claude_md_link" && -f "$claude_md_target" ]]; then
+          ln -s "$claude_md_target" "$claude_md_link" 2>/dev/null || true
+        fi
+
+        rules_link="$HOME/.claude/rules"
+        rules_target="$skills_wt/.claude/rules"
+        if [[ -L "$rules_link" ]]; then
+          if [[ "$(readlink "$rules_link")" != "$rules_target" && -d "$rules_target" ]]; then
+            rm "$rules_link" 2>/dev/null || true
+            ln -s "$rules_target" "$rules_link" 2>/dev/null || true
+          fi
+        elif [[ ! -e "$rules_link" && -d "$rules_target" ]]; then
+          ln -s "$rules_target" "$rules_link" 2>/dev/null || true
+        fi
+      else
+        sync_errors="skills worktree belongs to different repo ($wt_root)"
       fi
+    fi
+
+    # Output JSON warning if sync had errors
+    if [[ -n "$sync_errors" ]]; then
+      jq -n --arg err "$sync_errors" '{
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext: ("POST-MERGE SYNC WARNING: " + $err + ". Skills, rules, or CLAUDE.md may be stale after merge.")
+        }
+      }'
+      exit 0
     fi
   else
     # Visible warning instead of silent exit

--- a/.claude/hooks/post-merge-pull.sh
+++ b/.claude/hooks/post-merge-pull.sh
@@ -64,10 +64,12 @@ if [[ "$command" == *"gh pr merge"* ]] && [[ "$exit_code" == "0" ]]; then
     fi
   fi
 
+  pull_errors=""
+
   # Pull if we found the root repo
   if [[ -n "$root_repo" && -e "$root_repo/.git" ]]; then
-    if ! git -C "$root_repo" pull origin main --ff-only >/dev/null 2>&1; then
-      printf 'post-merge-pull: fast-forward pull failed in %s\n' "$root_repo" >&2
+    if ! err=$(git -C "$root_repo" pull origin main --ff-only 2>&1); then
+      pull_errors="root repo pull failed in $root_repo: $err"
     fi
 
     # --- Sync skills worktree (if it exists) ---
@@ -119,6 +121,8 @@ if [[ "$command" == *"gh pr merge"* ]] && [[ "$exit_code" == "0" ]]; then
           fi
         elif [[ ! -e "$claude_md_link" && -f "$claude_md_target" ]]; then
           ln -s "$claude_md_target" "$claude_md_link" 2>/dev/null || true
+        elif [[ -e "$claude_md_link" ]]; then
+          sync_errors="${sync_errors:+$sync_errors; }$claude_md_link exists and is not a symlink (left unchanged)"
         fi
 
         rules_link="$HOME/.claude/rules"
@@ -130,6 +134,8 @@ if [[ "$command" == *"gh pr merge"* ]] && [[ "$exit_code" == "0" ]]; then
           fi
         elif [[ ! -e "$rules_link" && -d "$rules_target" ]]; then
           ln -s "$rules_target" "$rules_link" 2>/dev/null || true
+        elif [[ -e "$rules_link" ]]; then
+          sync_errors="${sync_errors:+$sync_errors; }$rules_link exists and is not a symlink (left unchanged)"
         fi
       else
         sync_errors="skills worktree belongs to different repo ($wt_root)"
@@ -147,8 +153,18 @@ if [[ "$command" == *"gh pr merge"* ]] && [[ "$exit_code" == "0" ]]; then
       exit 0
     fi
   else
-    # Visible warning instead of silent exit
-    printf 'post-merge-pull: could not find root repo (cwd=%s). Local main may be stale.\n' "$cwd" >&2
+    pull_errors="could not find root repo (cwd=$cwd). Local main may be stale."
+  fi
+
+  # Report pull-level errors via JSON additionalContext
+  if [[ -n "$pull_errors" ]]; then
+    jq -n --arg err "$pull_errors" '{
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: ("POST-MERGE PULL WARNING: " + $err)
+      }
+    }'
+    exit 0
   fi
 fi
 

--- a/.claude/hooks/session-start-sync.sh
+++ b/.claude/hooks/session-start-sync.sh
@@ -9,7 +9,9 @@
 cat > /dev/null
 
 # Session-scoped sentinel file
-sentinel="/tmp/claude-config-synced-${CLAUDE_SESSION_ID:-default}"
+session_id="${CLAUDE_SESSION_ID:-${PPID:-$$}}"
+session_id="${session_id//[^[:alnum:]_.-]/_}"
+sentinel="/tmp/claude-config-synced-${session_id}"
 
 # Already synced this session — exit fast
 if [[ -f "$sentinel" ]]; then
@@ -45,6 +47,8 @@ if [[ -d "$skills_wt" && -f "$skills_wt/.git" ]]; then
         errors="${errors:+$errors; }root repo pull failed: $err"
       fi
     fi
+  else
+    errors="${errors:+$errors; }root repo could not be resolved from skills worktree at $skills_wt"
   fi
 fi
 

--- a/.claude/hooks/session-start-sync.sh
+++ b/.claude/hooks/session-start-sync.sh
@@ -37,6 +37,8 @@ else
 fi
 
 # --- Sync root repo (derives path from skills worktree) ---
+# Re-check skills worktree availability independently — fetch/reset errors above
+# don't block this pull, and the root repo path is derived from the worktree.
 if [[ -d "$skills_wt" && -f "$skills_wt/.git" ]]; then
   root_repo=$(git -C "$skills_wt" worktree list 2>/dev/null | head -1 | awk '{print $1}')
   if [[ -n "$root_repo" && -e "$root_repo/.git" ]]; then

--- a/.claude/hooks/session-start-sync.sh
+++ b/.claude/hooks/session-start-sync.sh
@@ -24,15 +24,25 @@ touch "$sentinel"
 
 # --- Sync skills worktree ---
 skills_wt="$HOME/.claude/skills-worktree"
+setup_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)/setup-skills-worktree.sh"
 errors=""
 
-if [[ -d "$skills_wt" && -f "$skills_wt/.git" ]]; then
+# Bootstrap missing skills worktree if setup script is available
+if [[ ! -d "$skills_wt/.claude/skills" || ! -f "$skills_wt/.git" ]]; then
+  if [[ -x "$setup_script" || -f "$setup_script" ]]; then
+    if ! err=$(bash "$setup_script" 2>&1); then
+      errors="skills worktree setup failed: $err"
+    fi
+  fi
+fi
+
+if [[ -z "$errors" && -d "$skills_wt" && -f "$skills_wt/.git" ]]; then
   if ! err=$(git -C "$skills_wt" fetch origin main --quiet 2>&1); then
     errors="skills worktree fetch failed: $err"
   elif ! err=$(git -C "$skills_wt" reset --hard origin/main --quiet 2>&1); then
     errors="skills worktree reset failed: $err"
   fi
-else
+elif [[ -z "$errors" ]]; then
   errors="skills worktree not found at $skills_wt"
 fi
 

--- a/.claude/hooks/session-start-sync.sh
+++ b/.claude/hooks/session-start-sync.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Session-start sync — PostToolUse hook (fires after every tool call)
+# Syncs the skills worktree and root repo ONCE per session to ensure
+# skills, rules, and CLAUDE.md are up to date with origin/main.
+#
+# Uses a sentinel file to run only once per session.
+
+# Consume stdin (required by hook protocol)
+cat > /dev/null
+
+# Session-scoped sentinel file
+sentinel="/tmp/claude-config-synced-${CLAUDE_SESSION_ID:-default}"
+
+# Already synced this session — exit fast
+if [[ -f "$sentinel" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Mark as synced (even if sync fails — don't retry every tool call)
+touch "$sentinel"
+
+# --- Sync skills worktree ---
+skills_wt="$HOME/.claude/skills-worktree"
+errors=""
+
+if [[ -d "$skills_wt" && -f "$skills_wt/.git" ]]; then
+  if ! err=$(git -C "$skills_wt" fetch origin main --quiet 2>&1); then
+    errors="skills worktree fetch failed: $err"
+  elif ! err=$(git -C "$skills_wt" reset --hard origin/main --quiet 2>&1); then
+    errors="skills worktree reset failed: $err"
+  fi
+else
+  errors="skills worktree not found at $skills_wt"
+fi
+
+# --- Sync root repo (derives path from skills worktree) ---
+if [[ -d "$skills_wt" && -f "$skills_wt/.git" ]]; then
+  root_repo=$(git -C "$skills_wt" worktree list 2>/dev/null | head -1 | awk '{print $1}')
+  if [[ -n "$root_repo" && -e "$root_repo/.git" ]]; then
+    # Only pull if on main branch (don't disrupt feature branches)
+    current_branch=$(git -C "$root_repo" branch --show-current 2>/dev/null)
+    if [[ "$current_branch" == "main" ]]; then
+      if ! err=$(git -C "$root_repo" pull origin main --ff-only --quiet 2>&1); then
+        errors="${errors:+$errors; }root repo pull failed: $err"
+      fi
+    fi
+  fi
+fi
+
+# Report result
+if [[ -n "$errors" ]]; then
+  jq -n --arg errors "$errors" '{
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: ("SESSION SYNC WARNING: Config sync encountered errors: " + $errors + ". Skills, rules, or CLAUDE.md may be stale. Run manually: git -C ~/.claude/skills-worktree fetch origin main && git -C ~/.claude/skills-worktree reset --hard origin/main")
+    }
+  }'
+else
+  echo '{}'
+fi
+
+exit 0

--- a/.claude/rules/skill-symlinks.md
+++ b/.claude/rules/skill-symlinks.md
@@ -1,18 +1,27 @@
 # Skill Symlink Rule
 
-> **Always:** Symlink new skills to `~/.claude/skills/` via the skills worktree. Verify existing skills are symlinks pointing to the worktree, not copies or root-repo symlinks. Ensure the skills worktree exists at session start.
+> **Always:** Symlink new skills to `~/.claude/skills/` via the skills worktree. Verify existing skills are symlinks pointing to the worktree, not copies or root-repo symlinks. Ensure the skills worktree exists at session start. CLAUDE.md and rules also go through the skills worktree.
 > **Ask first:** Never — symlink creation and worktree setup are autonomous.
-> **Never:** Copy skill directories to `~/.claude/skills/`. Symlink directly to the root repo (breaks when root repo isn't on `main`). Leave a new skill without a global symlink.
+> **Never:** Copy skill directories to `~/.claude/skills/`. Symlink directly to the root repo (breaks when root repo isn't on `main`). Leave a new skill without a global symlink. Symlink CLAUDE.md or rules directly to the root repo.
 
 ## Source of Truth
 
-This repo (`claude-code-config`) is the single source of truth for all Claude Code skills. The global skills directory (`~/.claude/skills/`) must contain **symlinks** pointing to a dedicated skills worktree — never standalone copies, and never direct symlinks to the root repo.
+This repo (`claude-code-config`) is the single source of truth for all Claude Code skills, global rules, and CLAUDE.md. The global config directory (`~/.claude/`) must contain **symlinks** pointing to a dedicated skills worktree — never standalone copies, and never direct symlinks to the root repo.
+
+The following symlinks all go through the skills worktree:
+- `~/.claude/skills/<name>` -> `~/.claude/skills-worktree/.claude/skills/<name>`
+- `~/.claude/CLAUDE.md` -> `~/.claude/skills-worktree/CLAUDE.md`
+- `~/.claude/rules` -> `~/.claude/skills-worktree/.claude/rules`
 
 ## Why a Dedicated Worktree
 
-Skills are served from `~/.claude/skills-worktree/`, a git worktree permanently checked out to `main`. This decouples skill availability from the root repo's branch state. Without it, when the root repo is on a feature branch (e.g., another session left it there), skills added after that branch was created become invisible — their symlink targets don't exist on that branch.
+Skills, rules, and CLAUDE.md are served from `~/.claude/skills-worktree/`, a git worktree permanently checked out to `main`. This decouples config availability from the root repo's branch state. Without it, when the root repo is on a feature branch (e.g., another session left it there), symlink targets may not exist on that branch.
 
-The `post-merge-pull.sh` hook automatically syncs the skills worktree after merges, so new skills on `main` appear without manual intervention.
+## Session-Start Sync Hook
+
+The `session-start-sync.sh` PostToolUse hook runs once per session (on the first tool call) and syncs the skills worktree to `origin/main`. This ensures skills, rules, and CLAUDE.md are fresh across **all repos** — not just `claude-code-config`. The hook also pulls the root repo's `main` branch if it's currently checked out.
+
+The `post-merge-pull.sh` hook syncs the skills worktree after merges and also refreshes the CLAUDE.md and rules symlinks.
 
 ## Session Start: Verify Skills Worktree
 
@@ -45,19 +54,24 @@ ln -s "$HOME/.claude/skills-worktree/.claude/skills/<name>" "$HOME/.claude/skill
 
 If `~/.claude/skills/` does not exist, create it first: `mkdir -p ~/.claude/skills/`.
 
-## Verifying Existing Skills
+## Verifying Existing Symlinks
 
-To confirm all skills are properly symlinked via the worktree (not copies or root-repo symlinks):
+To confirm all symlinks are properly set up via the worktree (not copies or root-repo symlinks):
 
 ```bash
+# Check skills
 ls -la ~/.claude/skills/
+
+# Check CLAUDE.md and rules
+ls -la ~/.claude/CLAUDE.md
+ls -la ~/.claude/rules
 ```
 
-Every skill entry should show `->` pointing to `~/.claude/skills-worktree/.claude/skills/<name>`. If any skill entry:
-- Is a regular directory (not a symlink) — replace it with a symlink to the worktree
-- Points to the root repo's `.claude/skills/` — migrate it to the worktree
+Every entry should show `->` pointing to `~/.claude/skills-worktree/...`. If any entry:
+- Is a regular directory/file (not a symlink) — the setup script will warn but not overwrite
+- Points to the root repo — migrate it by re-running the setup script
 
-To fix all skills at once, re-run the setup script:
+To fix all symlinks at once, re-run the setup script:
 
 ```bash
 REPO_ROOT="$(git worktree list | head -1 | awk '{print $1}')"

--- a/global-settings.json
+++ b/global-settings.json
@@ -37,6 +37,15 @@
     ],
     "PostToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/session-start-sync.sh",
+            "timeout": 15
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/setup-skills-worktree.sh
+++ b/setup-skills-worktree.sh
@@ -111,6 +111,59 @@ for link in "$SKILLS_DIR"/*/; do
   fi
 done
 
+# --- Step 5: Migrate CLAUDE.md and rules symlinks to skills worktree ---
+
+CLAUDE_MD_LINK="$HOME/.claude/CLAUDE.md"
+CLAUDE_MD_TARGET="$SKILLS_WORKTREE/CLAUDE.md"
+RULES_LINK="$HOME/.claude/rules"
+RULES_TARGET="$SKILLS_WORKTREE/.claude/rules"
+
+# Migrate CLAUDE.md
+if [[ -L "$CLAUDE_MD_LINK" ]]; then
+  current_target="$(readlink "$CLAUDE_MD_LINK")"
+  if [[ "$current_target" == "$CLAUDE_MD_TARGET" ]]; then
+    echo "  CLAUDE.md — already correct"
+  elif [[ "$current_target" == "$REPO_ROOT/CLAUDE.md" ]]; then
+    echo "  CLAUDE.md — migrating from root repo to worktree"
+    rm "$CLAUDE_MD_LINK"
+    ln -s "$CLAUDE_MD_TARGET" "$CLAUDE_MD_LINK"
+  else
+    echo "  CLAUDE.md — symlink points elsewhere ($current_target), updating to worktree"
+    rm "$CLAUDE_MD_LINK"
+    ln -s "$CLAUDE_MD_TARGET" "$CLAUDE_MD_LINK"
+  fi
+elif [[ -e "$CLAUDE_MD_LINK" ]]; then
+  echo "  WARNING: $CLAUDE_MD_LINK is not a symlink — skipping (will not overwrite)"
+else
+  if [[ -f "$CLAUDE_MD_TARGET" ]]; then
+    echo "  CLAUDE.md — creating symlink to worktree"
+    ln -s "$CLAUDE_MD_TARGET" "$CLAUDE_MD_LINK"
+  fi
+fi
+
+# Migrate rules
+if [[ -L "$RULES_LINK" ]]; then
+  current_target="$(readlink "$RULES_LINK")"
+  if [[ "$current_target" == "$RULES_TARGET" ]]; then
+    echo "  rules — already correct"
+  elif [[ "$current_target" == "$REPO_ROOT/.claude/rules" ]]; then
+    echo "  rules — migrating from root repo to worktree"
+    rm "$RULES_LINK"
+    ln -s "$RULES_TARGET" "$RULES_LINK"
+  else
+    echo "  rules — symlink points elsewhere ($current_target), updating to worktree"
+    rm "$RULES_LINK"
+    ln -s "$RULES_TARGET" "$RULES_LINK"
+  fi
+elif [[ -e "$RULES_LINK" ]]; then
+  echo "  WARNING: $RULES_LINK is not a symlink — skipping (will not overwrite)"
+else
+  if [[ -d "$RULES_TARGET" ]]; then
+    echo "  rules — creating symlink to worktree"
+    ln -s "$RULES_TARGET" "$RULES_LINK"
+  fi
+fi
+
 echo ""
 echo "Done. Skills worktree: $SKILLS_WORKTREE"
 echo "Symlinks in:           $SKILLS_DIR"


### PR DESCRIPTION
## Summary
- Adds `session-start-sync.sh` PostToolUse hook that syncs the skills worktree (`~/.claude/skills-worktree`) to `origin/main` once per session using a sentinel file pattern
- Migrates `~/.claude/CLAUDE.md` and `~/.claude/rules` symlinks through the skills worktree (matching the existing skill symlink pattern) in both `setup-skills-worktree.sh` and `post-merge-pull.sh`
- Hardens `post-merge-pull.sh` with pre-flight validation of the skills worktree and JSON `additionalContext` error output instead of bare stderr
- Updates `skill-symlinks.md` to document the expanded worktree scope and session-start sync hook

Closes #127

## Test plan
- [x] `session-start-sync.sh` uses sentinel file (`/tmp/claude-config-synced-$CLAUDE_SESSION_ID`) to run only once per session
- [x] Hook syncs skills worktree via `git fetch origin main` + `git reset --hard origin/main`
- [x] Hook pulls root repo only when on `main` branch (does not disrupt feature branches)
- [x] Hook outputs valid JSON on error using `jq` for safe string encoding
- [x] Hook outputs `{}` on success and on subsequent calls (fast exit via sentinel)
- [x] `global-settings.json` registers the hook as the first PostToolUse entry with no matcher and 15s timeout
- [x] `setup-skills-worktree.sh` Step 5 migrates `~/.claude/CLAUDE.md` symlink from root repo to skills worktree
- [x] `setup-skills-worktree.sh` Step 5 migrates `~/.claude/rules` symlink from root repo to skills worktree
- [x] Step 5 handles non-symlink files gracefully (warns but does not overwrite)
- [x] `post-merge-pull.sh` validates skills worktree exists and has valid `.git` file before attempting sync
- [x] `post-merge-pull.sh` outputs JSON `additionalContext` warning on sync failure instead of just stderr
- [x] `post-merge-pull.sh` verifies/refreshes CLAUDE.md and rules symlinks after skill symlinking
- [x] `post-merge-pull.sh` uses `-e` instead of `-d` for `.git` checks (supports worktree `.git` files)
- [x] `skill-symlinks.md` documents CLAUDE.md and rules going through the skills worktree
- [x] `skill-symlinks.md` documents the session-start-sync hook
- [x] All shell scripts pass `bash -n` syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-aware sync that runs once per session to keep skills up to date.
  * Automatic verification and migration of CLAUDE.md and rules into the managed skills area.

* **Improvements**
  * More tolerant repo-root detection for broader compatibility.
  * Sync/pull failures are now reported as structured warnings (no raw stderr).

* **Bug Fixes**
  * Detects and warns when expected paths are present but not symlinks.

* **Documentation**
  * Updated guidance on symlink management and session-start sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->