### PR TITLE
feat: extend setup-skills-worktree.sh to manage hook registration

### DIFF
--- a/setup-skills-worktree.sh
+++ b/setup-skills-worktree.sh
@@ -59,9 +59,8 @@ mkdir -p "$SKILLS_DIR"
 WORKTREE_SKILLS="$SKILLS_WORKTREE/.claude/skills"
 
 if [[ ! -d "$WORKTREE_SKILLS" ]]; then
-  echo "WARNING: No .claude/skills/ directory in the worktree. Nothing to symlink."
-  exit 0
-fi
+  echo "WARNING: No .claude/skills/ directory in the worktree. Skipping skill symlinks."
+else
 
 echo "Symlinking skills from worktree..."
 
@@ -110,6 +109,8 @@ for link in "$SKILLS_DIR"/*/; do
     fi
   fi
 done
+
+fi  # end of skills directory check
 
 # --- Step 5: Migrate CLAUDE.md and rules symlinks to skills worktree ---
 
@@ -227,9 +228,13 @@ if os.path.isfile(settings_file):
         backup = settings_file + ".bak"
         shutil.copy2(settings_file, backup)
         print(f"  WARNING: {settings_file} contains invalid JSON: {e}")
-        print(f"  Backed up to {backup}, starting fresh for hooks section")
+        print(f"  Backed up to {backup}, starting fresh (all settings will be re-created)")
         settings = {}
 else:
+    settings = {}
+
+if not isinstance(settings, dict):
+    print(f"  WARNING: {settings_file} top-level value is not an object; resetting")
     settings = {}
 
 if "hooks" not in settings or not isinstance(settings["hooks"], dict):


### PR DESCRIPTION
## Summary

- Adds Step 6 to `setup-skills-worktree.sh` that manages hook registration in `~/.claude/settings.json`
- Uses an inline manifest (bash array) to declaratively define which hooks should be registered, with event, matcher, script name, and timeout
- Uses `python3` for JSON read-modify-write (no `jq` dependency, guaranteed on macOS)
- Idempotent: detects existing hooks by exact basename match, never duplicates
- Preserves all existing settings.json entries not in the manifest

Closes #146

## Test plan

- [x] Running with all hooks already registered reports "already registered" for each
- [x] Running with missing hooks adds only the missing ones and reports "added"
- [x] Running with no existing `settings.json` creates the file with all hooks
- [x] Existing non-hook settings (permissions, env, model) are preserved
- [x] Matchers are correctly applied (Bash matcher for post-merge-pull.sh, none for others)
- [x] Inline comment explains how to add a new hook to the manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now automatically registers repository-provided Claude hook scripts into the user's Claude settings and reports per-hook status ("added", "already registered", or "WARNING not found") for clear feedback.
  * Existing hook registrations are preserved; missing scripts are skipped with warnings, and newly discovered hooks are appended without removing prior entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->