### PR TITLE
docs: clarify /merge vs /wrap usage guidance

### DIFF
--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -5,6 +5,13 @@ description: Squash merge the current PR, delete the branch, log to work-log, an
 
 Squash merge the current PR. This is the "we're done here" command.
 
+## When to use /merge vs /wrap
+
+- Use **/merge** for a quick mid-session merge when you'll continue working in the same session. It handles AC verification, CI check, and squash-merge — nothing else.
+- Use **/wrap** for end-of-session cleanup. /wrap is a superset: runs the same merge flow PLUS detects follow-up issues, extracts session lessons, syncs the work log, and cleans up the worktree.
+- If you're done for the session, use /wrap. If you're merging and immediately starting the next issue, use /merge.
+- Note: /merge aborts if invoked from inside a worktree (see Step 1) — use /wrap in that case since it removes the worktree before deleting the branch.
+
 ## Steps
 
 ### Step 1: Identify the PR

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -5,6 +5,12 @@ description: End-of-session command — verify no unresolved findings, squash me
 
 Wrap up the current PR and session. This is the "we're done here" command that handles everything from final verification through worktree cleanup.
 
+## When to use /wrap vs /merge
+
+- Use **/wrap** at end-of-session. Handles merge + follow-up detection + lessons + work-log sync + worktree cleanup in one command.
+- Use **/merge** for a quick mid-session merge when you'll keep working. Skips the cleanup steps and only runs outside worktrees.
+- /wrap includes everything /merge does, plus the cleanup. Don't run both.
+
 ## Phase 1: Pre-Merge Verification — Check for Unresolved Findings
 
 Before merging, verify that all reviewer feedback has been addressed.


### PR DESCRIPTION
Closes #196

## Summary
Adds "When to use" sections to both /merge and /wrap SKILL.md files explaining when to pick each. /wrap is a superset (merge + cleanup); /merge is the quick mid-session path.

This is a documentation-only change — no behavioral refactoring. Both skills share merge-gate, AC verification, and CI check logic; if that shared verification should be extracted into a common helper, a follow-up issue can track that (not in scope here).

## Test plan
- [x] .claude/skills/merge/SKILL.md has "When to use" section
- [x] .claude/skills/wrap/SKILL.md has "When to use" section
- [x] Both cross-reference the other skill
- [x] No behavioral changes to either skill
- [x] Existing frontmatter and step logic preserved

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated `/merge` and `/wrap` command documentation with clear usage guidelines
* `/merge` is designated for mid-session merges with AC verification and CI checking
* `/wrap` is the end-of-session command that includes `/merge` functionality plus follow-up detection, lesson extraction, work-log syncing, and worktree cleanup
* Added constraint that `/merge` cannot be used inside worktrees

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
