### PR TITLE
docs: add proactive memory-saving guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,24 @@ Rules consume tokens on every turn — keep them tight. Limits apply to CLAUDE.m
   ```
 
   If the total exceeds 14,000, condense before merging.
+
+---
+
+## Memory System
+
+The auto-memory system persists insights across sessions at `~/.claude/projects/*/memory/`. Save memories **proactively** (without being asked) when you encounter information future sessions will need. Explicit user requests ("remember this", "save that") always override — save what the user says even if it doesn't fit these heuristics.
+
+**Save proactively:**
+- **Feedback patterns:** CR false positives specific to this repo, user-preferred approaches confirmed across sessions, recurring corrections.
+- **Project context:** non-obvious repo quirks, deadlines, stakeholder decisions, undocumented conventions that shape future work.
+- **External references:** dashboards, docs, or systems where current state lives but isn't in the repo.
+- **Incident lessons:** things that went wrong and the fix — so the next session doesn't repeat the mistake.
+
+**Do NOT save:**
+- Code patterns or API signatures — read the current code instead.
+- Git history facts — `git log`/`git blame` is authoritative.
+- Anything already covered in CLAUDE.md or rule files.
+- Ephemeral task state — use handoff files (`~/.claude/handoffs/`) instead.
+- One-off details with no expected reuse.
+
+Before creating a memory, check for existing ones to avoid duplicates. Update or remove stale memories when you encounter them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Rules consume tokens on every turn — keep them tight. Limits apply to CLAUDE.m
 
 ## Memory System
 
-The auto-memory system persists insights across sessions at `~/.claude/projects/*/memory/`. Save memories **proactively** (without being asked) when you encounter information future sessions will need. Explicit user requests ("remember this", "save that") always override — save what the user says even if it doesn't fit these heuristics.
+The auto-memory system persists insights across sessions at `~/.claude/projects/*/memory/`. Save memories **proactively** (without being asked) when you encounter information future sessions will need. Explicit user requests ("remember this", "save that") normally override these heuristics, but never persist secrets, credentials, tokens, or regulated/sensitive personal data — if the user asks, confirm before saving and redact sensitive values.
 
 **Save proactively:**
 - **Feedback patterns:** CR false positives specific to this repo, user-preferred approaches confirmed across sessions, recurring corrections.


### PR DESCRIPTION
Closes #206

## Summary
Adds a concise Memory System section to CLAUDE.md explaining when agents should proactively save memories and what NOT to save. Kept at the 200-word cap to respect the size budget from #189. Includes security exception: user-requested saves never persist secrets/credentials/PII.

- Distinguishes proactive saves from explicit user requests (user requests override, with security exception)
- Lists what to save: feedback patterns, project context, external references, incident lessons
- Lists what to skip: code patterns, git history, content already in rules, ephemeral task state
- Reminds agents to check for duplicates and remove stale memories

## Test plan
- [x] Memory guidance documented in CLAUDE.md
- [x] Distinguishes proactive saves from user-requested saves
- [x] Clear examples of what to save vs what to skip
- [x] Word count impact <= 200 words (actual: +200 words, 900 -> 1100; total budget 13,426/14,000)

Generated with Claude Code