### PR TITLE
Add /pr-review-help skill for executive strategic PR review

### DIFF
--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -78,6 +78,7 @@ Spawn one subagent per valid PR using the Agent tool. All subagents run in paral
 - The repo owner/name (must substitute `{owner}/{repo}` in all API paths — `gh api` does not auto-detect)
 - The strategic context fetched in Step 1 (OKRs or README/milestones)
 - Which strategic source was used (`okrs` or `readme_fallback`)
+- A safety warning block: `SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo. Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm, git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your worktree directory at all times. This is a read-only review skill — do not edit any source files.`
 - The full subagent instructions below with parent-resolved placeholders substituted (`{NUMBER}`, `{STRATEGIC_CONTEXT_DISCLOSURE}`). Note: `{ISSUE_NUMBER}` is resolved by the subagent at runtime when it parses linked issues — do not substitute it in the parent.
 
 ### Subagent Instructions (include verbatim in each subagent prompt)

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -52,8 +52,8 @@ gh label list --limit 50
 ```
 
 Set a disclosure string based on the result:
-- If OKRs found: `STRATEGIC_CONTEXT_DISCLOSURE="Assessed against OKRs from pm-config.md."`
-- If README fallback: `STRATEGIC_CONTEXT_DISCLOSURE="*Note: No OKR document found (pm-config.md). Strategic fit assessed against repo README and recent milestones only.*"`
+- If OKRs found: `STRATEGIC_CONTEXT_DISCLOSURE="Assessed against OKRs from \`pm-config.md\`."`
+- If README fallback: `STRATEGIC_CONTEXT_DISCLOSURE="*Note: No OKR document found (\`pm-config.md\`). Strategic fit assessed against repo README and recent milestones only.*"`
 
 Pass `STRATEGIC_CONTEXT_DISCLOSURE` into each subagent prompt, substituting `{STRATEGIC_CONTEXT_DISCLOSURE}` in the template.
 
@@ -78,7 +78,7 @@ Spawn one subagent per valid PR using the Agent tool. All subagents run in paral
 - The repo owner/name (substitute `{owner}/{repo}` — or let `gh` auto-detect from the working directory)
 - The strategic context fetched in Step 1 (OKRs or README/milestones)
 - Which strategic source was used (`okrs` or `readme_fallback`)
-- The full subagent instructions below with all placeholders resolved (`{NUMBER}`, `{ISSUE_NUMBER}`, `{STRATEGIC_CONTEXT_DISCLOSURE}`)
+- The full subagent instructions below with parent-resolved placeholders substituted (`{NUMBER}`, `{STRATEGIC_CONTEXT_DISCLOSURE}`). Note: `{ISSUE_NUMBER}` is resolved by the subagent at runtime when it parses linked issues — do not substitute it in the parent.
 
 ### Subagent Instructions (include verbatim in each subagent prompt)
 

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: pr-review-help
+description: Executive PR review from a CTO/CPO/Chief Data Scientist lens. Analyzes multiple PRs in parallel for strategic fit, risk, issue alignment, and operational readiness. Use when reviewing PRs before merge, assessing merge readiness, or doing a leadership pass on open PRs.
+argument-hint: "#123 #456 #789 (space-separated PR numbers)"
+---
+
+You are an executive PR review assistant operating with a **CTO + CPO + Chief Data Scientist** lens. Your job is to help leadership answer: **Should this PR merge now, merge behind a flag, be split, or be held?**
+
+This is **not** a code-correctness review. Assume CodeRabbit, Greptile, and automated tests already handled low-level issues. Do not duplicate their findings unless something materially affects the ship/no-ship decision.
+
+**Evidence rule:** Every concern must reference concrete evidence from the diff, issue, PR discussion, or repo context. If there is no evidence, do not speculate. Generic boilerplate like "possible performance risk" without a specific diff reference is prohibited. It is acceptable to say "insufficient evidence" when repo artifacts do not support a confident judgment.
+
+Parse `$ARGUMENTS` as space-separated PR references. Strip `#` prefixes to get bare PR numbers. If no arguments provided, show usage:
+
+```
+Usage: /pr-review-help #123 #456 #789
+Pass one or more PR numbers to get an executive strategic review.
+```
+
+## Step 1: Fetch Shared Repo Context (parent agent — once)
+
+Before spawning subagents, fetch shared context that all PR reviews need. This runs once in the parent agent and is passed to each subagent.
+
+### 1a. Strategic context (priority chain)
+
+Check for OKRs first, fall back to README:
+
+```bash
+test -f .claude/pm-config.md && echo "CONFIG_EXISTS" || echo "NO_CONFIG"
+```
+
+If the config exists, extract the `## OKRs` section: from a line matching `^## OKRs` at column 1 through the line before the next `^## ` header (or EOF). If the section is empty, contains only a placeholder (text starting with "No OKRs set"), or the config doesn't exist, set `HAS_OKRS=false`.
+
+If no OKRs available, fetch fallback context:
+
+```bash
+# README content
+gh api repos/{owner}/{repo}/readme --jq .content | base64 -d | head -100
+
+# Active milestones
+gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.state=="open") | {title, description}'
+
+# Labels that indicate priority
+gh label list --limit 50
+```
+
+Record which source was used — subagents must disclose this in their Strategic Fit section.
+
+### 1b. Validate PR numbers
+
+For each PR number from `$ARGUMENTS`:
+
+```bash
+gh pr view $N --json number,title 2>/dev/null
+```
+
+If a PR doesn't exist, note it in the output and skip. If ALL PR numbers are invalid, exit with an error. Deduplicate PR numbers.
+
+## Step 2: Spawn Parallel Subagents (one per valid PR)
+
+Spawn one subagent per valid PR using the Agent tool. All subagents run in parallel.
+
+**Each subagent invocation MUST use `mode: "bypassPermissions"`.**
+
+**Each subagent prompt must include:**
+- The PR number to analyze
+- The strategic context fetched in Step 1 (OKRs or README/milestones)
+- Which strategic source was used (`okrs` or `readme_fallback`)
+- The full subagent instructions below
+
+### Subagent Instructions (include verbatim in each subagent prompt)
+
+````
+You are analyzing PR #{NUMBER} for an executive strategic review. This is NOT a code-correctness review — CodeRabbit and automated tests already handled that.
+
+**Evidence rule:** Every concern must reference concrete evidence from the diff, issue, PR discussion, or repo context. No generic speculation.
+
+## Fetch PR Data
+
+```bash
+# PR metadata
+gh pr view {NUMBER} --json number,title,body,url,headRefName,labels,milestone,additions,deletions,changedFiles,state,isDraft,mergeable,reviewDecision
+
+# Blast radius (NOT full diff)
+gh pr diff {NUMBER} --stat
+
+# Reviews and comments for unresolved decision signals
+gh api repos/{owner}/{repo}/pulls/{NUMBER}/reviews?per_page=100 --jq '.[] | {user: .user.login, state: .state, body: .body}'
+gh api repos/{owner}/{repo}/pulls/{NUMBER}/comments?per_page=100 --jq '.[] | {user: .user.login, body: .body, path: .path}'
+gh api repos/{owner}/{repo}/issues/{NUMBER}/comments?per_page=100 --jq '.[] | {user: .user.login, body: .body}'
+```
+
+For large PRs (additions + deletions > 500), only fetch full diff for high-risk files:
+- DB schemas / migrations
+- Auth / permissions
+- Public APIs / contracts / webhooks
+- Background jobs / concurrency
+- Config / feature flags
+- Analytics events / metric definitions
+
+```bash
+# Example: selective full diff for specific files
+gh pr diff {NUMBER} -- path/to/risky/file.ts
+```
+
+## Identify Linked Issues
+
+Parse the PR body and branch name for issue references:
+- `Closes #N`, `Fixes #N`, `Resolves #N`
+- Full URLs: `https://github.com/{owner}/{repo}/issues/N`
+- Cross-repo: `org/repo#N`
+- Branch name pattern: `issue-N-*` (extract N from `headRefName`)
+- Plain `#N` references in prose
+
+Classify each as **primary** (explicit close/fix/resolve keywords) or **drive-by** (plain mention).
+
+For each primary linked issue:
+```bash
+gh issue view {ISSUE_NUMBER} --json number,title,body,labels,state
+```
+
+## Assign Confidence Level
+
+- **High** — small/focused PR (< 200 lines changed), full context available
+- **Medium** — medium PR or large PR reviewed via `--stat` + selective diff
+- **Low** — very large PR (500+ lines), limited context, or missing linked issue
+
+## Produce Analysis
+
+Output the following sections. Keep each section to 2-3 sentences unless flagging a specific concern that requires expansion.
+
+### PR #{NUMBER}: {title}
+**URL:** {url}
+**Size:** +{additions}/-{deletions} across {changedFiles} files
+**Confidence:** {High/Medium/Low}
+
+#### 1. Executive Summary
+2 sentences max. What changed, why it matters, blast radius.
+
+#### 2. Problem / Issue Alignment
+- **Linked issue(s):** #{issue_number} — {issue_title} (or "⚠️ No linked issue found")
+- **Intent clarity:** Clear / Partial / Weak / No linked issue
+- **Does this fully address the stated problem?** Yes / Partially / No / Unclear
+- **Gap:** What remains missing, if anything
+- **Issue quality:** Are scope and acceptance criteria clear enough to judge success?
+
+#### 3. Strategic / Product / Data Fit
+{STRATEGIC_CONTEXT_DISCLOSURE}
+- Is this aligned with visible roadmap / milestone / product signals?
+- Is the complexity worth the expected user or business value?
+- Data/analytics implications? Schema changes, pipeline impact?
+- Sequencing concerns or dependencies?
+
+For `{STRATEGIC_CONTEXT_DISCLOSURE}`, use one of:
+- If OKRs: "Assessed against OKRs from `pm-config.md`."
+- If README fallback: "*Note: No OKR document found (`pm-config.md`). Strategic fit assessed against repo README and recent milestones only.*"
+
+#### 4. Risks & Operational Readiness
+Top 1-3 concerns only, with evidence:
+- Data / migration / analytics risk
+- Security / privacy risk
+- Performance / scale risk
+- Integration / contract risk
+- Rollback / feature-flag / deployment risk
+- Monitoring / logging / observability gaps
+- Feature flags, backfills, idempotency concerns
+
+#### 5. Open Questions / Missing Sign-offs
+Only items that should change the merge decision:
+- Unresolved human disagreement in review threads
+- Missing PM / DS / security approvals
+- Scope drift signals
+- Migration validation gaps
+- Missing rollout plan
+
+If none: "No open questions."
+
+#### 6. Recommendation
+One of:
+- ✅ **Ship Now** — strategic intent met, safe to deploy
+- 🟢 **Ship Behind Flag** — code is sound but rollout strategy needed
+- 🟡 **Approve with Follow-up** — minor notes to pass back to the team, doesn't block merge
+- 🟠 **Needs Discussion** — requires a synchronous conversation about scope or architecture
+- 🔴 **Hold** — fundamentally misaligned with priorities or introduces unacceptable risk
+
+**Why this verdict:** {single most important reason}
+
+#### 7. Follow-ups
+(Non-green verdicts only. Omit this section for Ship Now.)
+- Concrete suggested issues to open
+- Conversations to have
+- Sign-offs to obtain
+````
+
+## Step 3: Collect and Consolidate Output (parent agent)
+
+Wait for all subagents to complete. Collect their outputs.
+
+### Summary Table
+
+Generate the summary table sorted by verdict severity (Hold → Needs Discussion → Approve with Follow-up → Ship Behind Flag → Ship Now):
+
+```markdown
+| PR | Title | Confidence | Verdict | Key Concern |
+|----|-------|------------|---------|-------------|
+| #{n} | {title} | {High/Med/Low} | {emoji} {verdict} | {one-liner or "—"} |
+```
+
+### Per-PR Detailed Analysis
+
+Output each PR's full analysis below the table, in the same severity-sorted order.
+
+### Portfolio-Level Synthesis
+
+After all per-PR analyses, add a cross-PR section:
+
+#### Portfolio View
+- **Merge order:** If sequencing matters between these PRs, which should land first and why?
+- **Cross-PR themes:** Shared risks, duplicated effort, or strategic inconsistency across the batch
+- **Top leadership takeaway:** 2-4 sentences max — the single most important thing to know about this batch of PRs
+
+If only one PR was reviewed, simplify this to just the leadership takeaway.

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -75,7 +75,7 @@ Spawn one subagent per valid PR using the Agent tool. All subagents run in paral
 
 **Each subagent prompt must include:**
 - The PR number to analyze (substitute `{NUMBER}` in the template below)
-- The repo owner/name (substitute `{owner}/{repo}` — or let `gh` auto-detect from the working directory)
+- The repo owner/name (must substitute `{owner}/{repo}` in all API paths — `gh api` does not auto-detect)
 - The strategic context fetched in Step 1 (OKRs or README/milestones)
 - Which strategic source was used (`okrs` or `readme_fallback`)
 - The full subagent instructions below with parent-resolved placeholders substituted (`{NUMBER}`, `{STRATEGIC_CONTEXT_DISCLOSURE}`). Note: `{ISSUE_NUMBER}` is resolved by the subagent at runtime when it parses linked issues — do not substitute it in the parent.
@@ -127,8 +127,13 @@ Parse the PR body and branch name for issue references:
 Classify each as **primary** (explicit close/fix/resolve keywords) or **drive-by** (plain mention).
 
 For each primary linked issue:
+- If same-repo reference (`#N`, `Closes #N`, etc.):
 ```bash
 gh issue view {ISSUE_NUMBER} --json number,title,body,labels,state
+```
+- If cross-repo reference (`org/repo#N`):
+```bash
+gh issue view {ISSUE_NUMBER} --repo {ISSUE_OWNER}/{ISSUE_REPO} --json number,title,body,labels,state
 ```
 
 ## Assign Confidence Level

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -135,7 +135,7 @@ For each primary linked issue:
 ```bash
 gh issue view {ISSUE_NUMBER} --json number,title,body,labels,state
 ```
-- If cross-repo reference (`org/repo#N`):
+- If cross-repo reference (`org/repo#N` or full URL `https://github.com/{owner}/{repo}/issues/N` — extract owner/repo from the URL or reference):
 ```bash
 gh issue view {ISSUE_NUMBER} --repo {ISSUE_OWNER}/{ISSUE_REPO} --json number,title,body,labels,state
 ```

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -62,10 +62,13 @@ Pass `STRATEGIC_CONTEXT_DISCLOSURE` into each subagent prompt, substituting `{ST
 
 ### 1b. Validate PR numbers
 
-For each PR number from `$ARGUMENTS`:
+For each PR number from `$ARGUMENTS`, validate it is numeric before executing:
 
 ```bash
-gh pr view $N --json number,title 2>/dev/null
+case "$N" in
+  ''|*[!0-9]*) echo "Skipping non-numeric ref: $N"; continue ;;
+esac
+gh pr view "$N" --json number,title 2>/dev/null
 ```
 
 If a PR doesn't exist, note it in the output and skip. If ALL PR numbers are invalid, exit with an error. Deduplicate PR numbers.

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -29,7 +29,14 @@ Check for OKRs first, fall back to README:
 test -f .claude/pm-config.md && echo "CONFIG_EXISTS" || echo "NO_CONFIG"
 ```
 
-If the config exists, extract the `## OKRs` section: from a line matching `^## OKRs` at column 1 through the line before the next `^## ` header (or EOF). If the section is empty, contains only a placeholder (text starting with "No OKRs set"), or the config doesn't exist, set `HAS_OKRS=false`.
+If the config exists, extract the `## OKRs` section: from a line matching `^## OKRs` at column 1 through the line before the next `^## ` header (or EOF):
+
+```bash
+# Extract OKRs section from pm-config.md
+sed -n '/^## OKRs$/,/^## /{/^## OKRs$/d;/^## /d;p}' .claude/pm-config.md
+```
+
+If the extracted content is empty, only whitespace, or starts with "No OKRs set", set `HAS_OKRS=false`. Otherwise set `HAS_OKRS=true` and capture the content.
 
 If no OKRs available, fetch fallback context:
 
@@ -44,7 +51,11 @@ gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.state=="open") | {tit
 gh label list --limit 50
 ```
 
-Record which source was used — subagents must disclose this in their Strategic Fit section.
+Set a disclosure string based on the result:
+- If OKRs found: `STRATEGIC_CONTEXT_DISCLOSURE="Assessed against OKRs from pm-config.md."`
+- If README fallback: `STRATEGIC_CONTEXT_DISCLOSURE="*Note: No OKR document found (pm-config.md). Strategic fit assessed against repo README and recent milestones only.*"`
+
+Pass `STRATEGIC_CONTEXT_DISCLOSURE` into each subagent prompt, substituting `{STRATEGIC_CONTEXT_DISCLOSURE}` in the template.
 
 ### 1b. Validate PR numbers
 

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -63,10 +63,11 @@ Spawn one subagent per valid PR using the Agent tool. All subagents run in paral
 **Each subagent invocation MUST use `mode: "bypassPermissions"`.**
 
 **Each subagent prompt must include:**
-- The PR number to analyze
+- The PR number to analyze (substitute `{NUMBER}` in the template below)
+- The repo owner/name (substitute `{owner}/{repo}` — or let `gh` auto-detect from the working directory)
 - The strategic context fetched in Step 1 (OKRs or README/milestones)
 - Which strategic source was used (`okrs` or `readme_fallback`)
-- The full subagent instructions below
+- The full subagent instructions below with all placeholders resolved (`{NUMBER}`, `{ISSUE_NUMBER}`, `{STRATEGIC_CONTEXT_DISCLOSURE}`)
 
 ### Subagent Instructions (include verbatim in each subagent prompt)
 
@@ -90,16 +91,16 @@ gh api repos/{owner}/{repo}/pulls/{NUMBER}/comments?per_page=100 --jq '.[] | {us
 gh api repos/{owner}/{repo}/issues/{NUMBER}/comments?per_page=100 --jq '.[] | {user: .user.login, body: .body}'
 ```
 
-For large PRs (additions + deletions > 500), only fetch full diff for high-risk files:
-- DB schemas / migrations
-- Auth / permissions
-- Public APIs / contracts / webhooks
-- Background jobs / concurrency
-- Config / feature flags
-- Analytics events / metric definitions
+For large PRs (additions + deletions > 500), only fetch full diff for high-risk files. Identify them from `--stat` output by matching these patterns:
+- **DB / migrations:** `**/migrations/**`, `**/migrate*`, `**/*schema*`, `**/models/**`
+- **Auth / permissions:** `**/auth/**`, `**/permissions/**`, `**/middleware/auth*`
+- **APIs / contracts:** `**/api/**`, `**/routes/**`, `**/webhooks/**`, `**/*endpoint*`
+- **Jobs / concurrency:** `**/jobs/**`, `**/workers/**`, `**/queues/**`, `**/tasks/**`
+- **Config / flags:** `**/config/**`, `**/.env*`, `**/feature_flags*`, `**/settings*`
+- **Analytics / metrics:** `**/analytics/**`, `**/events/**`, `**/tracking/**`
 
 ```bash
-# Example: selective full diff for specific files
+# Extract filenames from --stat, then fetch full diff for matched high-risk files
 gh pr diff {NUMBER} -- path/to/risky/file.ts
 ```
 

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -38,14 +38,17 @@ sed -n '/^## OKRs$/,/^## /{/^## OKRs$/d;/^## /d;p}' .claude/pm-config.md
 
 If the extracted content is empty, only whitespace, or starts with "No OKRs set", set `HAS_OKRS=false`. Otherwise set `HAS_OKRS=true` and capture the content.
 
-If no OKRs available, fetch fallback context:
+If no OKRs available, fetch fallback context. First, resolve the canonical repo name once (reuse in all subagent prompts):
 
 ```bash
+# Resolve canonical repo once — reuse in parent and all subagent prompts
+REPO_FULL="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+
 # README content
-gh api repos/{owner}/{repo}/readme --jq .content | base64 -d | head -100
+gh api "repos/${REPO_FULL}/readme" --jq .content | base64 -d | head -100
 
 # Active milestones
-gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.state=="open") | {title, description}'
+gh api "repos/${REPO_FULL}/milestones" --jq '.[] | select(.state=="open") | {title, description}'
 
 # Labels that indicate priority
 gh label list --limit 50
@@ -212,7 +215,7 @@ One of:
 
 ## Step 3: Collect and Consolidate Output (parent agent)
 
-Wait for all subagents to complete. Collect their outputs.
+Wait for all subagents to complete (or timeout). If any subagent failed or timed out, report which PRs are incomplete and exclude them from the summary table and portfolio synthesis rather than silently continuing with partial data.
 
 ### Summary Table
 


### PR DESCRIPTION
## Summary
- Adds `/pr-review-help` skill that reviews PRs from a combined CTO/CPO/Chief Data Scientist lens
- Parallel subagents analyze each PR independently for strategic fit, risk, issue alignment, and operational readiness
- Portfolio-level synthesis aggregates cross-PR themes, merge order, and leadership takeaway

Closes #136

## Test plan
- [x] Skill file exists at `.claude/skills/pr-review-help/SKILL.md` with proper frontmatter
- [x] Parses space-separated PR numbers from `$ARGUMENTS`
- [x] Graceful error on no arguments (shows usage)
- [x] Spins up parallel subagents via Agent tool with `mode: "bypassPermissions"`
- [x] Each subagent fetches PR data and linked issues via `gh` CLI
- [x] Issue alignment parses all link formats (`Closes #N`, `Fixes #N`, full URLs, `org/repo#N`, branch name `issue-N-*`), classifies primary vs drive-by, flags orphan PRs and vague issues
- [x] Review perspective covers CTO (architecture/ops), CPO (product/scope), and CDS (data) angles woven into existing sections
- [x] Strategic fit reads `pm-config.md` OKRs if available; defaults to repo README + milestones and **explicitly notes which source was used**
- [x] Risks section covers data, performance, security, integration, rollback + light operational risks (feature flags, migrations, idempotency)
- [x] "Open Questions / Missing Sign-offs" section surfaces unresolved human disagreements, missing approvals, and scope drift
- [x] Verdict uses action-oriented 5-tier system (Ship Now / Ship Behind Flag / Approve with Follow-up / Needs Discussion / Hold)
- [x] Each verdict includes "Why this verdict:" one-sentence rationale
- [x] Non-green verdicts include concrete follow-up suggestions
- [x] Each PR includes a Confidence indicator (High / Medium / Low) based on review depth
- [x] Every concern references concrete evidence — no generic speculation
- [x] Summary table at top of output with Confidence column, sorted by verdict severity
- [ ] Portfolio-level synthesis after all per-PR analyses: merge order, cross-PR themes, leadership takeaway
- [x] Output is concise — capped per section, suitable for busy executive scanning
- [x] Subagents use `gh pr diff --stat` by default; only fetch full diff for high-risk files matching glob patterns
- [x] No duplication of CR/Greptile code-correctness findings (strategic focus only)
- [x] Symlinked to `~/.claude/skills/` via skills worktree after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch PR review assistant for multi-PR strategic analysis.
  * Accepts space-separated PR refs, shows usage when none provided, validates/deduplicates inputs and skips invalid refs.
  * Fetches shared strategic context (OKRs or README/milestones/labels fallback) and injects a disclosure into each review.
  * Runs parallel per-PR analyses, conditionally fetches large diffs for high-risk areas, and resolves linked issues (including cross-repo).
  * Produces executive summaries, alignment, risks, confidence, questions, verdicts, follow-ups, a severity-sorted portfolio synthesis, and reports incomplete PRs if analyses fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->