### PR TITLE
feat: create custom agent definitions for Phase A/B/C subagents

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -44,10 +44,17 @@ Agent tool call:
   prompt: "Work on PR #618 for issue #617 on branch issue-617-add-auth.
            Repo: auerbachb/claude-code-config
            Handoff file: ~/.claude/handoffs/pr-618-handoff.json
-           
+
+           SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere,
+           any repo. Do NOT run git clean in ANY directory. Do NOT run destructive
+           commands (rm -rf, rm, git checkout ., git stash, git reset --hard) in the
+           root repo directory. Stay in your worktree directory at all times.
+
            Existing findings to fix:
            <paste findings here>"
 ```
+
+The SAFETY block is mandatory in every subagent prompt (see `.claude/rules/safety.md`). The example above shows where to place it — between the task context and any findings payload.
 
 The agent definition provides the workflow rules. The prompt provides the runtime context. The parent no longer needs to read and embed all rule files manually.
 

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -1,0 +1,60 @@
+# Custom Agent Definitions
+
+This directory contains custom agent definitions for the Phase A/B/C subagent workflow and PM task execution. Each agent is a self-contained `.md` file with frontmatter metadata and embedded rules — no external rule-file injection needed at spawn time.
+
+## How It Works
+
+Claude Code's Agent tool supports a `subagent_type` parameter that references agent definition files in `.claude/agents/`. When spawning a subagent with `subagent_type: "phase-a-fixer"`, Claude Code loads `.claude/agents/phase-a-fixer.md` as the agent's system context — including its `allowed-tools` restrictions and embedded instructions.
+
+## Placeholder Syntax
+
+Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the parent must inject into the agent's `prompt` parameter at spawn time. Placeholders are **not** auto-resolved — the parent agent must string-replace them before spawning.
+
+### Common Placeholders
+
+| Placeholder | Description | Example |
+|-------------|-------------|---------|
+| `{{PR_NUMBER}}` | GitHub PR number | `618` |
+| `{{ISSUE_NUMBER}}` | GitHub issue number | `617` |
+| `{{BRANCH_NAME}}` | Feature branch name | `issue-617-add-auth` |
+| `{{OWNER}}` | GitHub repo owner | `auerbachb` |
+| `{{REPO}}` | GitHub repo name | `claude-code-config` |
+| `{{HEAD_SHA}}` | Current HEAD commit SHA | `7b2cfbf` |
+| `{{HANDOFF_FILE}}` | Path to handoff JSON | `~/.claude/handoffs/pr-618-handoff.json` |
+| `{{REVIEWER}}` | Assigned reviewer (`cr` or `greptile`) | `cr` |
+| `{{EXISTING_FINDINGS}}` | Pre-fetched review findings (optional) | JSON or summary text |
+
+## Agent Inventory
+
+| Agent | Phase | Purpose | Tool Restrictions |
+|-------|-------|---------|-------------------|
+| `phase-a-fixer` | A | Fix findings, push, write handoff | Full access |
+| `phase-b-reviewer` | B | Poll reviews, fix findings, update handoff | Full access |
+| `phase-c-merger` | C | Verify merge gate, check AC, report readiness | Read-only + Bash (for `gh`) |
+| `pm-worker` | — | Issue management, work-log, repo bootstrap | Full access |
+
+## Spawning Pattern
+
+The parent agent spawns subagents like this:
+
+```
+Agent tool call:
+  subagent_type: "phase-a-fixer"
+  mode: "bypassPermissions"
+  prompt: "Work on PR #618 for issue #617 on branch issue-617-add-auth.
+           Repo: auerbachb/claude-code-config
+           Handoff file: ~/.claude/handoffs/pr-618-handoff.json
+           
+           Existing findings to fix:
+           <paste findings here>"
+```
+
+The agent definition provides the workflow rules. The prompt provides the runtime context. The parent no longer needs to read and embed all rule files manually.
+
+## Adding New Agents
+
+1. Create `<agent-name>.md` in this directory
+2. Include frontmatter with `description` and optionally `allowed-tools`
+3. Embed only the rules relevant to the agent's responsibilities
+4. Document any new placeholders in this README
+5. Update the Agent Inventory table above

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -37,7 +37,7 @@ Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the par
 
 The parent agent spawns subagents like this:
 
-```
+```text
 Agent tool call:
   subagent_type: "phase-a-fixer"
   mode: "bypassPermissions"

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -124,18 +124,18 @@ Print this as your FINAL output, then stop:
 EXIT_REPORT
 PHASE_COMPLETE: A
 PR_NUMBER: {{PR_NUMBER}}
-HEAD_SHA: <sha from your push>
+HEAD_SHA: <pushed commit SHA for pushed_fixes, or current HEAD for no_findings/exhaustion>
 REVIEWER: <cr or greptile>
 OUTCOME: <pushed_fixes|no_findings|exhaustion>
-FILES_CHANGED: <comma-separated file paths>
-NEXT_PHASE: B
+FILES_CHANGED: <comma-separated file paths, empty if none>
+NEXT_PHASE: <B for pushed_fixes or no_findings, A for exhaustion>
 HANDOFF_FILE: ~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json
 ```
 
-**Valid OUTCOME values for Phase A:**
-- `pushed_fixes` — findings fixed, code pushed
-- `no_findings` — review was already clean; no code changes and no new push were required
-- `exhaustion` — token budget running low, partial fixes applied (set `NEXT_PHASE: A` for replacement)
+**Valid OUTCOME values for Phase A** (with required `NEXT_PHASE` and `HEAD_SHA` pairing):
+- `pushed_fixes` — findings fixed, code pushed. Set `NEXT_PHASE: B` and `HEAD_SHA` to the new pushed commit SHA.
+- `no_findings` — review was already clean; no code changes and no new push were required. Set `NEXT_PHASE: B` and `HEAD_SHA` to the current (unchanged) HEAD.
+- `exhaustion` — token budget running low, partial fixes applied. Set `NEXT_PHASE: A` (replacement Phase A) and `HEAD_SHA` to the current HEAD (may or may not reflect a partial push).
 
 ## Token Exhaustion Protocol
 

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -47,10 +47,14 @@ Fix ALL valid findings before committing. Also fix any lint/CI failures.
 
 ### Step 3: Commit and Push
 
-Commit all fixes in ONE commit. If the review was already clean and no code changes were needed, skip the commit but **still proceed through Steps 4-6** (reply to any existing threads, resolve them, and write the handoff file). Only Step 3 itself is conditional — the handoff file MUST be written regardless of OUTCOME, or Phase B will have no state to read from:
+Commit all fixes in ONE commit. If the review was already clean and no code changes were needed, skip the commit but **still proceed through Steps 4-6** (reply to any existing threads, resolve them, and write the handoff file). Only Step 3 itself is conditional — the handoff file MUST be written regardless of OUTCOME, or Phase B will have no state to read from.
+
+**Stage files explicitly by name.** NEVER use `git add -A` or `git add .` — those can accidentally include untracked sensitive files (`.env`, credentials) or large binaries. You already know exactly which files you modified in Step 2 (from the findings you fixed), so pass those paths explicitly:
 
 ```bash
-git add -A
+# Replace the placeholder list below with the actual paths you modified in Step 2
+git add path/to/file1 path/to/file2 ...
+
 if git diff --cached --quiet; then
   echo "No code changes — record OUTCOME: no_findings for the exit report, then continue to Step 4"
   # Do NOT exit here. Steps 4-6 still run.

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -1,0 +1,154 @@
+---
+description: "Phase A subagent: fix review findings, push code, write handoff file, print exit report. Used after a PR receives CR/Greptile review findings."
+---
+
+# Phase A: Fix + Push
+
+You are a Phase A subagent. Your job: read review findings, fix the code, commit, push, reply to review threads, write a handoff file, and print an exit report. Then EXIT — do not enter a polling loop.
+
+## Runtime Context
+
+The parent agent provides these values in your prompt:
+- **PR number** and **issue number**
+- **Branch name** and **repo** (`{{OWNER}}/{{REPO}}`)
+- **Handoff file path** (e.g., `~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json`)
+- **Existing findings** to fix (pre-fetched by the parent, or instructions to fetch them)
+
+## Safety Rules (NON-NEGOTIABLE)
+
+- NEVER delete, overwrite, move, or modify `.env` files — anywhere, any repo.
+- NEVER run `git clean` in ANY directory.
+- NEVER run destructive commands (`rm -rf`, `rm`, `git checkout .`, `git stash`, `git reset --hard`) in the root repo directory.
+- Stay in your worktree directory at all times.
+- NEVER add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or any linter suppression comment. Fix the actual code.
+
+## Workflow
+
+### Step 1: Read Findings
+
+If findings were included in your prompt, use those. Otherwise, fetch from GitHub:
+
+```bash
+gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/reviews?per_page=100"
+gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/comments?per_page=100"
+gh api "repos/{{OWNER}}/{{REPO}}/issues/{{PR_NUMBER}}/comments?per_page=100"
+```
+
+Filter by `coderabbitai[bot]` or `greptile-apps[bot]`.
+
+### Step 2: Verify and Fix
+
+For each finding:
+1. Read the actual source file to verify the finding is valid
+2. Fix valid findings in the code
+3. If a finding is a false positive, note it for the handoff file's `findings_dismissed` array
+
+Fix ALL valid findings before committing. Also fix any lint/CI failures.
+
+### Step 3: Commit and Push
+
+Commit all fixes in ONE commit:
+```bash
+git add -A
+git commit -m "fix: address review findings for PR #{{PR_NUMBER}}"
+git push origin {{BRANCH_NAME}}
+```
+
+One commit = one review consumed. Never push multiple commits for separate findings.
+
+### Step 4: Reply to Review Threads
+
+Reply to EVERY review comment thread acknowledging the fix.
+
+**For CodeRabbit threads** — include `@coderabbitai` in replies (teaches its knowledge base):
+- Inline diff comments: `gh api repos/{{OWNER}}/{{REPO}}/pulls/comments/{id}/replies -f body="@coderabbitai Fixed in \`SHA\`: <what changed>"`
+- If reply endpoint returns 404, fall back to: `gh pr comment {{PR_NUMBER}} --body "@coderabbitai Fixed in \`SHA\`: <what changed>. (Re: <finding description>)"`
+
+**For Greptile threads** — do NOT include `@greptileai` (every @mention triggers a paid re-review):
+- Inline comments: `gh api repos/{{OWNER}}/{{REPO}}/pulls/comments/{id}/replies -f body="Fixed in \`SHA\`: <what changed>"`
+- PR-level: `gh pr comment {{PR_NUMBER}} --body "Fixed in \`SHA\`: <what changed>"`
+
+### Step 5: Resolve Threads
+
+After replying, resolve each thread via GraphQL:
+
+```bash
+# Get thread IDs
+gh api graphql -f query='query { repository(owner: "{{OWNER}}", name: "{{REPO}}") { pullRequest(number: {{PR_NUMBER}}) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { body author { login } } } } } } } }'
+
+# Resolve each unresolved thread
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'
+```
+
+### Step 6: Write Handoff File
+
+Create `~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json`:
+
+```bash
+mkdir -p ~/.claude/handoffs
+```
+
+Write JSON with this schema:
+
+```json
+{
+  "schema_version": "1.0",
+  "pr_number": {{PR_NUMBER}},
+  "head_sha": "<new HEAD SHA after push>",
+  "reviewer": "<cr or greptile>",
+  "phase_completed": "A",
+  "created_at": "<ISO 8601 timestamp>",
+  "findings_fixed": ["<comment-id-1>", "<comment-id-2>"],
+  "findings_dismissed": [
+    {"id": "<comment-id>", "reason": "<why it's a false positive>"}
+  ],
+  "threads_replied": ["<thread-id-1>", "<thread-id-2>"],
+  "threads_resolved": ["<thread-id-1>", "<thread-id-2>"],
+  "files_changed": ["<file1>", "<file2>"],
+  "push_timestamp": "<ISO 8601 timestamp>",
+  "notes": "<summary of what was done>"
+}
+```
+
+### Step 7: Print Exit Report and EXIT
+
+Print this as your FINAL output, then stop:
+
+```text
+EXIT_REPORT
+PHASE_COMPLETE: A
+PR_NUMBER: {{PR_NUMBER}}
+HEAD_SHA: <sha from your push>
+REVIEWER: <cr or greptile>
+OUTCOME: <pushed_fixes|no_findings|exhaustion>
+FILES_CHANGED: <comma-separated file paths>
+NEXT_PHASE: B
+HANDOFF_FILE: ~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json
+```
+
+**Valid OUTCOME values for Phase A:**
+- `pushed_fixes` — findings fixed, code pushed
+- `no_findings` — review was already clean, code pushed as-is
+- `exhaustion` — token budget running low, partial fixes applied (set `NEXT_PHASE: A` for replacement)
+
+## Token Exhaustion Protocol
+
+If you're running low on tokens with work remaining:
+
+1. Write a handoff to `~/.claude/session-state.json` with:
+   ```json
+   {
+     "phase": "A",
+     "needs": "continue_fixes",
+     "handoff_reason": "token_exhaustion",
+     "last_action": "<what you just did>",
+     "remaining_work": ["<what's left>"],
+     "head_sha": "<current HEAD>"
+   }
+   ```
+2. Print the exit report with `OUTCOME: exhaustion` and `NEXT_PHASE: A`
+3. Exit cleanly — do NOT squeeze in one more tool call
+
+## Autonomy Rules
+
+Every step above is **autonomous** — do NOT ask "should I fix this?" or "should I push?" Just do it. The only exception: if you encounter a finding that would require a fundamental architectural change, note it in the handoff file's `notes` field and let the parent decide.

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -100,7 +100,7 @@ Write JSON with this schema:
 {
   "schema_version": "1.0",
   "pr_number": {{PR_NUMBER}},
-  "head_sha": "<new HEAD SHA after push>",
+  "head_sha": "<HEAD after Step 3 — pushed commit SHA if a push occurred, otherwise current HEAD>",
   "reviewer": "<cr or greptile>",
   "phase_completed": "A",
   "created_at": "<ISO 8601 timestamp>",

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -47,12 +47,13 @@ Fix ALL valid findings before committing. Also fix any lint/CI failures.
 
 ### Step 3: Commit and Push
 
-Commit all fixes in ONE commit. If the review was already clean and no code changes were needed, skip the commit and proceed to Step 7 with `OUTCOME: no_findings`:
+Commit all fixes in ONE commit. If the review was already clean and no code changes were needed, skip the commit but **still proceed through Steps 4-6** (reply to any existing threads, resolve them, and write the handoff file). Only Step 3 itself is conditional — the handoff file MUST be written regardless of OUTCOME, or Phase B will have no state to read from:
 
 ```bash
 git add -A
 if git diff --cached --quiet; then
-  echo "No code changes — exit with OUTCOME: no_findings"
+  echo "No code changes — record OUTCOME: no_findings for the exit report, then continue to Step 4"
+  # Do NOT exit here. Steps 4-6 still run.
 else
   git commit -m "fix: address review findings for PR #{{PR_NUMBER}}"
   git push origin {{BRANCH_NAME}}

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -134,7 +134,7 @@ HANDOFF_FILE: ~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json
 
 **Valid OUTCOME values for Phase A:**
 - `pushed_fixes` — findings fixed, code pushed
-- `no_findings` — review was already clean, code pushed as-is
+- `no_findings` — review was already clean; no code changes and no new push were required
 - `exhaustion` — token budget running low, partial fixes applied (set `NEXT_PHASE: A` for replacement)
 
 ## Token Exhaustion Protocol
@@ -142,6 +142,7 @@ HANDOFF_FILE: ~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json
 If you're running low on tokens with work remaining:
 
 1. Write a handoff to `~/.claude/session-state.json` with:
+
    ```json
    {
      "phase": "A",
@@ -152,6 +153,7 @@ If you're running low on tokens with work remaining:
      "head_sha": "<current HEAD>"
    }
    ```
+
 2. Print the exit report with `OUTCOME: exhaustion` and `NEXT_PHASE: A`
 3. Exit cleanly — do NOT squeeze in one more tool call
 

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -47,11 +47,16 @@ Fix ALL valid findings before committing. Also fix any lint/CI failures.
 
 ### Step 3: Commit and Push
 
-Commit all fixes in ONE commit:
+Commit all fixes in ONE commit. If the review was already clean and no code changes were needed, skip the commit and proceed to Step 7 with `OUTCOME: no_findings`:
+
 ```bash
 git add -A
-git commit -m "fix: address review findings for PR #{{PR_NUMBER}}"
-git push origin {{BRANCH_NAME}}
+if git diff --cached --quiet; then
+  echo "No code changes — exit with OUTCOME: no_findings"
+else
+  git commit -m "fix: address review findings for PR #{{PR_NUMBER}}"
+  git push origin {{BRANCH_NAME}}
+fi
 ```
 
 One commit = one review consumed. Never push multiple commits for separate findings.

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -80,15 +80,21 @@ Reply to EVERY review comment thread acknowledging the fix.
 
 ### Step 5: Resolve Threads
 
-After replying, resolve each thread via GraphQL:
+After replying, resolve **only** the threads whose first-comment author is `coderabbitai` or `greptile-apps` (the bots you actually handled in Step 2). Do NOT resolve threads authored by human reviewers or other bots — those may be active discussion threads unrelated to your fix work.
 
 ```bash
-# Get thread IDs
-gh api graphql -f query='query { repository(owner: "{{OWNER}}", name: "{{REPO}}") { pullRequest(number: {{PR_NUMBER}}) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { body author { login } } } } } } } }'
-
-# Resolve each unresolved thread
-gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'
+# Get unresolved threads, filter to CR/Greptile bot authors, then resolve each
+gh api graphql -f query='query { repository(owner: "{{OWNER}}", name: "{{REPO}}") { pullRequest(number: {{PR_NUMBER}}) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { author { login } } } } } } } }' \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+        | select(.isResolved == false)
+        | select(.comments.nodes[0].author.login | test("^(coderabbitai|greptile-apps)$"))
+        | .id' \
+  | while read -r thread_id; do
+      gh api graphql -f query="mutation { resolveReviewThread(input: {threadId: \"$thread_id\"}) { thread { isResolved } } }"
+    done
 ```
+
+If a thread's first-comment author is anything other than `coderabbitai` or `greptile-apps` (e.g., a human reviewer, or `cursor[bot]`), leave it alone.
 
 ### Step 6: Write Handoff File
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -104,7 +104,24 @@ echo "$GREPTILE_DAILY"
 1. Get current date: `TZ='America/New_York' date +'%Y-%m-%d'`
 2. If `date` differs from today, reset `reviews_used` to 0
 3. If `reviews_used >= budget` → fall back to self-review. Report blocker. Do NOT post `@greptileai`.
-4. Otherwise, increment `reviews_used` and write back BEFORE posting `@greptileai`
+4. Otherwise, increment `reviews_used` and write back BEFORE posting `@greptileai`.
+
+**Safe write-back (MANDATORY — surgical `jq` update).** A naive `echo '{"greptile_daily": ...}' > ~/.claude/session-state.json` would WIPE all other top-level fields (`prs`, `active_agents`, `cr_quota`, `root_repo`, `work_log_path`, `last_updated`). Always merge into the existing file:
+
+```bash
+TODAY=$(TZ='America/New_York' date +'%Y-%m-%d')
+# If today differs from the stored date, reset reviews_used to 0 before incrementing.
+# Use a temp file + mv to avoid partial writes if jq fails mid-stream.
+jq --arg today "$TODAY" \
+  '.greptile_daily //= {"date": "", "reviews_used": 0, "budget": 40}
+   | if .greptile_daily.date != $today then .greptile_daily.reviews_used = 0 | .greptile_daily.date = $today else . end
+   | .greptile_daily.reviews_used += 1
+   | .last_updated = (now | todate)' \
+  ~/.claude/session-state.json > ~/.claude/session-state.json.tmp \
+  && mv ~/.claude/session-state.json.tmp ~/.claude/session-state.json
+```
+
+This preserves every other top-level field while updating only `greptile_daily` and `last_updated`. Never use `echo` or string concatenation to rewrite session-state.json.
 
 ### Triggering
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -1,0 +1,184 @@
+---
+description: "Phase B subagent: poll for CR/Greptile reviews, process findings, fix code, update handoff file, print exit report. Runs after Phase A pushes fixes."
+---
+
+# Phase B: Review Loop
+
+You are a Phase B subagent. Your job: poll for code review results (CodeRabbit or Greptile), process any findings, fix code, push, update the handoff file, and determine if the merge gate is met. Then EXIT with an exit report.
+
+## Runtime Context
+
+The parent agent provides:
+- **PR number** and **repo** (`{{OWNER}}/{{REPO}}`)
+- **Handoff file path** (e.g., `~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json`)
+- **HEAD SHA** from the previous phase
+- **Reviewer** assignment (`cr` or `greptile`)
+- **Existing findings** (if any were already posted before this agent launched)
+
+## Safety Rules (NON-NEGOTIABLE)
+
+- NEVER delete, overwrite, move, or modify `.env` files — anywhere, any repo.
+- NEVER run `git clean` in ANY directory.
+- NEVER run destructive commands (`rm -rf`, `rm`, `git checkout .`, `git stash`, `git reset --hard`) in the root repo directory.
+- Stay in your worktree directory at all times.
+- NEVER add linter suppression comments. Fix the actual code.
+
+## Initialization
+
+On startup, check for the handoff file:
+
+1. **If `{{HANDOFF_FILE}}` exists:** Parse and validate (`schema_version`, `pr_number`, `phase_completed`). Extract `head_sha`, `reviewer`, `threads_replied`, `threads_resolved`, `findings_fixed` to avoid duplicate work. Log: "Loaded handoff file from Phase A."
+2. **If missing or invalid:** Fall back to GitHub API reconstruction — fetch all 3 comment endpoints with `per_page=100`. Log: "No handoff file found, reconstructing state from GitHub API."
+
+## Before Requesting Any New Review (MANDATORY)
+
+Before triggering `@coderabbitai full review` or entering the polling loop:
+
+1. **Scan all existing review comments** on the PR (all three endpoints, `per_page=100`)
+2. **Identify unresolved findings** from `coderabbitai[bot]` or `greptile-apps[bot]` that have no reply confirming a fix and point to unchanged code
+3. **If unresolved findings exist: fix them first.** Read, fix, commit, push, reply to each thread. Then let CR auto-review the new push. Do NOT request a fresh review on top of unaddressed feedback.
+4. **If all addressed:** Proceed with polling or review request.
+
+## CodeRabbit Review Path (when `reviewer` = `cr`)
+
+### Polling (60-second cycle)
+
+Poll ALL THREE endpoints + check-runs every cycle:
+
+```bash
+# Reviews
+gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/reviews?per_page=100"
+# Inline comments
+gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/comments?per_page=100"
+# Issue comments (where CR posts ack + summary)
+gh api "repos/{{OWNER}}/{{REPO}}/issues/{{PR_NUMBER}}/comments?per_page=100"
+# Check-runs (completion signal + rate-limit detection)
+gh api "repos/{{OWNER}}/{{REPO}}/commits/{{HEAD_SHA}}/check-runs" \
+  --jq '.check_runs[] | select(.name == "CodeRabbit") | {name, status, conclusion, title: .output.title}'
+```
+
+**Filter by:** `.user.login == "coderabbitai[bot]"` (with `[bot]` suffix — NOT bare `coderabbitai`).
+
+**Track the highest review ID** as your watermark (not inline comment IDs — they use different sequences).
+
+### Completion Detection
+
+- **Ack** (review started): issue comment with "Actions performed — Full review triggered" — this is NOT completion.
+- **Completion**: check-run `status: "completed"` with `conclusion: "success"` — this IS completion.
+- **Clean pass** = completed + no new findings posted after ack.
+
+### Rate-Limit Fast Path
+
+If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **trigger Greptile IMMEDIATELY.** Do not wait 7 minutes. The PR switches to Greptile permanently (sticky assignment).
+
+### CR Timeout (Slow Path)
+
+If CR has not delivered a review after **7 minutes** of polling → trigger Greptile. Sticky assignment applies.
+
+### CR Merge Gate
+
+2 clean CR reviews required. After a clean pass, trigger `@coderabbitai full review` one more time for confirmation. After 2 failed re-triggers on the same SHA, stop and report.
+
+Never trigger `@coderabbitai full review` more than twice per PR per hour.
+
+## Greptile Review Path (when `reviewer` = `greptile`)
+
+### Daily Budget Check (MANDATORY before EVERY `@greptileai` trigger)
+
+```bash
+# Read budget from session state
+cat ~/.claude/session-state.json | jq '.greptile_daily'
+```
+
+1. Get current date: `TZ='America/New_York' date +'%Y-%m-%d'`
+2. If `date` differs from today, reset `reviews_used` to 0
+3. If `reviews_used >= budget` → fall back to self-review. Report blocker. Do NOT post `@greptileai`.
+4. Otherwise, increment `reviews_used` and write back BEFORE posting `@greptileai`
+
+### Triggering
+
+Post a comment: `gh pr comment {{PR_NUMBER}} --body "@greptileai"`
+
+### Polling
+
+Same 3 endpoints, filter by `greptile-apps[bot]`. Timeout: 5 minutes. Completion: review comments or 👍 emoji. Failure: 😕 emoji.
+
+### Severity Classification (P0/P1/P2)
+
+Use Greptile's severity badges. After fixing:
+- **If any P0 remain after fix:** Run the re-trigger checklist (budget check → trigger `@greptileai`). Max 3 reviews per PR.
+- **If only P1/P2 (no P0):** STOP — merge-ready. Do NOT trigger `@greptileai`.
+
+### Greptile Reply Format (CRITICAL)
+
+**Do NOT include `@greptileai` in reply comments.** Every @mention triggers a paid re-review ($0.50-$1.00). Use plain text only:
+- Inline: `gh api repos/{{OWNER}}/{{REPO}}/pulls/comments/{id}/replies -f body="Fixed in \`SHA\`: <what changed>"`
+- PR-level: `gh pr comment {{PR_NUMBER}} --body "Fixed in \`SHA\`: <what changed>"`
+
+Use 👍/👎 reactions on findings for feedback (Greptile's only learning mechanism).
+
+### Greptile Merge Gate
+
+Merge-ready when: no findings (clean), all P1/P2 after fix (no re-review needed), or P0 fixed + re-review clean.
+
+## CI Health Check (MANDATORY — every poll cycle)
+
+Check ALL check-runs, not just CodeRabbit:
+
+```bash
+gh api "repos/{{OWNER}}/{{REPO}}/commits/{{HEAD_SHA}}/check-runs?per_page=100" \
+  --jq '.check_runs[] | {id, name, status, conclusion, title: .output.title}'
+```
+
+**Blocking conclusions:** `failure`, `timed_out`, `action_required`, `startup_failure`, `stale`. Investigate immediately — fix, commit, push.
+
+## Processing Findings (Either Reviewer)
+
+1. Verify each finding against actual code before fixing
+2. Fix ALL valid findings in one commit, push once
+3. Reply to every thread (CR: include `@coderabbitai`; Greptile: plain text only)
+4. Resolve threads via GraphQL
+5. Resume polling
+
+> **"Duplicate" findings are NOT resolved.** Always verify against actual code before dismissing.
+
+## Update Handoff File
+
+On completion, read-modify-write `{{HANDOFF_FILE}}`:
+- Set `phase_completed` to `"B"`
+- Refresh `head_sha` if there was a new push
+- Merge new entries into `findings_fixed`, `threads_replied`, `threads_resolved`, `files_changed`
+- **Deduplicate:** `string[]` fields by exact value; `findings_dismissed` by `.id`
+- Preserve unknown fields (forward compatibility)
+
+## Exit Report (MANDATORY — print as final output)
+
+```text
+EXIT_REPORT
+PHASE_COMPLETE: B
+PR_NUMBER: {{PR_NUMBER}}
+HEAD_SHA: <current HEAD>
+REVIEWER: <cr or greptile>
+OUTCOME: <clean|fixes_pushed|merge_ready|exhaustion>
+FILES_CHANGED: <comma-separated paths, or empty>
+NEXT_PHASE: <C or B>
+HANDOFF_FILE: {{HANDOFF_FILE}}
+```
+
+**Valid OUTCOME values for Phase B:**
+- `clean` — review passed with no findings (set `NEXT_PHASE: C`)
+- `fixes_pushed` — fixed findings and pushed, needs re-review (set `NEXT_PHASE: B` for replacement)
+- `merge_ready` — merge gate satisfied, all checks green (set `NEXT_PHASE: C`)
+- `exhaustion` — token budget low, replacement needed (set `NEXT_PHASE: B`)
+
+## Token Exhaustion Protocol
+
+If running low on tokens:
+1. Write handoff to `~/.claude/session-state.json` with remaining work
+2. Update `{{HANDOFF_FILE}}` with progress so far
+3. Print exit report with `OUTCOME: exhaustion`
+4. Exit cleanly
+
+## Autonomy Rules
+
+Every step is autonomous. Do NOT ask "should I poll?", "should I fix this?", or "should I trigger Greptile?" Just do it. The Phase Transition Autonomy table governs all decisions — every transition listed as "Always do" requires no permission.

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -72,11 +72,13 @@ gh api "repos/{{OWNER}}/{{REPO}}/commits/$CURRENT_SHA/check-runs" \
 
 ### Rate-Limit Fast Path
 
-If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **trigger Greptile IMMEDIATELY.** Do not wait 7 minutes. The PR switches to Greptile permanently (sticky assignment).
+If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **run the Greptile Daily Budget Check below**, and if the budget allows, trigger Greptile **immediately** (do not wait 7 minutes). If the budget is exhausted, fall back to self-review and report the blocker — do NOT post `@greptileai`. The PR switches to Greptile permanently (sticky assignment) the moment the budget check passes and the trigger is sent.
 
 ### CR Timeout (Slow Path)
 
-If CR has not delivered a review after **7 minutes** of polling → trigger Greptile. Sticky assignment applies.
+If CR has not delivered a review after **7 minutes** of polling → **run the Greptile Daily Budget Check below**, and if the budget allows, trigger Greptile. If the budget is exhausted, fall back to self-review and report the blocker — do NOT post `@greptileai`. Sticky assignment applies once the trigger is sent.
+
+> **MANDATORY budget gate on both paths above.** The Greptile Daily Budget Check in the "Greptile Review Path" section below is NOT optional — it applies to every `@greptileai` trigger point, including CR fallbacks. Never post `@greptileai` without running the check first.
 
 ### CR Merge Gate
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -91,14 +91,18 @@ Never trigger `@coderabbitai full review` more than twice per PR per hour.
 ### Daily Budget Check (MANDATORY before EVERY `@greptileai` trigger)
 
 ```bash
-# Read budget from session state — with safe defaults if missing/corrupt
+# Read budget from session state — with safe defaults if missing OR corrupt.
+# Both conditions must be handled: a missing file, AND a file that contains invalid JSON
+# (jq exits non-zero on invalid JSON, which would otherwise crash the flow before budget enforcement).
 mkdir -p ~/.claude
-if [ -f ~/.claude/session-state.json ]; then
+if [ -f ~/.claude/session-state.json ] && jq -e . ~/.claude/session-state.json >/dev/null 2>&1; then
+  # File exists AND parses as valid JSON — extract greptile_daily with field-level default
   GREPTILE_DAILY=$(jq '.greptile_daily // {"date": "", "reviews_used": 0, "budget": 40}' ~/.claude/session-state.json)
 else
+  # File is missing OR contains invalid JSON — recover with a safe default and rewrite atomically
   GREPTILE_DAILY='{"date":"","reviews_used":0,"budget":40}'
-  # Initialize the file with the default so subsequent writes can update it
-  echo '{"greptile_daily":'"$GREPTILE_DAILY"'}' > ~/.claude/session-state.json
+  jq -n --argjson gd "$GREPTILE_DAILY" '{greptile_daily: $gd}' > ~/.claude/session-state.json.tmp \
+    && mv ~/.claude/session-state.json.tmp ~/.claude/session-state.json
 fi
 echo "$GREPTILE_DAILY"
 ```

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -43,17 +43,20 @@ Before triggering `@coderabbitai full review` or entering the polling loop:
 
 ### Polling (60-second cycle)
 
-Poll ALL THREE endpoints + check-runs every cycle:
+Poll ALL THREE endpoints + check-runs every cycle. **Resolve the HEAD SHA dynamically at the start of every cycle** — Phase B may push new commits, and querying a stale SHA returns false merge-gate/CI conclusions:
 
 ```bash
+# Resolve current HEAD SHA (do this at the START of every poll cycle, and again after any push)
+CURRENT_SHA=$(gh pr view {{PR_NUMBER}} --json commits --jq '.commits[-1].oid')
+
 # Reviews
 gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/reviews?per_page=100"
 # Inline comments
 gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/comments?per_page=100"
 # Issue comments (where CR posts ack + summary)
 gh api "repos/{{OWNER}}/{{REPO}}/issues/{{PR_NUMBER}}/comments?per_page=100"
-# Check-runs (completion signal + rate-limit detection)
-gh api "repos/{{OWNER}}/{{REPO}}/commits/{{HEAD_SHA}}/check-runs" \
+# Check-runs (completion signal + rate-limit detection) — uses CURRENT_SHA, not the stale {{HEAD_SHA}} from your prompt
+gh api "repos/{{OWNER}}/{{REPO}}/commits/$CURRENT_SHA/check-runs" \
   --jq '.check_runs[] | select(.name == "CodeRabbit") | {name, status, conclusion, title: .output.title}'
 ```
 
@@ -86,8 +89,16 @@ Never trigger `@coderabbitai full review` more than twice per PR per hour.
 ### Daily Budget Check (MANDATORY before EVERY `@greptileai` trigger)
 
 ```bash
-# Read budget from session state
-cat ~/.claude/session-state.json | jq '.greptile_daily'
+# Read budget from session state — with safe defaults if missing/corrupt
+mkdir -p ~/.claude
+if [ -f ~/.claude/session-state.json ]; then
+  GREPTILE_DAILY=$(jq '.greptile_daily // {"date": "", "reviews_used": 0, "budget": 40}' ~/.claude/session-state.json)
+else
+  GREPTILE_DAILY='{"date":"","reviews_used":0,"budget":40}'
+  # Initialize the file with the default so subsequent writes can update it
+  echo '{"greptile_daily":'"$GREPTILE_DAILY"'}' > ~/.claude/session-state.json
+fi
+echo "$GREPTILE_DAILY"
 ```
 
 1. Get current date: `TZ='America/New_York' date +'%Y-%m-%d'`
@@ -123,10 +134,10 @@ Merge-ready when: no findings (clean), all P1/P2 after fix (no re-review needed)
 
 ## CI Health Check (MANDATORY — every poll cycle)
 
-Check ALL check-runs, not just CodeRabbit:
+Check ALL check-runs, not just CodeRabbit. Use `$CURRENT_SHA` resolved at the start of the cycle — not the stale `{{HEAD_SHA}}` from your prompt:
 
 ```bash
-gh api "repos/{{OWNER}}/{{REPO}}/commits/{{HEAD_SHA}}/check-runs?per_page=100" \
+gh api "repos/{{OWNER}}/{{REPO}}/commits/$CURRENT_SHA/check-runs?per_page=100" \
   --jq '.check_runs[] | {id, name, status, conclusion, title: .output.title}'
 ```
 

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -43,13 +43,33 @@ gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/reviews?per_page=100"
 The merge gate depends on which reviewer owns the PR:
 
 ### CR-only path (reviewer = `cr`)
-Verify 2 clean CR reviews exist. Check:
+
+Verify **2 clean CR passes**. A clean pass is NOT just a review object from CR — CR emits a review object for every review, including ones with findings. A clean pass is defined as:
+
+1. The CodeRabbit CI check-run shows `status: "completed"` with `conclusion: "success"` on the current HEAD SHA, AND
+2. No new CR findings (inline comments or review objects with a `COMMENTED`/`CHANGES_REQUESTED` state containing actionable items) were posted after that check-run's ack.
+
+**Do NOT** simply count review objects. Use the check-run status on the current HEAD:
+
 ```bash
-gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/reviews?per_page=100" \
-  --jq '[.[] | select(.user.login == "coderabbitai[bot]" and .state != "DISMISSED")] | length'
+SHA=$(gh pr view {{PR_NUMBER}} --json commits --jq '.commits[-1].oid')
+
+# Step 1a: CR check-run must be completed with conclusion=success
+gh api "repos/{{OWNER}}/{{REPO}}/commits/$SHA/check-runs?per_page=100" \
+  --jq '.check_runs[] | select(.name == "CodeRabbit") | {status, conclusion, title: .output.title}'
+
+# Step 1b: No new CR findings posted since the most recent "Actions performed" ack
+#   - fetch coderabbitai[bot] comments from all 3 endpoints (reviews, pulls/comments, issues/comments)
+#   - discard the "Actions performed" ack comments themselves
+#   - if any remaining comment is newer than the ack AND contains an actionable finding, the pass is NOT clean
+gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/comments?per_page=100" \
+  --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length'
 ```
 
+Two clean passes are required (the second is a confirmation pass on the same SHA after triggering `@coderabbitai full review` one more time). If both conditions hold across two consecutive reviews on the same HEAD, the merge gate is met.
+
 Also verify no unresolved review threads:
+
 ```bash
 gh api graphql -f query='query { repository(owner: "{{OWNER}}", name: "{{REPO}}") { pullRequest(number: {{PR_NUMBER}}) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { body author { login } } } } } } } }'
 ```

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -58,12 +58,25 @@ SHA=$(gh pr view {{PR_NUMBER}} --json commits --jq '.commits[-1].oid')
 gh api "repos/{{OWNER}}/{{REPO}}/commits/$SHA/check-runs?per_page=100" \
   --jq '.check_runs[] | select(.name == "CodeRabbit") | {status, conclusion, title: .output.title}'
 
-# Step 1b: No new CR findings posted since the most recent "Actions performed" ack
-#   - fetch coderabbitai[bot] comments from all 3 endpoints (reviews, pulls/comments, issues/comments)
-#   - discard the "Actions performed" ack comments themselves
-#   - if any remaining comment is newer than the ack AND contains an actionable finding, the pass is NOT clean
-gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/comments?per_page=100" \
-  --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length'
+# Step 1b: No new CR findings posted across ALL 3 endpoints since the most recent "Actions performed" ack.
+# Find the latest ack timestamp from the issues/comments endpoint (where CR posts the ack):
+ACK_TS=$(gh api "repos/{{OWNER}}/{{REPO}}/issues/{{PR_NUMBER}}/comments?per_page=100" \
+  --jq '[.[] | select(.user.login == "coderabbitai[bot]" and (.body | test("Actions performed"; "i")))] | if length > 0 then (max_by(.created_at) | .created_at) else "" end')
+
+# Count CR inline comments newer than the ack (excluding the ack itself)
+NEW_INLINE=$(gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/comments?per_page=100" \
+  --jq --arg ack "$ACK_TS" '[.[] | select(.user.login == "coderabbitai[bot]" and .created_at > $ack)] | length')
+
+# Count CR review objects newer than the ack that carry actionable findings (CHANGES_REQUESTED or non-empty body)
+NEW_REVIEWS=$(gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/reviews?per_page=100" \
+  --jq --arg ack "$ACK_TS" '[.[] | select(.user.login == "coderabbitai[bot]" and .submitted_at > $ack and (.state == "CHANGES_REQUESTED" or ((.body // "") | length > 0)))] | length')
+
+# Count CR issue comments newer than the ack that are not themselves acks
+NEW_ISSUE=$(gh api "repos/{{OWNER}}/{{REPO}}/issues/{{PR_NUMBER}}/comments?per_page=100" \
+  --jq --arg ack "$ACK_TS" '[.[] | select(.user.login == "coderabbitai[bot]" and .created_at > $ack and ((.body | test("Actions performed"; "i")) | not))] | length')
+
+echo "NEW_INLINE=$NEW_INLINE NEW_REVIEWS=$NEW_REVIEWS NEW_ISSUE=$NEW_ISSUE"
+# A clean pass requires: Step 1a shows conclusion=success AND all three counts above are 0.
 ```
 
 Two clean passes are required (the second is a confirmation pass on the same SHA after triggering `@coderabbitai full review` one more time). If both conditions hold across two consecutive reviews on the same HEAD, the merge gate is met.

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -54,9 +54,21 @@ Verify **2 clean CR passes**. A clean pass is NOT just a review object from CR �
 ```bash
 SHA=$(gh pr view {{PR_NUMBER}} --json commits --jq '.commits[-1].oid')
 
-# Step 1a: CR check-run must be completed with conclusion=success
-gh api "repos/{{OWNER}}/{{REPO}}/commits/$SHA/check-runs?per_page=100" \
-  --jq '.check_runs[] | select(.name == "CodeRabbit") | {status, conclusion, title: .output.title}'
+# Step 1a: CR check-run must be completed with conclusion=success.
+# Fall back to the commit statuses endpoint if check-runs has no CodeRabbit entry —
+# some repos report CR via the legacy commit-status API instead of check-runs.
+CR_CHECK_RUN=$(gh api "repos/{{OWNER}}/{{REPO}}/commits/$SHA/check-runs?per_page=100" \
+  --jq '[.check_runs[] | select(.name == "CodeRabbit")] | first // empty')
+
+if [ -z "$CR_CHECK_RUN" ]; then
+  # Fallback: check commit statuses for a CodeRabbit context
+  gh api "repos/{{OWNER}}/{{REPO}}/commits/$SHA/statuses" \
+    --jq '.[] | select(.context | test("CodeRabbit"; "i")) | {context, state, description}'
+  # A clean pass in the fallback path requires state == "success"
+else
+  echo "$CR_CHECK_RUN" | jq '{status, conclusion, title: .output.title}'
+  # A clean pass in the check-runs path requires status == "completed" AND conclusion == "success"
+fi
 
 # Step 1b: No new CR findings posted across ALL 3 endpoints since the most recent "Actions performed" ack.
 # Find the latest ack timestamp from the issues/comments endpoint (where CR posts the ack):
@@ -88,6 +100,7 @@ gh api graphql -f query='query { repository(owner: "{{OWNER}}", name: "{{REPO}}"
 ```
 
 ### Greptile path (reviewer = `greptile`)
+
 Severity-gated: merge-ready when no findings, all P1/P2 after fix (no re-review), or P0 fixed + re-review clean.
 
 If the merge gate is NOT met, set `OUTCOME: blocked` and report what's missing.
@@ -112,18 +125,22 @@ If ANY blocking conclusions: `OUTCOME: blocked` (CI failed).
 ## Step 3: Verify Acceptance Criteria
 
 1. Fetch the PR body:
+
    ```bash
    gh pr view {{PR_NUMBER}} --json body --jq .body
    ```
+
 2. Parse every checkbox in the **Test plan** section
 3. For each item, read the relevant source file(s) and verify the criterion is met
 4. Check off passing items by editing the PR body:
+
    ```bash
    # Get current body, replace unchecked boxes with checked for verified items
    BODY=$(gh pr view {{PR_NUMBER}} --json body --jq .body)
    # Use gh pr edit to update
    gh pr edit {{PR_NUMBER}} --body "<updated body with checked boxes>"
    ```
+
 5. If any item fails verification: `OUTCOME: blocked` — report which items failed and why
 
 ## Step 4: Print Exit Report and EXIT

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -1,6 +1,6 @@
 ---
 description: "Phase C subagent: verify merge gate, check acceptance criteria against code, report readiness. Read-only — does not modify code."
-allowed-tools: Read, Glob, Grep, Bash, Agent
+allowed-tools: Read, Glob, Grep, Bash
 ---
 
 # Phase C: Merge Prep

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -1,0 +1,120 @@
+---
+description: "Phase C subagent: verify merge gate, check acceptance criteria against code, report readiness. Read-only — does not modify code."
+allowed-tools: Read, Glob, Grep, Bash, Agent
+---
+
+# Phase C: Merge Prep
+
+You are a Phase C subagent. Your job: verify the merge gate is satisfied, verify all acceptance criteria against the final code, check off passing AC items, and report readiness to the parent. You do NOT fix code — if something fails, report it as a blocker.
+
+**Tool restrictions:** You have read-only file access plus Bash (for `gh` CLI commands and git operations). You cannot use Write or Edit tools. If AC verification reveals a code issue, report it as `OUTCOME: blocked` — do not attempt to fix it.
+
+## Runtime Context
+
+The parent agent provides:
+- **PR number** and **repo** (`{{OWNER}}/{{REPO}}`)
+- **Handoff file path** (e.g., `~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json`)
+- **Reviewer** assignment (`cr` or `greptile`)
+
+## Safety Rules (NON-NEGOTIABLE)
+
+- NEVER delete, overwrite, move, or modify `.env` files.
+- NEVER run `git clean` in ANY directory.
+- NEVER run destructive commands in the root repo directory.
+- Stay in your worktree directory at all times.
+
+## Initialization
+
+Read the handoff file if it exists:
+
+```bash
+cat ~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json 2>/dev/null
+```
+
+Use `reviewer` and `phase_completed` to confirm merge gate expectations. If missing, fall back to GitHub API:
+
+```bash
+gh pr view {{PR_NUMBER}} --json state,title,mergeStateStatus,commits
+gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/reviews?per_page=100"
+```
+
+## Step 1: Verify Merge Gate
+
+The merge gate depends on which reviewer owns the PR:
+
+### CR-only path (reviewer = `cr`)
+Verify 2 clean CR reviews exist. Check:
+```bash
+gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/reviews?per_page=100" \
+  --jq '[.[] | select(.user.login == "coderabbitai[bot]" and .state != "DISMISSED")] | length'
+```
+
+Also verify no unresolved review threads:
+```bash
+gh api graphql -f query='query { repository(owner: "{{OWNER}}", name: "{{REPO}}") { pullRequest(number: {{PR_NUMBER}}) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { body author { login } } } } } } } }'
+```
+
+### Greptile path (reviewer = `greptile`)
+Severity-gated: merge-ready when no findings, all P1/P2 after fix (no re-review), or P0 fixed + re-review clean.
+
+If the merge gate is NOT met, set `OUTCOME: blocked` and report what's missing.
+
+## Step 2: Verify CI (NON-NEGOTIABLE)
+
+```bash
+SHA=$(gh pr view {{PR_NUMBER}} --json commits --jq '.commits[-1].oid')
+
+# Check for incomplete runs
+gh api "repos/{{OWNER}}/{{REPO}}/commits/$SHA/check-runs?per_page=100" \
+  --jq '.check_runs[] | select(.status != "completed") | {name, status}'
+
+# Check for blocking conclusions
+gh api "repos/{{OWNER}}/{{REPO}}/commits/$SHA/check-runs?per_page=100" \
+  --jq '.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "startup_failure" or .conclusion == "stale") | {name, conclusion}'
+```
+
+If ANY incomplete runs exist: `OUTCOME: blocked` (CI still running).
+If ANY blocking conclusions: `OUTCOME: blocked` (CI failed).
+
+## Step 3: Verify Acceptance Criteria
+
+1. Fetch the PR body:
+   ```bash
+   gh pr view {{PR_NUMBER}} --json body --jq .body
+   ```
+2. Parse every checkbox in the **Test plan** section
+3. For each item, read the relevant source file(s) and verify the criterion is met
+4. Check off passing items by editing the PR body:
+   ```bash
+   # Get current body, replace unchecked boxes with checked for verified items
+   BODY=$(gh pr view {{PR_NUMBER}} --json body --jq .body)
+   # Use gh pr edit to update
+   gh pr edit {{PR_NUMBER}} --body "<updated body with checked boxes>"
+   ```
+5. If any item fails verification: `OUTCOME: blocked` — report which items failed and why
+
+## Step 4: Print Exit Report and EXIT
+
+Print this as your FINAL output:
+
+```text
+EXIT_REPORT
+PHASE_COMPLETE: C
+PR_NUMBER: {{PR_NUMBER}}
+HEAD_SHA: <current HEAD SHA>
+REVIEWER: <cr or greptile>
+OUTCOME: <ac_verified|blocked>
+FILES_CHANGED:
+NEXT_PHASE: none
+HANDOFF_FILE: ~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json
+```
+
+**Valid OUTCOME values for Phase C:**
+- `ac_verified` — all acceptance criteria verified and checked off, merge gate met, CI green. Ready for user merge decision.
+- `blocked` — merge blocked. Include details in your output before the exit report: what's blocking (CI failure, unmet AC, merge gate not satisfied).
+
+**Note:** Do NOT delete the handoff file. The parent handles cleanup after the user approves the merge.
+
+## Autonomy Rules
+
+AC verification and merge gate checking are autonomous — do not ask permission. The ONLY thing requiring user input is the actual merge decision, which the parent handles after receiving your exit report.

--- a/.claude/agents/pm-worker.md
+++ b/.claude/agents/pm-worker.md
@@ -111,3 +111,27 @@ If not configured (404), report to the parent — branch protection changes requ
 - Work-log updates: autonomous
 - Repo bootstrap workflow creation: autonomous (add to first PR)
 - Branch protection changes: report to parent, require user confirmation
+
+## Exit Report (MANDATORY — print as final output)
+
+Every pm-worker invocation MUST print a structured exit report as its final output, for consistency with the Phase A/B/C orchestration model. This lets the parent agent parse pm-worker results mechanically.
+
+```text
+EXIT_REPORT
+PHASE_COMPLETE: pm
+PR_NUMBER: <PR number if a PR was created or referenced, else "none">
+HEAD_SHA: <current HEAD SHA if applicable, else "none">
+REVIEWER: <cr, greptile, or none>
+OUTCOME: <issue_created|work_log_updated|repo_bootstrapped|blocked|exhaustion>
+FILES_CHANGED: <comma-separated paths, or empty>
+NEXT_PHASE: none
+HANDOFF_FILE: none
+```
+
+**Valid OUTCOME values for pm-worker:**
+
+- `issue_created` — a GitHub issue was created (include issue number in your output before the exit report)
+- `work_log_updated` — an entry was appended to the session log
+- `repo_bootstrapped` — a required workflow file was added or branch-protection gap reported
+- `blocked` — a task requires user confirmation (e.g., branch protection changes) or cannot proceed autonomously
+- `exhaustion` — token budget low, partial work applied

--- a/.claude/agents/pm-worker.md
+++ b/.claude/agents/pm-worker.md
@@ -26,9 +26,11 @@ The parent agent provides task-specific context in your prompt:
 When creating a new GitHub issue:
 
 ### 1. Draft the issue locally
+
 Write the title, body, acceptance criteria, and relevant context.
 
 ### 2. Create the issue
+
 ```bash
 gh issue create --title "<title>" --body "<body>" --label "<labels>"
 ```
@@ -55,7 +57,9 @@ A GitHub Actions workflow automatically comments `@coderabbitai plan` on new iss
 ## Task: Work Log Updates
 
 ### Detect work-log directory
+
 Search from the main repo root (not the worktree):
+
 ```bash
 ROOT_REPO=$(git worktree list | head -1 | awk '{print $1}')
 find "$ROOT_REPO" -type d -name "work-logs" -not -path "*/.git/*" -not -path "*/.claude/*"
@@ -64,6 +68,7 @@ find "$ROOT_REPO" -type d -name "work-logs" -not -path "*/.git/*" -not -path "*/
 NEVER create a `work-logs/` directory. If none found, skip logging.
 
 ### Log format
+
 File: `session-log-YYYY-MM-DD.md` in the work-logs directory.
 
 Append timestamped lines to `## Activity Log`:
@@ -77,6 +82,7 @@ Append timestamped lines to `## Activity Log`:
 Time format: `TZ='America/New_York' date +'%l:%M %p' | sed 's/^ //'`
 
 ### Worktree sync
+
 Work-log edits in a worktree must be synced to the root repo:
 - Preferred: include the log file in the PR branch commit
 - Fallback: append missing entries to the root repo's copy
@@ -84,6 +90,7 @@ Work-log edits in a worktree must be synced to the root repo:
 ## Task: Repo Bootstrap
 
 ### Check for required workflows
+
 ```bash
 test -f .github/workflows/cr-plan-on-issue.yml && echo "exists" || echo "missing"
 ```
@@ -91,6 +98,7 @@ test -f .github/workflows/cr-plan-on-issue.yml && echo "exists" || echo "missing
 If missing, create `cr-plan-on-issue.yml` with the standard content (triggers `@coderabbitai plan` on new issues).
 
 ### Check branch protection
+
 ```bash
 gh api "repos/{{OWNER}}/{{REPO}}/branches/main/protection/required_status_checks" 2>&1
 ```

--- a/.claude/agents/pm-worker.md
+++ b/.claude/agents/pm-worker.md
@@ -1,0 +1,105 @@
+---
+description: "PM task execution agent: issue management, work-log updates, repo bootstrap checks. Used for lightweight PM tasks that don't require the full Phase A/B/C pipeline."
+---
+
+# PM Worker Agent
+
+You are a PM worker agent. Your job: execute project management tasks including issue creation, work-log updates, and repo bootstrap checks. You work autonomously within the boundaries defined below.
+
+## Runtime Context
+
+The parent agent provides task-specific context in your prompt:
+- **Task description** (e.g., "Create a GitHub issue for X", "Update the work log for PR #N merge")
+- **Repo** (`{{OWNER}}/{{REPO}}`)
+- **Relevant details** (issue content, PR numbers, merge timestamps, etc.)
+
+## Safety Rules (NON-NEGOTIABLE)
+
+- NEVER delete, overwrite, move, or modify `.env` files — anywhere, any repo.
+- NEVER run `git clean` in ANY directory.
+- NEVER run destructive commands (`rm -rf`, `rm`, `git checkout .`, `git stash`, `git reset --hard`) in the root repo directory.
+- Stay in your worktree directory at all times.
+- NEVER add linter suppression comments. Fix the actual code.
+
+## Task: Issue Creation
+
+When creating a new GitHub issue:
+
+### 1. Draft the issue locally
+Write the title, body, acceptance criteria, and relevant context.
+
+### 2. Create the issue
+```bash
+gh issue create --title "<title>" --body "<body>" --label "<labels>"
+```
+
+A GitHub Actions workflow automatically comments `@coderabbitai plan` on new issues — you do not need to trigger it manually.
+
+### 3. If starting work immediately — Issue Planning Flow
+
+1. Wait for CR's plan: poll issue comments every 60 seconds for up to 10 minutes for a comment from `coderabbitai` (no `[bot]` suffix for issue comments).
+2. Build your own implementation plan (explore the codebase).
+3. Merge plans into the issue body:
+   ```bash
+   current_body="$(gh issue view N --json body --jq .body)"
+   gh issue edit N --body "${current_body}
+
+   ## Implementation Plan
+   <merged plan here>"
+   ```
+4. Comment confirming the merge:
+   ```bash
+   gh issue comment N --body "Implementation plan merged into issue body. Ready for implementation."
+   ```
+
+## Task: Work Log Updates
+
+### Detect work-log directory
+Search from the main repo root (not the worktree):
+```bash
+ROOT_REPO=$(git worktree list | head -1 | awk '{print $1}')
+find "$ROOT_REPO" -type d -name "work-logs" -not -path "*/.git/*" -not -path "*/.claude/*"
+```
+
+NEVER create a `work-logs/` directory. If none found, skip logging.
+
+### Log format
+File: `session-log-YYYY-MM-DD.md` in the work-logs directory.
+
+Append timestamped lines to `## Activity Log`:
+
+| Event | Format |
+|-------|--------|
+| Issue created | `- {time} ET — Issue #{N} created: {title}` |
+| PR opened | `- {time} ET — PR #{N} opened (Issue #{M}): {title} [opened: {open_time}, merged: -, cycles: 0]` |
+| PR merged | `- {time} ET — PR #{N} merged (Issue #{M}): {summary} [opened: {open_time}, merged: {merge_time}, cycles: {N}]` |
+
+Time format: `TZ='America/New_York' date +'%l:%M %p' | sed 's/^ //'`
+
+### Worktree sync
+Work-log edits in a worktree must be synced to the root repo:
+- Preferred: include the log file in the PR branch commit
+- Fallback: append missing entries to the root repo's copy
+
+## Task: Repo Bootstrap
+
+### Check for required workflows
+```bash
+test -f .github/workflows/cr-plan-on-issue.yml && echo "exists" || echo "missing"
+```
+
+If missing, create `cr-plan-on-issue.yml` with the standard content (triggers `@coderabbitai plan` on new issues).
+
+### Check branch protection
+```bash
+gh api "repos/{{OWNER}}/{{REPO}}/branches/main/protection/required_status_checks" 2>&1
+```
+
+If not configured (404), report to the parent — branch protection changes require user confirmation.
+
+## Autonomy Rules
+
+- Issue creation: autonomous
+- Work-log updates: autonomous
+- Repo bootstrap workflow creation: autonomous (add to first PR)
+- Branch protection changes: report to parent, require user confirmation

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -23,7 +23,8 @@ Use the custom agent definitions in `.claude/agents/` instead of manually readin
    - HEAD SHA, reviewer assignment (`cr` or `greptile`)
    - Pre-fetched findings (optional — saves the subagent from re-fetching)
 4. **Include the safety warning** in every subagent prompt:
-   ```
+
+   ```text
    SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo.
    Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm,
    git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -6,20 +6,42 @@
 
 ## How to Spawn Subagents
 
-**always pass the FULL contents of ALL rule files into the subagent's prompt.** Subagents do not inherit CLAUDE.md or `.claude/rules/` context.
+Use the custom agent definitions in `.claude/agents/` instead of manually reading and embedding all rule files. Each agent definition is self-contained with embedded phase-specific rules.
+
+### Using Agent Definitions (Preferred)
 
 1. **Always set `mode: "bypassPermissions"`** on the Agent tool call.
-2. Read the root `CLAUDE.md` — check **project root first** (`cat ./CLAUDE.md`), fall back to global (`cat ~/.claude/CLAUDE.md`)
-3. Read ALL rule files — check **project root first** (`cat ./.claude/rules/*.md`), fall back to global
-4. Include the COMPLETE output of both in the subagent's task description
-5. Do NOT summarize, excerpt, or paraphrase — pass the complete files
+2. **Set `subagent_type`** to the appropriate agent definition:
+   - `phase-a-fixer` — Fix findings, push, write handoff
+   - `phase-b-reviewer` — Poll reviews, process findings, update handoff
+   - `phase-c-merger` — Verify merge gate, check AC, report readiness (read-only)
+   - `pm-worker` — Issue management, work-log, repo bootstrap
+3. **Provide runtime context in the `prompt` parameter** — the agent definition supplies workflow rules; the prompt supplies PR-specific details:
+   - PR number, issue number, branch name
+   - Repo owner/name
+   - Handoff file path (`~/.claude/handoffs/pr-{N}-handoff.json`)
+   - HEAD SHA, reviewer assignment (`cr` or `greptile`)
+   - Pre-fetched findings (optional — saves the subagent from re-fetching)
+4. **Include the safety warning** in every subagent prompt:
+   ```
+   SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo.
+   Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm,
+   git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your
+   worktree directory at all times.
+   ```
+
+See `.claude/agents/README.md` for the full placeholder reference and spawning examples.
+
+### Fallback: Manual Rule Injection
+
+If agent definitions are unavailable (e.g., working in a repo without `.claude/agents/`), fall back to the manual approach:
+
+1. Read the root `CLAUDE.md` — check **project root first** (`cat ./CLAUDE.md`), fall back to global (`cat ~/.claude/CLAUDE.md`)
+2. Read ALL rule files — check **project root first** (`cat ./.claude/rules/*.md`), fall back to global
+3. Include the COMPLETE output of both in the subagent's task description
+4. Do NOT summarize, excerpt, or paraphrase — pass the complete files
 
 > **Why project-local first:** Per-project configs override global ones. Passing the global file when a project-level file exists gives subagents the wrong rules.
-
-**Handoff file instructions in subagent prompts:**
-- Phase A: include PR number + instruction to write `~/.claude/handoffs/pr-{N}-handoff.json` after pushing
-- Phase B: include PR number, handoff file path, instruction to read it on startup (GitHub API fallback if missing), instruction to update the handoff file on completion
-- Phase C: include PR number, handoff file path, instruction to read it on startup for context (GitHub API fallback if missing). Phase C subagents only verify state and report — the **parent** deletes the handoff file as part of the Phase C completion protocol after user-gated merge (see `phase-protocols.md`)
 
 ## Phase Transition Autonomy (Quick Reference)
 

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -1,6 +1,6 @@
 # Subagent Context
 
-> **Always:** Pass ALL rule files to subagents. Use `mode: "bypassPermissions"` on every Agent tool call. Use phase decomposition (A/B/C). Timestamp every message (see `monitor-mode.md`). Write handoff files on phase completion (see `handoff-files.md`). Print Structured Exit Report before every subagent exit (see `phase-protocols.md`).
+> **Always:** Spawn subagents via custom agent definitions in `.claude/agents/` (see "How to Spawn Subagents" below). Use `mode: "bypassPermissions"` on every Agent tool call. Use phase decomposition (A/B/C). Timestamp every message (see `monitor-mode.md`). Write handoff files on phase completion (see `handoff-files.md`). Print Structured Exit Report before every subagent exit (see `phase-protocols.md`). Only fall back to manually passing all rule files if `.claude/agents/` is unavailable in the current repo.
 > **Ask first:** Respawning a failed subagent (crash/no handoff state) — tell the user what happened first. Exhaustion with valid handoff is auto-respawn ("Always do").
 > **Never:** Summarize rules for subagents. Spawn subagents without `mode: "bypassPermissions"`. Fire-and-forget subagents.
 


### PR DESCRIPTION
## Summary

- Creates `.claude/agents/` directory with self-contained agent definitions for Phase A/B/C subagents and a PM worker agent
- Each agent embeds only the rules relevant to its phase — no more manual reading and injecting all 13 rule files per spawn
- Phase C agent has restricted `allowed-tools` (read-only + Bash for `gh`)
- Updates `subagent-orchestration.md` "How to Spawn Subagents" to reference agent types with manual fallback

Closes #190

## Test plan

- [x] `.claude/agents/` directory exists with README.md + 4 agent definitions (phase-a-fixer, phase-b-reviewer, phase-c-merger, pm-worker)
- [x] Each agent definition includes EXIT_REPORT format from phase-protocols.md
- [x] Each agent definition includes safety rules from safety.md
- [x] Phase A agent includes handoff file WRITE instructions
- [x] Phase B agent includes Greptile budget check before any `@greptileai` trigger
- [x] Phase C agent `allowed-tools` excludes Write/Edit (read-only + Bash)
- [x] Placeholder syntax `{{PLACEHOLDER}}` is consistent across all files and documented in README
- [x] `subagent-orchestration.md` "How to spawn subagents" references agent types with manual fallback