### PR TITLE
refactor: condense CLAUDE.md via deduplication into rule files

### DIFF
--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -169,6 +169,23 @@ The merge gate depends on which reviewer owns the PR:
   3. **Clean = completed + no new findings:** Once the CI check shows completed, check all three comment endpoints for any new findings posted after the ack. If there are none, the review is a clean pass. You do NOT need to keep polling to the 7-minute timeout once the CI check is green and no findings appeared.
 - Once the merge gate is met, proceed immediately to Step 2.
 
+**Step 1b — CI Must Pass Before Merge (NON-NEGOTIABLE):**
+
+Before running `gh pr merge` on ANY PR, check ALL CI check-runs:
+
+```bash
+SHA=$(gh pr view <PR_NUMBER> --json commits --jq '.commits[-1].oid')
+gh api "repos/{owner}/{repo}/commits/$SHA/check-runs?per_page=100" \
+  --jq '.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "startup_failure" or .conclusion == "stale") | {name, conclusion}'
+```
+
+**If ANY check-run has a blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`): DO NOT MERGE.** Instead:
+1. Read the failure output and fix the issue
+2. Commit, push, and wait for CI to re-run
+3. Only merge after ALL checks pass
+
+This applies to ALL merge paths: manual `gh pr merge`, the `/merge` skill, the `/wrap` skill, and Phase C merge prep.
+
 **Step 2 — Verify every Test Plan checkbox (MANDATORY — do NOT skip):**
 > This is the **immediate next step** after the merge gate is met. Do not ask the user about merging until this is done.
 >

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -167,7 +167,7 @@ The merge gate depends on which reviewer owns the PR:
   1. **Ack (review started):** CR posts an issue comment (on `issues/{N}/comments`) with "Actions performed — Full review triggered." This means CR **started** the review — it is NOT a completion signal.
   2. **Completion (review finished):** The commit status check for CodeRabbit shows `status: "completed"` with `conclusion: "success"` (visible as "CodeRabbit — Review completed" in the PR's CI checks). This is the **definitive completion signal**.
   3. **Clean = completed + no new findings:** Once the CI check shows completed, check all three comment endpoints for any new findings posted after the ack. If there are none, the review is a clean pass. You do NOT need to keep polling to the 7-minute timeout once the CI check is green and no findings appeared.
-- Once the merge gate is met, proceed immediately to Step 2.
+- Once the merge gate is met, proceed immediately to Step 1b (CI verification).
 
 **Step 1b — CI Must Pass Before Merge (NON-NEGOTIABLE):**
 
@@ -193,7 +193,7 @@ gh api "repos/{owner}/{repo}/commits/$SHA/check-runs?per_page=100" \
 This applies to ALL merge paths: manual `gh pr merge`, the `/merge` skill, the `/wrap` skill, and Phase C merge prep.
 
 **Step 2 — Verify every Test Plan checkbox (MANDATORY — do NOT skip):**
-> This is the **immediate next step** after the merge gate is met. Do not ask the user about merging until this is done.
+> This is the **immediate next step** after CI passes (Step 1b). Do not ask the user about merging until this is done.
 >
 > 1. Fetch the PR body via `gh pr view N --json body`
 > 2. Parse **every** checkbox in the **Test plan** section of the PR description

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -171,18 +171,24 @@ The merge gate depends on which reviewer owns the PR:
 
 **Step 1b — CI Must Pass Before Merge (NON-NEGOTIABLE):**
 
-Before running `gh pr merge` on ANY PR, check ALL CI check-runs:
+Before running `gh pr merge` on ANY PR, verify ALL CI check-runs are complete and passing:
 
 ```bash
 SHA=$(gh pr view <PR_NUMBER> --json commits --jq '.commits[-1].oid')
+# 1. Check for incomplete runs (queued or in_progress) — DO NOT merge while any exist
+gh api "repos/{owner}/{repo}/commits/$SHA/check-runs?per_page=100" \
+  --jq '.check_runs[] | select(.status != "completed") | {name, status}'
+# 2. Check for blocking conclusions among completed runs
 gh api "repos/{owner}/{repo}/commits/$SHA/check-runs?per_page=100" \
   --jq '.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "startup_failure" or .conclusion == "stale") | {name, conclusion}'
 ```
 
-**If ANY check-run has a blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`): DO NOT MERGE.** Instead:
+**If step 1 returns ANY incomplete check-runs: DO NOT MERGE.** Wait for them to finish — a null conclusion means the check hasn't reported yet, not that it passed.
+
+**If step 2 returns ANY blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`): DO NOT MERGE.** Instead:
 1. Read the failure output and fix the issue
 2. Commit, push, and wait for CI to re-run
-3. Only merge after ALL checks pass
+3. Only merge after ALL checks are `status: "completed"` with non-blocking conclusions
 
 This applies to ALL merge paths: manual `gh pr merge`, the `/merge` skill, the `/wrap` skill, and Phase C merge prep.
 

--- a/.claude/rules/cr-local-review.md
+++ b/.claude/rules/cr-local-review.md
@@ -36,6 +36,17 @@ Run the CLI directly via Bash from the repo root:
 4. Run `coderabbit review --prompt-only` again
 5. Repeat until CR returns no findings
 
+### Never Suppress Linter Errors (NON-NEGOTIABLE)
+
+**NEVER add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or any linter suppression comment** to work around CI failures. These hide bugs instead of fixing them.
+
+When CI lint/typecheck fails:
+1. Read the error messages
+2. Fix the actual code — unused vars, missing types, incorrect imports, etc.
+3. If the error is in a file you didn't modify, fix it anyway — broken lint blocks the entire pipeline
+
+The only acceptable use of suppression comments is when the linter is provably wrong about a specific line AND you add a comment explaining why.
+
 ### Timeout & fallback
 - If `coderabbit review` hangs for more than **2 minutes** or errors out, skip it and run a **self-review** instead (see self-review fallback rules).
 - Do not retry more than once. If CR CLI fails twice, it's down — move on with self-review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,12 @@ If you catch yourself composing a "should I...?" question about any workflow ste
 **At the start of every session, before doing anything else, sync local `main` and then create a worktree.**
 
 1. **Pull remote main into local main:**
+
    ```bash
    ROOT_REPO=$(git worktree list | head -1 | awk '{print $1}')
    git -C "$ROOT_REPO" pull origin main --ff-only
    ```
+
    If the pull fails (e.g., diverged history), tell the user — do not force-pull or reset.
 2. **Create a worktree** via the `EnterWorktree` tool for isolated work.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,123 +2,61 @@
 
 These apply to EVERY message the parent agent sends to the user. No exceptions, no degradation over time, no skipping after context compaction.
 
-1. **Timestamp prefix.** Every message starts with Eastern time: `Mon Mar 16 02:34 AM ET`. Get via: `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`. NEVER estimate, calculate, or mentally derive timestamps — always run the `date` command. This includes elapsed time: do not count poll cycles or steps to estimate minutes passed. If you need elapsed time, compare two `date` outputs. This is the FIRST thing in every message — before status updates, before questions, before summaries.
-2. **Active monitoring declaration.** If you are monitoring background agents, state how many and which PRs at the end of every message. Example: "Monitoring: PR #618 (Phase B), PR #620 (Phase B), PR #623 (Phase C) — next poll in ~60s."
-3. **5-minute heartbeat.** The user must never go more than 5 minutes without a status message. When you run `date` for the timestamp, check how long it has been since your last message to the user. If >5 minutes, your FIRST action must be a status update — before any tool call. Include: what you are currently doing, what is pending (open PRs, active agents), and any blocked items. See `subagent-orchestration.md` "User Heartbeat" for detailed rules. **Never go silent for >5 minutes — not while doing substantive work, not while polling, not after compaction.**
-4. **Dedicated monitor mode.** If you have active subagents, you are in **monitor mode**: your ONLY job is orchestration (polling subagent status, heartbeats, phase launches, output verification, and session-state/recovery tasks). Do NOT do substantive work (coding, issue creation, file editing) — delegate it to a subagent instead. If the user explicitly asks you to do something, warn that monitoring will pause, do the work, then re-enter monitor mode. See `subagent-orchestration.md` "Dedicated Monitor Mode" for the full rules, permitted/prohibited activities, and exit conditions.
+1. **Timestamp prefix.** Start every message with Eastern time (`Mon Mar 16 02:34 AM ET`). Get via: `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`. NEVER estimate timestamps — always run the `date` command.
+2. **Active monitoring declaration.** If monitoring background agents, state how many and which PRs at the end of every message.
+3. **5-minute heartbeat.** Never go >5 minutes without a status message. See `subagent-orchestration.md` "User Heartbeat" for detailed rules.
+4. **Dedicated monitor mode.** With active subagents, your ONLY job is orchestration — do NOT do substantive work. See `subagent-orchestration.md` "Dedicated Monitor Mode" for full rules.
 
-If you have just resumed from context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `subagent-orchestration.md`) and report it WITH a timestamp.
+After context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `subagent-orchestration.md`) and report it WITH a timestamp.
 
 ---
 
 ## AUTONOMOUS WORKFLOW EXECUTION — DO NOT ASK PERMISSION
 
-**The workflow defined in these rules is fully autonomous.** At every phase transition — local review, push, PR creation, polling, feedback processing, subagent spawning — **proceed immediately without asking the user.** The rules define what to do at each step. Follow them.
-
-**NEVER say any of the following (or variants) at a phase transition:**
-- "Should I push now?" / "Should I create a PR?"
-- "Want me to poll for reviews?" / "Should I enter the polling loop?"
-- ...or any "should I...?" / "want me to...?" question about a workflow step.
-
-**These transitions are ALWAYS automatic — just do them:**
-1. Coding complete → run local CR review (mandatory before push)
-2. Local review clean → commit, push, create PR
-3. PR created → enter GitHub review polling loop immediately
-4. Review findings received → fix, commit, push, reply — then resume polling
-5. Phase A complete → parent launches Phase B within 60 seconds
-6. Phase B clean → parent launches Phase C
-7. Merge gate met → verify AC checkboxes → then ask about merging
+The workflow is fully autonomous. At every phase transition — local review, push, PR creation, polling, feedback processing, subagent spawning — **proceed immediately without asking the user.** See `subagent-orchestration.md` "Phase Transition Autonomy" for the complete table.
 
 **The ONLY actions that require user permission:**
-- Merging the PR (Step 3 of Completion)
-- Respawning a failed subagent (tell the user what happened first)
+- Merging the PR
+- Respawning a failed subagent
 
-If you catch yourself composing a "should I...?" or "want me to...?" question about any workflow step, stop — the answer is always yes. Just do it.
+If you catch yourself composing a "should I...?" question about any workflow step, stop — the answer is always yes. Just do it.
 
 ---
 
-## ALWAYS USE A WORKTREE — READ THIS FIRST
+## ALWAYS USE A WORKTREE
 
 **At the start of every session, before doing anything else, sync local `main` and then create a worktree.**
 
-1. **Pull remote main into local main.** This ensures your worktree branches from the latest code — not a stale local `main` that missed merges from other sessions, the web UI, or hook failures.
-
+1. **Pull remote main into local main:**
    ```bash
    ROOT_REPO=$(git worktree list | head -1 | awk '{print $1}')
    git -C "$ROOT_REPO" pull origin main --ff-only
    ```
-
    If the pull fails (e.g., diverged history), tell the user — do not force-pull or reset.
-2. **Create a worktree.** Tell the user: "I'll create a worktree for isolated work." Then use the `EnterWorktree` tool (or ask the user to say "use a worktree"). This gives you your own working directory and branch — completely isolated from the root repo and from any other agents.
+2. **Create a worktree** via the `EnterWorktree` tool for isolated work.
 
-**Why this is mandatory:**
-- The root repo directory stays clean on `main`. You never touch it.
-- Multiple agents get separate worktrees — no shared working directory, no overwriting each other's files.
-- Each worktree has its own branch, its own staged files, its own uncommitted changes.
-- Push and pull work normally — worktrees share the same remote.
+**Do not write code, edit files, stage changes, commit, or push while on `main`. Ever.** If you cannot create a worktree, fall back to `git checkout -b issue-N-short-description`.
 
-**Do not write code, edit files, stage changes, commit, or push while on `main`. Ever.** If for any reason you cannot create a worktree, fall back to creating a feature branch manually (`git checkout -b issue-N-short-description`) before touching any files.
-
-**Worktree cleanup:** After your PR is merged, remove the worktree via `git worktree remove <path>` or let the session exit prompt handle it. Periodically run `git worktree list` to check for stale worktrees.
+**Worktree cleanup:** After merge, remove via `git worktree remove <path>` or let the session exit prompt handle it.
 
 ---
 
-## PR & Issue Workflow
+## PR & ISSUE WORKFLOW
 
-### Issues — MANDATORY before any code work
+**The flow is always:** GitHub issue → CR plan → implementation plan → feature branch → code → local review → push → PR → GitHub review → merge. Never jump straight to coding. See `issue-planning.md` for the full issue creation and planning flow.
 
-- **Every PR must link to a GitHub issue. No exceptions.** If no issue exists, create one via `gh issue create` before writing any code, creating a branch, or making any changes.
-- **Why this is non-negotiable:** Issues go through a CR planning review (`@coderabbitai plan`) that catches logic errors, identifies edge cases, and produces a refined spec — all before a single coding token is spent. Skipping the issue means skipping this spec refinement, which leads to wasted coding effort on poorly defined tasks.
-- **The flow is always:** Create issue -> CR reviews/refines the spec -> plan implementation -> create branch -> write code -> PR. Never jump straight to coding.
-- Use `Closes #N` in the PR body to auto-close the issue on merge.
-- If the user asks you to make a change and there's no existing issue, **create the issue first**, then proceed with the Issue Planning Flow (see `.claude/rules/issue-planning.md`). Do not treat "quick fixes" or "small changes" as exceptions — the issue is the record of what was done and why.
+**Key rules:**
+- **Every PR must link to a GitHub issue.** No exceptions — create one via `gh issue create` first. Use `Closes #N` in the PR body.
+- **Every PR must include a Test plan section** with checkboxes for acceptance criteria.
+- **We do not use TDD** unless the user explicitly requests it. AC is verified via code review and manual testing.
+- **CI must pass before merge.** See `cr-github-review.md` "CI Must Pass Before Merge" for the check-runs verification procedure.
+- **Never suppress linter errors.** See `cr-local-review.md` "Never Suppress Linter Errors" — fix the actual code, never add suppression comments.
 
-### Acceptance Criteria
-- Every PR must include a **Test plan** section with checkboxes for acceptance criteria.
-- Before merging, verify each item against the actual code and **check off** every box in the PR description.
-- If an item can't be verified from code alone (e.g. visual/runtime behavior), note that it requires manual testing.
-
-### Testing Approach
-- We do **not** use TDD unless the user explicitly requests it.
-- Acceptance criteria are verified via code review and manual testing after deploy, not automated test suites.
-- When verifying, read the relevant source files and confirm the logic satisfies each criterion.
-
-### CI Must Pass Before Merge (NON-NEGOTIABLE)
-
-Before running `gh pr merge` on ANY PR, check ALL CI check-runs:
-
-```bash
-SHA=$(gh pr view <PR_NUMBER> --json commits --jq '.commits[-1].oid')
-gh api "repos/{owner}/{repo}/commits/$SHA/check-runs?per_page=100" \
-  --jq '.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required") | {name, conclusion}'
-```
-
-**If ANY check-run has a blocking conclusion (`failure`, `timed_out`, `action_required`): DO NOT MERGE.** Instead:
-1. Read the failure output and fix the issue
-2. Commit, push, and wait for CI to re-run
-3. Only merge after ALL checks pass
-
-**Never disable linters, suppress warnings, or add eslint-disable comments to work around CI failures.** Fix the actual code errors. If lint errors exist in files you didn't touch, fix them anyway — they block the entire CI pipeline.
-
-This applies to ALL merge paths: manual `gh pr merge`, the `/merge` skill, the `/wrap` skill, and Phase C merge prep.
-
-### Never Suppress Linter Errors (NON-NEGOTIABLE)
-
-**NEVER add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or any linter suppression comment** to work around CI failures. These hide bugs instead of fixing them.
-
-When CI lint/typecheck fails:
-1. Read the error messages
-2. Fix the actual code — unused vars, missing types, incorrect imports, etc.
-3. If the error is in a file you didn't modify, fix it anyway — broken lint blocks the entire pipeline
-
-The only acceptable use of suppression comments is when the linter is provably wrong about a specific line AND you add a comment explaining why.
-
-### Branching & Merging
-- **NEVER work on `main` — not editing, not committing, not pushing.** All code changes happen in worktrees on feature branches. If you're not in a worktree, create one first. If `git branch --show-current` returns `main`, do not touch any files.
-- **Every change requires: GitHub issue -> feature branch -> PR -> squash merge.** No exceptions. This includes `.claude/rules/*.md` and `CLAUDE.md` — rule files are code and follow the same PR workflow.
-- Branch naming: `issue-N-short-description` (e.g. `issue-10-nav-welcome-header`).
-- Always **squash and merge** via `gh pr merge --squash --delete-branch`, then delete the branch.
-- **Never merge immediately after a rebase or force-push.** Even trivial conflict resolutions (e.g. a single import line) trigger a new CR review cycle. Always wait for CR to review the rebased commit and confirm no findings before merging. The safe flow is: resolve conflict -> force-push -> wait for CR -> confirm clean -> merge.
+**Branching & merging:**
+- **NEVER work on `main`.** All code changes happen in worktrees on feature branches. Every change requires: issue → feature branch → PR → squash merge.
+- Branch naming: `issue-N-short-description`.
+- Always **squash and merge** via `gh pr merge --squash --delete-branch`.
+- **Never merge immediately after a rebase or force-push.** Wait for CR to review the rebased commit and confirm clean before merging.
 
 ---
 
@@ -129,8 +67,8 @@ Detailed workflow rules are split into topic-specific files in `.claude/rules/`:
 | File | Contents |
 |------|----------|
 | `issue-planning.md` | Issue creation flow, CR plan integration, planning flow |
-| `cr-local-review.md` | Local CodeRabbit CLI review loop (primary review workflow) |
-| `cr-github-review.md` | GitHub CR polling, rate limits, fast-path detection, thread resolution, completion criteria |
+| `cr-local-review.md` | Local CodeRabbit CLI review loop (primary review workflow), linter suppression prohibition |
+| `cr-github-review.md` | GitHub CR polling, rate limits, fast-path detection, thread resolution, CI-must-pass gate, completion criteria |
 | `greptile.md` | Greptile peer reviewer + CR fallback + self-review fallback |
 | `subagent-orchestration.md` | Task decomposition (phases A/B/C), dedicated monitor mode, health monitoring, timestamps, subagent quick-reference |
 | `work-log.md` | Auto-update daily work log on issue create, PR open, PR merge |


### PR DESCRIPTION
## Summary
- Condenses CLAUDE.md from 1,745 → 760 words (56% reduction) by eliminating redundancy with rule files
- Migrates "Never Suppress Linter Errors" to `cr-local-review.md` and "CI Must Pass Before Merge" to `cr-github-review.md`
- Rewrites CLAUDE.md as an executive summary (what) with pointers to rule files (how)
- No behavioral rules lost — all content either migrated or was already covered
- Net 776 words saved from total auto-loaded context (17,058 → 16,282)

Closes #186

## Test plan
- [x] CLAUDE.md reduced to ≤1,000 words (verified: 760 words via `wc -w`)
- [x] No behavioral rules lost — "Never Suppress Linter Errors" present in cr-local-review.md, "CI Must Pass Before Merge" present in cr-github-review.md
- [x] Rule file index table remains in CLAUDE.md as navigation hub with all 10 entries accurate
- [x] Phase transition autonomy table lives only in subagent-orchestration.md, not duplicated in CLAUDE.md
- [x] CLAUDE.md reads as coherent executive summary with pointers to rules
- [x] Total auto-loaded context word count decreased from baseline
- [x] CI-must-pass blocking conclusions list matches existing CI Health Check section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a mandatory pre-merge CI gate: merges blocked until all check-runs on the PR’s latest commit are completed with no blocking conclusions; applies to all merge entry points.
  * Prohibited local suppression of linter/typecheck errors; fix failures unless a narrowly documented, justified exception is provided.

* **Documentation**
  * Condensed and clarified workflow, monitoring, heartbeat, timestamping, and worktree guidance; detailed procedures moved to dedicated orchestration and review rule documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->