### PR TITLE
feat: add PreToolUse hook for .env file protection

### DIFF
--- a/.claude/hooks/env-guard.py
+++ b/.claude/hooks/env-guard.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# .env file protection — PreToolUse hook
+# Blocks Write/Edit/Bash operations that would modify .env files.
+# Defense-in-depth enforcement of the rule in .claude/rules/safety.md.
+#
+# Matches basenames: .env, .env.local, .env.production, .env.test, .env.ci, etc.
+# Does NOT match: environment.ts, env-config.json, rails_env, my.env.backup.
+#
+# Hook protocol: reads tool-invocation JSON from stdin. Exit code 2 with a
+# message on stderr blocks the tool call and surfaces the reason to the agent.
+#
+# Scope and limitations
+# ---------------------
+# `bash_targets_env` is a best-effort static token analyzer. It is NOT a
+# sandbox and can be bypassed by constructs it cannot see statically:
+#   - Variable expansion:        `F=.env; rm "$F"`
+#   - Indirect execution:        `eval "rm .env"`, `bash -c "rm .env"`
+#   - Here-documents/scripts:    `bash script.sh` where script.sh removes .env
+#   - Parameter expansion tricks: `rm .en${X:-v}`
+# This hook is defense-in-depth alongside the behavioral rules in
+# `.claude/rules/safety.md`, not a foolproof security guarantee. The relevant
+# logic lives in `is_env_path`, `bash_targets_env`, and `DESTRUCTIVE_BINS`.
+
+import json
+import re
+import shlex
+import sys
+
+BLOCK_MSG = (
+    "BLOCKED: Cannot modify .env files. These contain secrets that cannot be "
+    "recovered. See .claude/rules/safety.md."
+)
+
+# Basename is `.env` or `.env.<suffix>` (letters/digits/underscore/hyphen).
+# Anchored to a path boundary so `environment.ts`, `env-config.json`,
+# `rails_env`, and `my.env.bak` do NOT match.
+ENV_BASENAME_RE = re.compile(r'(?:^|/)\.env(?:\.[A-Za-z0-9_-]+)?$')
+
+# Bash binaries that can mutate files. We only block a Bash command if one of
+# these appears AND the command also references a .env path. Non-mutating reads
+# like `cat .env` or `grep X .env` are not blocked by the hook — using the Read
+# tool is still the preferred path for auditing secrets.
+DESTRUCTIVE_BINS = {
+    'rm', 'mv', 'cp', 'rsync', 'install', 'dd', 'truncate', 'shred',
+    'chmod', 'chown', 'tee', 'sed', 'awk', 'perl', 'python', 'python3',
+    'ruby', 'node', 'touch', 'ln',
+}
+
+# Write-redirect operators we treat as mutation: `>`, `>>`, `2>`, `&>`, `>&N`.
+# Input redirect `<` is a read and is not treated as mutation.
+BARE_REDIRECT_RE = re.compile(r'^(?:\d*>{1,2}|&>|\d*>&\d*)$')
+EMBEDDED_REDIRECT_RE = re.compile(r'(?:\d*>{1,2}|&>)([^<>&].*)$')
+
+
+def is_env_path(path: str) -> bool:
+    if not path:
+        return False
+    p = path.strip().strip('"').strip("'").rstrip('/')
+    return bool(ENV_BASENAME_RE.search(p))
+
+
+def bash_targets_env(cmd: str) -> bool:
+    if not cmd:
+        return False
+    try:
+        tokens = shlex.split(cmd, posix=True)
+    except ValueError:
+        tokens = cmd.split()
+
+    has_env_token = False
+    has_write_op = False
+
+    for tok in tokens:
+        # Bare write-redirect operator: `>`, `>>`, `2>`, `&>`, `>&N`.
+        if BARE_REDIRECT_RE.match(tok):
+            has_write_op = True
+            continue
+        # Embedded redirect anywhere in the token: `>.env`, `foo>>.env.prod`.
+        # Using search (not match) catches the second form too.
+        redirect_m = EMBEDDED_REDIRECT_RE.search(tok)
+        if redirect_m:
+            has_write_op = True
+            if is_env_path(redirect_m.group(1)):
+                has_env_token = True
+            continue
+        # Destructive binary (match on basename so `/bin/rm` still counts).
+        base = tok.rsplit('/', 1)[-1]
+        if base in DESTRUCTIVE_BINS:
+            has_write_op = True
+            continue
+        # Plain token that looks like a .env path.
+        if is_env_path(tok):
+            has_env_token = True
+
+    return has_env_token and has_write_op
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    tool_name = payload.get('tool_name') or payload.get('toolName') or ''
+    tool_input = payload.get('tool_input') or payload.get('toolInput') or {}
+    if not isinstance(tool_input, dict):
+        return 0
+
+    blocked = False
+    reason = ''
+
+    if tool_name in ('Write', 'Edit', 'MultiEdit', 'NotebookEdit'):
+        path = tool_input.get('file_path') or tool_input.get('notebook_path') or ''
+        if is_env_path(path):
+            blocked = True
+            reason = f"{BLOCK_MSG} (tool={tool_name}, path={path})"
+    elif tool_name == 'Bash':
+        cmd = tool_input.get('command') or ''
+        if bash_targets_env(cmd):
+            blocked = True
+            reason = (
+                f"{BLOCK_MSG} (tool=Bash, command would modify a .env path). "
+                "If you need to read a .env file, use the Read tool."
+            )
+
+    if blocked:
+        sys.stderr.write(reason + "\n")
+        return 2
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/global-settings.json
+++ b/global-settings.json
@@ -64,6 +64,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/env-guard.py",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   },
   "extraKnownMarketplaces": {


### PR DESCRIPTION
Closes #199

## Summary
Mechanical enforcement of the .env protection rule from safety.md. PreToolUse hook blocks Write/Edit/Bash operations targeting .env files. Defense in depth — even if the agent ignores the rule, the hook blocks the operation.

## Implementation
- `.claude/hooks/env-guard.py` — pure-Python PreToolUse hook, reads tool-invocation JSON from stdin, exits 2 with a stderr message to block.
- Anchored basename regex `(?:^|/)\.env(?:\.[A-Za-z0-9_-]+)?$` matches `.env`, `.env.local`, `.env.production`, etc., and avoids false positives on `environment.ts`, `env-config.json`, `rails_env`, `my.env.backup`, `.envrc`.
- Bash detection is narrowly scoped: only blocks when a mutating binary (`rm`, `mv`, `cp`, `rsync`, `sed`, `chmod`, `tee`, `install`, `truncate`, `shred`, `chown`, `dd`, `touch`, `ln`, `awk`, `perl`, `python`, `ruby`, `node`) or a write-redirect (`>`, `>>`, `2>`, `&>`) appears alongside a `.env` path. `cat .env` / `grep X .env` are not blocked; Read tool is not blocked.
- Fail-open on malformed hook input.
- Registered in `global-settings.json` under PreToolUse with matcher `Write|Edit|MultiEdit|NotebookEdit|Bash`, following the placeholder convention of the other hooks (auto-registered by `session-start-sync.sh`).
- Includes an in-file comment documenting known bypass limitations (variable expansion, `eval`, `bash -c`, here-docs) so readers know this is defense-in-depth, not a sandbox.

## Test plan
- [x] PreToolUse hook blocks Write/Edit on .env files
- [x] Hook handles .env, .env.local, .env.production patterns
- [x] Hook blocks destructive Bash commands targeting .env (rm, mv, cp, rsync, sed, chmod, redirect)
- [x] Hook does NOT block Read operations
- [x] Minimal false positives (doesn't block environment.ts, env-config.json, rails_env, my.env.backup, .envrc)
- [x] Hook registered in global-settings.json PreToolUse

Verified locally with a 30-case test matrix (Write/Edit/MultiEdit block, Bash destructive block, read-only bash allow, false-positive allow, fail-open). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
