### PR TITLE
Add mandatory severity gate checklist before Greptile re-triggers

### DIFF
--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -48,6 +48,15 @@ Greptile charges $1/review beyond the 50/month included quota. To prevent runawa
   > "Greptile budget exhausted ({reviews_used}/{budget}). PR #{N} falling back to self-review — merge blocked until manual review or budget resets tomorrow."
 - **This check applies to all Greptile trigger points** (CR GitHub fallback, local post-push, Phase B polling, and per-PR re-reviews). No `@greptileai` comment may be posted without passing the budget check first.
 
+## Before EVERY `@greptileai` Re-Trigger (MANDATORY — after initial trigger)
+
+Applies to 2nd/3rd triggers only; initial trigger requires only the budget check (no severity classification).
+
+1. **Classify all findings from the previous review** (P0/P1/P2).
+2. **If NO P0:** STOP — do NOT trigger `@greptileai`. Proceed to Phase B completion (merge gate check).
+3. **If P0 present:** perform budget check (see "Daily Budget" above) → trigger `@greptileai`.
+4. **Log severity counts in handoff `notes`.**
+
 ## When to Trigger Greptile
 
 **Greptile is fallback-only.** Never trigger it proactively alongside CR. It is only triggered when CR fails for a specific PR:
@@ -90,7 +99,7 @@ Classify by severity (P0/P1/P2 — use Greptile badges only), verify against cod
 - Issue/PR-level comments: `gh pr comment N --body "Fixed in \`SHA\`: <what changed>"`
 - **Never** include `@greptileai` in reply bodies. The only valid use of `@greptileai` is posting a standalone comment to intentionally request a new review (P0 re-review trigger).
 
-**Severity-gated re-review:** P0 present → re-trigger `@greptileai` after fix (this is an intentional re-review request, not a reply). P1/P2 only → merge-ready after fix push, no re-review needed.
+**Severity-gated re-review:** See the "Before EVERY `@greptileai` Re-Trigger" checklist above.
 
 ## Detecting a Merge-Ready Greptile Review
 

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -119,8 +119,9 @@ Subagents have a hardcoded **32K output token limit** that cannot be configured 
 - If this PR is on CR: poll for CR review (fast-path + 7-minute slow-path Greptile trigger). If Greptile is triggered, the PR switches to Greptile permanently.
 - If this PR is already on Greptile: skip CR polling, trigger `@greptileai` and poll for Greptile response directly.
 - If Greptile posts findings: classify by severity (P0/P1/P2). Fix all valid findings, commit, push, reply.
-  - If any P0: trigger `@greptileai` again for re-review (max 3 total Greptile reviews per PR).
-  - If only P1/P2 (no P0): merge-ready after fix push — no re-review needed.
+  - **BEFORE any re-trigger:** Run the severity gate checklist (see `greptile.md` "Before EVERY `@greptileai` Re-Trigger (MANDATORY — after initial trigger)").
+  - If any P0: proceed through severity gate → budget check → trigger `@greptileai` again (max 3 total Greptile reviews per PR).
+  - If only P1/P2 (no P0): STOP — merge-ready after fix push. Do NOT trigger `@greptileai`. Proceed to Phase B completion.
 - If clean pass on CR: trigger one more `@coderabbitai full review` for confirmation (2 clean CR passes needed)
 - If clean Greptile pass (no findings at all): merge-ready immediately.
 - **Phase B Completion:** Update the handoff file at `~/.claude/handoffs/pr-{N}-handoff.json` — set `phase_completed` to `"B"`, refresh `head_sha` if there was a new push, and merge new entries into `findings_fixed`, `threads_replied`, `threads_resolved`, and `files_changed`. **Deduplicate deterministically per field:** for `string[]` fields (`findings_fixed`, `threads_replied`, `threads_resolved`, `files_changed`), dedupe by exact string value; for object arrays (`findings_dismissed`), dedupe by `.id`. This prevents duplicate accumulation when replacement agents re-process the same findings.
@@ -447,11 +448,13 @@ If you see the ack but no review within 7 minutes, CR failed to deliver.
    Greptile does not learn from text replies (only from 👍/👎 reactions). Replies are for thread management only.
    Pushing code does NOT resolve threads — you MUST post explicit replies.
 
-### After Greptile fix+push: severity-gated re-review
+### After Greptile fix+push: severity-gated re-review (MANDATORY checklist)
 Once a PR is on Greptile, it stays on Greptile. Do NOT switch back to CR.
-- **If the review had P0 findings:** After pushing fixes, trigger `@greptileai` again to confirm P0 resolution.
-- **If the review had only P1/P2 (no P0):** Do NOT trigger `@greptileai` again. The PR is merge-ready after the fix push.
-- **Max 3 Greptile reviews per PR** (initial + up to 2 P0 re-reviews). After 3, self-review + tell user.
+1. **Classify all findings** (P0/P1/P2).
+2. **If NO P0:** STOP — skip `@greptileai`. Proceed to merge gate.
+3. **If P0 present:** budget check → trigger `@greptileai`.
+4. **Log severity counts in handoff notes.**
+5. **Max 3 Greptile reviews per PR** (initial + up to 2 P0 re-reviews). After 3, self-review + tell user.
 
 ### Greptile clean / merge-ready detection
 A Greptile review is merge-ready when:


### PR DESCRIPTION
## Summary
- Converts the declarative "only re-review for P0" rule into a procedural checklist that mirrors the budget gate pattern
- Adds new "Before EVERY @greptileai Re-Trigger (MANDATORY)" section to `greptile.md` with 4-step numbered checklist
- Updates `subagent-orchestration.md` quick-reference with numbered steps and explicit STOP condition
- Adds gate reference to Phase B flow before any re-trigger decision

Closes #132

## Test plan
- [x] `greptile.md` has a new "Before EVERY @greptileai Re-Trigger" section with the numbered checklist
- [x] `subagent-orchestration.md` quick-reference "After Greptile fix+push" section uses numbered steps with explicit STOP condition
- [x] `subagent-orchestration.md` Phase B flow includes explicit gate reference before re-trigger
- [x] Existing severity-gate language in both files is preserved (the new sections complement, not replace)
- [x] No changes to the initial Greptile trigger flow (CR fallback path) — only re-triggers are gated
- [x] Old duplicate "Severity-gated re-review" prose in Processing Greptile Findings replaced with forward reference
- [x] Step ordering in quick-reference matches canonical greptile.md order

🤖 Generated with [Claude Code](https://claude.com/claude-code)