### PR TITLE
docs: add CLI command hint to SETUP.md CodeRabbit CLI entry

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -38,7 +38,7 @@ The script handles everything: directory creation, symlinks, settings merge, hoo
 
 Optional tools (for the full review workflow):
 - [CodeRabbit](https://coderabbit.ai) — AI code review on PRs
-- [CodeRabbit CLI](https://docs.coderabbit.ai/cli) — local pre-push reviews
+- [CodeRabbit CLI](https://docs.coderabbit.ai/cli) — local pre-push reviews (`coderabbit review --prompt-only`)
 - [Greptile](https://greptile.com) — fallback reviewer when CodeRabbit is rate-limited
 
 See [README.md](README.md) for full documentation.


### PR DESCRIPTION
## Summary
- Adds the `coderabbit review --prompt-only` command hint to the CodeRabbit CLI prerequisite in SETUP.md

Test vehicle for verifying structured exit reports and phase transition protocols (issue #162).

## Test plan
- [x] SETUP.md CodeRabbit CLI entry includes the command hint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CodeRabbit CLI setup instructions with explicit command example for local pre-push reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->