### PR TITLE
fix: update stale repo name in hooks README

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -42,7 +42,7 @@ Add the following to your **global** `~/.claude/settings.json` (create the file 
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/claude-code-coderabbit/.claude/hooks/post-merge-pull.sh",
+            "command": "/absolute/path/to/claude-code-config/.claude/hooks/post-merge-pull.sh",
             "timeout": 15
           }
         ]
@@ -52,7 +52,7 @@ Add the following to your **global** `~/.claude/settings.json` (create the file 
 }
 ```
 
-Replace `/absolute/path/to/claude-code-coderabbit` with the actual path to your clone of this repo.
+Replace `/absolute/path/to/claude-code-config` with the actual path to your clone of this repo.
 
 ### Prerequisites
 
@@ -82,7 +82,7 @@ The heartbeat file is session-scoped (`/tmp/claude-heartbeat-$CLAUDE_SESSION_ID`
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/claude-code-coderabbit/.claude/hooks/silence-detector-ack.sh",
+            "command": "/absolute/path/to/claude-code-config/.claude/hooks/silence-detector-ack.sh",
             "timeout": 5
           }
         ]
@@ -93,7 +93,7 @@ The heartbeat file is session-scoped (`/tmp/claude-heartbeat-$CLAUDE_SESSION_ID`
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/claude-code-coderabbit/.claude/hooks/silence-detector.sh",
+            "command": "/absolute/path/to/claude-code-config/.claude/hooks/silence-detector.sh",
             "timeout": 5
           }
         ]
@@ -103,7 +103,7 @@ The heartbeat file is session-scoped (`/tmp/claude-heartbeat-$CLAUDE_SESSION_ID`
 }
 ```
 
-Replace `/absolute/path/to/claude-code-coderabbit` with the actual path to your clone of this repo.
+Replace `/absolute/path/to/claude-code-config` with the actual path to your clone of this repo.
 
 ### Prerequisites
 


### PR DESCRIPTION
## Summary
- Updates 5 references from the old repo name `claude-code-coderabbit` to `claude-code-config` in `.claude/hooks/README.md`
- Fixes example paths in JSON snippets and prose instructions

This is also a test vehicle for verifying the wrap/merge lifecycle fixes from PRs #141, #143, #159.

Closes #161

## Test plan
- [x] All `claude-code-coderabbit` references replaced with `claude-code-config`
- [x] Example JSON paths updated to match
- [x] No other files affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hook script documentation paths for accurate installation directory references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->