### PR TITLE
refactor: collapse issue-planning.md into single linear flow

### DIFF
--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -1,57 +1,37 @@
-# Issue Creation Flow
+# Issue Flow
 
-> **Always:** Create a GitHub issue before any code work. Ensure `@coderabbitai plan` runs on every new issue (automated via workflow). Merge CR's plan into the issue body.
+> **Always:** Create a GitHub issue before any code work. Merge CR's plan into the issue body before coding.
 > **Ask first:** Never — issue creation and planning are autonomous.
 > **Never:** Skip the issue. Start coding without a plan. Post the plan as scattered comments instead of editing the issue body.
-
-When creating a new GitHub issue (whether the user asked for it or you identified the need):
 
 ## 1. Draft the issue locally
 - Write the title, body, acceptance criteria, and any relevant context
 - Do NOT post it yet
 
-## 2. Create the issue (CR plan is auto-triggered)
+## 2. Create the issue
+- Post via `gh issue create`
+- A GitHub Actions workflow (`.github/workflows/cr-plan-on-issue.yml`) automatically comments `@coderabbitai plan` on every new issue. The workflow skips bot-created issues.
+- Do not manually post `@coderabbitai plan` unless the workflow failed (visible in the Actions tab).
 
-- Post the issue via `gh issue create`
-- **A GitHub Actions workflow (`.github/workflows/cr-plan-on-issue.yml`) automatically comments `@coderabbitai plan` on every new issue.** You do not need to manually trigger it. The workflow skips bot-created issues.
-- If you want to confirm the trigger fired, check the issue comments — but do not manually post `@coderabbitai plan` unless the workflow failed (visible in the Actions tab).
-- CR will analyze the issue and post an implementation plan with file recommendations, edge cases, and architectural considerations. This feedback is valuable — it catches gaps in the spec before any coding begins.
-
-## 3. If starting work immediately
-- If you're about to start coding on this issue right away, proceed to the **Issue Planning Flow** below — it handles waiting for CR's plan.
-- If the issue is for later (backlog), you're done — CR's plan will be there when someone picks it up.
-
----
-
-## Issue Planning Flow
-
-**Prerequisite:** Same CR check as the review loop below. If CR is not configured, skip the CR-specific steps.
-
-When starting work on a GitHub issue, always follow this flow before writing any code:
-
-### 1. Read the issue
-- Fetch the full issue body and comments via `gh issue view N --comments`
-- Understand the requirements, context, and any discussion
-
-### 2. Check for CR's implementation plan
-CR automatically posts an implementation plan when issues are created (triggered by `@coderabbitai plan`). Check whether it exists:
+## 3. Check for CR's implementation plan
 
 > **Username note:** Use `coderabbitai` (no `[bot]` suffix) for issue comments; PR reviews use `coderabbitai[bot]`.
 
-- **Issue age determines the polling strategy:**
-  - Older than 10 minutes: Check comments for a plan from `coderabbitai`. If it exists, read it. If it doesn't exist (CR may not have been triggered), post `@coderabbitai plan` now and poll for up to 5 minutes. If still no response, proceed without it.
-  - Less than 10 minutes old: CR may still be generating the plan. Poll every 60 seconds for a comment from `coderabbitai` on the issue. Timeout after 10 minutes from issue creation time — if no plan appears by then, proceed without it.
+Issue age determines the polling strategy:
+- **Older than 10 minutes:** Check comments for a plan from `coderabbitai`. If missing, post `@coderabbitai plan` and poll up to 5 minutes.
+- **Less than 10 minutes old:** Poll every 60 seconds for a comment from `coderabbitai`. Timeout after 10 minutes from issue creation time.
+- **No response after timeout:** Log "CR plan unavailable" and continue — Claude's plan (step 4) is always required regardless.
 
-### 3. Build Claude's plan
+## 4. Build Claude's plan
 - Explore the codebase and design an implementation plan (use plan mode)
 - Draft the plan internally — do not post it yet
 
-### 4. Merge the plans into the issue body
+## 5. Merge plans into the issue body
 This creates **one canonical document** for the coding agent to work from:
 
-1. **If CR posted a plan:** Compare CR's plan against Claude's plan. Incorporate anything CR identified that Claude missed (files, edge cases, architectural considerations, risks). The goal is the most robust plan — pick the best ideas from each.
+1. **If CR posted a plan:** Compare CR's plan against Claude's plan. Incorporate anything CR identified that Claude missed (files, edge cases, risks). Pick the best ideas from each.
 2. **If CR did not post a plan:** Use Claude's plan as-is.
-3. **Edit the issue body** to include the merged plan. Fetch the current body first, then write back both the original content and the plan:
+3. **Edit the issue body** — fetch the current body first, then write back both the original content and the plan:
    ```bash
    current_body="$(gh issue view N --json body --jq .body)"
    gh issue edit N --body "${current_body}
@@ -59,20 +39,20 @@ This creates **one canonical document** for the coding agent to work from:
    ## Implementation Plan
    <merged plan here>"
    ```
-   This preserves the original issue description. (`gh issue edit --body` replaces the entire body — you must fetch-concatenate-edit to append.)
-4. **Comment on the issue** confirming the merge:
-   ```
-   gh issue comment N --body "Implementation plan merged into issue body (Claude's analysis + CodeRabbit's recommendations). Ready for implementation."
-   ```
-   If CR's plan was not available, note that:
-   ```
-   gh issue comment N --body "Implementation plan added to issue body (Claude's analysis only — CodeRabbit plan was not available). Ready for implementation."
-   ```
+   `gh issue edit --body` replaces the entire body — you must fetch-concatenate-edit to append.
 
-### 5. Start coding
+## 6. Comment confirming the merge
+```
+gh issue comment N --body "Implementation plan merged into issue body (Claude's analysis + CodeRabbit's recommendations). Ready for implementation."
+```
+If CR's plan was not available:
+```
+gh issue comment N --body "Implementation plan added to issue body (Claude's analysis only — CodeRabbit plan was not available). Ready for implementation."
+```
 
+## 7. Begin implementation
 1. **Create the feature branch** (`issue-N-short-description`).
 2. **Read the issue body** (not scattered comments) for the canonical implementation plan.
 3. **Implement the changes.**
-4. **Run the Local CodeRabbit Review Loop** (see `cr-local-review.md` "Fix loop" section) — two clean passes required before pushing.
+4. **Run the Local CodeRabbit Review Loop** (see `cr-local-review.md`) — two clean passes required before pushing.
 5. **Execute the post-clean checklist** (see `cr-local-review.md` "Post-Clean" section) — commit, push, create PR, enter GitHub review loop.

--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -43,12 +43,9 @@ This creates **one canonical document** for the coding agent to work from:
 
 ## 6. Comment confirming the merge
 ```
-gh issue comment N --body "Implementation plan merged into issue body (Claude's analysis + CodeRabbit's recommendations). Ready for implementation."
+gh issue comment N --body "Implementation plan merged into issue body (<source>). Ready for implementation."
 ```
-If CR's plan was not available:
-```
-gh issue comment N --body "Implementation plan added to issue body (Claude's analysis only — CodeRabbit plan was not available). Ready for implementation."
-```
+Use "Claude's analysis + CodeRabbit's recommendations" when CR contributed, or "Claude's analysis only — CodeRabbit plan was not available" when it didn't.
 
 ## 7. Begin implementation
 1. **Create the feature branch** (`issue-N-short-description`).


### PR DESCRIPTION
## Summary
- Merges the dual-flow structure (Issue Creation Flow + Issue Planning Flow) in `issue-planning.md` into one linear 7-step flow
- Removes the if-starting-work-immediately fork, redundant CR prerequisite check, and separate "Start coding" sub-list
- Consolidates duplicate comment examples into a single template with variant note
- Word count reduced from 759 to 470 (target ≤550)

Closes #236

## Test plan
- [x] `issue-planning.md` ≤ 550 words
- [x] One linear flow — no duplicated prereq checks
- [x] Fetch-concatenate-edit example preserved
- [x] All behavior enforced: issue → CR plan → merged plan → code
- [x] Total word count budget check passes (≤14,000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)