### PR TITLE
docs: fix README settings.json description and add missing hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,20 @@ Rule files in `.claude/rules/` auto-load alongside `CLAUDE.md` for the parent ag
 
 `setup.sh` merges non-hook settings from `global-settings.json` into `~/.claude/settings.json`, preserving any existing keys (permissions, model, env). Hook registration is handled separately by `setup-skills-worktree.sh` (Step 6), which resolves placeholder paths to the skills worktree automatically.
 
-If setting up manually, seed `settings.json` and replace placeholder paths:
+Manual fallback (not recommended):
 
 ```bash
+# WARNING: This overwrites ~/.claude/settings.json — back up first if you have custom settings.
 cp global-settings.json ~/.claude/settings.json
 
+# Replace placeholder paths with your clone's absolute path:
 # macOS:
 sed -i '' 's|/path/to/claude-code-config|'"$(pwd)"'|g' ~/.claude/settings.json
 # Linux:
 sed -i 's|/path/to/claude-code-config|'"$(pwd)"'|g' ~/.claude/settings.json
 ```
 
-> **Note:** Use `setup.sh` instead — it handles merge semantics (preserving existing keys) and path resolution automatically. The manual steps above are for reference only.
+> **Note:** Use `setup.sh` instead — it merges settings (preserving existing keys like `permissions`, `model`, `env`) and resolves hook paths automatically. The `cp` above overwrites everything.
 
 This file configures:
 - **Permissions** — Broad allow rules so Claude operates autonomously without prompting for every tool call.


### PR DESCRIPTION
## Summary
- Fixes `global-settings.json` config table: "Copied" → "Merged into" with note about preserving existing keys (reflects PR #156 behavior)
- Adds missing `session-start-sync.sh` to the hook table (added in PR #158, was not documented)
- Updates Step 5 manual instructions with overwrite warning and note to prefer `setup.sh`
- Fixes step reference (Step 3 → Step 6) for `setup-skills-worktree.sh` hook registration

This PR also serves as a test vehicle for the `/merge` skill (issue #161 scenario 2).

## Test plan
- [x] Config table says "Merged into" not "Copied to" for `global-settings.json`
- [x] `session-start-sync.sh` appears in the hook table
- [x] Manual fallback has explicit overwrite warning
- [x] Step reference corrected to Step 6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced global configuration setup instructions with safer merge approach
  * Clarified manual fallback option with warnings for direct configuration updates
  * Updated documentation to reflect configuration merging behavior and key preservation

* **New Features**
  * Added session-start-sync hook for post-tool-use session initialization with automatic worktree synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->