### PR TITLE
refactor: compress greptile.md, skill-symlinks.md, repo-bootstrap.md via reference extraction

### DIFF
--- a/.claude/reference/greptile-reply-format.md
+++ b/.claude/reference/greptile-reply-format.md
@@ -1,0 +1,13 @@
+# CR vs Greptile Reply Format Comparison
+
+| | CodeRabbit | Greptile |
+|--|-----------|----------|
+| Reply format | Include `@coderabbitai` (teaches knowledge base) | **No @mention** — plain text only |
+| Learns from replies | Yes | No — only from 👍/👎 reactions |
+| @mention cost | Within hourly quota | $0.50-$1.00 per triggered review |
+
+## Reply Format for Greptile Threads
+
+- Inline comments: `gh api repos/{owner}/{repo}/pulls/comments/{id}/replies -f body="Fixed in \`SHA\`: <what changed>"`
+- Issue/PR-level comments: `gh pr comment N --body "Fixed in \`SHA\`: <what changed>"`
+- **Never** include `@greptileai` in reply bodies. The only valid use of `@greptileai` is posting a standalone comment to intentionally request a new review (P0 re-review trigger).

--- a/.claude/reference/greptile-setup.md
+++ b/.claude/reference/greptile-setup.md
@@ -1,0 +1,13 @@
+# Greptile Dashboard Configuration (app.greptile.com)
+
+Auto-review on PR open is disabled via a "Labels: includes: `greptile`" filter in the Greptile dashboard (app.greptile.com/review → Settings → Review Triggers). Since we never add that label, no PRs get auto-reviewed — manual `@greptileai` triggers still work.
+
+| Setting | Value |
+|---------|-------|
+| Authors Exclude | `dependabot[bot]`, `renovate[bot]` |
+| Labels: includes | `greptile` |
+| File Change Limit | 100 |
+| Automatically trigger on new commits | OFF |
+| Review draft pull requests | OFF |
+
+**Setup:** Add the "Labels: includes: greptile" filter at app.greptile.com/review → Settings → Review Triggers. The "new commits" toggle only affects commits to existing PRs, not PR-open events.

--- a/.claude/reference/skill-sync-hooks.md
+++ b/.claude/reference/skill-sync-hooks.md
@@ -1,0 +1,23 @@
+# Skill Sync Hooks — How They Work
+
+## Session-Start Sync Hook
+
+The `session-start-sync.sh` PostToolUse hook runs once per session (on the first tool call) and syncs the skills worktree to `origin/main`. This ensures skills, rules, and CLAUDE.md are fresh across **all repos** — not just `claude-code-config`. The hook also pulls the root repo's `main` branch if it's currently checked out.
+
+The `post-merge-pull.sh` hook syncs the skills worktree after merges and also refreshes the CLAUDE.md and rules symlinks.
+
+## Hook Auto-Registration
+
+The session-start sync also registers hooks from `global-settings.json` into `~/.claude/settings.json`. This ensures new hooks added to the template are picked up automatically — no need to re-run the setup script.
+
+**How it works:**
+- Reads `global-settings.json` from the skills worktree (always at `origin/main`)
+- Resolves placeholder paths to the skills worktree hooks directory
+- Compares against `~/.claude/settings.json` by script basename per event/matcher
+- Adds only missing hooks; existing hooks (including user-customized timeouts) are preserved
+- User hooks not in the template are never touched
+
+**To add a new hook to the repo:**
+1. Create the hook script in `.claude/hooks/`
+2. Add the hook entry to `global-settings.json` (use the `/path/to/claude-code-config` placeholder)
+3. Merge to `main` — the next session start auto-registers it in every user's `settings.json`

--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -9,14 +9,14 @@ Greptile is a **fallback** AI code reviewer for when CR is rate-limited or unres
 ## Greptile Basics
 
 - **Bot username:** `greptile-apps[bot]`
-- **Trigger:** Comment `@greptileai` on any PR
+- **Trigger:** Comment `@greptileai` on any PR (no "full review" suffix, unlike CR)
 - **Auto-trigger:** OFF (see `.claude/reference/greptile-setup.md`). Must be explicitly triggered.
 - **Rate limits:** 50 reviews/seat/month included, $1/extra — no per-hour throttle
 - **Review time:** ~1-3 minutes
 - **Completion signals:** 👀 = analyzing, 👍 = complete, 😕 = failed
 - **No CLI** — local review loop uses CR CLI only
-- **Config:** Optional `greptile.json` in repo root. Trigger filters configured at app.greptile.com.
-- **Feedback:** 👍/👎 reactions on comments train it over 2-3 weeks
+- **Config:** Optional `greptile.json` in repo root. Trigger filters at app.greptile.com.
+- **Feedback:** 👍/👎 reactions train it over 2-3 weeks
 
 ## Dashboard Configuration
 

--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -4,40 +4,29 @@
 > **Ask first:** Never — fix findings autonomously.
 > **Never:** Trigger Greptile proactively on a PR where CR hasn't failed yet. Ignore Greptile findings. Switch a PR back to CR after Greptile has been triggered. Include `@greptileai` in reply comments (triggers a paid re-review with no learning benefit).
 
-Greptile is an AI code reviewer used as a **fallback** when CR is rate-limited or unresponsive. Both tools' findings must be verified against code. Differences: cost ($0.50-$1.00/review beyond 50/month quota) and completion-signal reliability (Greptile completion signals are accurate; CR completion signals require confirmation passes).
+Greptile is a **fallback** AI code reviewer for when CR is rate-limited or unresponsive. Verify all findings against code. Key differences from CR: cost ($0.50-$1.00/review beyond 50/month quota), accurate completion signals (no confirmation pass needed).
 
 ## Greptile Basics
 
-- **GitHub App:** Greptile Apps
 - **Bot username:** `greptile-apps[bot]`
-- **Trigger:** Comment `@greptileai` on any PR (no special "full review" suffix needed)
-- **Auto-trigger:** OFF — disabled via dashboard filter (see "Dashboard Configuration" below). Must be explicitly triggered via @mention.
-- **Rate limits:** None documented (50 reviews/seat/month included, $1/extra — no per-hour throttle)
-- **Review time:** ~1-3 minutes for most PRs
-- **Completion signals:** 👀 emoji on the PR = analyzing, 👍 = complete, 😕 = failed
-- **No CLI:** Greptile cannot do local pre-push reviews. Local review loop uses CR CLI only.
-- **Config:** Optional `greptile.json` in repo root (supports `strictness`, `customInstructions`, `scope`). Review trigger filters are configured in the Greptile web dashboard (app.greptile.com), not in repo files.
-- **Feedback loop:** 👍/👎 reactions on Greptile comments train it over 2-3 weeks
+- **Trigger:** Comment `@greptileai` on any PR
+- **Auto-trigger:** OFF (see `.claude/reference/greptile-setup.md`). Must be explicitly triggered.
+- **Rate limits:** 50 reviews/seat/month included, $1/extra — no per-hour throttle
+- **Review time:** ~1-3 minutes
+- **Completion signals:** 👀 = analyzing, 👍 = complete, 😕 = failed
+- **No CLI** — local review loop uses CR CLI only
+- **Config:** Optional `greptile.json` in repo root. Trigger filters configured at app.greptile.com.
+- **Feedback:** 👍/👎 reactions on comments train it over 2-3 weeks
 
-## Dashboard Configuration (app.greptile.com)
+## Dashboard Configuration
 
-Auto-review on PR open is disabled via a "Labels: includes: `greptile`" filter in the Greptile dashboard (app.greptile.com/review → Settings → Review Triggers). Since we never add that label, no PRs get auto-reviewed — manual `@greptileai` triggers still work.
-
-| Setting | Value |
-|---------|-------|
-| Authors Exclude | `dependabot[bot]`, `renovate[bot]` |
-| Labels: includes | `greptile` |
-| File Change Limit | 100 |
-| Automatically trigger on new commits | OFF |
-| Review draft pull requests | OFF |
-
-**Setup:** Add the "Labels: includes: greptile" filter at app.greptile.com/review → Settings → Review Triggers. The "new commits" toggle only affects commits to existing PRs, not PR-open events.
+One-time setup at app.greptile.com. See `.claude/reference/greptile-setup.md` for settings table and setup steps.
 
 ## Daily Budget
 
-Greptile charges $1/review beyond the 50/month included quota. To prevent runaway costs when many PRs are processed in parallel, enforce a hard daily cap.
+Hard daily cap prevents runaway costs when many PRs run in parallel.
 
-- **Default budget: 40 reviews/day** (adjustable — set `budget` field in `session-state.json`).
+- **Default budget: 40 reviews/day** (set `budget` in `session-state.json`).
 - **Tracking:** The `greptile_daily` section in `~/.claude/session-state.json` tracks `reviews_used`, `date` (YYYY-MM-DD in ET timezone), and `budget`. See `handoff-files.md` for the schema.
 - **Before EVERY `@greptileai` trigger**, read `greptile_daily` from session state and run the budget check:
   1. Get the current date in ET: `TZ='America/New_York' date +'%Y-%m-%d'`
@@ -70,34 +59,17 @@ Applies to 2nd/3rd triggers only; initial trigger requires only the budget check
 
 ## Polling for Greptile Response
 
-Poll every 60 seconds on all three endpoints (same pattern as CR):
+Poll every 60 seconds on all three endpoints (same pattern as CR — `pulls/{N}/reviews`, `pulls/{N}/comments`, `issues/{N}/comments` with `per_page=100`). Filter by `greptile-apps[bot]`.
 
-- `repos/{owner}/{repo}/pulls/{N}/reviews?per_page=100`
-- `repos/{owner}/{repo}/pulls/{N}/comments?per_page=100`
-- `repos/{owner}/{repo}/issues/{N}/comments?per_page=100`
-
-Filter by `greptile-apps[bot]` (with `[bot]` suffix).
-
-**Timeout:** 5 minutes (typical response: 1-3 min). No response after 5 min = timeout.
-
-**Completion detection:** 👍 or review comments from `greptile-apps[bot]` = done. 😕 = failed (stop polling, report failure). No signal after 5 min = timeout.
+**Timeout:** 5 minutes. **Completion:** 👍 or review comments = done. 😕 = failed. No signal after 5 min = timeout.
 
 ## Processing Greptile Findings
 
 Classify by severity (P0/P1/P2 — use Greptile badges only), verify against code, fix all valid findings in one commit, push once, reply to every thread, resolve via GraphQL. Use 👍/👎 reactions for feedback (this is Greptile's only learning mechanism).
 
-> **CRITICAL: Do NOT include `@greptileai` in reply comments.** Every `@greptileai` mention — even in a reply — triggers a new paid review ($0.50-$1.00). Greptile does not learn from text replies (unlike CR which has a knowledge base). Replies are purely for GitHub thread management and human readability.
->
-> | | CodeRabbit | Greptile |
-> |--|-----------|----------|
-> | Reply format | Include `@coderabbitai` (teaches knowledge base) | **No @mention** — plain text only |
-> | Learns from replies | Yes | No — only from 👍/👎 reactions |
-> | @mention cost | Within hourly quota | $0.50-$1.00 per triggered review |
+> **CRITICAL: Do NOT include `@greptileai` in reply comments.** Every `@greptileai` mention — even in a reply — triggers a new paid review ($0.50-$1.00). Greptile does not learn from text replies. Use plain text only in replies — `@greptileai` is ONLY for intentionally requesting a new review.
 
-**Reply format for Greptile threads:**
-- Inline comments: `gh api repos/{owner}/{repo}/pulls/comments/{id}/replies -f body="Fixed in \`SHA\`: <what changed>"`
-- Issue/PR-level comments: `gh pr comment N --body "Fixed in \`SHA\`: <what changed>"`
-- **Never** include `@greptileai` in reply bodies. The only valid use of `@greptileai` is posting a standalone comment to intentionally request a new review (P0 re-review trigger).
+Reply commands and CR-vs-Greptile comparison: `.claude/reference/greptile-reply-format.md`.
 
 **Severity-gated re-review:** See the "Before EVERY `@greptileai` Re-Trigger" checklist above.
 

--- a/.claude/rules/repo-bootstrap.md
+++ b/.claude/rules/repo-bootstrap.md
@@ -16,36 +16,7 @@ Verify that the repo has the required GitHub Actions workflows. If any are missi
 
 **Check:** Does `.github/workflows/cr-plan-on-issue.yml` exist?
 
-**If missing**, create it with this exact content (canonical source: `.github/workflows/cr-plan-on-issue.yml` — keep both in sync):
-
-```yaml
-name: Trigger CodeRabbit Plan on New Issues
-
-on:
-  issues:
-    types: [opened]
-
-permissions:
-  issues: write
-
-jobs:
-  trigger-cr-plan:
-    runs-on: ubuntu-latest
-    if: "!endsWith(github.event.issue.user.login, '[bot]')"
-    steps:
-      - name: Comment @coderabbitai plan
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: '@coderabbitai plan'
-            });
-```
-
-**How to add it:** Include it in your first feature PR in that repo — do not open a bootstrap-only PR. If you're only planning (no PR yet), note it for the first PR.
+**If missing:** Canonical source is `.github/workflows/cr-plan-on-issue.yml` in this repo. Copy that file verbatim into the target repo. Include it in your first feature PR — do not open a bootstrap-only PR.
 
 ### 2. Branch Protection — Required Status Checks
 
@@ -63,12 +34,9 @@ gh api "repos/{owner}/{repo}/branches/main/protection/required_status_checks" 2>
 
 **Remediation (requires user confirmation):**
 
-1. **Discover CI check names** from the latest `main` commit's check-runs; if none exist, fall back to parsing `.github/workflows/*.yml` (extract each job's `name` field, or the job key if unnamed).
-2. **Ask the user:** "This repo's `main` branch has no required status checks — PRs can merge with failing CI. Found checks: `lint`, `test`, `build`. Want me to enable branch protection requiring these to pass?"
-3. **If approved:**
-   - Read existing protection via `gh api repos/{owner}/{repo}/branches/main/protection` (may 404).
-   - PUT to the same endpoint with `required_status_checks.contexts` set to the discovered check names and `strict: true` (prevents merging stale branches).
-   - Preserve all existing protection settings from the read response (merge in the updated `required_status_checks` only). If no prior protection exists (404), use sensible defaults (`enforce_admins: false`, others `null`).
+1. **Discover CI check names** from latest `main` commit's check-runs; fall back to parsing `.github/workflows/*.yml` job names.
+2. **Ask the user:** "No required status checks on `main` — PRs can merge with failing CI. Found checks: `lint`, `test`, `build`. Want me to enable protection?"
+3. **If approved:** PUT to `repos/{owner}/{repo}/branches/main/protection` with `required_status_checks.contexts` set to discovered checks and `strict: true`. Preserve existing protection settings; use sensible defaults if none exist.
 4. **If declined:** move on. Do not ask again in the same session.
 
 ### Rules

--- a/.claude/rules/repo-bootstrap.md
+++ b/.claude/rules/repo-bootstrap.md
@@ -36,7 +36,7 @@ gh api "repos/{owner}/{repo}/branches/main/protection/required_status_checks" 2>
 
 1. **Discover CI check names** from latest `main` commit's check-runs; fall back to parsing `.github/workflows/*.yml` job names.
 2. **Ask the user:** "No required status checks on `main` — PRs can merge with failing CI. Found checks: `lint`, `test`, `build`. Want me to enable protection?"
-3. **If approved:** PUT to `repos/{owner}/{repo}/branches/main/protection` with `required_status_checks.contexts` set to discovered checks and `strict: true`. Preserve existing protection settings; use sensible defaults if none exist.
+3. **If approved:** Read existing protection first (`gh api repos/{owner}/{repo}/branches/main/protection`; ignore 404). PUT to the same endpoint, merging `required_status_checks.contexts` with `strict: true` into any existing protection settings; use sensible defaults (`enforce_admins: false`) if 404.
 4. **If declined:** move on. Do not ask again in the same session.
 
 ### Rules

--- a/.claude/rules/skill-symlinks.md
+++ b/.claude/rules/skill-symlinks.md
@@ -17,27 +17,9 @@ The following symlinks all go through the skills worktree:
 
 Skills, rules, and CLAUDE.md are served from `~/.claude/skills-worktree/`, a git worktree permanently checked out to `main`. This decouples config availability from the root repo's branch state. Without it, when the root repo is on a feature branch (e.g., another session left it there), symlink targets may not exist on that branch.
 
-## Session-Start Sync Hook
+## Session-Start Sync & Hook Auto-Registration
 
-The `session-start-sync.sh` PostToolUse hook runs once per session (on the first tool call) and syncs the skills worktree to `origin/main`. This ensures skills, rules, and CLAUDE.md are fresh across **all repos** — not just `claude-code-config`. The hook also pulls the root repo's `main` branch if it's currently checked out.
-
-The `post-merge-pull.sh` hook syncs the skills worktree after merges and also refreshes the CLAUDE.md and rules symlinks.
-
-### Hook Auto-Registration
-
-The session-start sync also registers hooks from `global-settings.json` into `~/.claude/settings.json`. This ensures new hooks added to the template are picked up automatically — no need to re-run the setup script.
-
-**How it works:**
-- Reads `global-settings.json` from the skills worktree (always at `origin/main`)
-- Resolves placeholder paths to the skills worktree hooks directory
-- Compares against `~/.claude/settings.json` by script basename per event/matcher
-- Adds only missing hooks; existing hooks (including user-customized timeouts) are preserved
-- User hooks not in the template are never touched
-
-**To add a new hook to the repo:**
-1. Create the hook script in `.claude/hooks/`
-2. Add the hook entry to `global-settings.json` (use the `/path/to/claude-code-config` placeholder)
-3. Merge to `main` — the next session start auto-registers it in every user's `settings.json`
+Hooks sync the skills worktree to `origin/main` on session start and after merges. Details: `.claude/reference/skill-sync-hooks.md`.
 
 ## Session Start: Verify Skills Worktree
 


### PR DESCRIPTION
## Summary

- **greptile.md**: 1,097 → 796 words. Extracted dashboard config settings table to `.claude/reference/greptile-setup.md` and CR-vs-Greptile reply format comparison to `.claude/reference/greptile-reply-format.md`. Critical "no @greptileai in replies" rule stays inline.
- **skill-symlinks.md**: 674 → 497 words. Extracted session-start sync hook + hook auto-registration narrative to `.claude/reference/skill-sync-hooks.md`.
- **repo-bootstrap.md**: 560 → 436 words. Replaced inline YAML workflow block with pointer to canonical source at `.github/workflows/cr-plan-on-issue.yml`.

Total rule budget: 12,824 / 14,000 words.

Closes #234
Closes #238

## Test plan

- [x] `greptile.md` ≤ 800 words
- [x] Dashboard setup extracted to reference with 1-line pointer inline
- [x] "No @mention in replies" rule is still unambiguous inline in greptile.md
- [x] All cross-references resolve (greptile-setup.md, greptile-reply-format.md, skill-sync-hooks.md exist)
- [x] `skill-symlinks.md` ≤ 500 words
- [x] `repo-bootstrap.md` ≤ 480 words
- [x] YAML workflow content no longer duplicated in repo-bootstrap.md
- [x] New reference file for skill sync hooks created
- [x] All behavior preserved — no rules removed, only relocated
- [x] Total word count budget check passes (≤ 14,000)