### PR TITLE
docs: add Claude Code docs link to SETUP.md prerequisites

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -34,7 +34,7 @@ The script handles everything: directory creation, symlinks, settings merge, hoo
 
 - **Git** — the repo must be cloned (not downloaded as a zip)
 - **GitHub CLI (`gh`)** — needed for the PR workflow: `brew install gh && gh auth login`
-- **Claude Code** — `npm install -g @anthropic-ai/claude-code`
+- **Claude Code** — install via `npm install -g @anthropic-ai/claude-code` (see [docs](https://docs.anthropic.com/en/docs/claude-code))
 
 Optional tools (for the full review workflow):
 - [CodeRabbit](https://coderabbit.ai) — AI code review on PRs


### PR DESCRIPTION
## Summary
- Adds link to Claude Code docs in the SETUP.md prerequisites section

Test vehicle for edge case testing (issue #161 scenarios 3-4).

## Test plan
- [x] SETUP.md prerequisites link is correct and points to docs.anthropic.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced setup guide with expanded installation instructions and reference to official Claude Code documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->