### PR TITLE
Fix wrap skill: sync main + explicit branch-before-worktree cleanup order

### DIFF
--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -121,11 +121,13 @@ First check that the root repo is clean before switching branches:
 
 ```bash
 ROOT_REPO=$(git worktree list | head -1 | awk '{print $1}')
-if [ -z "$(git -C "$ROOT_REPO" status --porcelain)" ]; then
+if [ -z "$ROOT_REPO" ] || [ ! -d "$ROOT_REPO" ]; then
+  echo "Warning: could not determine root repo path — skipping main sync"
+elif [ -z "$(git -C "$ROOT_REPO" status --porcelain)" ]; then
   git -C "$ROOT_REPO" checkout main
   git -C "$ROOT_REPO" pull origin main --ff-only
 else
-  echo "Warning: root repo has uncommitted changes — skipping main sync. Run manually: git -C $ROOT_REPO checkout main && git -C $ROOT_REPO pull origin main --ff-only"
+  echo "Warning: root repo has uncommitted changes — skipping main sync. Run manually: git -C \"$ROOT_REPO\" checkout main && git -C \"$ROOT_REPO\" pull origin main --ff-only"
 fi
 ```
 


### PR DESCRIPTION
## Summary

- After squash merge, checkout and pull `origin/main` on the root repo (with a `git status --porcelain` clean-state guard) so subsequent sessions branch from latest code
- Phase 5 now explicitly deletes the local feature branch via `git branch -d` before calling `ExitWorktree remove`, enforcing the required git cleanup order
- Branch deletion failure is treated as non-fatal — cleanup continues regardless
- Captures `BRANCH_NAME` from `headRefName` early in Phase 2 for use in Phase 5

## Test plan

- [x] After squash merge, wrap checkouts `main` on the root repo and pulls from `origin/main` before any cleanup steps
- [x] If root repo has uncommitted changes, sync is skipped with a warning instead of erroring
- [x] Phase 5 deletes the local feature branch (`git branch -d`) before removing the worktree
- [x] Branch deletion uses the root repo (not the worktree being removed)
- [x] Worktree removal happens after branch deletion
- [x] If branch deletion fails (already deleted), cleanup continues non-fatally

Closes #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wrap skill captures the active feature branch early to ensure consistent tracking across the workflow.

* **Improvements**
  * Syncs the root repository to main after a squash merge, but skips sync with a clear warning if the repo has uncommitted changes.
  * Cleanup now deletes the local tracking branch (non-fatal on failure) before removing the worktree directory for safer teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->