### PR TITLE
Standup skill: smart lookback window for weekends and holidays

### DIFF
--- a/.claude/skills/standup/SKILL.md
+++ b/.claude/skills/standup/SKILL.md
@@ -80,12 +80,15 @@ Generate a standup report summarizing what was accomplished since $ARGUMENTS (de
      while [ "$d" -le "$max_days" ]; do
        local candidate="${ym}-$(printf '%02d' $d)"
        local dow
-       dow=$(get_day_of_week "$candidate" 2>/dev/null) || break
+       dow=$(get_day_of_week "$candidate")
        if [ "$dow" -eq "$wd" ]; then
          last="$candidate"
        fi
        d=$((d + 1))
      done
+     if [ -z "$last" ]; then
+       return 1
+     fi
      echo "$last"
    }
 
@@ -177,7 +180,15 @@ Generate a standup report summarizing what was accomplished since $ARGUMENTS (de
      fi
    else
      # Smart default — LOOKBACK_DATE was computed above (most recent prior workday)
+     if [ -z "$LOOKBACK_DATE" ]; then
+       echo "Error: Failed to compute lookback date" >&2
+       exit 1
+     fi
      SINCE_ISO=$(TZ='America/New_York' date -d "${LOOKBACK_DATE} 12:00" '+%Y-%m-%dT%H:%M:%S%z' 2>/dev/null || TZ='America/New_York' date -jf '%Y-%m-%d %H:%M' "${LOOKBACK_DATE} 12:00" '+%Y-%m-%dT%H:%M:%S%z')
+     if [ -z "$SINCE_ISO" ]; then
+       echo "Error: Failed to convert lookback date to ISO timestamp" >&2
+       exit 1
+     fi
    fi
    SINCE_ISO=$(printf '%s' "$SINCE_ISO" | sed -E 's/([+-][0-9]{2})([0-9]{2})$/\1:\2/')
    ```


### PR DESCRIPTION
## Summary

- Adds smart lookback algorithm to `/standup` skill that finds the most recent prior workday, skipping weekends and US federal holidays (+ day-after-Thanksgiving)
- Computes holidays dynamically for current and previous year (handles year boundaries like Jan 2 → Dec 31)
- Explicit `$ARGUMENTS` override bypasses smart logic entirely
- Cross-platform: Linux `date -d` / macOS `date -v` fallbacks throughout

Closes #129

## Test plan

- [x] When called on Monday with no arguments, lookback defaults to previous Friday noon ET
- [x] When called on Tuesday after a Monday holiday, lookback defaults to previous Friday noon ET
- [x] When called the day after a multi-day holiday stretch, lookback goes to the last non-holiday weekday noon ET
- [x] When called with an explicit time argument, the smart lookback is bypassed entirely
- [x] When called on a regular Tuesday-Friday with no arguments, lookback defaults to previous day noon ET (existing behavior preserved)
- [x] Holiday list covers all 11 US federal holidays plus day-after-Thanksgiving
- [x] Observed-date rules are applied for fixed-date holidays falling on weekends
- [x] Floating-date holidays (MLK, Presidents' Day, etc.) are computed correctly for the current year

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standup skill now auto-determines the most recent prior business day when no date is specified, accounting for weekends, US federal holidays (including observed dates and the day after Thanksgiving), floating holidays, and year boundaries.
  * Auto cutoff is set to 12:00 America/New_York for consistent time references.

* **Bug Fixes / Robustness**
  * Manual date input remains supported and now fails loudly with a clear error if an invalid date is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->