### PR TITLE
Fix /wrap and /merge: add explicit main sync with status reporting

### DIFF
--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -113,11 +113,16 @@ After merging, update the local `main` so subsequent sessions branch from the la
 ```bash
 MAIN_SYNC_STATUS=""
 
+# Guard: uncommitted changes would block checkout
+if [ -n "$(git status --porcelain)" ]; then
+  MAIN_SYNC_STATUS="skipped: working tree has uncommitted changes — run manually: git checkout main && git pull origin main --ff-only"
+fi
+
 # Ensure we're on main before pulling
 CURRENT_BRANCH=$(git branch --show-current)
-if [ "$CURRENT_BRANCH" != "main" ]; then
-  if ! git checkout main 2>&1; then
-    MAIN_SYNC_STATUS="failed: could not checkout main"
+if [ -z "$MAIN_SYNC_STATUS" ] && [ "$CURRENT_BRANCH" != "main" ]; then
+  if ! CHECKOUT_OUTPUT=$(git checkout main 2>&1); then
+    MAIN_SYNC_STATUS="failed: could not checkout main — $CHECKOUT_OUTPUT"
   fi
 fi
 

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -131,8 +131,8 @@ elif [ -n "$(git -C "$ROOT_REPO" status --porcelain)" ]; then
 else
   CURRENT_BRANCH=$(git -C "$ROOT_REPO" branch --show-current)
   if [ "$CURRENT_BRANCH" != "main" ]; then
-    if ! git -C "$ROOT_REPO" checkout main 2>&1; then
-      MAIN_SYNC_STATUS="failed: could not checkout main in root repo"
+    if ! CHECKOUT_OUTPUT=$(git -C "$ROOT_REPO" checkout main 2>&1); then
+      MAIN_SYNC_STATUS="failed: could not checkout main in root repo — $CHECKOUT_OUTPUT"
     fi
   fi
   if [ -z "$MAIN_SYNC_STATUS" ]; then


### PR DESCRIPTION
## Summary
- **`/wrap` Step 2.6**: Replaced silent sync with result-capturing logic — tracks before/after SHA, handles checkout failure, uncommitted changes, and pull failure. Stores `MAIN_SYNC_STATUS` for the final report.
- **`/wrap` Step 5.4**: Added "Main branch" line to the wrap-up report so users always see whether main was synced (and why not if it failed).
- **`/merge` Step 5b**: New sync step — `/merge` previously had NO explicit sync (relied solely on the `post-merge-pull.sh` hook which could timeout/fail silently). Now captures result for reporting.
- **`/merge` Step 7**: Added main sync status to completion report.

Closes #155

## Test plan
- [x] `/wrap` Step 2.6 captures sync status when root repo is clean and pull succeeds (shows "updated X → Y" or "up to date")
- [x] `/wrap` Step 2.6 captures failure when root repo has uncommitted changes (shows "skipped: ...")
- [x] `/wrap` Step 5.4 final report includes "Main branch" line with the sync status
- [x] `/merge` Step 5b syncs local main after squash merge and captures result
- [x] `/merge` Step 5b handles non-main branch edge case (explicit checkout guard)
- [x] `/merge` Step 7 completion report includes main sync status line
- [x] `post-merge-pull.sh` hook still fires as safety net alongside the explicit sync steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)