### PR TITLE
feat: extract trust-dialog repair scripts to .claude/scripts/

### DIFF
--- a/.claude/rules/trust-dialog-fix.md
+++ b/.claude/rules/trust-dialog-fix.md
@@ -1,141 +1,31 @@
 # Trust Dialog Re-Prompting Fix
 
-> **Always:** Check `~/.claude.json` flags when the user reports trust dialog or CLAUDE.md external includes re-prompting.
-> **Ask first:** Never — diagnosis and repair are safe read/write operations on a JSON config file.
+> **Always:** Check `~/.claude.json` flags when the user reports trust dialog re-prompting.
 > **Never:** Delete `~/.claude.json` entirely (Claude Code recreates it with `false` defaults).
 
 ## Problem
 
-Claude Code re-prompts for the trust dialog and CLAUDE.md external includes approval even when bypass permissions are enabled. This happens because `~/.claude.json` stores per-project flags that can reset to `false` — for example, when a new project entry is created or the file is deleted and recreated.
+Claude Code re-prompts for trust dialog and external includes approval because `~/.claude.json` stores per-project flags that reset to `false` on new project entries (e.g., new worktrees).
 
-The three flags that must be `true` per project:
+Three flags must be `true` per project:
 
 | Flag | Purpose |
 |------|---------|
-| `hasTrustDialogAccepted` | Suppresses the "trust this project?" dialog |
-| `hasClaudeMdExternalIncludesApproved` | Suppresses re-approval of external includes in CLAUDE.md |
-| `hasClaudeMdExternalIncludesWarningShown` | Suppresses the warning banner for external includes |
+| `hasTrustDialogAccepted` | Suppresses trust dialog |
+| `hasClaudeMdExternalIncludesApproved` | Suppresses external includes re-approval |
+| `hasClaudeMdExternalIncludesWarningShown` | Suppresses external includes warning |
 
-## Repair Script
+Worktrees are the primary cause — each gets a unique path registered as a new project with `false` defaults. The `claude-code-config` repo is especially affected because global symlinks point back into it, triggering "external includes" detection.
 
-Run this to fix flags for a specific project. Replace the `proj_key` value with the absolute path to the affected project:
+## Manual Repair
 
-```bash
-python3 -c "
-import json, os, sys
+Run from the repo root:
 
-path = os.path.expanduser('~/.claude.json')
-try:
-    with open(path) as f:
-        data = json.load(f)
-except FileNotFoundError:
-    print(f'Config not found: {path}')
-    print('Open Claude Code once to recreate it, then re-run this fix.')
-    sys.exit(1)
-except json.JSONDecodeError as e:
-    print(f'Invalid JSON in {path}: {e}')
-    print('Repair or restore ~/.claude.json, then re-run this fix.')
-    sys.exit(1)
+- **Single project:** `bash .claude/scripts/repair-trust-single.sh /path/to/project`
+- **All projects:** `bash .claude/scripts/repair-trust-all.sh`
 
-projects = data.get('projects') or {}
-if not isinstance(projects, dict):
-    print('Invalid ~/.claude.json: \"projects\" must be an object.')
-    sys.exit(1)
-
-# Replace with the absolute path to your project
-proj_key = '/Users/yourname/path/to/project'
-
-if proj_key not in projects:
-    print(f'Project key not found: {proj_key}')
-    print('Available projects:')
-    for k in projects:
-        print(f'  {k}')
-    sys.exit(1)
-
-proj = projects[proj_key]
-if not isinstance(proj, dict):
-    print(f'Invalid project entry for {proj_key}: expected object, got {type(proj).__name__}.')
-    sys.exit(1)
-changed = []
-for flag in ['hasTrustDialogAccepted', 'hasClaudeMdExternalIncludesApproved', 'hasClaudeMdExternalIncludesWarningShown']:
-    if not proj.get(flag):
-        proj[flag] = True
-        changed.append(flag)
-
-if changed:
-    with open(path, 'w') as f:
-        json.dump(data, f, indent=2)
-    print(f'Fixed {len(changed)} flag(s): {changed}')
-else:
-    print('All flags already set — no changes needed.')
-"
-```
-
-To fix **all** projects at once:
-
-```bash
-python3 -c "
-import json, os, sys
-
-path = os.path.expanduser('~/.claude.json')
-try:
-    with open(path) as f:
-        data = json.load(f)
-except FileNotFoundError:
-    print(f'Config not found: {path}')
-    print('Open Claude Code once to recreate it, then re-run this fix.')
-    sys.exit(1)
-except json.JSONDecodeError as e:
-    print(f'Invalid JSON in {path}: {e}')
-    print('Repair or restore ~/.claude.json, then re-run this fix.')
-    sys.exit(1)
-
-projects = data.get('projects') or {}
-if not isinstance(projects, dict):
-    print('Invalid ~/.claude.json: \"projects\" must be an object.')
-    sys.exit(1)
-
-flags = ['hasTrustDialogAccepted', 'hasClaudeMdExternalIncludesApproved', 'hasClaudeMdExternalIncludesWarningShown']
-total = 0
-for proj_key, proj in projects.items():
-    if not isinstance(proj, dict):
-        print(f'Skipping invalid project entry {proj_key}: expected object, got {type(proj).__name__}.')
-        continue
-    for flag in flags:
-        if not proj.get(flag):
-            proj[flag] = True
-            total += 1
-
-if total:
-    with open(path, 'w') as f:
-        json.dump(data, f, indent=2)
-    print(f'Fixed {total} flag(s) across {len(projects)} project(s).')
-else:
-    print('All flags already set across all projects — no changes needed.')
-"
-```
-
-## Worktree Root Cause
-
-Every worktree gets its own absolute path (e.g., `/Users/you/repo/.claude/worktrees/my-worktree/`), and Claude Code registers this as a separate project in `~/.claude.json`. New project entries start with all trust flags set to `false`, triggering the trust dialog and external includes approval prompts.
-
-This is especially problematic for the `claude-code-config` repo because it is the global config source — `~/.claude/CLAUDE.md` and `~/.claude/rules` are symlinks pointing **into** this repo. From a worktree's perspective, those symlinks resolve to paths outside the worktree directory, so Claude Code treats them as "external includes." Other repos using worktrees don't have this problem because their global symlinks don't point back into themselves.
-
-See the README troubleshooting section (Cause 3) for the full topology explanation and upstream issue links. The `trust-flag-repair.sh` Stop hook (see "Automatic Hook" below) mitigates this automatically.
-
-## When to Run
-
-- **Symptom:** Claude Code prompts you to trust a project or approve external includes when it shouldn't (bypass permissions is already enabled).
-- **After deleting `~/.claude.json`:** Claude Code recreates it with `false` defaults. Run the repair script after the file is recreated.
-- **After cloning/moving a project:** A new project entry in `~/.claude.json` starts with `false` flags.
+Both use atomic writes (`tempfile` + `os.replace`) for safety.
 
 ## Automatic Hook
 
-The `trust-flag-repair.sh` script runs as a `Stop` hook after every agent response. It repairs all trust flags across all projects in `~/.claude.json`, preventing re-prompting on subsequent operations within a session.
-
-- **Script:** `.claude/hooks/trust-flag-repair.sh`
-- **Registered in:** `global-settings.json` under `hooks.Stop`
-- **Behavior:** Idempotent — safe to run repeatedly. Exits silently when all flags are already set. Handles missing `~/.claude.json` gracefully.
-- **Limitation:** Cannot prevent the initial trust prompt when a brand-new worktree is created for the first time (the project entry doesn't exist yet). The hook repairs it after the first response, so subsequent operations in that session won't re-prompt.
-
-The manual repair scripts above remain useful for debugging and one-off fixes (e.g., after deleting `~/.claude.json`).
+The `trust-flag-repair.sh` Stop hook (`.claude/hooks/trust-flag-repair.sh`, registered in `global-settings.json`) repairs all flags after every agent response. It cannot prevent the initial prompt on brand-new worktrees — the project entry doesn't exist yet. The hook repairs it after the first response.

--- a/.claude/rules/trust-dialog-fix.md
+++ b/.claude/rules/trust-dialog-fix.md
@@ -1,6 +1,7 @@
 # Trust Dialog Re-Prompting Fix
 
 > **Always:** Check `~/.claude.json` flags when the user reports trust dialog re-prompting.
+> **Ask first:** Never — diagnosis and repair are safe read/write operations on a JSON config file.
 > **Never:** Delete `~/.claude.json` entirely (Claude Code recreates it with `false` defaults).
 
 ## Problem

--- a/.claude/scripts/README.md
+++ b/.claude/scripts/README.md
@@ -4,7 +4,7 @@ Manually-invoked utility scripts. Run these from the command line when needed.
 
 | Script | Purpose |
 |--------|---------|
-| `repair-trust-single.sh <path>` | Fix trust flags for one project in `~/.claude.json` |
+| `repair-trust-single.sh <absolute-project-path>` | Fix trust flags for one project in `~/.claude.json` |
 | `repair-trust-all.sh` | Fix trust flags for all projects in `~/.claude.json` |
 
 ## scripts/ vs hooks/

--- a/.claude/scripts/README.md
+++ b/.claude/scripts/README.md
@@ -1,0 +1,15 @@
+# .claude/scripts/
+
+Manually-invoked utility scripts. Run these from the command line when needed.
+
+| Script | Purpose |
+|--------|---------|
+| `repair-trust-single.sh <path>` | Fix trust flags for one project in `~/.claude.json` |
+| `repair-trust-all.sh` | Fix trust flags for all projects in `~/.claude.json` |
+
+## scripts/ vs hooks/
+
+- **`scripts/`** — manual utilities, run on demand
+- **`hooks/`** — auto-triggered by Claude Code lifecycle events (Stop, PostToolUse, etc.)
+
+The `trust-flag-repair.sh` hook in `hooks/` runs automatically after every agent response. These scripts are for manual diagnosis and one-off repairs (e.g., after deleting `~/.claude.json`).

--- a/.claude/scripts/README.md
+++ b/.claude/scripts/README.md
@@ -12,4 +12,4 @@ Manually-invoked utility scripts. Run these from the command line when needed.
 - **`scripts/`** — manual utilities, run on demand
 - **`hooks/`** — auto-triggered by Claude Code lifecycle events (Stop, PostToolUse, etc.)
 
-The `trust-flag-repair.sh` hook in `hooks/` runs automatically after every agent response. These scripts are for manual diagnosis and one-off repairs (e.g., after deleting `~/.claude.json`).
+The `trust-flag-repair.sh` hook in `hooks/` runs automatically after every agent response. These scripts are for manual diagnosis and one-off repairs (e.g., after new worktree/project entries, cloning/moving projects, or config recreation).

--- a/.claude/scripts/repair-trust-all.sh
+++ b/.claude/scripts/repair-trust-all.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Fix trust flags for ALL projects in ~/.claude.json.
+# Usage: bash .claude/scripts/repair-trust-all.sh
+# See .claude/rules/trust-dialog-fix.md for details.
+
+set -euo pipefail
+
+python3 -c "
+import json, os, sys, tempfile
+
+path = os.path.expanduser('~/.claude.json')
+
+try:
+    with open(path) as f:
+        data = json.load(f)
+except FileNotFoundError:
+    print(f'Config not found: {path}')
+    print('Open Claude Code once to recreate it, then re-run this fix.')
+    sys.exit(1)
+except json.JSONDecodeError as e:
+    print(f'Invalid JSON in {path}: {e}')
+    print('Repair or restore ~/.claude.json, then re-run this fix.')
+    sys.exit(1)
+
+projects = data.get('projects') or {}
+if not isinstance(projects, dict):
+    print('Invalid ~/.claude.json: \"projects\" must be an object.')
+    sys.exit(1)
+
+flags = ['hasTrustDialogAccepted', 'hasClaudeMdExternalIncludesApproved', 'hasClaudeMdExternalIncludesWarningShown']
+total = 0
+affected = set()
+for proj_key, proj in projects.items():
+    if not isinstance(proj, dict):
+        print(f'Skipping invalid project entry {proj_key}: expected object, got {type(proj).__name__}.')
+        continue
+    for flag in flags:
+        if not proj.get(flag):
+            proj[flag] = True
+            total += 1
+            affected.add(proj_key)
+
+if total:
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try: os.unlink(tmp)
+        except OSError: pass
+        raise
+    print(f'Fixed {total} flag(s) across {len(affected)} project(s).')
+else:
+    print('All flags already set across all projects — no changes needed.')
+"

--- a/.claude/scripts/repair-trust-all.sh
+++ b/.claude/scripts/repair-trust-all.sh
@@ -22,6 +22,10 @@ except json.JSONDecodeError as e:
     print('Repair or restore ~/.claude.json, then re-run this fix.')
     sys.exit(1)
 
+if not isinstance(data, dict):
+    print('Invalid ~/.claude.json: root must be an object.')
+    sys.exit(1)
+
 projects = data.get('projects') or {}
 if not isinstance(projects, dict):
     print('Invalid ~/.claude.json: \"projects\" must be an object.')

--- a/.claude/scripts/repair-trust-all.sh
+++ b/.claude/scripts/repair-trust-all.sh
@@ -42,7 +42,7 @@ for proj_key, proj in projects.items():
         print(f'Skipping invalid project entry {proj_key}: expected object, got {type(proj).__name__}.')
         continue
     for flag in flags:
-        if not proj.get(flag):
+        if proj.get(flag) is not True:
             proj[flag] = True
             total += 1
             affected.add(proj_key)

--- a/.claude/scripts/repair-trust-all.sh
+++ b/.claude/scripts/repair-trust-all.sh
@@ -26,10 +26,13 @@ if not isinstance(data, dict):
     print('Invalid ~/.claude.json: root must be an object.')
     sys.exit(1)
 
-projects = data.get('projects') or {}
-if not isinstance(projects, dict):
-    print('Invalid ~/.claude.json: \"projects\" must be an object.')
-    sys.exit(1)
+if 'projects' not in data:
+    projects = {}
+else:
+    projects = data['projects']
+    if not isinstance(projects, dict):
+        print('Invalid ~/.claude.json: \"projects\" must be an object.')
+        sys.exit(1)
 
 flags = ['hasTrustDialogAccepted', 'hasClaudeMdExternalIncludesApproved', 'hasClaudeMdExternalIncludesWarningShown']
 total = 0

--- a/.claude/scripts/repair-trust-all.sh
+++ b/.claude/scripts/repair-trust-all.sh
@@ -5,6 +5,11 @@
 
 set -euo pipefail
 
+if [[ $# -ne 0 ]]; then
+  echo "Usage: $0"
+  exit 1
+fi
+
 python3 -c "
 import json, os, sys, tempfile
 

--- a/.claude/scripts/repair-trust-single.sh
+++ b/.claude/scripts/repair-trust-single.sh
@@ -31,6 +31,10 @@ except json.JSONDecodeError as e:
     print('Repair or restore ~/.claude.json, then re-run this fix.')
     sys.exit(1)
 
+if not isinstance(data, dict):
+    print('Invalid ~/.claude.json: root must be an object.')
+    sys.exit(1)
+
 projects = data.get('projects') or {}
 if not isinstance(projects, dict):
     print('Invalid ~/.claude.json: \"projects\" must be an object.')

--- a/.claude/scripts/repair-trust-single.sh
+++ b/.claude/scripts/repair-trust-single.sh
@@ -35,10 +35,13 @@ if not isinstance(data, dict):
     print('Invalid ~/.claude.json: root must be an object.')
     sys.exit(1)
 
-projects = data.get('projects') or {}
-if not isinstance(projects, dict):
-    print('Invalid ~/.claude.json: \"projects\" must be an object.')
-    sys.exit(1)
+if 'projects' not in data:
+    projects = {}
+else:
+    projects = data['projects']
+    if not isinstance(projects, dict):
+        print('Invalid ~/.claude.json: \"projects\" must be an object.')
+        sys.exit(1)
 
 if proj_key not in projects:
     print(f'Project key not found: {proj_key}')

--- a/.claude/scripts/repair-trust-single.sh
+++ b/.claude/scripts/repair-trust-single.sh
@@ -58,7 +58,7 @@ if not isinstance(proj, dict):
 flags = ['hasTrustDialogAccepted', 'hasClaudeMdExternalIncludesApproved', 'hasClaudeMdExternalIncludesWarningShown']
 changed = []
 for flag in flags:
-    if not proj.get(flag):
+    if proj.get(flag) is not True:
         proj[flag] = True
         changed.append(flag)
 

--- a/.claude/scripts/repair-trust-single.sh
+++ b/.claude/scripts/repair-trust-single.sh
@@ -13,6 +13,12 @@ fi
 
 proj_key="$1"
 
+if [[ "$proj_key" != /* ]]; then
+  echo "Error: <absolute-project-path> must start with '/'"
+  echo "Example: $0 /Users/you/repos/my-project"
+  exit 1
+fi
+
 python3 -c "
 import json, os, sys, tempfile
 

--- a/.claude/scripts/repair-trust-single.sh
+++ b/.claude/scripts/repair-trust-single.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Fix trust flags for a single project in ~/.claude.json.
+# Usage: bash .claude/scripts/repair-trust-single.sh /absolute/path/to/project
+# See .claude/rules/trust-dialog-fix.md for details.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <absolute-project-path>"
+  echo "Example: $0 /Users/you/repos/my-project"
+  exit 1
+fi
+
+proj_key="$1"
+
+python3 -c "
+import json, os, sys, tempfile
+
+proj_key = sys.argv[1]
+path = os.path.expanduser('~/.claude.json')
+
+try:
+    with open(path) as f:
+        data = json.load(f)
+except FileNotFoundError:
+    print(f'Config not found: {path}')
+    print('Open Claude Code once to recreate it, then re-run this fix.')
+    sys.exit(1)
+except json.JSONDecodeError as e:
+    print(f'Invalid JSON in {path}: {e}')
+    print('Repair or restore ~/.claude.json, then re-run this fix.')
+    sys.exit(1)
+
+projects = data.get('projects') or {}
+if not isinstance(projects, dict):
+    print('Invalid ~/.claude.json: \"projects\" must be an object.')
+    sys.exit(1)
+
+if proj_key not in projects:
+    print(f'Project key not found: {proj_key}')
+    print('Available projects:')
+    for k in projects:
+        print(f'  {k}')
+    sys.exit(1)
+
+proj = projects[proj_key]
+if not isinstance(proj, dict):
+    print(f'Invalid project entry for {proj_key}: expected object, got {type(proj).__name__}.')
+    sys.exit(1)
+
+flags = ['hasTrustDialogAccepted', 'hasClaudeMdExternalIncludesApproved', 'hasClaudeMdExternalIncludesWarningShown']
+changed = []
+for flag in flags:
+    if not proj.get(flag):
+        proj[flag] = True
+        changed.append(flag)
+
+if changed:
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try: os.unlink(tmp)
+        except OSError: pass
+        raise
+    print(f'Fixed {len(changed)} flag(s): {changed}')
+else:
+    print('All flags already set — no changes needed.')
+" "$proj_key"


### PR DESCRIPTION
## Summary

Closes #185

- Extracted inline Python repair scripts from `trust-dialog-fix.md` into standalone executables under `.claude/scripts/`
- Condensed the rule file from 792 to 199 words (~600 words saved from auto-loaded context)
- Both scripts use atomic writes (`tempfile.mkstemp` + `os.replace`) matching the existing hook pattern
- Added `.claude/scripts/README.md` explaining scripts/ vs hooks/ directory purpose

## Changes

| File | Action |
|------|--------|
| `.claude/rules/trust-dialog-fix.md` | Rewritten: removed all inline Python, kept problem description + flag table + script pointers + hook section |
| `.claude/scripts/repair-trust-single.sh` | Created: single-project repair, accepts path as CLI arg |
| `.claude/scripts/repair-trust-all.sh` | Created: all-projects repair with accurate affected-project count |
| `.claude/scripts/README.md` | Created: explains scripts/ vs hooks/ purpose |

## Test plan

- [x] `wc -w .claude/rules/trust-dialog-fix.md` confirms ≤200 words (currently 199)
- [x] `bash .claude/scripts/repair-trust-all.sh` executes without error and reports flag status
- [x] `bash .claude/scripts/repair-trust-single.sh /Users/brettonauerbach/Documents/Develop/claude-code-config` executes without error
- [x] Both scripts use atomic writes (tempfile + os.replace pattern)
- [x] Rule file retains problem description, flag table, script pointers, and hook reference
- [x] `.claude/scripts/README.md` exists and documents scripts/ vs hooks/ distinction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated trust-dialog guidance and shortened trust-warning wording; clarified root cause (per-worktree flag resets). Replaced embedded repair examples with instructions pointing to manual repair utilities and clarified automatic hook behavior: repairs flags after each agent response but can't prevent the initial prompt for brand-new worktrees.

* **New Features**
  * Added two manual repair utilities (single-project and all-project) and a README describing their usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->