### PR TITLE
feat: add per-task model overrides for cost-efficient subagent spawning

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -35,7 +35,7 @@ Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the par
 
 ### Model Selection
 
-Each agent definition declares a default `model` in frontmatter. The parent should also set `model` explicitly at the Agent tool call site per `.claude/rules/subagent-orchestration.md` "Model Selection" — the call-site parameter overrides the frontmatter default and keeps cost decisions visible at every spawn point.
+Each agent definition declares a default `model` in frontmatter. The parent must also set `model` explicitly at every Agent tool call site per `.claude/rules/subagent-orchestration.md` "Model Selection" — the call-site parameter overrides the frontmatter default and keeps cost decisions visible at every spawn point.
 
 **Per-phase rationale:**
 

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -26,12 +26,27 @@ Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the par
 
 ## Agent Inventory
 
-| Agent | Phase | Purpose | Tool Restrictions |
-|-------|-------|---------|-------------------|
-| `phase-a-fixer` | A | Fix findings, push, write handoff | Full access |
-| `phase-b-reviewer` | B | Poll reviews, fix findings, update handoff | Full access |
-| `phase-c-merger` | C | Verify merge gate, check AC, report readiness | Read-only + Bash (for `gh`) |
-| `pm-worker` | — | Issue management, work-log, repo bootstrap | Full access |
+| Agent | Phase | Purpose | Tool Restrictions | Default Model |
+|-------|-------|---------|-------------------|---------------|
+| `phase-a-fixer` | A | Fix findings, push, write handoff | Full access | `opus` |
+| `phase-b-reviewer` | B | Poll reviews, fix findings, update handoff | Full access | `opus` |
+| `phase-c-merger` | C | Verify merge gate, check AC, report readiness | Read-only + Bash (for `gh`) | `sonnet` |
+| `pm-worker` | — | Issue management, work-log, repo bootstrap | Full access | `sonnet` |
+
+### Model Selection
+
+Each agent definition declares a default `model` in frontmatter. The parent should also set `model` explicitly at the Agent tool call site per `.claude/rules/subagent-orchestration.md` "Model Selection" — the call-site parameter overrides the frontmatter default and keeps cost decisions visible at every spawn point.
+
+**Per-phase rationale:**
+
+| Agent | Model | Why |
+|-------|-------|-----|
+| `phase-a-fixer` | `opus` | Heaviest reasoning: reads findings, edits source files across multiple locations, resolves rule conflicts, designs fixes. Quality regressions here cost a full review cycle. |
+| `phase-b-reviewer` | `opus` | Evaluates review findings (many are false positives), decides when to dismiss vs. fix, handles multi-reviewer edge cases, judges severity. Needs strong judgment. |
+| `phase-c-merger` | `sonnet` | Lightweight verification: reads PR body, checks boxes against code, runs `gh` commands. Read-only tool restrictions (no Write/Edit) — the mechanical work does not need Opus-level reasoning. |
+| `pm-worker` | `sonnet` | Data gathering and formatting: issue creation, work-log updates, repo bootstrap checks. Each task follows a well-defined template. |
+
+The global env var `CLAUDE_CODE_SUBAGENT_MODEL=opus` remains the fallback default for any spawn site that doesn't specify a model — it's the safety net for undocumented spawns.
 
 ## Spawning Pattern
 
@@ -41,6 +56,7 @@ The parent agent spawns subagents like this:
 Agent tool call:
   subagent_type: "phase-a-fixer"
   mode: "bypassPermissions"
+  model: "opus"
   prompt: "Work on PR #618 for issue #617 on branch issue-617-add-auth.
            Repo: auerbachb/claude-code-config
            Handoff file: ~/.claude/handoffs/pr-618-handoff.json

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -46,7 +46,7 @@ Each agent definition declares a default `model` in frontmatter. The parent must
 | `phase-c-merger` | `sonnet` | Lightweight verification: reads PR body, checks boxes against code, runs `gh` commands. Read-only tool restrictions (no Write/Edit) — the mechanical work does not need Opus-level reasoning. |
 | `pm-worker` | `sonnet` | Data gathering and formatting: issue creation, work-log updates, repo bootstrap checks. Each task follows a well-defined template. |
 
-The global env var `CLAUDE_CODE_SUBAGENT_MODEL=opus` remains the fallback default for any spawn site that doesn't specify a model — it's the safety net for undocumented spawns.
+The global env var `CLAUDE_CODE_SUBAGENT_MODEL=opus` is a legacy safety net for unexpected/undocumented spawns only — **not** a compliant spawn pattern. Compliant calls must still set `model` explicitly at the call site and must not rely on either the frontmatter default or this env var.
 
 ## Spawning Pattern
 

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -1,5 +1,6 @@
 ---
 description: "Phase A subagent: fix review findings, push code, write handoff file, print exit report. Used after a PR receives CR/Greptile review findings."
+model: opus
 ---
 
 # Phase A: Fix + Push

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -1,5 +1,6 @@
 ---
 description: "Phase B subagent: poll for CR/Greptile reviews, process findings, fix code, update handoff file, print exit report. Runs after Phase A pushes fixes."
+model: opus
 ---
 
 # Phase B: Review Loop

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -1,6 +1,7 @@
 ---
 description: "Phase C subagent: verify merge gate, check acceptance criteria against code, report readiness. Read-only — does not modify code."
 allowed-tools: Read, Glob, Grep, Bash
+model: sonnet
 ---
 
 # Phase C: Merge Prep

--- a/.claude/agents/pm-worker.md
+++ b/.claude/agents/pm-worker.md
@@ -1,5 +1,6 @@
 ---
 description: "PM task execution agent: issue management, work-log updates, repo bootstrap checks. Used for lightweight PM tasks that don't require the full Phase A/B/C pipeline."
+model: sonnet
 ---
 
 # PM Worker Agent

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -65,7 +65,7 @@ Full per-phase rationale lives in `.claude/agents/README.md` "Model Selection". 
 
 - **Set `model` at the call site explicitly.** Every Agent tool invocation MUST include `model` alongside `mode` and `subagent_type`. Relying on frontmatter defaults or the global `CLAUDE_CODE_SUBAGENT_MODEL` env var hides cost decisions.
 - **Call-site `model` overrides agent-definition frontmatter.** Override to `opus` when a specific spawn needs more firepower.
-- **Keep `CLAUDE_CODE_SUBAGENT_MODEL=opus` as the global fallback.** Do not modify it — it's the safety net for undocumented spawn sites.
+- **`CLAUDE_CODE_SUBAGENT_MODEL=opus` is a legacy safety net — not a compliant pattern.** Do not modify it, and do not rely on it: compliant calls must still set `model` explicitly at the call site. The env var only catches unexpected/undocumented spawns.
 - **Cost-optimization ≠ quality regression.** If a Sonnet-tier agent underperforms, escalate that phase's default to `opus` and document why.
 
 ## Phase Transition Autonomy (Quick Reference)

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -1,8 +1,8 @@
 # Subagent Context
 
-> **Always:** Spawn subagents via custom agent definitions in `.claude/agents/` (see "How to Spawn Subagents" below). Use `mode: "bypassPermissions"` on every Agent tool call. Use phase decomposition (A/B/C). Timestamp every message (see `monitor-mode.md`). Write handoff files on phase completion (see `handoff-files.md`). Print Structured Exit Report before every subagent exit (see `phase-protocols.md`). Only fall back to manually passing all rule files if `.claude/agents/` is unavailable in the current repo.
+> **Always:** Spawn subagents via custom agent definitions in `.claude/agents/` (see "How to Spawn Subagents" below). Use `mode: "bypassPermissions"` on every Agent tool call. Set `model` explicitly at every call site per the Model Selection policy (see below). Use phase decomposition (A/B/C). Timestamp every message (see `monitor-mode.md`). Write handoff files on phase completion (see `handoff-files.md`). Print Structured Exit Report before every subagent exit (see `phase-protocols.md`). Only fall back to manually passing all rule files if `.claude/agents/` is unavailable in the current repo.
 > **Ask first:** Respawning a failed subagent (crash/no handoff state) — tell the user what happened first. Exhaustion with valid handoff is auto-respawn ("Always do").
-> **Never:** Summarize rules for subagents. Spawn subagents without `mode: "bypassPermissions"`. Fire-and-forget subagents.
+> **Never:** Summarize rules for subagents. Spawn subagents without `mode: "bypassPermissions"`. Spawn without an explicit `model` parameter. Fire-and-forget subagents.
 
 ## How to Spawn Subagents
 
@@ -16,13 +16,14 @@ Use the custom agent definitions in `.claude/agents/` instead of manually readin
    - `phase-b-reviewer` — Poll reviews, process findings, update handoff
    - `phase-c-merger` — Verify merge gate, check AC, report readiness (read-only)
    - `pm-worker` — Issue management, work-log, repo bootstrap
-3. **Provide runtime context in the `prompt` parameter** — the agent definition supplies workflow rules; the prompt supplies PR-specific details:
+3. **Set `model` explicitly at the call site** (see "Model Selection" below). Each agent definition also declares a frontmatter default (`opus` for Phase A/B; `sonnet` for Phase C and pm-worker), but the call-site `model` parameter takes precedence and makes the choice visible at every spawn.
+4. **Provide runtime context in the `prompt` parameter** — the agent definition supplies workflow rules; the prompt supplies PR-specific details:
    - PR number, issue number, branch name
    - Repo owner/name
    - Handoff file path (`~/.claude/handoffs/pr-{N}-handoff.json`)
    - HEAD SHA, reviewer assignment (`cr` or `greptile`)
    - Pre-fetched findings (optional — saves the subagent from re-fetching)
-4. **Include the safety warning** in every subagent prompt:
+5. **Include the safety warning** in every subagent prompt:
 
    ```text
    SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo.
@@ -43,6 +44,29 @@ If agent definitions are unavailable (e.g., working in a repo without `.claude/a
 4. Do NOT summarize, excerpt, or paraphrase — pass the complete files
 
 > **Why project-local first:** Per-project configs override global ones. Passing the global file when a project-level file exists gives subagents the wrong rules.
+
+## Model Selection
+
+The Agent tool's `model` parameter selects which Claude model runs the subagent. Match the model to the phase's cognitive load — this is the cost-efficiency lever.
+
+**Defaults (set at every spawn site):**
+
+| Phase / Agent | Model |
+|---------------|-------|
+| Phase A (`phase-a-fixer`) | `opus` |
+| Phase B (`phase-b-reviewer`) | `opus` |
+| Phase C (`phase-c-merger`) | `sonnet` |
+| `pm-worker` | `sonnet` |
+| Read-only review agents (e.g., `/pr-review-help`) | `sonnet` |
+
+Full per-phase rationale lives in `.claude/agents/README.md` "Model Selection". In short: A/B do the heavy reasoning (fixes, dismissals, severity judgment); C and pm-worker do mechanical verification and data gathering.
+
+**Rules:**
+
+- **Set `model` at the call site explicitly.** Every Agent tool invocation MUST include `model` alongside `mode` and `subagent_type`. Relying on frontmatter defaults or the global `CLAUDE_CODE_SUBAGENT_MODEL` env var hides cost decisions.
+- **Call-site `model` overrides agent-definition frontmatter.** Override to `opus` when a specific spawn needs more firepower.
+- **Keep `CLAUDE_CODE_SUBAGENT_MODEL=opus` as the global fallback.** Do not modify it — it's the safety net for undocumented spawn sites.
+- **Cost-optimization ≠ quality regression.** If a Sonnet-tier agent underperforms, escalate that phase's default to `opus` and document why.
 
 ## Phase Transition Autonomy (Quick Reference)
 

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -305,6 +305,12 @@ The **user** decides when and where to paste the prompts. The user starts the co
 
 **Exception:** If the user explicitly says "go ahead and run those", "spin up agents", or "execute those prompts" — then and only then may you spawn subagents via the Agent tool to execute the coding thread prompts.
 
+**Model selection for spawned subagents:**
+
+- **Coding subagents** (Phase A/B executing a selected issue): prefer the `/subagent` skill, which already enforces per-phase model selection (`opus` for Phase A/B, `sonnet` for Phase C). See `.claude/rules/subagent-orchestration.md` "Model Selection".
+- **Read-only PM data-gathering subagents** (e.g., scanning GitHub for backlog context, summarizing recent PR activity, reviewing progress on in-flight threads): spawn with `subagent_type: "pm-worker"`, `mode: "bypassPermissions"`, and `model: "sonnet"`. These tasks are template-driven data collection — Sonnet is the right cost tier and the frontmatter default on `pm-worker` matches.
+- **Never omit `model`** at the call site. Explicit model selection keeps cost decisions visible at every spawn point and prevents silent Opus usage for lightweight work.
+
 ---
 
 ## Writing Rules

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -77,7 +77,7 @@ If a PR doesn't exist, note it in the output and skip. If ALL PR numbers are inv
 
 Spawn one subagent per valid PR using the Agent tool. All subagents run in parallel.
 
-**Each subagent invocation MUST use `mode: "bypassPermissions"`.**
+**Each subagent invocation MUST use `mode: "bypassPermissions"` and `model: "sonnet"`.** This is a read-only strategic review — analysis from a well-defined template, no code modification. Sonnet keeps per-review cost low so parallel portfolio reviews stay economical. See `.claude/rules/subagent-orchestration.md` "Model Selection" for the rationale.
 
 **Each subagent prompt must include:**
 - The PR number to analyze (substitute `{NUMBER}` in the template below)

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -245,7 +245,9 @@ worktree directory at all times.
 ```
 
 **Agent tool call parameters:**
+- `subagent_type: "phase-a-fixer"`
 - `mode: "bypassPermissions"`
+- `model: "opus"` (Phase A does heavy reasoning — see `subagent-orchestration.md` "Model Selection")
 - `isolation: "worktree"`
 - `run_in_background: true` (so you can monitor multiple agents)
 
@@ -341,6 +343,13 @@ If missing, reconstruct state from GitHub API.
 12. EXIT immediately.
 ```
 
+**Phase B Agent tool call parameters:**
+- `subagent_type: "phase-b-reviewer"`
+- `mode: "bypassPermissions"`
+- `model: "opus"` (Phase B evaluates review findings and fixes code — see `subagent-orchestration.md` "Model Selection")
+- `isolation: "worktree"` (same as Phase A — Phase B fetches and checks out the PR branch inside its own fresh worktree)
+- `run_in_background: true`
+
 ### Phase B Completion
 
 When a Phase B subagent returns:
@@ -397,6 +406,13 @@ worktree directory at all times.
    ```
 10. EXIT immediately. Do NOT merge — the parent presents the merge decision to the user.
 ```
+
+**Phase C Agent tool call parameters:**
+- `subagent_type: "phase-c-merger"`
+- `mode: "bypassPermissions"`
+- `model: "sonnet"` (Phase C is lightweight read-only verification — see `subagent-orchestration.md` "Model Selection")
+- `isolation: "worktree"` (same as Phase A — Phase C fetches and checks out the PR branch inside its own fresh worktree)
+- `run_in_background: true`
 
 ### Phase C Completion
 

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -245,11 +245,12 @@ worktree directory at all times.
 ```
 
 **Agent tool call parameters:**
-- `subagent_type: "phase-a-fixer"`
 - `mode: "bypassPermissions"`
-- `model: "opus"` (Phase A does heavy reasoning — see `subagent-orchestration.md` "Model Selection")
+- `model: "opus"` (heavy reasoning — initial implementation, multi-file edits, PR creation — see `subagent-orchestration.md` "Model Selection")
 - `isolation: "worktree"`
 - `run_in_background: true` (so you can monitor multiple agents)
+
+> **Note on `subagent_type`:** Do NOT set `subagent_type: "phase-a-fixer"` here. The `/subagent` skill's "Phase A" does **initial implementation** of a new issue (no PR exists yet), but `.claude/agents/phase-a-fixer.md` is designed for **fixing existing review findings** on an already-open PR — its workflow references findings, review threads, and push replies that don't apply to green-field implementation. Let this Agent call fall back to the default general-purpose agent; the long custom prompt below carries all the rules the subagent needs.
 
 Record each spawned agent in `session-state.json` under `active_agents`.
 


### PR DESCRIPTION
## Summary

Introduces per-task model selection for Agent-tool subagents so cheaper/faster Sonnet runs light verification work while Opus stays on the heavy reasoning phases.

- **Phase A (`phase-a-fixer`)** — stays on `opus` (reads findings, edits source across multiple files, resolves rule conflicts)
- **Phase B (`phase-b-reviewer`)** — stays on `opus` (evaluates reviewer output, decides dismiss vs. fix, judges severity)
- **Phase C (`phase-c-merger`)** — moves to `sonnet` (read-only verification: PR body parsing, box-checking, `gh` calls)
- **`pm-worker`** — moves to `sonnet` (template-driven: issue creation, work-log updates, repo bootstrap)
- **`/pr-review-help`** — moves to `sonnet` (parallel read-only strategic review from a fixed template)

Design choice: per-spawn `model` parameter at the call site, with matching frontmatter defaults on each agent definition as a safety net. The global `CLAUDE_CODE_SUBAGENT_MODEL=opus` env var in `global-settings.json` is unchanged — it remains the fallback for undocumented spawn sites.

Closes #201

## Test plan

- [x] `phase-c-merger.md` frontmatter contains `model: sonnet`
- [x] `pm-worker.md` frontmatter contains `model: sonnet`
- [x] `phase-a-fixer.md` and `phase-b-reviewer.md` frontmatter contain `model: opus`
- [x] `.claude/rules/subagent-orchestration.md` documents the `model` parameter in "How to Spawn Subagents" and includes a compact Model Selection defaults table
- [x] `.claude/rules/subagent-orchestration.md` top-of-file Always/Never rules require explicit `model` at every call site
- [x] `.claude/agents/README.md` has per-phase rationale (Agent Inventory shows Default Model column + "Model Selection" section with rationale table)
- [x] `.claude/skills/subagent/SKILL.md` Phase A/B/C parameter blocks each set explicit `model` (`opus`/`opus`/`sonnet`)
- [x] `.claude/skills/pr-review-help/SKILL.md` requires `model: "sonnet"` alongside `mode: "bypassPermissions"` in the subagent spawn instructions
- [x] `.claude/skills/pm/SKILL.md` Execution Boundary documents model selection for spawned subagents (Sonnet for read-only PM data gathering)
- [x] `global-settings.json` still sets `CLAUDE_CODE_SUBAGENT_MODEL: "opus"` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Require explicit model selection on every agent spawn; call-site model overrides agent defaults.
  * Added a Model Selection section, tightened orchestration rules to forbid implicit/legacy model usage, and added per-phase rationale.

* **Chores**
  * Declared default models for Phase A/B (opus) and Phase C/PM (sonnet); marked legacy fallback as non-compliant.

* **Examples**
  * Updated spawn and PM/PR guidance to include explicit model parameters and enforced read-only/review models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->