### PR TITLE
feat: add triggers frontmatter to 5 skills

### DIFF
--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: pm
 description: Active PM orchestrator — manages issue pipeline, tracks coding threads, suggests next work. Cold-starts from GitHub state or resumes from a /pm-handoff prompt. Triggers on "pm", "project manager", "orchestrate", "what should I work on".
+triggers:
+  - project manager
+  - orchestrate
+  - what should I work on
+  - manage issues
 argument-hint: "[resume] (optional — 'resume' reads in-flight state from session files to continue a previous PM session)"
 ---
 

--- a/.claude/skills/prioritize/SKILL.md
+++ b/.claude/skills/prioritize/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prioritize
 description: Scan a repo's open issue backlog and produce a ranked priority list of what a specific engineer should work on next, ordered by impact on a stated business goal. When OKRs are defined in `.claude/pm-config.md`, uses them as an additional ranking signal.
+triggers:
+  - rank issues
+  - what to work on next
+  - priority list
 argument-hint: "business goal | @username role-constraints | depth (e.g. \"increase scraping throughput | @auerbachb backend-python | 50\")"
 ---
 

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: prompt
 description: Analyze GitHub issues to assess complexity, classify effort tier, recommend model selection, and generate tailored prompts with pre-extracted context. Use when starting work, planning sprints, estimating effort, right-sizing model choice, or analyzing issue batches. When called with no args in a PM thread, auto-detects suggested issues and partitions subagent candidates from thread prompts.
+triggers:
+  - analyze issue
+  - generate prompt
+  - estimate effort
+  - complexity check
 argument-hint: "[#123 #124 ...] (issue numbers, or omit for PM auto-detect)"
 ---
 

--- a/.claude/skills/standup/SKILL.md
+++ b/.claude/skills/standup/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: standup
 description: Generate a daily standup summary of what was accomplished since the last standup, from a business logic perspective. Reads PR bodies to understand what changes actually enabled.
+triggers:
+  - daily standup
+  - what did I do yesterday
+  - recent work summary
 argument-hint: "[since-time] — omit for smart default (skips weekends/holidays); e.g. \"Friday at noon ET\""
 ---
 

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: status
 description: Show a dashboard of all open PRs with review state, unresolved findings, and blockers.
+triggers:
+  - show PRs
+  - PR dashboard
+  - what's open
+  - review status
 ---
 
 Build a status dashboard of all open PRs in this repo.


### PR DESCRIPTION
Closes #194

## Summary
Adds natural-language trigger phrases to pm, standup, status, prioritize, and prompt skills for improved discoverability via autocomplete and model-invocation matching.

## Test plan
- [x] At least 5 skills have triggers frontmatter added
- [x] Trigger phrases are natural language
- [x] No duplicate triggers across skills
- [x] Skills remain invocable by name

Generated with Claude Code