### PR TITLE
feat: JSON-based skill usage audit script + seed data (#248)

### DIFF
--- a/.claude/data/skill-usage.json
+++ b/.claude/data/skill-usage.json
@@ -1,0 +1,107 @@
+{
+  "check-acceptance-criteria": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "continue": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "lessons": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "merge": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "pm-clean": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "pm-handoff": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "pm-okr": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "pm-rate-team": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "pm-sprint-plan": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "pm-sprint-review": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "pm-team-standup": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "pm-update": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "pm": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "pr-review-help": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "prioritize": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "prompt": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "standup": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "start-issue": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "status": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "subagent": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  },
+  "wrap": {
+    "use_count": 0,
+    "first_seen": "2026-04-13",
+    "last_used": null
+  }
+}

--- a/.claude/scripts/audit-skill-usage.sh
+++ b/.claude/scripts/audit-skill-usage.sh
@@ -97,7 +97,8 @@ if [[ -d "$SKILLS_DIR" ]]; then
 fi
 
 # Write back the (possibly updated) data file
-echo "$USAGE_DATA" | jq '.' > "$DATA_FILE"
+_tmp="$(mktemp "$(dirname "$DATA_FILE")/skill-usage.XXXXXX.json")"
+echo "$USAGE_DATA" | jq '.' > "$_tmp" && mv "$_tmp" "$DATA_FILE"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Detect orphaned entries (in data file but no longer in skills dir)
@@ -137,9 +138,9 @@ while IFS= read -r skill_name; do
   age_days=$(( (today_epoch - first_epoch) / 86400 ))
 
   if (( age_days >= 60 )); then
-    RECOMMEND+=("${skill_name}:${age_days}")
+    RECOMMEND+=("${skill_name}	${age_days}")
   elif (( age_days >= 30 )); then
-    FLAGGED+=("${skill_name}:${age_days}")
+    FLAGGED+=("${skill_name}	${age_days}")
   fi
 done < <(echo "$USAGE_DATA" | jq -r 'keys[]')
 
@@ -184,10 +185,13 @@ fi
 if (( ${#RECOMMEND[@]} > 0 )); then
   printf "RECOMMEND REMOVAL (%d skill(s), 60+ days unused):\n" "${#RECOMMEND[@]}"
   # Sort by age descending
-  mapfile -t sorted < <(printf '%s\n' "${RECOMMEND[@]}" | sort -t: -k2 -rn)
+  sorted=()
+  while IFS= read -r entry; do
+    sorted+=("$entry")
+  done < <(printf '%s\n' "${RECOMMEND[@]}" | sort -t$'\t' -k2 -rn)
   for entry in "${sorted[@]}"; do
-    skill_name="${entry%%:*}"
-    age_days="${entry##*:}"
+    skill_name="${entry%%$'\t'*}"
+    age_days="${entry##*$'\t'}"
     printf "  - %s (unused for %d days)\n" "$skill_name" "$age_days"
   done
   echo ""
@@ -199,10 +203,13 @@ fi
 # Review flags (30–59 days unused)
 if (( ${#FLAGGED[@]} > 0 )); then
   printf "FLAGGED — REVIEW RECOMMENDED (%d skill(s), 30–59 days unused):\n" "${#FLAGGED[@]}"
-  mapfile -t sorted < <(printf '%s\n' "${FLAGGED[@]}" | sort -t: -k2 -rn)
+  sorted=()
+  while IFS= read -r entry; do
+    sorted+=("$entry")
+  done < <(printf '%s\n' "${FLAGGED[@]}" | sort -t$'\t' -k2 -rn)
   for entry in "${sorted[@]}"; do
-    skill_name="${entry%%:*}"
-    age_days="${entry##*:}"
+    skill_name="${entry%%$'\t'*}"
+    age_days="${entry##*$'\t'}"
     printf "  - %s (unused for %d days)\n" "$skill_name" "$age_days"
   done
   echo ""

--- a/.claude/scripts/audit-skill-usage.sh
+++ b/.claude/scripts/audit-skill-usage.sh
@@ -184,8 +184,7 @@ fi
 if (( ${#RECOMMEND[@]} > 0 )); then
   printf "RECOMMEND REMOVAL (%d skill(s), 60+ days unused):\n" "${#RECOMMEND[@]}"
   # Sort by age descending
-  IFS=$'\n' sorted=($(printf '%s\n' "${RECOMMEND[@]}" | sort -t: -k2 -rn))
-  unset IFS
+  mapfile -t sorted < <(printf '%s\n' "${RECOMMEND[@]}" | sort -t: -k2 -rn)
   for entry in "${sorted[@]}"; do
     skill_name="${entry%%:*}"
     age_days="${entry##*:}"
@@ -200,8 +199,7 @@ fi
 # Review flags (30–59 days unused)
 if (( ${#FLAGGED[@]} > 0 )); then
   printf "FLAGGED — REVIEW RECOMMENDED (%d skill(s), 30–59 days unused):\n" "${#FLAGGED[@]}"
-  IFS=$'\n' sorted=($(printf '%s\n' "${FLAGGED[@]}" | sort -t: -k2 -rn))
-  unset IFS
+  mapfile -t sorted < <(printf '%s\n' "${FLAGGED[@]}" | sort -t: -k2 -rn)
   for entry in "${sorted[@]}"; do
     skill_name="${entry%%:*}"
     age_days="${entry##*:}"

--- a/.claude/scripts/audit-skill-usage.sh
+++ b/.claude/scripts/audit-skill-usage.sh
@@ -1,92 +1,219 @@
-#!/bin/bash
-# Audit skill usage — manual monthly utility
+#!/usr/bin/env bash
+# audit-skill-usage.sh — Monthly skill usage audit
 #
-# Reads the LIVE skill-usage CSV (~/.claude/skill-usage.csv, bootstrapped
-# by skill-usage-tracker.sh on first Skill invocation). Reports skills that
-# appear unused:
-#   - 30-59 days since start_date with use_count == 0 → FLAG (tracking issue)
-#   - 60+  days since start_date with use_count == 0 → RECOMMEND REMOVAL
+# PURPOSE:
+#   Reads .claude/data/skill-usage.json and reports skills that have not been
+#   used since they were first tracked:
+#     - 30–59 days with use_count == 0 → FLAG (review recommended)
+#     - 60+  days with use_count == 0 → RECOMMEND REMOVAL
 #
-# Output only — does NOT modify files or remove skills.
+#   Also syncs the data file with the current .claude/skills/ directory:
+#     - Skills found in .claude/skills/ but missing from the data file get
+#       a new entry (first_seen = today, use_count = 0, last_used = null).
+#     - Skills in the data file but no longer in .claude/skills/ are noted
+#       in the report (orphaned entries are preserved, not deleted).
 #
-# Override the CSV path with SKILL_USAGE_CSV env var (useful for testing
-# or for auditing the committed seed file directly).
+# USAGE:
+#   bash .claude/scripts/audit-skill-usage.sh [--help]
+#
+# IDEMPOTENT: Safe to run multiple times. Running it twice on the same day
+# produces the same output and the same data file state.
+#
+# DEPENDENCIES:
+#   - jq  (available at /usr/bin/jq on macOS + standard Linux distros)
+#
+# DATA SOURCE:
+#   .claude/data/skill-usage.json (relative to the repo root).
+#   The file is initialized automatically on first run if it does not exist.
+#   Use_counts are incremented by the skill-usage-tracker hook (see #121).
+#   Until that hook is active, all skills will show use_count == 0.
+#
+# EXIT STATUS:
+#   0 — no removal recommendations (all clean, or only review flags)
+#   1 — at least one skill is recommended for removal (60+ days unused)
 
 set -euo pipefail
 
-CSV="${SKILL_USAGE_CSV:-${HOME}/.claude/skill-usage.csv}"
+# ──────────────────────────────────────────────────────────────────────────────
+# Help flag
+# ──────────────────────────────────────────────────────────────────────────────
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  sed -n '2,/^# EXIT STATUS:/{ /^# EXIT STATUS:/d; s/^# \{0,1\}//; p }' "$0"
+  exit 0
+fi
 
-if [ ! -f "$CSV" ]; then
-  echo "Error: skill-usage CSV not found at $CSV" >&2
-  echo "  (the tracker hook creates it on first Skill invocation)" >&2
+# ──────────────────────────────────────────────────────────────────────────────
+# Locate repo root (supports running from any subdirectory or a worktree)
+# ──────────────────────────────────────────────────────────────────────────────
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "Error: not inside a git repository. Run this script from within the repo." >&2
   exit 1
 fi
 
-python3 - "$CSV" <<'PY'
-import csv, sys
-from datetime import datetime
+SKILLS_DIR="${REPO_ROOT}/.claude/skills"
+DATA_FILE="${REPO_ROOT}/.claude/data/skill-usage.json"
+TODAY="$(TZ='America/New_York' date +'%Y-%m-%d')"
 
-try:
-    import zoneinfo
-    today = datetime.now(zoneinfo.ZoneInfo("America/New_York")).date()
-except Exception:
-    # Fallback: machine local date (Python 3.8 or unusual environments)
-    today = datetime.now().date()
+# ──────────────────────────────────────────────────────────────────────────────
+# Ensure jq is available
+# ──────────────────────────────────────────────────────────────────────────────
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required but not found in PATH." >&2
+  echo "  Install via: brew install jq  OR  apt-get install jq" >&2
+  exit 1
+fi
 
-csv_path = sys.argv[1]
+# ──────────────────────────────────────────────────────────────────────────────
+# Initialize data file if missing
+# ──────────────────────────────────────────────────────────────────────────────
+if [[ ! -f "$DATA_FILE" ]]; then
+  mkdir -p "$(dirname "$DATA_FILE")"
+  echo "{}" > "$DATA_FILE"
+  echo "Initialized empty data file at $DATA_FILE"
+fi
 
-flagged = []    # 30-59 days unused
-recommend = []  # 60+ days unused
+# ──────────────────────────────────────────────────────────────────────────────
+# Sync: add entries for skills not yet tracked
+# ──────────────────────────────────────────────────────────────────────────────
+USAGE_DATA="$(cat "$DATA_FILE")"
+NEW_SKILLS=()
 
-with open(csv_path, newline="") as f:
-    reader = csv.DictReader(f)
-    for row in reader:
-        name = row.get("skill_name", "").strip()
-        start = row.get("start_date", "").strip()
-        count_s = row.get("use_count", "0").strip()
-        if not name or not start:
-            continue
-        try:
-            count = int(count_s)
-        except ValueError:
-            count = 0
-        if count != 0:
-            continue
-        try:
-            start_d = datetime.strptime(start, "%Y-%m-%d").date()
-        except ValueError:
-            continue
-        age = (today - start_d).days
-        if age >= 60:
-            recommend.append((name, age))
-        elif age >= 30:
-            flagged.append((name, age))
+if [[ -d "$SKILLS_DIR" ]]; then
+  for skill_dir in "$SKILLS_DIR"/*/; do
+    [[ -f "${skill_dir}SKILL.md" ]] || continue
+    skill_name="$(basename "$skill_dir")"
+    # Check if already in data file
+    existing=$(echo "$USAGE_DATA" | jq -r --arg n "$skill_name" '.[$n] // empty')
+    if [[ -z "$existing" ]]; then
+      # New skill — add with first_seen=today, use_count=0, last_used=null
+      USAGE_DATA=$(echo "$USAGE_DATA" | jq \
+        --arg name "$skill_name" \
+        --arg date "$TODAY" \
+        '.[$name] = {"use_count": 0, "first_seen": $date, "last_used": null}')
+      NEW_SKILLS+=("$skill_name")
+    fi
+  done
+fi
 
-total_unused = len(flagged) + len(recommend)
+# Write back the (possibly updated) data file
+echo "$USAGE_DATA" | jq '.' > "$DATA_FILE"
 
-print(f"Skill Usage Audit — {today.isoformat()}")
-print("=" * 60)
-print()
+# ──────────────────────────────────────────────────────────────────────────────
+# Detect orphaned entries (in data file but no longer in skills dir)
+# ──────────────────────────────────────────────────────────────────────────────
+ORPHANS=()
+while IFS= read -r skill_name; do
+  [[ -n "$skill_name" ]] || continue
+  if [[ ! -d "${SKILLS_DIR}/${skill_name}" ]]; then
+    ORPHANS+=("$skill_name")
+  fi
+done < <(echo "$USAGE_DATA" | jq -r 'keys[]')
 
-if not total_unused:
-    print("No unused skills found. All tracked skills have use_count > 0")
-    print("or are still within their 30-day grace period.")
-    sys.exit(0)
+# ──────────────────────────────────────────────────────────────────────────────
+# Age-based flagging
+# ──────────────────────────────────────────────────────────────────────────────
+FLAGGED=()      # 30–59 days unused
+RECOMMEND=()    # 60+ days unused
 
-if recommend:
-    print(f"RECOMMEND REMOVAL ({len(recommend)} skills, 60+ days unused):")
-    for name, age in sorted(recommend, key=lambda x: -x[1]):
-        print(f"  - {name} (unused for {age} days)")
-    print()
-    print("  Suggested action: delete these skills from .claude/skills/")
-    print("  via a PR. File an issue to track removal.")
-    print()
+# today as epoch seconds (portable: works on macOS and Linux)
+today_epoch=$(date -j -f "%Y-%m-%d" "$TODAY" "+%s" 2>/dev/null \
+  || date -d "$TODAY" "+%s")
 
-if flagged:
-    print(f"FLAGGED ({len(flagged)} skills, 30-59 days unused):")
-    for name, age in sorted(flagged, key=lambda x: -x[1]):
-        print(f"  - {name} (unused for {age} days)")
-    print()
-    print("  Suggested action: file a tracking issue. Re-check in 30 days.")
-    print()
-PY
+while IFS= read -r skill_name; do
+  [[ -n "$skill_name" ]] || continue
+
+  use_count=$(echo "$USAGE_DATA" | jq -r --arg n "$skill_name" '.[$n].use_count // 0')
+  # Skip skills with any recorded usage
+  [[ "$use_count" -eq 0 ]] || continue
+
+  first_seen=$(echo "$USAGE_DATA" | jq -r --arg n "$skill_name" '.[$n].first_seen // ""')
+  [[ -n "$first_seen" ]] || continue
+
+  # Parse first_seen date to epoch seconds
+  first_epoch=$(date -j -f "%Y-%m-%d" "$first_seen" "+%s" 2>/dev/null \
+    || date -d "$first_seen" "+%s" 2>/dev/null) || continue
+
+  age_days=$(( (today_epoch - first_epoch) / 86400 ))
+
+  if (( age_days >= 60 )); then
+    RECOMMEND+=("${skill_name}:${age_days}")
+  elif (( age_days >= 30 )); then
+    FLAGGED+=("${skill_name}:${age_days}")
+  fi
+done < <(echo "$USAGE_DATA" | jq -r 'keys[]')
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Report output
+# ──────────────────────────────────────────────────────────────────────────────
+TOTAL_SKILLS=$(echo "$USAGE_DATA" | jq 'keys | length')
+
+echo "Skill Usage Audit — ${TODAY}"
+echo "============================================================"
+printf "Total skills tracked: %s\n" "$TOTAL_SKILLS"
+
+# New skills added during this run
+if (( ${#NEW_SKILLS[@]} > 0 )); then
+  echo ""
+  printf "NEW (added to tracking today, %d skill(s)):\n" "${#NEW_SKILLS[@]}"
+  for s in "${NEW_SKILLS[@]}"; do
+    printf "  + %s\n" "$s"
+  done
+fi
+
+# Orphaned entries
+if (( ${#ORPHANS[@]} > 0 )); then
+  echo ""
+  printf "ORPHANED entries (%d) — in data file but no skill directory found:\n" "${#ORPHANS[@]}"
+  for s in "${ORPHANS[@]}"; do
+    printf "  ? %s\n" "$s"
+  done
+  echo "  (These entries are preserved. Remove manually if the skill was deleted.)"
+fi
+
+echo ""
+
+# Early exit if nothing to flag
+if (( ${#RECOMMEND[@]} == 0 && ${#FLAGGED[@]} == 0 )); then
+  echo "No unused skills found. All tracked skills have use_count > 0"
+  echo "or are still within their 30-day grace period."
+  exit 0
+fi
+
+# Removal recommendations (60+ days unused)
+if (( ${#RECOMMEND[@]} > 0 )); then
+  printf "RECOMMEND REMOVAL (%d skill(s), 60+ days unused):\n" "${#RECOMMEND[@]}"
+  # Sort by age descending
+  IFS=$'\n' sorted=($(printf '%s\n' "${RECOMMEND[@]}" | sort -t: -k2 -rn))
+  unset IFS
+  for entry in "${sorted[@]}"; do
+    skill_name="${entry%%:*}"
+    age_days="${entry##*:}"
+    printf "  - %s (unused for %d days)\n" "$skill_name" "$age_days"
+  done
+  echo ""
+  echo "  Suggested action: open a PR to delete these skills from .claude/skills/"
+  echo "  and remove their entries from .claude/data/skill-usage.json."
+  echo ""
+fi
+
+# Review flags (30–59 days unused)
+if (( ${#FLAGGED[@]} > 0 )); then
+  printf "FLAGGED — REVIEW RECOMMENDED (%d skill(s), 30–59 days unused):\n" "${#FLAGGED[@]}"
+  IFS=$'\n' sorted=($(printf '%s\n' "${FLAGGED[@]}" | sort -t: -k2 -rn))
+  unset IFS
+  for entry in "${sorted[@]}"; do
+    skill_name="${entry%%:*}"
+    age_days="${entry##*:}"
+    printf "  - %s (unused for %d days)\n" "$skill_name" "$age_days"
+  done
+  echo ""
+  echo "  Suggested action: file a tracking issue. Re-check in 30 days."
+  echo ""
+fi
+
+# Exit 1 if any removal recommendations exist
+if (( ${#RECOMMEND[@]} > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Replaces the Python/CSV `audit-skill-usage.sh` with a pure bash + jq implementation that reads/writes `.claude/data/skill-usage.json`
- Adds `.claude/data/skill-usage.json` seeded with all 21 current skills (`use_count: 0`, `first_seen: 2026-04-13`)
- Script auto-syncs new skills on each run, flags 30+ day zero-usage skills for review, and recommends removal at 60+ days
- Idempotent: safe to run multiple times; exits 1 if any removal recommendations exist, 0 otherwise

Closes #248

## Test plan
- [x] Script runs without errors (`bash .claude/scripts/audit-skill-usage.sh` exits 0 with fresh data)
- [x] Skills with zero usage after 30 days are flagged as "FLAGGED — REVIEW RECOMMENDED"
- [x] Skills with zero usage after 60 days appear under "RECOMMEND REMOVAL" and script exits 1
- [x] Script is idempotent — running twice produces identical output and data file
- [x] New skills not yet in the data file are added automatically on first run
- [x] Orphaned entries (in data file but no skill directory) are reported but preserved
- [x] `--help` flag prints usage instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive skill usage tracking that initializes and tracks per-skill activity metrics.

* **Refactor**
  * Reworked the audit tooling to use JSON-backed tracking, automatic skill discovery and synchronization, and clearer inactive-skill categorization (30–59 days vs 60+ days).
  * Expanded reporting to show totals, newly added skills, and orphaned entries; improved help and usage output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->