### PR TITLE
feat: add BugBot (Cursor) as second-tier reviewer between CR and Greptile

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -21,7 +21,7 @@ Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the par
 | `{{REPO}}` | GitHub repo name | `claude-code-config` |
 | `{{HEAD_SHA}}` | Current HEAD commit SHA | `7b2cfbf` |
 | `{{HANDOFF_FILE}}` | Path to handoff JSON | `~/.claude/handoffs/pr-618-handoff.json` |
-| `{{REVIEWER}}` | Assigned reviewer (`cr` or `greptile`) | `cr` |
+| `{{REVIEWER}}` | Assigned reviewer (`cr`, `bugbot`, or `greptile`) | `cr` |
 | `{{EXISTING_FINDINGS}}` | Pre-fetched review findings (optional) | JSON or summary text |
 | `{{RESEARCH_QUESTION}}` | Research/audit question for the `researcher` agent | `"List every skill that uses the `Bash` tool"` |
 | `{{SCOPE}}` | Optional scope hints for `researcher` (dirs, files, date ranges) | `".claude/skills/*/SKILL.md"` |

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -1,5 +1,5 @@
 ---
-description: "Phase A subagent: fix review findings, push code, write handoff file, print exit report. Used after a PR receives CR/Greptile review findings."
+description: "Phase A subagent: fix review findings, push code, write handoff file, print exit report. Used after a PR receives CR/BugBot/Greptile review findings."
 model: opus
 ---
 
@@ -35,7 +35,7 @@ gh api "repos/{{OWNER}}/{{REPO}}/pulls/{{PR_NUMBER}}/comments?per_page=100"
 gh api "repos/{{OWNER}}/{{REPO}}/issues/{{PR_NUMBER}}/comments?per_page=100"
 ```
 
-Filter by `coderabbitai[bot]` or `greptile-apps[bot]`.
+Filter by `coderabbitai[bot]`, `cursor[bot]`, or `greptile-apps[bot]`.
 
 ### Step 2: Verify and Fix
 
@@ -75,27 +75,31 @@ Reply to EVERY review comment thread acknowledging the fix.
 - Inline diff comments: `gh api repos/{{OWNER}}/{{REPO}}/pulls/comments/{id}/replies -f body="@coderabbitai Fixed in \`SHA\`: <what changed>"`
 - If reply endpoint returns 404, fall back to: `gh pr comment {{PR_NUMBER}} --body "@coderabbitai Fixed in \`SHA\`: <what changed>. (Re: <finding description>)"`
 
+**For BugBot threads** — do NOT include `@cursor` in replies (may trigger a re-review):
+- Inline comments: `gh api repos/{{OWNER}}/{{REPO}}/pulls/comments/{id}/replies -f body="Fixed in \`SHA\`: <what changed>"`
+- PR-level: `gh pr comment {{PR_NUMBER}} --body "Fixed in \`SHA\`: <what changed>"`
+
 **For Greptile threads** — do NOT include `@greptileai` (every @mention triggers a paid re-review):
 - Inline comments: `gh api repos/{{OWNER}}/{{REPO}}/pulls/comments/{id}/replies -f body="Fixed in \`SHA\`: <what changed>"`
 - PR-level: `gh pr comment {{PR_NUMBER}} --body "Fixed in \`SHA\`: <what changed>"`
 
 ### Step 5: Resolve Threads
 
-After replying, resolve **only** the threads whose first-comment author is `coderabbitai` or `greptile-apps` (the bots you actually handled in Step 2). Do NOT resolve threads authored by human reviewers or other bots — those may be active discussion threads unrelated to your fix work.
+After replying, resolve **only** the threads whose first-comment author is `coderabbitai`, `cursor`, or `greptile-apps` (the bots you actually handled in Step 2). Do NOT resolve threads authored by human reviewers or other bots — those may be active discussion threads unrelated to your fix work.
 
 ```bash
 # Get unresolved threads, filter to CR/Greptile bot authors, then resolve each
 gh api graphql -f query='query { repository(owner: "{{OWNER}}", name: "{{REPO}}") { pullRequest(number: {{PR_NUMBER}}) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { author { login } } } } } } } }' \
   --jq '.data.repository.pullRequest.reviewThreads.nodes[]
         | select(.isResolved == false)
-        | select(.comments.nodes[0].author.login | test("^(coderabbitai|greptile-apps)$"))
+        | select(.comments.nodes[0].author.login | test("^(coderabbitai|cursor|greptile-apps)$"))
         | .id' \
   | while read -r thread_id; do
       gh api graphql -f query="mutation { resolveReviewThread(input: {threadId: \"$thread_id\"}) { thread { isResolved } } }"
     done
 ```
 
-If a thread's first-comment author is anything other than `coderabbitai` or `greptile-apps` (e.g., a human reviewer, or `cursor[bot]`), leave it alone.
+If a thread's first-comment author is anything other than `coderabbitai`, `cursor`, or `greptile-apps` (e.g., a human reviewer), leave it alone.
 
 ### Step 6: Write Handoff File
 
@@ -112,7 +116,7 @@ Write JSON with this schema:
   "schema_version": "1.0",
   "pr_number": {{PR_NUMBER}},
   "head_sha": "<HEAD after Step 3 — pushed commit SHA if a push occurred, otherwise current HEAD>",
-  "reviewer": "<cr or greptile>",
+  "reviewer": "<cr, bugbot, or greptile>",
   "phase_completed": "A",
   "created_at": "<ISO 8601 timestamp>",
   "findings_fixed": ["<comment-id-1>", "<comment-id-2>"],
@@ -136,7 +140,7 @@ EXIT_REPORT
 PHASE_COMPLETE: A
 PR_NUMBER: {{PR_NUMBER}}
 HEAD_SHA: <pushed commit SHA for pushed_fixes, or current HEAD for no_findings/exhaustion>
-REVIEWER: <cr or greptile>
+REVIEWER: <cr, bugbot, or greptile>
 OUTCOME: <pushed_fixes|no_findings|exhaustion>
 FILES_CHANGED: <comma-separated file paths, empty if none>
 NEXT_PHASE: <B for pushed_fixes or no_findings, A for exhaustion>

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -77,7 +77,7 @@ If check-runs show `conclusion: "failure"` with `output.title` containing "rate 
 
 ### CR Timeout (Slow Path)
 
-If CR has not delivered a review after **7 minutes** of polling → **check if BugBot (`cursor[bot]`) already posted a review.** If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review yet, wait up to 5 minutes for BugBot. If BugBot times out → run the Greptile Daily Budget Check below. Sticky assignment applies at each tier.
+If CR has not delivered a review after **7 minutes** of polling → **check if BugBot (`cursor[bot]`) already posted a review** (BugBot's 5-min window from push has already expired at this point). If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review exists, trigger Greptile immediately (do NOT wait another 5 min) → run the Greptile Daily Budget Check below. Sticky assignment applies at each tier.
 
 > **MANDATORY budget gate on both paths above.** The Greptile Daily Budget Check in the "Greptile Review Path" section below is NOT optional — it applies to every `@greptileai` trigger point, including CR fallbacks. Never post `@greptileai` without running the check first.
 
@@ -86,6 +86,32 @@ If CR has not delivered a review after **7 minutes** of polling → **check if B
 2 clean CR reviews required. After a clean pass, trigger `@coderabbitai full review` one more time for confirmation. After 2 failed re-triggers on the same SHA, stop and report.
 
 Never trigger `@coderabbitai full review` more than twice per PR per hour.
+
+## BugBot Review Path (when `reviewer` = `bugbot`)
+
+BugBot auto-reviews every push — no manual trigger needed. Poll for `cursor[bot]` reviews on all 3 endpoints every 60 seconds.
+
+### Polling
+
+Same 3 endpoints as CR, filter by `.user.login == "cursor[bot]"`. Check-run name: `Cursor Bugbot`.
+
+**Completion:** check-run `status: "completed"` (any conclusion — BugBot uses `neutral` for reviews with findings). Also check for review objects from `cursor[bot]`.
+
+**Timeout:** 5 minutes from push. If no BugBot review after 5 min, trigger Greptile (budget gate applies).
+
+### BugBot Merge Gate
+
+1 clean BugBot review satisfies the gate — no confirmation pass needed. Clean = review posted with no inline findings, OR all findings fixed and BugBot's subsequent auto-review has no new findings.
+
+### BugBot Reply Format
+
+Do NOT include `@cursor` in reply comments (may trigger a re-review). Use plain text only:
+- Inline: `gh api repos/{{OWNER}}/{{REPO}}/pulls/comments/{id}/replies -f body="Fixed in \`SHA\`: <what changed>"`
+- PR-level: `gh pr comment {{PR_NUMBER}} --body "Fixed in \`SHA\`: <what changed>"`
+
+### Re-Reviews
+
+After fixing BugBot findings and pushing, BugBot auto-reviews the new push. If auto-review doesn't fire within 5 min, trigger manually: `gh pr comment {{PR_NUMBER}} --body "@cursor review"`
 
 ## Greptile Review Path (when `reviewer` = `greptile`)
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -1,11 +1,11 @@
 ---
-description: "Phase B subagent: poll for CR/Greptile reviews, process findings, fix code, update handoff file, print exit report. Runs after Phase A pushes fixes."
+description: "Phase B subagent: poll for CR/BugBot/Greptile reviews, process findings, fix code, update handoff file, print exit report. Runs after Phase A pushes fixes."
 model: opus
 ---
 
 # Phase B: Review Loop
 
-You are a Phase B subagent. Your job: poll for code review results (CodeRabbit or Greptile), process any findings, fix code, push, update the handoff file, and determine if the merge gate is met. Then EXIT with an exit report.
+You are a Phase B subagent. Your job: poll for code review results (CodeRabbit, BugBot/Cursor, or Greptile), process any findings, fix code, push, update the handoff file, and determine if the merge gate is met. Then EXIT with an exit report.
 
 ## Runtime Context
 
@@ -13,7 +13,7 @@ The parent agent provides:
 - **PR number** and **repo** (`{{OWNER}}/{{REPO}}`)
 - **Handoff file path** (e.g., `~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json`)
 - **HEAD SHA** from the previous phase
-- **Reviewer** assignment (`cr` or `greptile`)
+- **Reviewer** assignment (`cr`, `bugbot`, or `greptile`)
 - **Existing findings** (if any were already posted before this agent launched)
 
 ## Safety Rules (NON-NEGOTIABLE)
@@ -36,7 +36,7 @@ On startup, check for the handoff file:
 Before triggering `@coderabbitai full review` or entering the polling loop:
 
 1. **Scan all existing review comments** on the PR (all three endpoints, `per_page=100`)
-2. **Identify unresolved findings** from `coderabbitai[bot]` or `greptile-apps[bot]` that have no reply confirming a fix and point to unchanged code
+2. **Identify unresolved findings** from `coderabbitai[bot]`, `cursor[bot]`, or `greptile-apps[bot]` that have no reply confirming a fix and point to unchanged code
 3. **If unresolved findings exist: fix them first.** Read, fix, commit, push, reply to each thread. Then let CR auto-review the new push. Do NOT request a fresh review on top of unaddressed feedback.
 4. **If all addressed:** Proceed with polling or review request.
 
@@ -73,11 +73,11 @@ gh api "repos/{{OWNER}}/{{REPO}}/commits/$CURRENT_SHA/check-runs" \
 
 ### Rate-Limit Fast Path
 
-If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **run the Greptile Daily Budget Check below**, and if the budget allows, trigger Greptile **immediately** (do not wait 7 minutes). If the budget is exhausted, fall back to self-review and report the blocker — do NOT post `@greptileai`. The PR switches to Greptile permanently (sticky assignment) the moment the budget check passes and the trigger is sent.
+If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **check if BugBot (`cursor[bot]`) already posted a review** on any of the 3 endpoints. If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review yet, wait up to 5 minutes for BugBot. If BugBot times out → run the Greptile Daily Budget Check below, and if the budget allows, trigger Greptile. If the budget is exhausted, fall back to self-review and report the blocker.
 
 ### CR Timeout (Slow Path)
 
-If CR has not delivered a review after **7 minutes** of polling → **run the Greptile Daily Budget Check below**, and if the budget allows, trigger Greptile. If the budget is exhausted, fall back to self-review and report the blocker — do NOT post `@greptileai`. Sticky assignment applies once the trigger is sent.
+If CR has not delivered a review after **7 minutes** of polling → **check if BugBot (`cursor[bot]`) already posted a review.** If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review yet, wait up to 5 minutes for BugBot. If BugBot times out → run the Greptile Daily Budget Check below. Sticky assignment applies at each tier.
 
 > **MANDATORY budget gate on both paths above.** The Greptile Daily Budget Check in the "Greptile Review Path" section below is NOT optional — it applies to every `@greptileai` trigger point, including CR fallbacks. Never post `@greptileai` without running the check first.
 
@@ -171,7 +171,7 @@ gh api "repos/{{OWNER}}/{{REPO}}/commits/$CURRENT_SHA/check-runs?per_page=100" \
 
 1. Verify each finding against actual code before fixing
 2. Fix ALL valid findings in one commit, push once
-3. Reply to every thread (CR: include `@coderabbitai`; Greptile: plain text only)
+3. Reply to every thread (CR: include `@coderabbitai`; BugBot: plain text only, no `@cursor`; Greptile: plain text only, no `@greptileai`)
 4. Resolve threads via GraphQL
 5. Resume polling
 
@@ -193,7 +193,7 @@ EXIT_REPORT
 PHASE_COMPLETE: B
 PR_NUMBER: {{PR_NUMBER}}
 HEAD_SHA: <current HEAD>
-REVIEWER: <cr or greptile>
+REVIEWER: <cr, bugbot, or greptile>
 OUTCOME: <clean|fixes_pushed|merge_ready|exhaustion>
 FILES_CHANGED: <comma-separated paths, or empty>
 NEXT_PHASE: <C or B>

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -73,7 +73,7 @@ gh api "repos/{{OWNER}}/{{REPO}}/commits/$CURRENT_SHA/check-runs" \
 
 ### Rate-Limit Fast Path
 
-If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **check if BugBot (`cursor[bot]`) already posted a review** on any of the 3 endpoints. If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review yet, wait up to 5 minutes **from push time** for BugBot (the window runs concurrently with CR's, so some or all of it may have already elapsed). If BugBot times out → run the Greptile Daily Budget Check below, and if the budget allows, trigger Greptile. If the budget is exhausted, fall back to self-review and report the blocker.
+If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **check if BugBot (`cursor[bot]`) already posted a review** on any of the 3 endpoints. If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review yet, continue polling for BugBot until 5 minutes after push time have elapsed (do NOT start a new 5-minute timer now — the window runs concurrently with CR's, so some or all of it may have already passed). When BugBot times out, run the Greptile Daily Budget Check below: if budget allows, trigger Greptile; if exhausted, fall back to self-review and report the blocker.
 
 ### CR Timeout (Slow Path)
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -37,7 +37,7 @@ Before triggering `@coderabbitai full review` or entering the polling loop:
 
 1. **Scan all existing review comments** on the PR (all three endpoints, `per_page=100`)
 2. **Identify unresolved findings** from `coderabbitai[bot]`, `cursor[bot]`, or `greptile-apps[bot]` that have no reply confirming a fix and point to unchanged code
-3. **If unresolved findings exist: fix them first.** Read, fix, commit, push, reply to each thread. Then let CR auto-review the new push. Do NOT request a fresh review on top of unaddressed feedback.
+3. **If unresolved findings exist: fix them first.** Read, fix, commit, push, reply to each thread. The assigned reviewer auto-reviews the new push (CR and BugBot auto-trigger; Greptile requires explicit `@greptileai`). Do NOT request a fresh review on top of unaddressed feedback.
 4. **If all addressed:** Proceed with polling or review request.
 
 ## CodeRabbit Review Path (when `reviewer` = `cr`)
@@ -77,7 +77,7 @@ If check-runs show `conclusion: "failure"` with `output.title` containing "rate 
 
 ### CR Timeout (Slow Path)
 
-If CR has not delivered a review after **7 minutes** of polling → **check if BugBot (`cursor[bot]`) already posted a review** (BugBot's 5-min window from push has already expired at this point). If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review exists, trigger Greptile immediately (do NOT wait another 5 min) → run the Greptile Daily Budget Check below. Sticky assignment applies at each tier.
+If CR has not delivered a review after **7 minutes** of polling → **check if BugBot (`cursor[bot]`) already posted a review** (BugBot's 5-min window from push has already expired at this point). If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review exists → run the Greptile Daily Budget Check below: if budget allows, trigger Greptile immediately (do NOT wait another 5 min); if budget exhausted, fall back to self-review and report the blocker. Sticky assignment applies at each tier.
 
 > **MANDATORY budget gate on both paths above.** The Greptile Daily Budget Check in the "Greptile Review Path" section below is NOT optional — it applies to every `@greptileai` trigger point, including CR fallbacks. Never post `@greptileai` without running the check first.
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -73,7 +73,7 @@ gh api "repos/{{OWNER}}/{{REPO}}/commits/$CURRENT_SHA/check-runs" \
 
 ### Rate-Limit Fast Path
 
-If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **check if BugBot (`cursor[bot]`) already posted a review** on any of the 3 endpoints. If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review yet, continue polling for BugBot until 5 minutes after push time have elapsed (do NOT start a new 5-minute timer now — the window runs concurrently with CR's, so some or all of it may have already passed). When BugBot times out, run the Greptile Daily Budget Check below: if budget allows, trigger Greptile; if exhausted, fall back to self-review and report the blocker.
+If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **check if BugBot (`cursor[bot]`) already posted a review** on any of the 3 endpoints. If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review yet, continue polling for BugBot until 5 minutes from push time have elapsed (do NOT start a new 5-minute timer now — the window runs concurrently with CR's, so some or all of it may have already passed). When BugBot times out, run the Greptile Daily Budget Check below: if budget allows, trigger Greptile; if exhausted, fall back to self-review and report the blocker.
 
 ### CR Timeout (Slow Path)
 
@@ -97,7 +97,7 @@ Same 3 endpoints as CR, filter by `.user.login == "cursor[bot]"`. Check-run name
 
 **Completion:** check-run `status: "completed"` (any conclusion — BugBot uses `neutral` for reviews with findings). Also check for review objects from `cursor[bot]`.
 
-**Timeout:** 5 minutes from push. If no BugBot review after 5 min, trigger Greptile (budget gate applies).
+**Timeout:** 5 minutes from push. If no BugBot review after 5 min, run the Greptile Daily Budget Check below: if budget allows, trigger Greptile; if exhausted, fall back to self-review and report the blocker.
 
 ### BugBot Merge Gate
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -73,7 +73,7 @@ gh api "repos/{{OWNER}}/{{REPO}}/commits/$CURRENT_SHA/check-runs" \
 
 ### Rate-Limit Fast Path
 
-If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **check if BugBot (`cursor[bot]`) already posted a review** on any of the 3 endpoints. If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review yet, wait up to 5 minutes for BugBot. If BugBot times out → run the Greptile Daily Budget Check below, and if the budget allows, trigger Greptile. If the budget is exhausted, fall back to self-review and report the blocker.
+If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **check if BugBot (`cursor[bot]`) already posted a review** on any of the 3 endpoints. If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review yet, wait up to 5 minutes **from push time** for BugBot (the window runs concurrently with CR's, so some or all of it may have already elapsed). If BugBot times out → run the Greptile Daily Budget Check below, and if the budget allows, trigger Greptile. If the budget is exhausted, fall back to self-review and report the blocker.
 
 ### CR Timeout (Slow Path)
 

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -15,7 +15,7 @@ You are a Phase C subagent. Your job: verify the merge gate is satisfied, verify
 The parent agent provides:
 - **PR number** and **repo** (`{{OWNER}}/{{REPO}}`)
 - **Handoff file path** (e.g., `~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json`)
-- **Reviewer** assignment (`cr` or `greptile`)
+- **Reviewer** assignment (`cr`, `bugbot`, or `greptile`)
 
 ## Safety Rules (NON-NEGOTIABLE)
 
@@ -100,6 +100,10 @@ Also verify no unresolved review threads:
 gh api graphql -f query='query { repository(owner: "{{OWNER}}", name: "{{REPO}}") { pullRequest(number: {{PR_NUMBER}}) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { body author { login } } } } } } } }'
 ```
 
+### BugBot path (reviewer = `bugbot`)
+
+1 clean BugBot review satisfies the gate — no confirmation pass needed. Check for `cursor[bot]` review comments on the current HEAD SHA. If a review exists with no actionable findings, the gate is met. If findings exist but were all fixed and BugBot's subsequent auto-review is clean, the gate is met.
+
 ### Greptile path (reviewer = `greptile`)
 
 Severity-gated: merge-ready when no findings, all P1/P2 after fix (no re-review), or P0 fixed + re-review clean.
@@ -153,7 +157,7 @@ EXIT_REPORT
 PHASE_COMPLETE: C
 PR_NUMBER: {{PR_NUMBER}}
 HEAD_SHA: <current HEAD SHA>
-REVIEWER: <cr or greptile>
+REVIEWER: <cr, bugbot, or greptile>
 OUTCOME: <ac_verified|blocked>
 FILES_CHANGED:
 NEXT_PHASE: none

--- a/.claude/agents/pm-worker.md
+++ b/.claude/agents/pm-worker.md
@@ -122,7 +122,7 @@ EXIT_REPORT
 PHASE_COMPLETE: pm
 PR_NUMBER: <PR number if a PR was created or referenced, else "none">
 HEAD_SHA: <current HEAD SHA if applicable, else "none">
-REVIEWER: <cr, greptile, or none>
+REVIEWER: <cr, bugbot, greptile, or none>
 OUTCOME: <issue_created|work_log_updated|repo_bootstrapped|blocked|exhaustion>
 FILES_CHANGED: <comma-separated paths, or empty>
 NEXT_PHASE: none

--- a/.claude/reference/cr-polling-commands.md
+++ b/.claude/reference/cr-polling-commands.md
@@ -18,7 +18,7 @@ gh api "repos/{owner}/{repo}/commits/{SHA}/statuses" \
 
 **Completion signal:** `status: "completed"` + `conclusion: "success"` = review done.
 
-**Fast-path rate-limit signal:** check-run with `conclusion: "failure"` and `output.title` containing "rate limit" (case-insensitive), OR status `state: "failure"`/`"error"` with `description` containing "rate limit" → trigger Greptile immediately.
+**Fast-path rate-limit signal:** check-run with `conclusion: "failure"` and `output.title` containing "rate limit" (case-insensitive), OR status `state: "failure"`/`"error"` with `description` containing "rate limit" → check BugBot (`cursor[bot]`) first. If BugBot already posted a review, use it. If not, wait up to 5 min for BugBot. If BugBot also times out, trigger Greptile (see `bugbot.md`).
 
 ## CI Health Check — every poll cycle
 

--- a/.claude/reference/exit-report-format.md
+++ b/.claude/reference/exit-report-format.md
@@ -23,7 +23,7 @@ HANDOFF_FILE: ~/.claude/handoffs/pr-618-handoff.json
 | `PHASE_COMPLETE` | `A`, `B`, `C` | Which phase just finished |
 | `PR_NUMBER` | integer | The PR number |
 | `HEAD_SHA` | string | HEAD SHA after last push (or current HEAD) |
-| `REVIEWER` | `cr`, `greptile` | Which reviewer owns this PR |
+| `REVIEWER` | `cr`, `bugbot`, `greptile` | Which reviewer owns this PR |
 | `OUTCOME` | see below | What happened |
 | `FILES_CHANGED` | comma-separated paths | Files modified (empty string if none) |
 | `NEXT_PHASE` | `B`, `C`, `none` | What parent should launch next |

--- a/.claude/reference/greptile-reply-format.md
+++ b/.claude/reference/greptile-reply-format.md
@@ -1,10 +1,17 @@
-# CR vs Greptile Reply Format Comparison
+# CR vs BugBot vs Greptile Reply Format Comparison
 
-| | CodeRabbit | Greptile |
-|--|-----------|----------|
-| Reply format | Include `@coderabbitai` (teaches knowledge base) | **No @mention** — plain text only |
-| Learns from replies | Yes | No — only from 👍/👎 reactions |
-| @mention cost | Within hourly quota | $0.50-$1.00 per triggered review |
+| | CodeRabbit | BugBot (Cursor) | Greptile |
+|--|-----------|----------------|----------|
+| Reply format | Include `@coderabbitai` (teaches knowledge base) | **No @mention** — plain text only | **No @mention** — plain text only |
+| Learns from replies | Yes | TBD | No — only from 👍/👎 reactions |
+| @mention cost | Within hourly quota | May trigger re-review | $0.50-$1.00 per triggered review |
+| Bot login | `coderabbitai[bot]` | `cursor[bot]` | `greptile-apps[bot]` |
+
+## Reply Format for BugBot Threads
+
+- Inline comments: `gh api repos/{owner}/{repo}/pulls/comments/{id}/replies -f body="Fixed in \`SHA\`: <what changed>"`
+- Issue/PR-level comments: `gh pr comment N --body "Fixed in \`SHA\`: <what changed>"`
+- **Never** include `@cursor` in reply bodies — it may trigger a re-review.
 
 ## Reply Format for Greptile Threads
 

--- a/.claude/reference/handoff-file-schema.json
+++ b/.claude/reference/handoff-file-schema.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0",
   "pr_number": 618,
   "head_sha": "abc1234",
-  "reviewer": "cr",
+  "reviewer": "cr or bugbot or greptile",
   "phase_completed": "A",
   "created_at": "2026-03-24T17:00:00Z",
   "findings_fixed": ["comment-id-1", "comment-id-2"],

--- a/.claude/reference/handoff-file-schema.json
+++ b/.claude/reference/handoff-file-schema.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0",
   "pr_number": 618,
   "head_sha": "abc1234",
-  "reviewer": "cr or bugbot or greptile",
+  "reviewer": "cr",
   "phase_completed": "A",
   "created_at": "2026-03-24T17:00:00Z",
   "findings_fixed": ["comment-id-1", "comment-id-2"],

--- a/.claude/reference/phase-decomposition.md
+++ b/.claude/reference/phase-decomposition.md
@@ -4,7 +4,7 @@ Canonical reference for per-phase subagent procedures. Used by agent definitions
 
 ## Phase A: Fix + Push (heaviest)
 
-1. Read CR/Greptile findings, read affected files, fix all valid findings + lint/CI failures
+1. Read CR/BugBot/Greptile findings, read affected files, fix all valid findings + lint/CI failures
 2. Commit all fixes in ONE commit, push once
 3. Reply to all review threads (see `greptile.md` for Greptile reply format)
 4. Write handoff file (see `handoff-files.md`)
@@ -14,7 +14,7 @@ Canonical reference for per-phase subagent procedures. Used by agent definitions
 
 1. Read handoff file on startup (GitHub API fallback if missing)
 2. Before ANY `@greptileai` trigger, check daily budget (see `greptile.md`)
-3. CR path: poll for review (fast-path + 7-min Greptile trigger). Greptile path: trigger and poll directly.
+3. CR path: poll for review (fast-path → check BugBot → 5-min BugBot timeout → Greptile trigger). BugBot path: poll for BugBot review. Greptile path: trigger and poll directly.
 4. Greptile findings: classify P0/P1/P2, fix all, commit, push, reply. Re-trigger only for P0 (max 3 reviews/PR).
 5. CR clean pass: trigger one more `@coderabbitai full review` for confirmation (2 clean passes needed)
 6. Update handoff file. Deduplicate: `string[]` by exact value, `findings_dismissed` by `.id`.

--- a/.claude/reference/phase-decomposition.md
+++ b/.claude/reference/phase-decomposition.md
@@ -14,7 +14,7 @@ Canonical reference for per-phase subagent procedures. Used by agent definitions
 
 1. Read handoff file on startup (GitHub API fallback if missing)
 2. Before ANY `@greptileai` trigger, check daily budget (see `greptile.md`)
-3. CR path: poll for review (fast-path → check BugBot → 5-min BugBot timeout → Greptile trigger). BugBot path: poll for BugBot review. Greptile path: trigger and poll directly.
+3. CR path: poll for review (fast-path → check BugBot → 5-min BugBot timeout → Greptile trigger). BugBot path: poll for BugBot review on the 3 endpoints. Greptile path: poll for existing Greptile review; only re-trigger `@greptileai` for P0 findings (max 3 reviews/PR).
 4. Greptile findings: classify P0/P1/P2, fix all, commit, push, reply. Re-trigger only for P0 (max 3 reviews/PR).
 5. CR clean pass: trigger one more `@coderabbitai full review` for confirmation (2 clean passes needed)
 6. Update handoff file. Deduplicate: `string[]` by exact value, `findings_dismissed` by `.id`.

--- a/.claude/reference/pm-data-patterns.md
+++ b/.claude/reference/pm-data-patterns.md
@@ -84,7 +84,7 @@ Count reviews per reviewer. Exclude self-reviews (reviewer == PR author). Used b
 
 Drop contributors whose `login` matches any of:
 
-- ends with `[bot]` (e.g., `coderabbitai[bot]`, `greptile-apps[bot]`, `dependabot[bot]`)
+- ends with `[bot]` (e.g., `coderabbitai[bot]`, `cursor[bot]`, `greptile-apps[bot]`, `dependabot[bot]`)
 - equals `github-actions`, `dependabot`, `renovate`
 
 jq filter for an author stream:

--- a/.claude/reference/session-state-schema.json
+++ b/.claude/reference/session-state-schema.json
@@ -5,6 +5,7 @@
   "work_log_path": "docs/work-logs",
   "prs": {
     "618": {"phase": "B", "head_sha": "7b2cfbf", "reviewer": "cr", "needs": "cr_confirmation_pass"},
+    "619": {"phase": "B", "head_sha": "a1b2c3d", "reviewer": "bugbot", "needs": "bugbot_review_poll"},
     "620": {"phase": "B", "head_sha": "d0e4fef", "reviewer": "greptile", "needs": "fix_and_push"}
   },
   "cr_quota": {"reviews_used": 5, "window_start": "2026-03-16T15:00:00Z"},

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -1,0 +1,50 @@
+# BugBot (Cursor) — Second-Tier Reviewer
+
+> **Always:** Poll for BugBot reviews alongside CR after every push. Process findings same as CR/Greptile. Use BugBot as the first fallback when CR fails — before Greptile.
+> **Ask first:** Never — fix findings autonomously.
+> **Never:** Trigger Greptile before checking if BugBot already posted a review. Include `@cursor` in reply comments (may trigger a re-review). Ignore BugBot findings.
+
+BugBot is the **second-tier** AI code reviewer — free, auto-triggers on every push/PR open, and sits between CR (primary) and Greptile (last resort). The full review chain: **CR → BugBot → Greptile → self-review.**
+
+## BugBot Basics
+
+- **Bot username:** `cursor[bot]`
+- **Auto-trigger:** ON — runs on every push and every PR open (both "Only Run When Mentioned" and "Only Run Once Automatically" are OFF)
+- **Manual trigger:** Comment `@cursor review` on any PR (for re-reviews or when auto-trigger didn't fire)
+- **Cost:** Free (included with Cursor)
+- **Review time:** Typically fast (~1-3 minutes)
+- **No CLI** — local review loop uses CR CLI only; BugBot is GitHub-only
+
+## Polling for BugBot Reviews
+
+Poll alongside CR every 60 seconds on all three endpoints (same pattern — `pulls/{N}/reviews`, `pulls/{N}/comments`, `issues/{N}/comments` with `per_page=100`). Filter by `.user.login == "cursor[bot]"`.
+
+**Timeout:** 5 minutes. If BugBot has not posted a review within 5 minutes of push, and CR has also failed, trigger Greptile (see `greptile.md` "When to Trigger Greptile").
+
+**Completion signal:** BugBot review comments appearing on any of the three endpoints = review complete. No separate CI check-run signal like CR.
+
+## When BugBot Becomes the Active Reviewer
+
+BugBot becomes the active reviewer (`reviewer: bugbot`) when:
+1. **CR fails** (rate-limited or 7-min timeout) AND BugBot has already posted a review, OR
+2. **CR fails** AND BugBot posts a review within its 5-minute window
+
+**Sticky assignment:** Once a PR is assigned to BugBot (CR failed, BugBot responded), it stays on BugBot unless BugBot also fails — then Greptile takes over permanently.
+
+## Processing BugBot Findings
+
+Verify all findings against actual code. Fix all valid findings in one commit, push once, reply to every thread, resolve via GraphQL.
+
+**Reply format:** Use plain text only in replies — do NOT include `@cursor` in reply comments (may trigger a re-review). This matches Greptile's reply behavior.
+
+**Thread resolution:** Same GraphQL mutations as CR/Greptile — `resolveReviewThread(threadId)` or `minimizeComment(subjectId, classifier: RESOLVED)`.
+
+## Merge Gate
+
+**A clean BugBot review independently satisfies the merge gate.** Unlike CR (which needs 2 clean passes), BugBot requires only 1 clean pass — no confirmation pass needed.
+
+**Canonical definition:** See `cr-merge-gate.md` (Step 1) for the authoritative merge gate including the BugBot path.
+
+## Re-Reviews
+
+After fixing BugBot findings, BugBot auto-reviews the new push (since auto-trigger is ON). No need to manually trigger `@cursor review` unless the auto-review didn't fire within 5 minutes — then post `@cursor review` as a manual trigger.

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -19,7 +19,7 @@ BugBot is the **second-tier** AI code reviewer — free, auto-triggers on every 
 
 Poll alongside CR every 60 seconds on all three endpoints (same pattern — `pulls/{N}/reviews`, `pulls/{N}/comments`, `issues/{N}/comments` with `per_page=100`). Filter by `.user.login == "cursor[bot]"`.
 
-**Timeout:** 5 minutes. If BugBot has not posted a review within 5 minutes of push, and CR has also failed, trigger Greptile (see `greptile.md` "When to Trigger Greptile").
+**Timeout:** 5 minutes **from push time** (not from CR failure detection). Since BugBot auto-triggers at push time, its timeout runs concurrently with CR's 7-minute window. If the 7-minute CR timeout fires and BugBot hasn't posted a review, BugBot's 5-minute window has already expired — trigger Greptile immediately (see `greptile.md` "When to Trigger Greptile"). Do NOT wait another 5 minutes.
 
 **Completion signal:** BugBot review comments appearing on any of the three endpoints = review complete. No separate CI check-run signal like CR.
 

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -21,7 +21,7 @@ Poll alongside CR every 60 seconds on all three endpoints (same pattern — `pul
 
 **Timeout:** 5 minutes **from push time** (not from CR failure detection). Since BugBot auto-triggers at push time, its timeout runs concurrently with CR's 7-minute window. If the 7-minute CR timeout fires and BugBot hasn't posted a review, BugBot's 5-minute window has already expired — trigger Greptile immediately (see `greptile.md` "When to Trigger Greptile"). Do NOT wait another 5 minutes.
 
-**Completion signal:** BugBot review comments appearing on any of the three endpoints = review complete. No separate CI check-run signal like CR.
+**Completion signal:** BugBot creates a CI check-run named `Cursor Bugbot` that transitions to `status: "completed"` when the review finishes. The `conclusion` field is `neutral` when BugBot posted findings (still counts as a completed review — `neutral` is not a failure). Completion can also be detected via BugBot review comments appearing on any of the three endpoints.
 
 ## When BugBot Becomes the Active Reviewer
 

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -16,7 +16,7 @@ After pushing a commit to a PR, **automatically** enter the CR review loop. Do n
 - **Batch fixes into ONE commit** before pushing — 4 fixes = 1 review consumed, not 4.
 - **Max 2 explicit `@coderabbitai full review` triggers per PR per hour.** After 2 with no response, tell the user CR may be rate-limited.
 - **Parallel agents:** stagger pushes; max 3-4 PRs triggering CR reviews in the same hour.
-- **"Reviews paused" or rate-limit language:** fall back to **Greptile** (see `greptile.md`). If Greptile unavailable, fall back to **self-review**.
+- **"Reviews paused" or rate-limit language:** fall back to **BugBot** (see `bugbot.md`). If BugBot also fails, fall back to **Greptile** (see `greptile.md`). If Greptile unavailable, fall back to **self-review**.
 
 ### Polling
 - Poll every 60 seconds. Always use `per_page=100` on all GitHub API calls.
@@ -26,11 +26,11 @@ After pushing a commit to a PR, **automatically** enter the CR review loop. Do n
   3. `repos/{owner}/{repo}/issues/{N}/comments` — PR conversation (summary, ack, general findings). Missing this endpoint causes indefinite polling on clean passes.
 - **Check commit status every cycle.** Query `repos/{owner}/{repo}/commits/{SHA}/check-runs` filtered to `name == "CodeRabbit"`; fallback: `/statuses` filtered to `context ~ "CodeRabbit"`. Full commands: `.claude/reference/cr-polling-commands.md`.
   - **Completion signal:** `status: "completed"` + `conclusion: "success"` = review done. Definitive signal.
-  - **Fast-path rate limit:** check-run `conclusion: "failure"` with "rate limit" in `output.title`, OR status `state: "failure"`/`"error"` with "rate limit" in `description` — **trigger Greptile IMMEDIATELY.** Sticky assignment applies.
+  - **Fast-path rate limit:** check-run `conclusion: "failure"` with "rate limit" in `output.title`, OR status `state: "failure"`/`"error"` with "rate limit" in `description` — **check BugBot first** (see `bugbot.md`). If BugBot already posted a review, use it. If not, wait up to 5 min for BugBot. If BugBot also times out, trigger Greptile. Sticky assignment applies at each tier.
   - **Ack ≠ completion.** "Actions performed — Full review triggered" = CR started. "CodeRabbit — Review completed" CI check = CR finished.
 - **CR username:** `coderabbitai[bot]` (with `[bot]` suffix). Filter by `.user.login == "coderabbitai[bot]"` — NOT bare `coderabbitai`.
 - **Watermark:** Track highest review ID from `pulls/{N}/reviews`. New reviews can have inline comment IDs lower than previous reviews (different ID sequences). For `issues/{N}/comments`, track by comment ID.
-- **Hard timeout: 7 minutes.** No review after 7 min → trigger Greptile. Sticky assignment applies.
+- **Hard timeout: 7 minutes.** No CR review after 7 min → check BugBot (see `bugbot.md`). If BugBot already posted a review, use it. If not, wait up to 5 min for BugBot. If BugBot also times out, trigger Greptile. Sticky assignment applies at each tier.
 
 ### CI Health Check (MANDATORY — every poll cycle)
 
@@ -42,13 +42,16 @@ After pushing a commit to a PR, **automatically** enter the CR review loop. Do n
   - Transient/infra failure (e.g., `timed_out`, `startup_failure`): note it, retry with a no-op commit if needed.
 - CI failures block merge independently of CR — a PR with passing CR but failing tests is not merge-ready. Report pass/fail summary to the user: "CI: 5/6 passed, `test` failed — investigating."
 
-### Timeout & Fallback — Two Trigger Paths to Greptile
+### Timeout & Fallback — Three-Tier Review Chain
 
-- **Budget gate (applies to both paths below):** Before triggering `@greptileai`, check the Greptile daily budget (see `greptile.md` "Daily Budget"). If budget is exhausted, fall back to self-review and notify the user. Self-review does NOT satisfy the merge gate.
-- **Fast path (~1-2 min):** The check-runs or commit statuses API shows "Review rate limit exceeded" -> trigger Greptile immediately if budget allows. Do not wait.
-- **Slow path (7 min):** No rate-limit signal visible, but CR has not delivered review content after 7 minutes -> trigger Greptile if budget allows. The distinction between "rate-limited" and "slow" is irrelevant at this point — the action is the same.
-- **Sticky Greptile assignment:** Once either trigger path fires for a PR, that PR stays on Greptile permanently (see `greptile.md` "Sticky Assignment" for full details). Do not switch back to CR.
-- **If Greptile also fails** (5-minute timeout with no response): fall back to **self-review**.
+**Review chain:** CR (primary) → BugBot (second tier, free) → Greptile (last resort, paid) → self-review (emergency).
+
+BugBot auto-runs on every push — poll for its reviews alongside CR. When CR fails, check BugBot before triggering Greptile.
+
+- **Fast path (~1-2 min):** CR rate-limit detected → check if BugBot (`cursor[bot]`) already posted a review. If yes, use BugBot review (assign `reviewer: bugbot`). If no, wait up to 5 min for BugBot. If BugBot times out, trigger Greptile (budget gate applies — see `greptile.md` "Daily Budget").
+- **Slow path (7 min):** CR has not delivered review content after 7 min → same BugBot-first check as fast path.
+- **Sticky assignment:** CR fail → BugBot owns the PR. If BugBot also fails → Greptile owns permanently. Do not switch back up the chain.
+- **If all three fail** (CR rate-limited + BugBot 5-min timeout + Greptile 5-min timeout): fall back to **self-review**. Self-review does NOT satisfy the merge gate.
 - Tell the user which fallback was used and why.
 
 ### Before Requesting Any New Review (MANDATORY — applies to ALL agents)
@@ -61,7 +64,7 @@ After pushing a commit to a PR, **automatically** enter the CR review loop. Do n
    - `repos/{owner}/{repo}/pulls/{N}/comments?per_page=100` (inline comments)
    - `repos/{owner}/{repo}/pulls/{N}/reviews?per_page=100` (review-level comments)
    - `repos/{owner}/{repo}/issues/{N}/comments?per_page=100` (PR conversation)
-2. **Identify unresolved findings** — any comment from `coderabbitai[bot]` or `greptile-apps[bot]` that:
+2. **Identify unresolved findings** — any comment from `coderabbitai[bot]`, `cursor[bot]`, or `greptile-apps[bot]` that:
    - Has no reply confirming a fix
    - Points to code that hasn't been changed since the comment was posted
    - Is not marked as resolved/outdated
@@ -81,8 +84,8 @@ After pushing a commit to a PR, **automatically** enter the CR review loop. Do n
 ### Autonomy Boundaries
 - **Fix autonomously:** All files unless the user instructed otherwise
 - **Poll autonomously:** Enter and remain in the polling loop without asking — this is the default behavior after any push
-- **Process feedback autonomously:** When CR/Greptile posts findings, fix them immediately — do not ask "should I fix these?"
-- **Trigger fallbacks autonomously:** Greptile on CR timeout, self-review on Greptile timeout — these are automatic, not user-prompted
+- **Process feedback autonomously:** When CR/BugBot/Greptile posts findings, fix them immediately — do not ask "should I fix these?"
+- **Trigger fallbacks autonomously:** BugBot on CR timeout, Greptile on BugBot timeout, self-review on Greptile timeout — these are automatic, not user-prompted
 
 ### Completion
 

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -48,8 +48,8 @@ After pushing a commit to a PR, **automatically** enter the CR review loop. Do n
 
 BugBot auto-runs on every push — poll for its reviews alongside CR. When CR fails, check BugBot before triggering Greptile.
 
-- **Fast path (~1-2 min):** CR rate-limit detected → check if BugBot (`cursor[bot]`) already posted a review. If yes, use BugBot review (assign `reviewer: bugbot`). If no, wait up to 5 min for BugBot. If BugBot times out, trigger Greptile (budget gate applies — see `greptile.md` "Daily Budget").
-- **Slow path (7 min):** CR has not delivered review content after 7 min → same BugBot-first check as fast path.
+- **Fast path (~1-2 min):** CR rate-limit detected → check if BugBot (`cursor[bot]`) already posted a review (BugBot auto-triggers at push time, so it may already be done). If yes, use BugBot review (assign `reviewer: bugbot`). If no BugBot review yet, wait up to 5 min **from push time** (not from CR failure detection). If BugBot times out, trigger Greptile (budget gate applies — see `greptile.md` "Daily Budget").
+- **Slow path (7 min):** CR has not delivered review content after 7 min → check if BugBot already posted a review (since BugBot's 5-min window from push has already passed by this point). If yes, use BugBot review. If no, trigger Greptile immediately — do NOT wait another 5 min for BugBot.
 - **Sticky assignment:** CR fail → BugBot owns the PR. If BugBot also fails → Greptile owns permanently. Do not switch back up the chain.
 - **If all three fail** (CR rate-limited + BugBot 5-min timeout + Greptile 5-min timeout): fall back to **self-review**. Self-review does NOT satisfy the merge gate.
 - Tell the user which fallback was used and why.

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -26,11 +26,11 @@ After pushing a commit to a PR, **automatically** enter the CR review loop. Do n
   3. `repos/{owner}/{repo}/issues/{N}/comments` — PR conversation (summary, ack, general findings). Missing this endpoint causes indefinite polling on clean passes.
 - **Check commit status every cycle.** Query `repos/{owner}/{repo}/commits/{SHA}/check-runs` filtered to `name == "CodeRabbit"`; fallback: `/statuses` filtered to `context ~ "CodeRabbit"`. Full commands: `.claude/reference/cr-polling-commands.md`.
   - **Completion signal:** `status: "completed"` + `conclusion: "success"` = review done. Definitive signal.
-  - **Fast-path rate limit:** check-run `conclusion: "failure"` with "rate limit" in `output.title`, OR status `state: "failure"`/`"error"` with "rate limit" in `description` — **check BugBot first** (see `bugbot.md`). If BugBot already posted a review, use it. If not, wait up to 5 min for BugBot. If BugBot also times out, trigger Greptile. Sticky assignment applies at each tier.
+  - **Fast-path rate limit:** check-run `conclusion: "failure"` with "rate limit" in `output.title`, OR status `state: "failure"`/`"error"` with "rate limit" in `description` — **check BugBot first** (see `bugbot.md`). If BugBot already posted a review, use it. If not, wait up to 5 min **from push time** for BugBot. If BugBot also times out, trigger Greptile. Sticky assignment applies at each tier.
   - **Ack ≠ completion.** "Actions performed — Full review triggered" = CR started. "CodeRabbit — Review completed" CI check = CR finished.
 - **CR username:** `coderabbitai[bot]` (with `[bot]` suffix). Filter by `.user.login == "coderabbitai[bot]"` — NOT bare `coderabbitai`.
 - **Watermark:** Track highest review ID from `pulls/{N}/reviews`. New reviews can have inline comment IDs lower than previous reviews (different ID sequences). For `issues/{N}/comments`, track by comment ID.
-- **Hard timeout: 7 minutes.** No CR review after 7 min → check BugBot (see `bugbot.md`). If BugBot already posted a review, use it. If not, wait up to 5 min for BugBot. If BugBot also times out, trigger Greptile. Sticky assignment applies at each tier.
+- **Hard timeout: 7 minutes.** No CR review after 7 min → check BugBot (see `bugbot.md`). If BugBot already posted a review, use it. If not, trigger Greptile immediately (BugBot's 5-min window from push has already elapsed). Sticky assignment applies at each tier.
 
 ### CI Health Check (MANDATORY — every poll cycle)
 

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -48,8 +48,8 @@ After pushing a commit to a PR, **automatically** enter the CR review loop. Do n
 
 BugBot auto-runs on every push — poll for its reviews alongside CR. When CR fails, check BugBot before triggering Greptile.
 
-- **Fast path (~1-2 min):** CR rate-limit detected → check if BugBot (`cursor[bot]`) already posted a review (BugBot auto-triggers at push time, so it may already be done). If yes, use BugBot review (assign `reviewer: bugbot`). If no BugBot review yet, wait up to 5 min **from push time** (not from CR failure detection). If BugBot times out, trigger Greptile (budget gate applies — see `greptile.md` "Daily Budget").
-- **Slow path (7 min):** CR has not delivered review content after 7 min → check if BugBot already posted a review (since BugBot's 5-min window from push has already passed by this point). If yes, use BugBot review. If no, trigger Greptile immediately — do NOT wait another 5 min for BugBot.
+When CR fails (rate-limited or 7-min timeout), check BugBot before Greptile. BugBot's 5-min timeout runs from push time, concurrent with CR's window. See `bugbot.md` for full BugBot behavior and `greptile.md` for Greptile trigger conditions.
+
 - **Sticky assignment:** CR fail → BugBot owns the PR. If BugBot also fails → Greptile owns permanently. Do not switch back up the chain.
 - **If all three fail** (CR rate-limited + BugBot 5-min timeout + Greptile 5-min timeout): fall back to **self-review**. Self-review does NOT satisfy the merge gate.
 - Tell the user which fallback was used and why.

--- a/.claude/rules/cr-local-review.md
+++ b/.claude/rules/cr-local-review.md
@@ -2,7 +2,7 @@
 
 > **Always:** Run local CR review before pushing. Verify findings against code before fixing. Two clean passes to exit.
 > **Ask first:** Never — fix all findings autonomously. Never ask "should I run the review?", "should I push?", or "should I create a PR?" — these transitions are automatic.
-> **Never:** Push code without running local review. Fall back to GitHub polling when CLI works. Ask permission at any step in this workflow. Treat local review as satisfying the merge gate — only the GitHub review loop (CR + Greptile) satisfies the merge requirement.
+> **Never:** Push code without running local review. Fall back to GitHub polling when CLI works. Ask permission at any step in this workflow. Treat local review as satisfying the merge gate — only the GitHub review loop (CR + BugBot + Greptile) satisfies the merge requirement.
 
 This is the **primary** review workflow. Run CodeRabbit locally in your terminal to catch issues **before** pushing or creating a PR. This is faster than GitHub-based reviews (instant feedback, no polling), produces no noise on the PR, and doesn't consume your GitHub-based CR review quota.
 
@@ -60,9 +60,9 @@ The only acceptable use of suppression comments is when the linter is provably w
 
 After two consecutive clean local reviews, execute this checklist immediately:
 
-> **STOP — Local review does NOT satisfy the merge gate.** The GitHub review loop (CR + Greptile) is mandatory: 2 clean CR passes or a clean Greptile severity gate (see `cr-merge-gate.md`). Proceed immediately — do not ask.
+> **STOP — Local review does NOT satisfy the merge gate.** The GitHub review loop (CR + BugBot + Greptile) is mandatory: 2 clean CR passes, 1 clean BugBot pass, or a clean Greptile severity gate (see `cr-merge-gate.md`). Proceed immediately — do not ask.
 
 1. **Commit all changes** in a single commit.
 2. **Push the branch** to the remote.
 3. **Create the PR** via `gh pr create` with `Closes #N` in the body and a Test Plan section with acceptance criteria checkboxes.
-4. **Enter the GitHub CodeRabbit Review Loop** (see `cr-github-review.md` "Polling" section). CR auto-reviews on push — poll immediately, do not wait. Greptile is fallback-only: it triggers automatically if CR is rate-limited or times out (see `greptile.md` "When to Trigger Greptile"). Never trigger Greptile proactively while CR is still expected to respond.
+4. **Enter the GitHub CodeRabbit Review Loop** (see `cr-github-review.md` "Polling" section). CR and BugBot both auto-review on push — poll for both immediately, do not wait. BugBot is second-tier fallback if CR fails (see `bugbot.md`). Greptile is last-resort: triggered only when both CR and BugBot have failed (see `greptile.md` "When to Trigger Greptile"). Never trigger Greptile proactively while CR or BugBot is still expected to respond.

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -9,20 +9,25 @@
 
 The merge gate depends on which reviewer owns the PR:
 
-**CR-only path** (Greptile was never triggered for this PR):
+**CR-only path** (neither BugBot nor Greptile was triggered for this PR):
 - 2 clean CR reviews required. The second is a confirmation pass — CR's completion signal is unreliable (it may mark the check as "completed" but post findings minutes later), so a second clean pass is needed.
 - If CR responds with no findings after a round of fixes, post `@coderabbitai full review` one more time to confirm.
 - **After 2 failed re-triggers on the same SHA**, stop and tell the user. Do not loop forever.
 
-**Greptile path** (Greptile was triggered at any point for this PR — sticky assignment, see `greptile.md`):
+**BugBot path** (CR failed, BugBot responded, Greptile was never triggered — sticky assignment, see `bugbot.md`):
+- 1 clean BugBot review satisfies the gate — no confirmation pass needed (BugBot's completion signals are reliable).
+- After fixing BugBot findings, BugBot auto-reviews the new push. If auto-review doesn't fire within 5 min, trigger manually via `@cursor review`.
+- Stay on BugBot — do not switch back to CR. Ignore late CR reviews.
+
+**Greptile path** (Greptile was triggered at any point — both CR and BugBot failed — sticky assignment, see `greptile.md`):
 - Severity-gated: merge-ready when ANY of these hold:
   1. **Clean review:** no findings (thumbs-up with no inline comments).
   2. **No P0 findings:** only P1/P2 findings present — fix all of them, push, reply to threads; no re-review required.
   3. **P0 fixed + re-review clean:** P0 findings were present, fixed, and a re-triggered `@greptileai` review came back clean.
-- Stay on Greptile — do not switch back to CR. Ignore any late CR reviews.
+- Stay on Greptile — do not switch back to CR or BugBot. Ignore any late CR/BugBot reviews.
 - Max 3 Greptile reviews per PR (initial + up to 2 P0 re-reviews). At 3 with persistent P0, self-review and report blocker.
 
-**If both CR and Greptile are down** (CR rate-limited/timed out + Greptile 5-min timeout): perform a self-review for risk reduction. A clean self-review does NOT satisfy the merge gate — report the blocker to the user.
+**If CR, BugBot, and Greptile are all down** (CR rate-limited/timed out + BugBot 5-min timeout + Greptile 5-min timeout): perform a self-review for risk reduction. A clean self-review does NOT satisfy the merge gate — report the blocker to the user.
 
 - **How to detect a clean CR pass:** After triggering `@coderabbitai full review`, watch for these signals in order:
   1. **Ack (review started):** CR posts an issue comment (on `issues/{N}/comments`) with "Actions performed — Full review triggered." This means CR **started** the review — it is NOT a completion signal.

--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -1,10 +1,10 @@
-# Greptile — CodeRabbit Fallback Reviewer
+# Greptile — Last-Resort Fallback Reviewer
 
 > **Always:** Poll for response after triggering. Reply to every thread. Fix all valid findings. Classify by severity (P0/P1/P2). Only re-review for P0. Stay on G once triggered for a PR.
 > **Ask first:** Never — fix findings autonomously.
-> **Never:** Trigger Greptile proactively on a PR where CR hasn't failed yet. Ignore Greptile findings. Switch a PR back to CR after Greptile has been triggered. Include `@greptileai` in reply comments (triggers a paid re-review with no learning benefit).
+> **Never:** Trigger Greptile before both CR AND BugBot have failed. Ignore Greptile findings. Switch a PR back to CR/BugBot after Greptile has been triggered. Include `@greptileai` in reply comments (triggers a paid re-review with no learning benefit).
 
-Greptile is a **fallback** AI code reviewer for when CR is rate-limited or unresponsive. Verify all findings against code. Key differences from CR: cost ($0.50-$1.00/review beyond 50/month quota), accurate completion signals (no confirmation pass needed).
+Greptile is the **last-resort paid** AI code reviewer — only triggered when both CR and BugBot (Cursor) have failed. Review chain: **CR → BugBot → Greptile → self-review.** Verify all findings against code. Key differences from CR/BugBot: cost ($0.50-$1.00/review beyond 50/month quota), accurate completion signals (no confirmation pass needed).
 
 ## Greptile Basics
 
@@ -48,14 +48,16 @@ Applies to 2nd/3rd triggers only; initial trigger requires only the budget check
 
 ## When to Trigger Greptile
 
-**Greptile is fallback-only.** Never trigger it proactively alongside CR. It is only triggered when CR fails for a specific PR:
+**Greptile is last-resort only.** Never trigger it before both CR AND BugBot have failed. It is only triggered when both upstream reviewers fail for a specific PR:
 
-1. **CR rate limit detected (fast-path):** Check-runs or commit statuses show rate limiting → trigger Greptile immediately.
-2. **CR timeout (slow-path):** CR has not delivered a review within 7 minutes of push → trigger Greptile.
+1. **CR rate-limit + BugBot timeout:** CR is rate-limited (fast-path) AND BugBot has not posted a review within 5 minutes → trigger Greptile.
+2. **CR timeout + BugBot timeout:** CR has not delivered a review within 7 minutes AND BugBot has not posted a review within 5 minutes → trigger Greptile.
+
+In both cases, always check if BugBot (`cursor[bot]`) already posted a review before triggering Greptile — BugBot auto-runs on every push, so it may have responded while you were waiting for CR.
 
 ### Sticky Assignment
 
-**Once Greptile is triggered for a PR, it stays on Greptile permanently.** Do not switch back to CR. After fixing findings, only re-trigger `@greptileai` for P0 findings. Ignore late CR reviews. Merge gate is severity-dependent — see `cr-merge-gate.md` (Step 1) for the authoritative definition.
+**Once Greptile is triggered for a PR, it stays on Greptile permanently.** Do not switch back to CR or BugBot. After fixing findings, only re-trigger `@greptileai` for P0 findings. Ignore late CR/BugBot reviews. Merge gate is severity-dependent — see `cr-merge-gate.md` (Step 1) for the authoritative definition.
 
 ## Polling for Greptile Response
 
@@ -75,4 +77,4 @@ Reply commands and CR-vs-Greptile comparison: `.claude/reference/greptile-reply-
 
 ## Merge Gate
 
-**Canonical definition:** See `cr-merge-gate.md` (Step 1). That file is the single authoritative source for both the CR 2-clean-pass path and the Greptile severity-gated path (including the 3-review-per-PR cap and the self-review fallback when both reviewers are down).
+**Canonical definition:** See `cr-merge-gate.md` (Step 1). That file is the single authoritative source for the CR 2-clean-pass path, the BugBot 1-clean-pass path, and the Greptile severity-gated path (including the 3-review-per-PR cap and the self-review fallback when all three reviewers are down).

--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -4,7 +4,7 @@
 > **Ask first:** Never — fix findings autonomously.
 > **Never:** Trigger Greptile before both CR AND BugBot have failed. Ignore Greptile findings. Switch a PR back to CR/BugBot after Greptile has been triggered. Include `@greptileai` in reply comments (triggers a paid re-review with no learning benefit).
 
-Greptile is the **last-resort paid** AI code reviewer — only triggered when both CR and BugBot (Cursor) have failed. Review chain: **CR → BugBot → Greptile → self-review.** Verify all findings against code. Key differences from CR/BugBot: cost ($0.50-$1.00/review beyond 50/month quota), accurate completion signals (no confirmation pass needed).
+Greptile is the **last-resort paid** AI code reviewer — only triggered when both CR and BugBot (Cursor) have failed. Review chain: **CR → BugBot → Greptile → self-review.** Verify all findings against code. Key differences from CR/BugBot: cost ($1/review beyond 50/month quota), accurate completion signals (no confirmation pass needed).
 
 ## Greptile Basics
 

--- a/.claude/rules/handoff-files.md
+++ b/.claude/rules/handoff-files.md
@@ -47,7 +47,7 @@ Full example JSON: `.claude/reference/handoff-file-schema.json`.
 | `schema_version` | string | yes | Always `"1.0"` |
 | `pr_number` | number | yes | The PR number |
 | `head_sha` | string | yes | HEAD SHA after the phase's last push |
-| `reviewer` | string | yes | `"cr"` or `"greptile"` |
+| `reviewer` | string | yes | `"cr"`, `"bugbot"`, or `"greptile"` |
 | `phase_completed` | string | yes | `"A"`, `"B"`, or `"C"` |
 | `created_at` | string | yes | ISO 8601 timestamp |
 | `findings_fixed` | string[] | yes | Comment/review IDs of fixed findings |

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -21,7 +21,7 @@ Use the custom agent definitions in `.claude/agents/` instead of manually readin
    - PR number, issue number, branch name
    - Repo owner/name
    - Handoff file path (`~/.claude/handoffs/pr-{N}-handoff.json`)
-   - HEAD SHA, reviewer assignment (`cr` or `greptile`)
+   - HEAD SHA, reviewer assignment (`cr`, `bugbot`, or `greptile`)
    - Pre-fetched findings (optional — saves the subagent from re-fetching)
 5. **Include the safety warning** in every subagent prompt:
 
@@ -71,10 +71,11 @@ If agent definitions are unavailable (e.g., repo without `.claude/agents/`):
 | Local review clean (2 passes) | Commit all changes, push branch | **Always do** |
 | Branch pushed | Create PR via `gh pr create` | **Always do** |
 | PR created/updated | Enter GitHub review polling loop (60s cycle) | **Always do** |
-| CR/Greptile posts findings | Fix all valid findings, commit, push, reply to threads | **Always do** |
-| CR rate-limited (fast-path) | Trigger Greptile immediately | **Always do** |
-| CR timeout (7 min) | Trigger Greptile | **Always do** |
-| Both reviewers down | Self-review for risk reduction | **Always do** |
+| CR/BugBot/Greptile posts findings | Fix all valid findings, commit, push, reply to threads | **Always do** |
+| CR rate-limited (fast-path) | Check BugBot review; if absent, wait 5 min for BugBot | **Always do** |
+| CR timeout (7 min) | Check BugBot review; if absent, wait 5 min for BugBot | **Always do** |
+| BugBot timeout (5 min, CR already failed) | Trigger Greptile | **Always do** |
+| All three reviewers down | Self-review for risk reduction | **Always do** |
 | Phase A subagent completes | Parent launches Phase B within 60s | **Always do** |
 | Phase B reports clean | Parent launches Phase C | **Always do** |
 | Merge gate met | Verify AC checkboxes against code | **Always do** |
@@ -117,6 +118,7 @@ Review protocol is defined authoritatively in these canonical sources — do NOT
 
 - **CR polling, CI checks, thread resolution:** `cr-github-review.md`
 - **Merge gate, CI-must-pass, AC verification:** `cr-merge-gate.md`
+- **BugBot (Cursor) second-tier reviewer, auto-trigger, merge gate:** `bugbot.md`
 - **Greptile trigger, severity classification, daily budget, reply format:** `greptile.md`
 - **Local review before push, fix loop, 2 clean passes:** `cr-local-review.md`
 

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -73,7 +73,7 @@ If agent definitions are unavailable (e.g., repo without `.claude/agents/`):
 | PR created/updated | Enter GitHub review polling loop (60s cycle) | **Always do** |
 | CR/BugBot/Greptile posts findings | Fix all valid findings, commit, push, reply to threads | **Always do** |
 | CR rate-limited (fast-path) | Check BugBot review; if absent, wait 5 min for BugBot | **Always do** |
-| CR timeout (7 min) | Check BugBot review; if absent, wait 5 min for BugBot | **Always do** |
+| CR timeout (7 min) | Check BugBot review; if absent, trigger Greptile immediately (BugBot's 5-min window from push has already elapsed) | **Always do** |
 | BugBot timeout (5 min, CR already failed) | Trigger Greptile | **Always do** |
 | All three reviewers down | Self-review for risk reduction | **Always do** |
 | Phase A subagent completes | Parent launches Phase B within 60s | **Always do** |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,8 @@ Detailed workflow rules are split into topic-specific files in `.claude/rules/`:
 | `cr-local-review.md` | Local CodeRabbit CLI review loop (primary review workflow), linter suppression prohibition |
 | `cr-github-review.md` | GitHub CR polling, rate limits, fast-path detection, thread resolution, feedback processing, autonomy boundaries |
 | `cr-merge-gate.md` | Merge gate definition (CR/Greptile paths), CI-must-pass gate, AC verification, merge confirmation |
-| `greptile.md` | Greptile peer reviewer + CR fallback + self-review fallback |
+| `bugbot.md` | BugBot (Cursor) second-tier reviewer, auto-trigger, merge gate contribution |
+| `greptile.md` | Greptile last-resort reviewer + CR/BugBot fallback + self-review fallback |
 | `subagent-orchestration.md` | Subagent spawning, phase transition autonomy table, token exhaustion, phase A/B/C decomposition |
 | `monitor-mode.md` | Dedicated monitor mode, monitor loop, heartbeats, health monitoring, post-compaction recovery |
 | `handoff-files.md` | Handoff file schema, session-state.json format, lifecycle (create/update/delete) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Detailed workflow rules are split into topic-specific files in `.claude/rules/`:
 | `issue-planning.md` | Issue creation flow, CR plan integration, planning flow |
 | `cr-local-review.md` | Local CodeRabbit CLI review loop (primary review workflow), linter suppression prohibition |
 | `cr-github-review.md` | GitHub CR polling, rate limits, fast-path detection, thread resolution, feedback processing, autonomy boundaries |
-| `cr-merge-gate.md` | Merge gate definition (CR/Greptile paths), CI-must-pass gate, AC verification, merge confirmation |
+| `cr-merge-gate.md` | Merge gate definition (CR/BugBot/Greptile paths), CI-must-pass gate, AC verification, merge confirmation |
 | `bugbot.md` | BugBot (Cursor) second-tier reviewer, auto-trigger, merge gate contribution |
 | `greptile.md` | Greptile last-resort reviewer + CR/BugBot fallback + self-review fallback |
 | `subagent-orchestration.md` | Subagent spawning, phase transition autonomy table, token exhaustion, phase A/B/C decomposition |


### PR DESCRIPTION
## Summary

- Inserts BugBot (Cursor's free code reviewer) between CodeRabbit and Greptile in the review fallback chain
- New chain: **CR → BugBot (free) → Greptile (paid) → self-review**
- BugBot auto-runs on every push/PR open, requires no manual trigger
- Clean BugBot review independently satisfies the merge gate (1 pass, no confirmation needed)
- Greptile now only triggers when BOTH CR and BugBot have failed — drastically reducing paid review costs

Closes #256

## Changes

**New file:**
- `.claude/rules/bugbot.md` — BugBot config, polling, merge gate, reply format

**Updated rule files (6):**
- `cr-github-review.md` — three-tier fallback chain
- `greptile.md` — require both CR+BugBot failure
- `cr-merge-gate.md` — add BugBot merge gate path
- `subagent-orchestration.md` — Phase Transition Autonomy table
- `cr-local-review.md` — mention BugBot auto-review
- `CLAUDE.md` — rule files table

**Updated agent definitions (5):**
- `phase-a-fixer.md`, `phase-b-reviewer.md`, `phase-c-merger.md`, `pm-worker.md`, `README.md`
- Added `cursor[bot]` to all bot filters, reply format blocks, GraphQL regex, REVIEWER enums

**Updated reference files (7):**
- `exit-report-format.md`, `cr-polling-commands.md`, `greptile-reply-format.md`, `phase-decomposition.md`, `handoff-file-schema.json`, `session-state-schema.json`, `pm-data-patterns.md`

## Test plan

- [x] New `bugbot.md` rule file exists with bot username, auto-trigger, polling, merge gate, reply format
- [x] `cr-github-review.md` references three-tier chain (CR → BugBot → Greptile) in timeout/fallback section
- [x] `greptile.md` requires BOTH CR and BugBot failure before triggering
- [x] `cr-merge-gate.md` has BugBot path (1 clean pass satisfies gate)
- [x] All `REVIEWER` enums include `bugbot` across agents and reference files
- [x] `cursor[bot]` added to all bot username filters in agent definitions
- [x] Word count ≤ 14,000 (currently 12,276)
- [x] No stale `cr or greptile` enums without `bugbot`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added BugBot as a second-tier reviewer between CodeRabbit and Greptile across workflow docs.
  * Added a new BugBot rules doc describing identity, polling behavior, 5-minute review window, reply formatting, re-review triggers, sticky assignment, and merge-gate behavior.
  * Updated phase/fallback sequencing to CR → BugBot → Greptile → self-review and to check BugBot before triggering Greptile.
  * Expanded exit-report reviewer fields and templates to include BugBot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->