### PR TITLE
docs: establish rule file size guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Rules consume tokens on every turn — keep them tight. Limits apply to CLAUDE.m
 
 - **Per-file soft cap:** ~150 lines / ~1,500 words. Consider splitting if exceeded.
 - **Per-file hard cap:** 200 lines / 2,000 words. Must split — extract a sub-topic into a new rule file.
-- **Total budget:** ≤10,000 words across CLAUDE.md + all rule files (matches the 10K target enforced by `.coderabbit.yaml`).
+- **Total budget:** ≤10,000 words across CLAUDE.md + all rule files (matches the 10K target documented in `.coderabbit.yaml`).
 - **Verify on every PR that touches CLAUDE.md or `.claude/rules/`:**
 
   ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,18 @@ Detailed workflow rules are split into topic-specific files in `.claude/rules/`:
 | `skill-symlinks.md` | Symlink new skills to `~/.claude/skills/` after creation; this repo is source of truth |
 
 These files auto-load for the parent agent session. **Subagents do NOT auto-load these files.** See `subagent-orchestration.md` for how to pass rules to subagents.
+
+### Rule File Size Guidelines
+
+Rules consume tokens on every turn — keep them tight. Limits apply to CLAUDE.md and every file in `.claude/rules/`:
+
+- **Per-file soft cap:** ~150 lines / ~1,500 words. Consider splitting if exceeded.
+- **Per-file hard cap:** 200 lines / 2,000 words. Must split — extract a sub-topic into a new rule file.
+- **Total budget:** ≤10,000 words across CLAUDE.md + all rule files (matches the 10K target enforced by `.coderabbit.yaml`).
+- **Verify on every PR that touches CLAUDE.md or `.claude/rules/`:**
+
+  ```bash
+  { cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } | wc -w
+  ```
+
+  If the total exceeds 10,000, condense before merging.


### PR DESCRIPTION
Closes #189

## Summary
Adds explicit size guidelines to CLAUDE.md to prevent future context-budget regression after the token cleanup campaign. Per-file soft/hard caps and a 10K-word total budget (aligned with `.coderabbit.yaml`) keep rule-file bloat in check.

## Test plan
- [x] Size guidelines documented in CLAUDE.md
- [x] Word count verification command documented
- [x] Per-file soft cap (~150 lines / ~1,500 words) and hard cap (200 lines / 2,000 words) defined
- [x] Total budget ≤10,000 words
- [x] Guidelines reference 10K target from .coderabbit.yaml

🤖 Generated with Claude Code