### PR TITLE
Fix CR issue plan polling: use 'coderabbitai' not 'coderabbitai[bot]' for issue comments

### DIFF
--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -38,8 +38,9 @@ CR automatically posts an implementation plan when issues are created (triggered
 
 > **Username note:** Use `coderabbitai` (no `[bot]` suffix) for issue comments; PR reviews use `coderabbitai[bot]`.
 
-- **If the issue is older than 10 minutes:** Check comments for a plan from `coderabbitai`. If it exists, read it. If it doesn't exist (CR may not have been triggered), post `@coderabbitai plan` now and poll for up to 5 minutes. If still no response, proceed without it.
-- **If the issue is less than 10 minutes old:** CR may still be generating the plan. Poll every 60 seconds for a comment from `coderabbitai` on the issue. Timeout after 10 minutes from issue creation time — if no plan appears by then, proceed without it.
+- **Issue age determines the polling strategy:**
+  - Older than 10 minutes: Check comments for a plan from `coderabbitai`. If it exists, read it. If it doesn't exist (CR may not have been triggered), post `@coderabbitai plan` now and poll for up to 5 minutes. If still no response, proceed without it.
+  - Less than 10 minutes old: CR may still be generating the plan. Poll every 60 seconds for a comment from `coderabbitai` on the issue. Timeout after 10 minutes from issue creation time — if no plan appears by then, proceed without it.
 
 ### 3. Build Claude's plan
 - Explore the codebase and design an implementation plan (use plan mode)

--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -36,8 +36,10 @@ When starting work on a GitHub issue, always follow this flow before writing any
 ### 2. Check for CR's implementation plan
 CR automatically posts an implementation plan when issues are created (triggered by `@coderabbitai plan`). Check whether it exists:
 
-- **If the issue is older than 10 minutes:** Check comments for a plan from `coderabbitai[bot]`. If it exists, read it. If it doesn't exist (CR may not have been triggered), post `@coderabbitai plan` now and poll for up to 5 minutes. If still no response, proceed without it.
-- **If the issue is less than 10 minutes old:** CR may still be generating the plan. Poll every 60 seconds for a comment from `coderabbitai[bot]` on the issue. Timeout after 10 minutes from issue creation time — if no plan appears by then, proceed without it.
+> **Username note:** Use `coderabbitai` (no `[bot]` suffix) for issue comments; PR reviews use `coderabbitai[bot]`.
+
+- **If the issue is older than 10 minutes:** Check comments for a plan from `coderabbitai`. If it exists, read it. If it doesn't exist (CR may not have been triggered), post `@coderabbitai plan` now and poll for up to 5 minutes. If still no response, proceed without it.
+- **If the issue is less than 10 minutes old:** CR may still be generating the plan. Poll every 60 seconds for a comment from `coderabbitai` on the issue. Timeout after 10 minutes from issue creation time — if no plan appears by then, proceed without it.
 
 ### 3. Build Claude's plan
 - Explore the codebase and design an implementation plan (use plan mode)


### PR DESCRIPTION
## Summary
- CR uses `coderabbitai` (no `[bot]`) for issue comments but `coderabbitai[bot]` for PR reviews
- `issue-planning.md` was filtering by `coderabbitai[bot]` on issue endpoints, silently missing CR's plan
- Added a username note callout and updated both polling rules to use the correct login

## Test plan
- [x] `issue-planning.md` filters issue comments by `coderabbitai` (no `[bot]` suffix)
- [x] A note distinguishing the two CR usernames is present to prevent future regression

Closes #137