### PR TITLE
feat: add PreToolUse hook to enforce worktree-only writes

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -35,6 +35,8 @@ TOOL_NAME="${PARSED##*|}"
 
 [ -z "$CWD" ] && exit 0
 
+# Defense-in-depth: also filter here in case the matcher in global-settings.json
+# is ever widened or the script is invoked directly during testing.
 case "$TOOL_NAME" in
   Write|Edit|NotebookEdit) ;;
   *) exit 0 ;;
@@ -45,8 +47,12 @@ TOPLEVEL=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
 
 # Scope enforcement to the claude-code-config repo only. The hook is registered
 # globally in ~/.claude/settings.json, but we only want to block writes on main
-# for this specific repo. Match the repo name as a full path component so paths
-# like /foo/claude-code-config-fork/bar do NOT trigger the guard.
+# for this specific repo. Match the repo's canonical directory name as a full
+# path component:
+#   - Excludes forks like /foo/claude-code-config-fork/bar (requires literal
+#     /claude-code-config trailing segment or /claude-code-config/ prefix segment)
+#   - Excludes clones under alternate names (e.g., ~/my-config) — intentional
+#     trade-off: the guard only protects the canonical directory name
 case "$TOPLEVEL" in
   */claude-code-config|*/claude-code-config/*) ;;
   *) exit 0 ;;
@@ -55,6 +61,9 @@ esac
 BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null || true)
 
 if [ "$BRANCH" = "main" ]; then
+  # If this python3 invocation fails for any reason (transient crash, etc.),
+  # the hook exits 0 with empty stdout — the framework treats that as "allow"
+  # (fail-open). The inline script is trivially simple so this is unlikely.
   python3 -c '
 import json
 print(json.dumps({

--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Worktree guard — PreToolUse hook
+# Blocks Write/Edit/NotebookEdit when the current branch of the claude-code-config
+# repo is `main`. Enforces the "ALWAYS USE A WORKTREE" rule mechanically.
+#
+# Hook contract (PreToolUse):
+#   stdin  — JSON with {tool_name, tool_input, cwd, ...}
+#   stdout — JSON with hookSpecificOutput.permissionDecision ("deny" to block)
+#   exit 0 — always (decision is carried in the JSON, not the exit code)
+
+set -u
+
+INPUT=$(cat 2>/dev/null || true)
+
+# Fail open if python3 is unavailable — never block work on tooling gaps
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Parse cwd and tool_name from the hook input JSON via stdin (safe for any content)
+PARSED=$(printf '%s' "$INPUT" | python3 -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read() or "{}")
+except Exception:
+    print("|")
+    sys.exit(0)
+cwd = (d.get("cwd") or "").replace("\n", " ").replace("\r", " ")
+tool = (d.get("tool_name") or "").replace("\n", " ").replace("\r", " ")
+print(f"{cwd}|{tool}")
+' 2>/dev/null)
+
+CWD="${PARSED%|*}"
+TOOL_NAME="${PARSED##*|}"
+
+[ -z "$CWD" ] && exit 0
+
+case "$TOOL_NAME" in
+  Write|Edit|NotebookEdit) ;;
+  *) exit 0 ;;
+esac
+
+TOPLEVEL=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+[ -z "$TOPLEVEL" ] && exit 0
+
+# Scope enforcement to the claude-code-config repo only. The hook is registered
+# globally in ~/.claude/settings.json, but we only want to block writes on main
+# for this specific repo. Match the repo name as a full path component so paths
+# like /foo/claude-code-config-fork/bar do NOT trigger the guard.
+case "$TOPLEVEL" in
+  */claude-code-config|*/claude-code-config/*) ;;
+  *) exit 0 ;;
+esac
+
+BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null || true)
+
+if [ "$BRANCH" = "main" ]; then
+  python3 -c '
+import json
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": (
+            "BLOCKED: Cannot write files on main branch in claude-code-config. "
+            "Use EnterWorktree to create a worktree first. "
+            "See CLAUDE.md \"ALWAYS USE A WORKTREE\" section."
+        ),
+    }
+}))
+'
+  exit 0
+fi
+
+exit 0

--- a/global-settings.json
+++ b/global-settings.json
@@ -35,6 +35,18 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/worktree-guard.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "hooks": [


### PR DESCRIPTION
Closes #198

## Summary
Mechanical enforcement of the "always use a worktree" rule. A PreToolUse hook blocks Write/Edit/NotebookEdit calls when the current branch is `main`, preventing accidental commits to `main`.

- New hook: `.claude/hooks/worktree-guard.sh` — reads the hook input JSON on stdin, resolves the git toplevel for `cwd`, checks the current branch, and emits a `permissionDecision: deny` JSON response if the branch is `main` and the repo is `claude-code-config`.
- Registered in `global-settings.json` as a PreToolUse hook with matcher `Write|Edit|NotebookEdit`.
- Scoped to `claude-code-config` via a path-component match (`*/claude-code-config` or `*/claude-code-config/*`) so forks like `claude-code-config-fork` are not affected.
- Fail-open on tooling gaps (missing `python3`, unparseable input) — never blocks work on infrastructure issues.
- Measured <150ms per invocation on macOS.

## Test plan
- [x] PreToolUse hook blocks Write/Edit on main branch
- [x] Hook registered in global-settings.json
- [x] Error message guides agent to create a worktree
- [x] Read-only operations not blocked
- [x] Hook is idempotent and fast (<1s)

🤖 Generated with Claude Code