### PR TITLE
fix: run rule-lint on every PR to unblock non-rules PRs

### DIFF
--- a/.github/workflows/rule-lint.yml
+++ b/.github/workflows/rule-lint.yml
@@ -2,12 +2,7 @@ name: Rule Index & Word Count Lint
 
 on:
   workflow_dispatch: {}
-  pull_request:
-    paths:
-      - 'CLAUDE.md'
-      - '.claude/rules/**'
-      - '.github/workflows/rule-lint.yml'
-      - '.github/scripts/rule-lint.sh'
+  pull_request: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #241

## Summary
Removes the `paths:` filter from `rule-lint.yml` so the workflow runs on every PR. Required by branch protection with `strict: true` — path-filtered workflows never trigger on non-matching PRs, permanently blocking them (e.g. PR #230 touching `.claude/agents/`).

The `rule-lint.sh` script is a fast no-op for PRs that don't touch CLAUDE.md or rules/** — it always scans the current tree and reports success if rules are clean.

## Test plan
- [ ] `.github/workflows/rule-lint.yml` triggers on every `pull_request`
- [ ] Workflow runs the same `rule-lint.sh` script unchanged
- [ ] This PR itself triggers rule-lint (meta-test)

🤖 Generated with Claude Code