### PR TITLE
feat: add /fixpr skill — single-pass PR cleanup

### DIFF
--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -43,32 +43,43 @@ Print: `[CONTEXT] PR #$PR_NUMBER on $OWNER/$REPO (branch: $BRANCH, HEAD: ${HEAD_
 
 ### 1a. Review threads (GraphQL — authoritative for resolution status)
 
+**Paginate** — `reviewThreads` caps at 100 per page, so PRs with more threads silently lose data. Loop until `hasNextPage` is false, accumulating all nodes before classifying.
+
 ```bash
-gh api graphql -f query='query {
-  repository(owner: "'$OWNER'", name: "'$REPO'") {
-    pullRequest(number: '$PR_NUMBER') {
-      reviewThreads(first: 100) {
-        nodes {
-          id
-          isResolved
-          isOutdated
-          comments(first: 10) {
-            nodes {
-              id
-              databaseId
-              body
-              author { login }
-              path
-              line
-              originalLine
-              url
+CURSOR="null"
+ALL_THREADS="[]"
+while :; do
+  RESP=$(gh api graphql -f query='query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            isOutdated
+            comments(first: 10) {
+              nodes {
+                id
+                databaseId
+                body
+                author { login }
+                path
+                line
+                originalLine
+                url
+              }
             }
           }
         }
       }
     }
-  }
-}'
+  }' -F owner="$OWNER" -F repo="$REPO" -F pr=$PR_NUMBER -f cursor="$CURSOR")
+  ALL_THREADS=$(jq -s '.[0] + .[1].data.repository.pullRequest.reviewThreads.nodes' <(echo "$ALL_THREADS") <(echo "$RESP"))
+  HAS_NEXT=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+  [ "$HAS_NEXT" = "true" ] || break
+  CURSOR=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+done
 ```
 
 ### 1b. CI check-runs (REST — every check, not just CodeRabbit)
@@ -227,19 +238,30 @@ Print per thread: `[RESOLVED] thread <id> — <summary>`
 
 ### 6a. Re-fetch threads
 
+**Paginate** — same cursor loop as Step 1a, applied to the simpler re-fetch query:
+
 ```bash
-gh api graphql -f query='query {
-  repository(owner: "'$OWNER'", name: "'$REPO'") {
-    pullRequest(number: '$PR_NUMBER') {
-      reviewThreads(first: 100) {
-        nodes { id isResolved comments(first: 1) { nodes { body author { login } } } }
+CURSOR="null"
+ALL_THREADS="[]"
+while :; do
+  RESP=$(gh api graphql -f query='query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes { id isResolved comments(first: 1) { nodes { body author { login } } } }
+        }
       }
     }
-  }
-}'
+  }' -F owner="$OWNER" -F repo="$REPO" -F pr=$PR_NUMBER -f cursor="$CURSOR")
+  ALL_THREADS=$(jq -s '.[0] + .[1].data.repository.pullRequest.reviewThreads.nodes' <(echo "$ALL_THREADS") <(echo "$RESP"))
+  HAS_NEXT=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+  [ "$HAS_NEXT" = "true" ] || break
+  CURSOR=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+done
 ```
 
-Count unresolved (`isResolved: false`).
+Count unresolved (`isResolved: false`) across `ALL_THREADS`.
 
 - **0 unresolved:** `[CLEAN] All threads resolved — zero uncollapsed in browser.`
 - **Any remain:** Retry resolution (max 2 attempts per thread). If still stuck:

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -4,131 +4,91 @@ description: Single-pass PR cleanup — audit every review thread + every CI che
 ---
 
 Single-pass cleanup of the current branch's PR. After this completes:
+
 1. **Zero uncollapsed review threads** in the browser (all resolved via GraphQL)
 2. **Zero failing CI checks** (all fixed and passing)
 3. **Every finding replied to** with what was done
 
+## How this skill is structured
+
+All mechanical GitHub API work — pagination, GraphQL queries, comment classification — lives in the companion script `audit.sh`. This file tells the AI layer how to invoke the script and what to do with its output (the JSON bundle).
+
+| Step | Kind | Done by |
+|------|------|---------|
+| 0. Gather PR state | Mechanical | `audit.sh` writes `/tmp/fixpr-audit-<PR>-<epoch>.json` |
+| 1. Classify review findings | Judgment | AI reads JSON + source files |
+| 2. Classify CI failures | Judgment | AI reads `check-runs/<id>.output.summary` |
+| 3. Fix & push | Judgment | AI edits files, commits, pushes |
+| 4. Reply & resolve | Mechanical | `gh api` calls against IDs from the JSON |
+| 5. Verify | Mechanical | Re-run `audit.sh --since $RUN_STARTED_AT` |
+| 6. Merge blockers | Judgment | AI reads `.merge_state` from the JSON |
+| 7. Final summary | Judgment | AI emits the status |
+
+Execute the steps sequentially. Do NOT poll in a loop — this is a single-pass tool. When a verify pass finds unfinished work, exit with a status code and instruct the user to re-run `/fixpr`.
+
 ---
 
-## Step 0: Identify PR context
+## Step 0: Run the initial audit
+
+Locate `audit.sh`. Prefer the global install; fall back to the in-repo copy when developing the skill itself. If neither exists, stop — the skill cannot run.
 
 ```bash
-BRANCH=$(git branch --show-current)
-PR_JSON=$(gh pr view --json number,headRefName,state,url 2>/dev/null)
-```
-
-If no PR exists for this branch, stop: "No PR found for branch `$BRANCH`."
-
-Extract:
-```bash
-PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
-
-if [ "$PR_STATE" != "OPEN" ]; then
-  echo "PR #$PR_NUMBER is already $PR_STATE — nothing to fix."
-  exit 0
+SCRIPT=""
+for candidate in "$HOME/.claude/skills/fixpr/audit.sh" ".claude/skills/fixpr/audit.sh"; do
+  if [[ -x "$candidate" ]]; then
+    SCRIPT="$candidate"
+    break
+  fi
+done
+if [[ -z "$SCRIPT" ]]; then
+  echo "ERROR: audit.sh not found (checked ~/.claude/skills/fixpr/ and .claude/skills/fixpr/)" >&2
+  exit 1
 fi
 
-OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
-REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
-HEAD_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[-1].oid')
-
-# Timestamp baseline for detecting NEW bot comments posted during/after this run.
-# Step 6b uses this to catch reviews that land between Step 1's audit and Step 6's verify.
-RUN_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+AUDIT=$("$SCRIPT")
 ```
 
-Print: `[CONTEXT] PR #$PR_NUMBER on $OWNER/$REPO (branch: $BRANCH, HEAD: ${HEAD_SHA:0:7})`
+If `audit.sh` itself exits non-zero it prints the reason to stderr (no PR, closed PR, detached HEAD, etc.). Stop and report.
+
+Pull the values that the later steps need out of the JSON once:
+
+```bash
+PR_NUMBER=$(jq -r '.pr.number' "$AUDIT")
+OWNER=$(jq -r '.pr.owner' "$AUDIT")
+REPO=$(jq -r '.pr.repo' "$AUDIT")
+BRANCH=$(jq -r '.pr.branch' "$AUDIT")
+HEAD_SHA=$(jq -r '.pr.head_sha' "$AUDIT")
+RUN_STARTED_AT=$(jq -r '.run_started_at' "$AUDIT")
+```
+
+Print the context and a one-line audit summary:
+
+```bash
+jq -r '
+  "[CONTEXT] PR #\(.pr.number) on \(.pr.owner)/\(.pr.repo) (branch: \(.pr.branch), HEAD: \(.pr.head_sha[0:7]))",
+  "[AUDIT] Threads: \(.threads.total) total — \(.threads.unresolved_count) unresolved, \(.threads.resolved_count) resolved",
+  "[AUDIT] CI checks: \(.check_runs.total) total (\(.check_runs.passing) passing, \(.check_runs.failing) failing, \(.check_runs.in_progress) in-progress)"
+' "$AUDIT"
+
+jq -r '.threads.unresolved[] | "  unresolved: \(.comments.nodes[0].path // "?"):\(.comments.nodes[0].line // "?") — \(.comments.nodes[0].body | split("\n")[0] | .[:120])"' "$AUDIT"
+jq -r '.check_runs.failing_runs[] | "  failing: \(.name) — \(.title // "no title")"' "$AUDIT"
+```
 
 ---
 
-## Step 1: Audit — fetch all threads + all CI in one pass
+## Step 1: Classify every unresolved finding (judgment)
 
-### 1a. Review threads (GraphQL — authoritative for resolution status)
+For each entry in `.threads.unresolved`:
 
-**Paginate** — `reviewThreads` caps at 100 per page, so PRs with more threads silently lose data. Loop until `hasNextPage` is false, accumulating all nodes before classifying.
-
-```bash
-CURSOR="null"
-ALL_THREADS="[]"
-while :; do
-  RESP=$(gh api graphql -f query='query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
-    repository(owner: $owner, name: $repo) {
-      pullRequest(number: $pr) {
-        reviewThreads(first: 100, after: $cursor) {
-          pageInfo { hasNextPage endCursor }
-          nodes {
-            id
-            isResolved
-            isOutdated
-            comments(first: 10) {
-              nodes {
-                id
-                databaseId
-                body
-                author { login }
-                path
-                line
-                originalLine
-                url
-              }
-            }
-          }
-        }
-      }
-    }
-  }' -F owner="$OWNER" -F repo="$REPO" -F pr=$PR_NUMBER -F cursor="$CURSOR")
-  ALL_THREADS=$(jq -s '.[0] + .[1].data.repository.pullRequest.reviewThreads.nodes' <(echo "$ALL_THREADS") <(echo "$RESP"))
-  HAS_NEXT=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
-  [ "$HAS_NEXT" = "true" ] || break
-  CURSOR=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
-done
-```
-
-**Note on `-F cursor`:** `-F` performs GraphQL type conversion (literal `"null"` → GraphQL `null`, `"true"` → boolean, numbers → int). `-f` would send the literal string `"null"` and break the first fetch. Same pattern applies to Step 6a.
-
-### 1b. CI check-runs (REST — every check, not just CodeRabbit)
-
-```bash
-gh api --paginate "repos/$OWNER/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
-  --jq '.check_runs[] | {id, name, status, conclusion, title: .output.title}'
-```
-
-### 1c. REST comment endpoints (for reply targets and comment IDs)
-
-Fetch all three endpoints with `--paginate` so large PRs don't silently truncate review/comment data.
-
-```bash
-gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100"
-gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100"
-gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100"
-```
-
-### 1d. Print audit summary
-
-```
-[AUDIT] Review threads: N total — M unresolved, K resolved (J outdated across both categories)
-[AUDIT] CI checks: X total (P passing, F failing, I in-progress)
-```
-
-List every failing check by name. List every unresolved thread with file:line and first sentence.
-
----
-
-## Step 2: Classify every unresolved finding
-
-For each unresolved thread (`isResolved: false`):
-
-1. Read the first comment (the original finding)
-2. Get `path` and `line` from comment metadata
-3. Read the current file at that location
-4. Classify:
+1. Read the first comment (`.comments.nodes[0].body`) plus its `path` + `line`
+2. Read the current file at that location
+3. Classify:
    - **actionable** — code still has the issue → must fix
-   - **already-fixed** — code no longer matches the finding (fixed in prior commit, thread not resolved) → resolve only
+   - **already-fixed** — code no longer matches the finding → resolve only
    - **outdated** — file/line no longer exists → resolve only
 
-Print numbered list:
+Print the numbered list:
+
 ```
 [FINDING 1] actionable — src/foo.ts:42 — "unused import" (coderabbitai[bot])
 [FINDING 2] already-fixed — src/bar.ts:10 — "missing null check" (coderabbitai[bot])
@@ -137,261 +97,216 @@ Print numbered list:
 
 ---
 
-## Step 3: Check every CI failure
+## Step 2: Classify every CI failure (judgment)
 
-For every check-run with a blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`):
+For each entry in `.check_runs.failing_runs` (blocking conclusions: `failure`, `timed_out`, `action_required`, `startup_failure`, `stale`):
 
-1. Read the failure output:
+1. Fetch the detailed output:
    ```bash
-   gh api "repos/$OWNER/$REPO/check-runs/{CHECK_RUN_ID}" --jq '.output.summary'
+   gh api "repos/$OWNER/$REPO/check-runs/<id>" --jq '.output.summary, .output.text'
    ```
-   If summary is empty, also check `.output.text` and the check-run's `details_url`.
-
-2. Classify the failure:
-   - **lint/typecheck** — read the errors, fix the code
-   - **test** — read the failing test output, fix the code or test
+   If both are empty, follow `.html_url` to the run log.
+2. Classify:
+   - **lint / typecheck** — read the errors, fix the code
+   - **test** — read the failing output, fix the code or test
    - **build** — read the build error, fix the code
-   - **security/audit** (gitleaks, npm audit, etc.) — read the finding, fix
-   - **infra/transient** (timeout, runner failure) — note it, cannot fix locally
-
-3. Fix every non-transient failure. Read the actual error messages — do not guess.
+   - **security / audit** (gitleaks, npm audit, etc.) — read the finding, fix
+   - **infra / transient** (timeout, runner failure) — note it, cannot fix locally
 
 Print per check:
+
 ```
-[CI:FAIL] "lint" — 3 errors in src/foo.ts (unused var, missing type, bad import) → fixing
-[CI:FAIL] "test" — 1 failure in tests/bar.test.ts:55 (expected 3, got 4) → fixing
-[CI:PASS] "build" — ok
-[CI:INFRA] "deploy-preview" — timed_out (transient, cannot fix locally)
+[CI:FAIL] "lint" — 3 errors in src/foo.ts → fixing
+[CI:INFRA] "deploy-preview" — timed_out (transient)
 ```
 
-**Do NOT skip any check.** Every check-run must be accounted for in the output.
+**Every entry in `.check_runs.failing_runs` must be accounted for — do not skip any.**
 
 ---
 
-## Step 4: Fix everything, push once
+## Step 3: Fix everything, push once
 
-Combine all fixes (review findings + CI failures) into a single commit:
+Combine actionable findings + non-transient CI failures into a single commit.
 
-1. Fix all **actionable** review findings (Step 2)
-2. Fix all **non-transient CI failures** (Step 3)
-3. Rules:
-   - **Never suppress linter errors** (`eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`) — fix the actual code
-   - Verify each fix against the original comment/error — partial fixes count as unresolved
-   - If a finding is ambiguous, fix it conservatively
-4. Commit and push:
+Rules:
+
+- **Never suppress linter errors** (`eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`) — fix the actual code.
+- Verify each fix against the original message — partial fixes count as unresolved.
+- If ambiguous, fix conservatively.
 
 ```bash
-# Stage only the files modified during fixing (tracked from Steps 2–3)
-git add <list of modified files>
+git add <modified files>
 git commit -m "fix: resolve all review findings and CI failures
 
 Fixes N review findings and M CI errors."
 git push
 ```
 
-Print: `[PUSH] All fixes committed and pushed (SHA: $(git rev-parse --short HEAD))`
+Print: `[PUSH] committed and pushed (SHA: $(git rev-parse --short HEAD))`.
 
-**If nothing needed fixing** (all already-fixed/outdated, CI all green), skip the commit/push.
-
----
-
-## Step 5: Reply to every thread and resolve via GraphQL
-
-For **every** unresolved thread — actionable, already-fixed, and outdated:
-
-### 5a. Reply
-
-Post a reply to the first comment in the thread:
-
-- **Actionable (just fixed):** `"Fixed in \`<short-sha>\`: <one-line description>"`
-- **Already fixed:** `"Addressed in a prior commit — current code no longer has this issue. Resolving."`
-- **Outdated:** `"Referenced code no longer exists after refactoring. Resolving."`
-
-Use inline reply endpoint first:
-```bash
-gh api "repos/$OWNER/$REPO/pulls/comments/{comment_id}/replies" -f body="<reply>"
-```
-On 404, fall back to:
-```bash
-gh pr comment $PR_NUMBER --body "<plain-text reply — do NOT include @greptileai>"
-```
-**CRITICAL:** Never include `@greptileai` in reply text. Every `@greptileai` mention triggers a paid Greptile re-review ($0.50–$1.00). Use plain text only; `@greptileai` is reserved exclusively for intentionally requesting a new review.
-
-### 5b. Resolve via GraphQL
-
-```bash
-gh api graphql -f query='mutation {
-  resolveReviewThread(input: {threadId: "<thread_node_id>"}) {
-    thread { isResolved }
-  }
-}'
-```
-
-Confirm `isResolved: true`. On failure, fall back to minimizing:
-```bash
-gh api graphql -f query='mutation {
-  minimizeComment(input: {subjectId: "<comment_node_id>", classifier: RESOLVED}) {
-    minimizedComment { isMinimized }
-  }
-}'
-```
-
-Print per thread: `[RESOLVED] thread <id> — <summary>`
+If nothing needed fixing (all already-fixed/outdated, CI all green), skip the commit/push.
 
 ---
 
-## Step 6: Verify — zero unresolved threads, zero new comments, CI status, review-bot completion
+## Step 4: Reply and resolve every thread
 
-> **Why four checks, not just threads:** GraphQL `reviewThreads` only sees inline-comment threads. A reviewer bot can post a new review body (or a new PR-conversation comment) that carries actionable findings without ever creating a thread. Relying on thread-resolution state alone is how premature "merge-ready" declarations happen — this section exists specifically to prevent that.
+For every entry in `.threads.unresolved` — actionable, already-fixed, or outdated:
 
-### 6a. Re-fetch threads
+### 4a. Reply
 
-**Paginate** — same cursor loop as Step 1a, applied to the simpler re-fetch query:
-
-```bash
-CURSOR="null"
-ALL_THREADS="[]"
-while :; do
-  RESP=$(gh api graphql -f query='query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
-    repository(owner: $owner, name: $repo) {
-      pullRequest(number: $pr) {
-        reviewThreads(first: 100, after: $cursor) {
-          pageInfo { hasNextPage endCursor }
-          nodes { id isResolved comments(first: 1) { nodes { body author { login } } } }
-        }
-      }
-    }
-  }' -F owner="$OWNER" -F repo="$REPO" -F pr=$PR_NUMBER -F cursor="$CURSOR")
-  ALL_THREADS=$(jq -s '.[0] + .[1].data.repository.pullRequest.reviewThreads.nodes' <(echo "$ALL_THREADS") <(echo "$RESP"))
-  HAS_NEXT=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
-  [ "$HAS_NEXT" = "true" ] || break
-  CURSOR=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
-done
-```
-
-Count unresolved (`isResolved: false`) across `ALL_THREADS`.
-
-- **0 unresolved:** `[CLEAN] All threads resolved — zero uncollapsed in browser.`
-- **Any remain:** Retry resolution (max 2 attempts per thread). If still stuck:
-  `[STUCK] Thread <id> — cannot resolve (permission or GitHub bug): "<first line>"`
-
-### 6b. Re-scan the three REST comment endpoints for NEW bot comments since `$RUN_STARTED_AT`
-
-This is the critical gap that thread-resolution checks alone miss. A reviewer bot can post a new review body or PR-conversation comment that contains findings without ever creating a resolvable thread — so Step 6a would report clean while the PR is still unaddressed.
-
-Filter each endpoint by `coderabbitai[bot]` / `greptile-apps[bot]` and by timestamp > `$RUN_STARTED_AT` (captured in Step 0):
+Pull the IDs from the JSON:
 
 ```bash
-SINCE="$RUN_STARTED_AT"
-NEW_REVIEWS=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
-  --jq --arg since "$SINCE" '[.[] | select((.user.login=="coderabbitai[bot]" or .user.login=="greptile-apps[bot]") and .submitted_at > $since)]')
-NEW_INLINE=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100" \
-  --jq --arg since "$SINCE" '[.[] | select((.user.login=="coderabbitai[bot]" or .user.login=="greptile-apps[bot]") and .created_at > $since)]')
-NEW_CONVO=$(gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
-  --jq --arg since "$SINCE" '[.[] | select((.user.login=="coderabbitai[bot]" or .user.login=="greptile-apps[bot]") and .created_at > $since)]')
+# index <i> in each call — iterate 0..unresolved_count-1
+DBID=$(jq -r ".threads.unresolved[$i].comments.nodes[0].databaseId" "$AUDIT")
+THREAD_ID=$(jq -r ".threads.unresolved[$i].id" "$AUDIT")
+NODE_ID=$(jq -r ".threads.unresolved[$i].comments.nodes[0].id" "$AUDIT")
 ```
 
-For each hit, classify the body with these explicit patterns (case-insensitive regex):
+Reply text by classification:
 
-**Finding patterns** (any match → treat as finding):
-- Severity words/badges: `\b(critical|major|minor|nitpick|p[0-2])\b` or `🔴|🟠|🟡`
-- Actionable language: `actionable comments posted|issues? found|findings?:|potential[_ ]issue`
-- Suggestion markers: a fenced block labeled `suggestion` (e.g., ` ```suggestion `) or a CR "Prompt for AI Agent" heading
-- A diff/patch proposal: a fenced code block whose first line starts with `+` or `-`
+- **actionable:** `"Fixed in \`<short-sha>\`: <one-line description>"`
+- **already-fixed:** `"Addressed in a prior commit — current code no longer has this issue. Resolving."`
+- **outdated:** `"Referenced code no longer exists after refactoring. Resolving."`
 
-**Acknowledgment patterns** (match only if NO finding pattern matches above):
-- HTML marker: `<!-- <review_comment_addressed> -->`
-- LGTM variants: `\b(lgtm|looks good|approved|confirmed|resolved)\b`
-
-**Default rule:** if neither set matches, treat as a finding (safer default — under-classifying leads to the premature-merge failure mode this section exists to prevent).
-
-**If any finding is detected:** do NOT loop in-process. Emit `NEW_FINDINGS` in Step 8, stop the run, and require a fresh `/fixpr` invocation. The new run captures a new `$RUN_STARTED_AT` and re-audits from Step 1.
-
-Print:
-```
-[VERIFY-COMMENTS] reviews: 0 new | inline: 0 new | convo: 1 new (acknowledgment, non-blocking)
-```
-or:
-```
-[VERIFY-COMMENTS] reviews: 1 new (CR, Major finding @ SKILL.md:98) → exit NEW_FINDINGS, re-run /fixpr
-```
-
-### 6c. Re-check CI (if a push was made)
-
-If Step 4 pushed, get the new HEAD SHA and poll check-runs once (wait up to 60s for checks to start):
+Post the reply (inline endpoint first, PR-comment fallback on 404):
 
 ```bash
-NEW_SHA=$(git rev-parse HEAD)
-gh api --paginate "repos/$OWNER/$REPO/commits/$NEW_SHA/check-runs?per_page=100" \
-  --jq '.check_runs[] | {name, status, conclusion}'
+gh api "repos/$OWNER/$REPO/pulls/comments/$DBID/replies" -f body="<reply>" \
+  || gh pr comment "$PR_NUMBER" --body "<plain-text reply>"
 ```
 
-- Report status of every check: `[CI] lint: queued | test: in_progress | build: success`
-- If checks haven't started yet, note: "CI triggered — checks not yet started. Run `/fixpr` again after CI completes if needed."
-- Do NOT poll in a loop — this is a single-pass tool.
+**Never include `@greptileai` in any reply text.** Every `@greptileai` mention triggers a paid Greptile re-review ($0.50–$1.00). Use plain text only; `@greptileai` is reserved exclusively for intentionally requesting a new review.
 
-### 6d. Verify review-bot commit statuses
+### 4b. Resolve via GraphQL
 
-CodeRabbit (and Greptile, if triggered) report review completion via commit statuses, not check-runs. A `pending` status means the bot is still analyzing the current HEAD — declaring CLEAN while `pending` is the exact failure mode Step 6 is designed to prevent.
+Pass IDs as typed GraphQL variables (`-F name=value`) — never shell-interpolate them into the query string.
 
 ```bash
-TARGET_SHA="${NEW_SHA:-$HEAD_SHA}"
-gh api "repos/$OWNER/$REPO/commits/$TARGET_SHA/statuses" \
-  --jq '[.[] | select(.context=="CodeRabbit" or .context=="Greptile") | {context, state, description, updated_at}]
-        | group_by(.context) | map(sort_by(.updated_at) | last)'
+gh api graphql -F threadId="$THREAD_ID" -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) { thread { isResolved } }
+  }'
 ```
 
-For each bot present on the PR:
-- `state: success` → review completed on this SHA. Clean pass signal.
-- `state: pending` → review still running. **Do NOT declare CLEAN.** Emit `REVIEW_PENDING` (see Step 8) and instruct re-run.
+On failure, fall back to minimize:
+
+```bash
+gh api graphql -F subjectId="$NODE_ID" -f query='
+  mutation($subjectId: ID!) {
+    minimizeComment(input: {subjectId: $subjectId, classifier: RESOLVED}) { minimizedComment { isMinimized } }
+  }'
+```
+
+Print per thread: `[RESOLVED] <thread-id> — <summary>`.
+
+---
+
+## Step 5: Verify
+
+Run the audit script again with `--since $RUN_STARTED_AT`. This picks up the new HEAD SHA (post-push) **and** pre-classifies any bot comment that landed between Step 0 and now:
+
+```bash
+VERIFY=$("$SCRIPT" --since "$RUN_STARTED_AT")
+```
+
+### 5a. Threads
+
+```bash
+UNRESOLVED=$(jq -r '.threads.unresolved_count' "$VERIFY")
+```
+
+- `0` → `[CLEAN] All threads resolved — zero uncollapsed in browser.`
+- otherwise → retry resolution (max 2 attempts per thread). Remaining stuck threads emit `[STUCK] thread <id> — cannot resolve`.
+
+### 5b. New bot comments since `$RUN_STARTED_AT`
+
+`audit.sh` has already classified every bot comment posted after `$RUN_STARTED_AT`. Read the rollup:
+
+```bash
+jq -r '
+  "[VERIFY-COMMENTS] new findings: \(.new_since_baseline.finding_count), acknowledgments: \(.new_since_baseline.acknowledgment_count)",
+  (.new_since_baseline.reviews[], .new_since_baseline.inline[], .new_since_baseline.conversation[]
+   | select(.classification.class == "finding")
+   | "  finding: \(.url) — \(.classification.reason)")
+' "$VERIFY"
+```
+
+**Classification rules** (these live in `audit.sh`; the list below is the contract — keep the two in sync if either changes). Patterns are checked in this order; first match wins:
+
+1. **Explicit-resolution overrides** (checked first — these signals mean CR has already marked the thread addressed, so they win even if the body still contains finding language from a quoted earlier review):
+   - HTML marker `<!-- <review_comment_addressed> -->` → `acknowledgment`
+   - `actionable comments posted: 0` → `acknowledgment`. This specific zero-count pattern MUST be checked before the general `actionable comments posted` pattern below — otherwise the general finding pattern would swallow the zero case.
+2. **Finding patterns**:
+   - Severity keywords `\b(critical|major|minor|nitpick|p[0-2])\b` or badges `🔴|🟠|🟡`
+   - Actionable phrases: `actionable comments posted` (non-zero), `issues? found`, `findings?:`, `potential[_ ]issue`
+   - Fix markers: a fenced ```` ```suggestion ```` block, or a `Prompt for AI Agent` heading
+3. **Weak-ack fallbacks** (only if no finding matched):
+   - LGTM variants: `lgtm`, `looks good`, `approved`, `confirmed`, `resolved`
+4. **Default** (no pattern matched) → `finding`. The safer default — under-classifying here is the failure mode this whole skill exists to prevent.
+
+**If `finding_count > 0`:** do NOT loop. Emit `NEW_FINDINGS` in Step 7 and stop. Re-running `/fixpr` captures a new `$RUN_STARTED_AT` and re-audits from Step 0, picking up the new findings.
+
+### 5c. CI (if a push was made)
+
+The verify audit's `.check_runs` reflects the new HEAD.
+
+```bash
+jq -r '.check_runs.all[] | "[CI] \(.name): \(.status)\(if .conclusion then " — \(.conclusion)" else "" end)"' "$VERIFY"
+
+FAILING=$(jq -r '.check_runs.failing' "$VERIFY")
+IN_PROGRESS=$(jq -r '.check_runs.in_progress' "$VERIFY")
+```
+
+Decide from those two counts:
+
+- `IN_PROGRESS > 0` → emit `CI_PENDING` in Step 7. Re-run `/fixpr` after CI finishes.
+- `IN_PROGRESS == 0 && FAILING > 0` → read each entry in `.check_runs.failing_runs` from the VERIFY audit. Classify:
+  - **deterministic** (lint/typecheck/test/build/security reports a real error) → emit `CI_FAILING` in Step 7 and stop. Re-run `/fixpr` so Steps 2–3 can retry the fix on the newly-visible error.
+  - **transient** (runner timeout, startup failure, flaky external dep) → emit `CI_FAILING` in Step 7, note the specific checks, and continue to Step 6 — local fixes aren't possible and the user decides whether to retry.
+- `IN_PROGRESS == 0 && FAILING == 0` → CI clean on this SHA.
+
+Do NOT poll.
+
+### 5d. Review-bot commit statuses on the current HEAD
+
+CR and Greptile report review completion via commit *statuses*, not check-runs. `pending` means the bot is still analyzing the current HEAD — declaring CLEAN while pending is the exact failure mode this verify step was built to prevent.
+
+```bash
+jq -r '
+  .bot_statuses | to_entries[] | "[VERIFY-BOTS] \(.key): \(.value.state) (\(.value.updated_at))"
+' "$VERIFY"
+```
+
+For each bot present:
+
+- `state: success` → review completed on this SHA. Clean-pass signal.
+- `state: pending` → bot still running. **Do NOT declare CLEAN.** Emit `REVIEW_PENDING` and stop.
 - `state: failure` / `error` with "rate limit" in `description` → CR rate-limited, fall back to Greptile per `cr-github-review.md`.
-- No CodeRabbit / Greptile status context at all after a push → the bot hasn't started. Re-run `/fixpr` after it does.
-
-Print:
-```
-[VERIFY-BOTS] CodeRabbit: success (21:43:01Z) | Greptile: n/a
-```
-or:
-```
-[VERIFY-BOTS] CodeRabbit: pending (21:38:21Z) → REVIEW_PENDING, stopping
-```
+- No CR/Greptile entry in `.bot_statuses` after a push → bot hasn't started. Re-run `/fixpr` after it does.
 
 ---
 
-## Step 7: Check merge blockers
-
-Verify nothing else blocks the merge button. Run:
+## Step 6: Check merge blockers
 
 ```bash
-gh pr view $PR_NUMBER --json mergeStateStatus,mergeable,reviewDecision,statusCheckRollup
+jq -r '.merge_state | "[MERGE] mergeable=\(.mergeable), status=\(.mergeStateStatus), review=\(.reviewDecision)"' "$VERIFY"
 ```
-
-Check each field:
 
 | Field | Blocking value | Action |
 |-------|---------------|--------|
-| `mergeable` | `CONFLICTING` | Rebase onto main: `git fetch origin main && git rebase origin/main`. If conflicts, fix them, `git rebase --continue`, force-push. |
-| `mergeable` | `UNKNOWN` | GitHub is still computing — note it, re-run `/fixpr` later. |
-| `mergeStateStatus` | `BEHIND` | Branch is behind main — rebase and force-push: `git fetch origin main && git rebase origin/main && git push --force-with-lease` |
-| `mergeStateStatus` | `BLOCKED` | Required status checks failing or required reviews missing — already handled by Steps 3-6, but report any remaining blockers. |
-| `mergeStateStatus` | `UNSTABLE` | A non-required check is pending or failing — most commonly the CR/Greptile review on the new SHA. If Step 6d emitted `REVIEW_PENDING`, stop with that status — do NOT declare CLEAN. Re-run `/fixpr` after the review completes. |
-| `reviewDecision` | `CHANGES_REQUESTED` | A human reviewer requested changes — report to user (cannot auto-resolve human review requests). |
+| `mergeable` | `CONFLICTING` | Rebase onto main: `git fetch origin main && git rebase origin/main`. Fix conflicts, continue, force-push. |
+| `mergeable` | `UNKNOWN` | GitHub still computing — note and re-run `/fixpr` later. |
+| `mergeStateStatus` | `BEHIND` | Rebase + force-push. |
+| `mergeStateStatus` | `BLOCKED` | Required checks/reviews missing — already covered by 5c/5d, but report any residual. |
+| `mergeStateStatus` | `UNSTABLE` | A non-required check pending/failing — typically CR/Greptile on the new SHA. If 5d emitted `REVIEW_PENDING`, stop with that status. |
+| `reviewDecision` | `CHANGES_REQUESTED` | A human reviewer requested changes — report; cannot auto-resolve. |
 
-Print:
-```
-[MERGE] mergeable: MERGEABLE, mergeStateStatus: CLEAN, reviewDecision: APPROVED → no blockers
-```
-or:
-```
-[MERGE] mergeable: CONFLICTING → rebasing onto main...
-[MERGE] rebase complete, force-pushed (SHA: <new-sha>)
-```
-
-**After any rebase + force-push:** Wait for CI to start, then note: "CI re-triggered after rebase. Run `/fixpr` again after CI completes to verify."
+After any rebase + force-push: `[MERGE] rebase complete, force-pushed (SHA: <new-sha>) — CI re-triggered. Re-run /fixpr after CI completes.`
 
 ---
 
-## Step 8: Final summary
+## Step 7: Final summary
 
 ```
 === fixpr complete ===
@@ -403,19 +318,18 @@ Threads:         N total, M were unresolved
 CI checks:       P total, Q were failing
   - Fixed:       R failures in code
   - Transient:   S (cannot fix locally)
-Merge state:     mergeable=$MERGEABLE, status=$MERGE_STATE, review=$REVIEW_DECISION
-  - Rebased:     yes/no
-  - Conflicts:   none | resolved | unresolvable
-Push:            <sha> (or "no push needed")
+Merge state:     mergeable=..., status=..., review=...
+Push:            <sha> or "no push needed"
 Status:          CLEAN | THREADS_STUCK | REVIEW_PENDING | CI_PENDING | CI_FAILING | CONFLICTS | NEEDS_HUMAN_REVIEW | NEW_FINDINGS
 ```
 
 **Status definitions:**
-- `CLEAN` — **all four conditions met simultaneously:** zero unresolved threads (Step 6a), zero new bot comments since `$RUN_STARTED_AT` that classify as findings (Step 6b), every CR/Greptile commit status is `success` on the current HEAD (Step 6d), and no merge blockers (Step 7). Missing any one of the four disqualifies `CLEAN` — use the more specific status below.
-- `THREADS_STUCK` — some threads could not be resolved via GraphQL (report which)
-- `REVIEW_PENDING` — Step 6d found a CR/Greptile commit status still in `pending` on the current HEAD. The bot has not finished reviewing the latest push. Re-run `/fixpr` after the status flips to `success`. Do NOT declare CLEAN.
-- `NEW_FINDINGS` — Step 6b found new bot comments (review body, inline, or PR-conversation) posted after `$RUN_STARTED_AT` that classify as findings. Stop the run. Re-run `/fixpr` (a fresh invocation captures a new `$RUN_STARTED_AT` and re-audits from Step 1, including the new findings).
-- `CI_PENDING` — push/rebase was made, CI not yet complete (re-run `/fixpr` after CI)
-- `CI_FAILING` — transient CI failures that cannot be fixed locally (report which)
-- `CONFLICTS` — merge conflicts could not be auto-resolved (needs manual intervention)
-- `NEEDS_HUMAN_REVIEW` — a human reviewer requested changes (cannot auto-resolve)
+
+- `CLEAN` — **all four conditions simultaneously:** zero unresolved threads (5a), `new_since_baseline.finding_count == 0` (5b), every entry in `bot_statuses` is `success` on the current HEAD (5d), no merge blockers (6). Missing any one disqualifies `CLEAN` — pick the more specific status below.
+- `THREADS_STUCK` — some threads could not be resolved via GraphQL (report which).
+- `REVIEW_PENDING` — 5d found a CR/Greptile status still `pending` on the current HEAD. Re-run `/fixpr` after it flips to `success`. Do NOT declare CLEAN.
+- `NEW_FINDINGS` — 5b's `finding_count > 0`. Stop the run. A fresh `/fixpr` captures a new `$RUN_STARTED_AT` and re-audits from Step 0.
+- `CI_PENDING` — push was made, CI not yet complete. Re-run `/fixpr` after CI.
+- `CI_FAILING` — transient CI failures that cannot be fixed locally (report which).
+- `CONFLICTS` — merge conflicts could not be auto-resolved (needs manual intervention).
+- `NEEDS_HUMAN_REVIEW` — a human reviewer requested changes (cannot auto-resolve).

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -22,6 +22,13 @@ If no PR exists for this branch, stop: "No PR found for branch `$BRANCH`."
 Extract:
 ```bash
 PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
+
+if [ "$PR_STATE" != "OPEN" ]; then
+  echo "PR #$PR_NUMBER is already $PR_STATE — nothing to fix."
+  exit 0
+fi
+
 OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
 REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
@@ -157,7 +164,8 @@ Combine all fixes (review findings + CI failures) into a single commit:
 4. Commit and push:
 
 ```bash
-git add -A
+# Stage only the files modified during fixing (tracked from Steps 2–3)
+git add <list of modified files>
 git commit -m "fix: resolve all review findings and CI failures
 
 Fixes N review findings and M CI errors."
@@ -188,8 +196,9 @@ gh api "repos/$OWNER/$REPO/pulls/comments/{comment_id}/replies" -f body="<reply>
 ```
 On 404, fall back to:
 ```bash
-gh pr comment $PR_NUMBER --body "<reply with @-mention of reviewer>"
+gh pr comment $PR_NUMBER --body "<plain-text reply — do NOT include @greptileai>"
 ```
+**CRITICAL:** Never include `@greptileai` in reply text. Every `@greptileai` mention triggers a paid Greptile re-review ($0.50–$1.00). Use plain text only; `@greptileai` is reserved exclusively for intentionally requesting a new review.
 
 ### 5b. Resolve via GraphQL
 

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -74,7 +74,7 @@ while :; do
         }
       }
     }
-  }' -F owner="$OWNER" -F repo="$REPO" -F pr=$PR_NUMBER -f cursor="$CURSOR")
+  }' -F owner="$OWNER" -F repo="$REPO" -F pr=$PR_NUMBER -F cursor="$CURSOR")
   ALL_THREADS=$(jq -s '.[0] + .[1].data.repository.pullRequest.reviewThreads.nodes' <(echo "$ALL_THREADS") <(echo "$RESP"))
   HAS_NEXT=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
   [ "$HAS_NEXT" = "true" ] || break
@@ -82,10 +82,12 @@ while :; do
 done
 ```
 
+**Note on `-F cursor`:** `-F` performs GraphQL type conversion (literal `"null"` → GraphQL `null`, `"true"` → boolean, numbers → int). `-f` would send the literal string `"null"` and break the first fetch. Same pattern applies to Step 6a.
+
 ### 1b. CI check-runs (REST — every check, not just CodeRabbit)
 
 ```bash
-gh api "repos/$OWNER/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
+gh api --paginate "repos/$OWNER/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
   --jq '.check_runs[] | {id, name, status, conclusion, title: .output.title}'
 ```
 
@@ -253,7 +255,7 @@ while :; do
         }
       }
     }
-  }' -F owner="$OWNER" -F repo="$REPO" -F pr=$PR_NUMBER -f cursor="$CURSOR")
+  }' -F owner="$OWNER" -F repo="$REPO" -F pr=$PR_NUMBER -F cursor="$CURSOR")
   ALL_THREADS=$(jq -s '.[0] + .[1].data.repository.pullRequest.reviewThreads.nodes' <(echo "$ALL_THREADS") <(echo "$RESP"))
   HAS_NEXT=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
   [ "$HAS_NEXT" = "true" ] || break
@@ -273,7 +275,7 @@ If Step 4 pushed, get the new HEAD SHA and poll check-runs once (wait up to 60s 
 
 ```bash
 NEW_SHA=$(git rev-parse HEAD)
-gh api "repos/$OWNER/$REPO/commits/$NEW_SHA/check-runs?per_page=100" \
+gh api --paginate "repos/$OWNER/$REPO/commits/$NEW_SHA/check-runs?per_page=100" \
   --jq '.check_runs[] | {name, status, conclusion}'
 ```
 

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -33,6 +33,10 @@ OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
 REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
 HEAD_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[-1].oid')
+
+# Timestamp baseline for detecting NEW bot comments posted during/after this run.
+# Step 6b uses this to catch reviews that land between Step 1's audit and Step 6's verify.
+RUN_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 ```
 
 Print: `[CONTEXT] PR #$PR_NUMBER on $OWNER/$REPO (branch: $BRANCH, HEAD: ${HEAD_SHA:0:7})`
@@ -236,7 +240,9 @@ Print per thread: `[RESOLVED] thread <id> — <summary>`
 
 ---
 
-## Step 6: Verify — zero unresolved threads, CI status
+## Step 6: Verify — zero unresolved threads, zero new comments, CI status, review-bot completion
+
+> **Why four checks, not just threads:** GraphQL `reviewThreads` only sees inline-comment threads. A reviewer bot can post a new review body (or a new PR-conversation comment) that carries actionable findings without ever creating a thread. Relying on thread-resolution state alone is how premature "merge-ready" declarations happen — this section exists specifically to prevent that.
 
 ### 6a. Re-fetch threads
 
@@ -269,7 +275,48 @@ Count unresolved (`isResolved: false`) across `ALL_THREADS`.
 - **Any remain:** Retry resolution (max 2 attempts per thread). If still stuck:
   `[STUCK] Thread <id> — cannot resolve (permission or GitHub bug): "<first line>"`
 
-### 6b. Re-check CI (if a push was made)
+### 6b. Re-scan the three REST comment endpoints for NEW bot comments since `$RUN_STARTED_AT`
+
+This is the critical gap that thread-resolution checks alone miss. A reviewer bot can post a new review body or PR-conversation comment that contains findings without ever creating a resolvable thread — so Step 6a would report clean while the PR is still unaddressed.
+
+Filter each endpoint by `coderabbitai[bot]` / `greptile-apps[bot]` and by timestamp > `$RUN_STARTED_AT` (captured in Step 0):
+
+```bash
+SINCE="$RUN_STARTED_AT"
+NEW_REVIEWS=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
+  --jq --arg since "$SINCE" '[.[] | select((.user.login=="coderabbitai[bot]" or .user.login=="greptile-apps[bot]") and .submitted_at > $since)]')
+NEW_INLINE=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100" \
+  --jq --arg since "$SINCE" '[.[] | select((.user.login=="coderabbitai[bot]" or .user.login=="greptile-apps[bot]") and .created_at > $since)]')
+NEW_CONVO=$(gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+  --jq --arg since "$SINCE" '[.[] | select((.user.login=="coderabbitai[bot]" or .user.login=="greptile-apps[bot]") and .created_at > $since)]')
+```
+
+For each hit, classify the body with these explicit patterns (case-insensitive regex):
+
+**Finding patterns** (any match → treat as finding):
+- Severity words/badges: `\b(critical|major|minor|nitpick|p[0-2])\b` or `🔴|🟠|🟡`
+- Actionable language: `actionable comments posted|issues? found|findings?:|potential[_ ]issue`
+- Suggestion markers: a fenced block labeled `suggestion` (e.g., ` ```suggestion `) or a CR "Prompt for AI Agent" heading
+- A diff/patch proposal: a fenced code block whose first line starts with `+` or `-`
+
+**Acknowledgment patterns** (match only if NO finding pattern matches above):
+- HTML marker: `<!-- <review_comment_addressed> -->`
+- LGTM variants: `\b(lgtm|looks good|approved|confirmed|resolved)\b`
+
+**Default rule:** if neither set matches, treat as a finding (safer default — under-classifying leads to the premature-merge failure mode this section exists to prevent).
+
+**If any finding is detected:** do NOT loop in-process. Emit `NEW_FINDINGS` in Step 8, stop the run, and require a fresh `/fixpr` invocation. The new run captures a new `$RUN_STARTED_AT` and re-audits from Step 1.
+
+Print:
+```
+[VERIFY-COMMENTS] reviews: 0 new | inline: 0 new | convo: 1 new (acknowledgment, non-blocking)
+```
+or:
+```
+[VERIFY-COMMENTS] reviews: 1 new (CR, Major finding @ SKILL.md:98) → exit NEW_FINDINGS, re-run /fixpr
+```
+
+### 6c. Re-check CI (if a push was made)
 
 If Step 4 pushed, get the new HEAD SHA and poll check-runs once (wait up to 60s for checks to start):
 
@@ -282,6 +329,32 @@ gh api --paginate "repos/$OWNER/$REPO/commits/$NEW_SHA/check-runs?per_page=100" 
 - Report status of every check: `[CI] lint: queued | test: in_progress | build: success`
 - If checks haven't started yet, note: "CI triggered — checks not yet started. Run `/fixpr` again after CI completes if needed."
 - Do NOT poll in a loop — this is a single-pass tool.
+
+### 6d. Verify review-bot commit statuses
+
+CodeRabbit (and Greptile, if triggered) report review completion via commit statuses, not check-runs. A `pending` status means the bot is still analyzing the current HEAD — declaring CLEAN while `pending` is the exact failure mode Step 6 is designed to prevent.
+
+```bash
+TARGET_SHA="${NEW_SHA:-$HEAD_SHA}"
+gh api "repos/$OWNER/$REPO/commits/$TARGET_SHA/statuses" \
+  --jq '[.[] | select(.context=="CodeRabbit" or .context=="Greptile") | {context, state, description, updated_at}]
+        | group_by(.context) | map(sort_by(.updated_at) | last)'
+```
+
+For each bot present on the PR:
+- `state: success` → review completed on this SHA. Clean pass signal.
+- `state: pending` → review still running. **Do NOT declare CLEAN.** Emit `REVIEW_PENDING` (see Step 8) and instruct re-run.
+- `state: failure` / `error` with "rate limit" in `description` → CR rate-limited, fall back to Greptile per `cr-github-review.md`.
+- No CodeRabbit / Greptile status context at all after a push → the bot hasn't started. Re-run `/fixpr` after it does.
+
+Print:
+```
+[VERIFY-BOTS] CodeRabbit: success (21:43:01Z) | Greptile: n/a
+```
+or:
+```
+[VERIFY-BOTS] CodeRabbit: pending (21:38:21Z) → REVIEW_PENDING, stopping
+```
 
 ---
 
@@ -301,6 +374,7 @@ Check each field:
 | `mergeable` | `UNKNOWN` | GitHub is still computing — note it, re-run `/fixpr` later. |
 | `mergeStateStatus` | `BEHIND` | Branch is behind main — rebase and force-push: `git fetch origin main && git rebase origin/main && git push --force-with-lease` |
 | `mergeStateStatus` | `BLOCKED` | Required status checks failing or required reviews missing — already handled by Steps 3-6, but report any remaining blockers. |
+| `mergeStateStatus` | `UNSTABLE` | A non-required check is pending or failing — most commonly the CR/Greptile review on the new SHA. If Step 6d emitted `REVIEW_PENDING`, stop with that status — do NOT declare CLEAN. Re-run `/fixpr` after the review completes. |
 | `reviewDecision` | `CHANGES_REQUESTED` | A human reviewer requested changes — report to user (cannot auto-resolve human review requests). |
 
 Print:
@@ -333,12 +407,14 @@ Merge state:     mergeable=$MERGEABLE, status=$MERGE_STATE, review=$REVIEW_DECIS
   - Rebased:     yes/no
   - Conflicts:   none | resolved | unresolvable
 Push:            <sha> (or "no push needed")
-Status:          CLEAN | THREADS_STUCK | CI_PENDING | CI_FAILING | CONFLICTS | NEEDS_HUMAN_REVIEW
+Status:          CLEAN | THREADS_STUCK | REVIEW_PENDING | CI_PENDING | CI_FAILING | CONFLICTS | NEEDS_HUMAN_REVIEW | NEW_FINDINGS
 ```
 
 **Status definitions:**
-- `CLEAN` — zero unresolved threads, all CI green, no merge blockers
+- `CLEAN` — **all four conditions met simultaneously:** zero unresolved threads (Step 6a), zero new bot comments since `$RUN_STARTED_AT` that classify as findings (Step 6b), every CR/Greptile commit status is `success` on the current HEAD (Step 6d), and no merge blockers (Step 7). Missing any one of the four disqualifies `CLEAN` — use the more specific status below.
 - `THREADS_STUCK` — some threads could not be resolved via GraphQL (report which)
+- `REVIEW_PENDING` — Step 6d found a CR/Greptile commit status still in `pending` on the current HEAD. The bot has not finished reviewing the latest push. Re-run `/fixpr` after the status flips to `success`. Do NOT declare CLEAN.
+- `NEW_FINDINGS` — Step 6b found new bot comments (review body, inline, or PR-conversation) posted after `$RUN_STARTED_AT` that classify as findings. Stop the run. Re-run `/fixpr` (a fresh invocation captures a new `$RUN_STARTED_AT` and re-audits from Step 1, including the new findings).
 - `CI_PENDING` — push/rebase was made, CI not yet complete (re-run `/fixpr` after CI)
 - `CI_FAILING` — transient CI failures that cannot be fixed locally (report which)
 - `CONFLICTS` — merge conflicts could not be auto-resolved (needs manual intervention)

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: fixpr
+description: Single-pass PR cleanup — audit every review thread + every CI check-run, fix all issues, push once, resolve all threads via GraphQL, verify CI green. Zero uncollapsed threads and zero failing checks when done.
+---
+
+Single-pass cleanup of the current branch's PR. After this completes:
+1. **Zero uncollapsed review threads** in the browser (all resolved via GraphQL)
+2. **Zero failing CI checks** (all fixed and passing)
+3. **Every finding replied to** with what was done
+
+---
+
+## Step 0: Identify PR context
+
+```bash
+BRANCH=$(git branch --show-current)
+PR_JSON=$(gh pr view --json number,headRefName,state,url 2>/dev/null)
+```
+
+If no PR exists for this branch, stop: "No PR found for branch `$BRANCH`."
+
+Extract:
+```bash
+PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
+REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
+HEAD_SHA=$(gh pr view $PR_NUMBER --json commits --jq '.commits[-1].oid')
+```
+
+Print: `[CONTEXT] PR #$PR_NUMBER on $OWNER/$REPO (branch: $BRANCH, HEAD: ${HEAD_SHA:0:7})`
+
+---
+
+## Step 1: Audit — fetch all threads + all CI in one pass
+
+### 1a. Review threads (GraphQL — authoritative for resolution status)
+
+```bash
+gh api graphql -f query='query {
+  repository(owner: "'$OWNER'", name: "'$REPO'") {
+    pullRequest(number: '$PR_NUMBER') {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first: 10) {
+            nodes {
+              id
+              databaseId
+              body
+              author { login }
+              path
+              line
+              originalLine
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+### 1b. CI check-runs (REST — every check, not just CodeRabbit)
+
+```bash
+gh api "repos/$OWNER/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
+  --jq '.check_runs[] | {id, name, status, conclusion, title: .output.title}'
+```
+
+### 1c. REST comment endpoints (for reply targets and comment IDs)
+
+Fetch all three endpoints with `per_page=100`. Paginate if `Link` header contains `rel="next"`.
+
+```bash
+gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100"
+gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100"
+gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100"
+```
+
+### 1d. Print audit summary
+
+```
+[AUDIT] Review threads: N total (M unresolved, K resolved, J outdated)
+[AUDIT] CI checks: X total (P passing, F failing, I in-progress)
+```
+
+List every failing check by name. List every unresolved thread with file:line and first sentence.
+
+---
+
+## Step 2: Classify every unresolved finding
+
+For each unresolved thread (`isResolved: false`):
+
+1. Read the first comment (the original finding)
+2. Get `path` and `line` from comment metadata
+3. Read the current file at that location
+4. Classify:
+   - **actionable** — code still has the issue → must fix
+   - **already-fixed** — code no longer matches the finding (fixed in prior commit, thread not resolved) → resolve only
+   - **outdated** — file/line no longer exists → resolve only
+
+Print numbered list:
+```
+[FINDING 1] actionable — src/foo.ts:42 — "unused import" (coderabbitai[bot])
+[FINDING 2] already-fixed — src/bar.ts:10 — "missing null check" (coderabbitai[bot])
+[FINDING 3] outdated — src/deleted.ts:5 — file removed (greptile-apps[bot])
+```
+
+---
+
+## Step 3: Check every CI failure
+
+For every check-run with a blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`):
+
+1. Read the failure output:
+   ```bash
+   gh api "repos/$OWNER/$REPO/check-runs/{CHECK_RUN_ID}" --jq '.output.summary'
+   ```
+   If summary is empty, also check `.output.text` and the check-run's `details_url`.
+
+2. Classify the failure:
+   - **lint/typecheck** — read the errors, fix the code
+   - **test** — read the failing test output, fix the code or test
+   - **build** — read the build error, fix the code
+   - **security/audit** (gitleaks, npm audit, etc.) — read the finding, fix
+   - **infra/transient** (timeout, runner failure) — note it, cannot fix locally
+
+3. Fix every non-transient failure. Read the actual error messages — do not guess.
+
+Print per check:
+```
+[CI:FAIL] "lint" — 3 errors in src/foo.ts (unused var, missing type, bad import) → fixing
+[CI:FAIL] "test" — 1 failure in tests/bar.test.ts:55 (expected 3, got 4) → fixing
+[CI:PASS] "build" — ok
+[CI:INFRA] "deploy-preview" — timed_out (transient, cannot fix locally)
+```
+
+**Do NOT skip any check.** Every check-run must be accounted for in the output.
+
+---
+
+## Step 4: Fix everything, push once
+
+Combine all fixes (review findings + CI failures) into a single commit:
+
+1. Fix all **actionable** review findings (Step 2)
+2. Fix all **non-transient CI failures** (Step 3)
+3. Rules:
+   - **Never suppress linter errors** (`eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`) — fix the actual code
+   - Verify each fix against the original comment/error — partial fixes count as unresolved
+   - If a finding is ambiguous, fix it conservatively
+4. Commit and push:
+
+```bash
+git add -A
+git commit -m "fix: resolve all review findings and CI failures
+
+Fixes N review findings and M CI errors."
+git push
+```
+
+Print: `[PUSH] All fixes committed and pushed (SHA: $(git rev-parse --short HEAD))`
+
+**If nothing needed fixing** (all already-fixed/outdated, CI all green), skip the commit/push.
+
+---
+
+## Step 5: Reply to every thread and resolve via GraphQL
+
+For **every** unresolved thread — actionable, already-fixed, and outdated:
+
+### 5a. Reply
+
+Post a reply to the first comment in the thread:
+
+- **Actionable (just fixed):** `"Fixed in \`<short-sha>\`: <one-line description>"`
+- **Already fixed:** `"Addressed in a prior commit — current code no longer has this issue. Resolving."`
+- **Outdated:** `"Referenced code no longer exists after refactoring. Resolving."`
+
+Use inline reply endpoint first:
+```bash
+gh api "repos/$OWNER/$REPO/pulls/comments/{comment_id}/replies" -f body="<reply>"
+```
+On 404, fall back to:
+```bash
+gh pr comment $PR_NUMBER --body "<reply with @-mention of reviewer>"
+```
+
+### 5b. Resolve via GraphQL
+
+```bash
+gh api graphql -f query='mutation {
+  resolveReviewThread(input: {threadId: "<thread_node_id>"}) {
+    thread { isResolved }
+  }
+}'
+```
+
+Confirm `isResolved: true`. On failure, fall back to minimizing:
+```bash
+gh api graphql -f query='mutation {
+  minimizeComment(input: {subjectId: "<comment_node_id>", classifier: RESOLVED}) {
+    minimizedComment { isMinimized }
+  }
+}'
+```
+
+Print per thread: `[RESOLVED] thread <id> — <summary>`
+
+---
+
+## Step 6: Verify — zero unresolved threads, CI status
+
+### 6a. Re-fetch threads
+
+```bash
+gh api graphql -f query='query {
+  repository(owner: "'$OWNER'", name: "'$REPO'") {
+    pullRequest(number: '$PR_NUMBER') {
+      reviewThreads(first: 100) {
+        nodes { id isResolved comments(first: 1) { nodes { body author { login } } } }
+      }
+    }
+  }
+}'
+```
+
+Count unresolved (`isResolved: false`).
+
+- **0 unresolved:** `[CLEAN] All threads resolved — zero uncollapsed in browser.`
+- **Any remain:** Retry resolution (max 2 attempts per thread). If still stuck:
+  `[STUCK] Thread <id> — cannot resolve (permission or GitHub bug): "<first line>"`
+
+### 6b. Re-check CI (if a push was made)
+
+If Step 4 pushed, get the new HEAD SHA and poll check-runs once (wait up to 60s for checks to start):
+
+```bash
+NEW_SHA=$(git rev-parse HEAD)
+gh api "repos/$OWNER/$REPO/commits/$NEW_SHA/check-runs?per_page=100" \
+  --jq '.check_runs[] | {name, status, conclusion}'
+```
+
+- Report status of every check: `[CI] lint: queued | test: in_progress | build: success`
+- If checks haven't started yet, note: "CI triggered — checks not yet started. Run `/fixpr` again after CI completes if needed."
+- Do NOT poll in a loop — this is a single-pass tool.
+
+---
+
+## Step 7: Check merge blockers
+
+Verify nothing else blocks the merge button. Run:
+
+```bash
+gh pr view $PR_NUMBER --json mergeStateStatus,mergeable,reviewDecision,statusCheckRollup
+```
+
+Check each field:
+
+| Field | Blocking value | Action |
+|-------|---------------|--------|
+| `mergeable` | `CONFLICTING` | Rebase onto main: `git fetch origin main && git rebase origin/main`. If conflicts, fix them, `git rebase --continue`, force-push. |
+| `mergeable` | `UNKNOWN` | GitHub is still computing — note it, re-run `/fixpr` later. |
+| `mergeStateStatus` | `BEHIND` | Branch is behind main — rebase and force-push: `git fetch origin main && git rebase origin/main && git push --force-with-lease` |
+| `mergeStateStatus` | `BLOCKED` | Required status checks failing or required reviews missing — already handled by Steps 3-6, but report any remaining blockers. |
+| `reviewDecision` | `CHANGES_REQUESTED` | A human reviewer requested changes — report to user (cannot auto-resolve human review requests). |
+
+Print:
+```
+[MERGE] mergeable: MERGEABLE, mergeStateStatus: CLEAN, reviewDecision: APPROVED → no blockers
+```
+or:
+```
+[MERGE] mergeable: CONFLICTING → rebasing onto main...
+[MERGE] rebase complete, force-pushed (SHA: <new-sha>)
+```
+
+**After any rebase + force-push:** Wait for CI to start, then note: "CI re-triggered after rebase. Run `/fixpr` again after CI completes to verify."
+
+---
+
+## Step 8: Final summary
+
+```
+=== fixpr complete ===
+PR:              #$PR_NUMBER ($BRANCH)
+Threads:         N total, M were unresolved
+  - Fixed:       X findings in code
+  - Resolved:    Y threads via GraphQL
+  - Stuck:       Z threads (0 = clean)
+CI checks:       P total, Q were failing
+  - Fixed:       R failures in code
+  - Transient:   S (cannot fix locally)
+Merge state:     mergeable=$MERGEABLE, status=$MERGE_STATE, review=$REVIEW_DECISION
+  - Rebased:     yes/no
+  - Conflicts:   none | resolved | unresolvable
+Push:            <sha> (or "no push needed")
+Status:          CLEAN | THREADS_STUCK | CI_PENDING | CI_FAILING | CONFLICTS | NEEDS_HUMAN_REVIEW
+```
+
+**Status definitions:**
+- `CLEAN` — zero unresolved threads, all CI green, no merge blockers
+- `THREADS_STUCK` — some threads could not be resolved via GraphQL (report which)
+- `CI_PENDING` — push/rebase was made, CI not yet complete (re-run `/fixpr` after CI)
+- `CI_FAILING` — transient CI failures that cannot be fixed locally (report which)
+- `CONFLICTS` — merge conflicts could not be auto-resolved (needs manual intervention)
+- `NEEDS_HUMAN_REVIEW` — a human reviewer requested changes (cannot auto-resolve)

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -89,7 +89,7 @@ For each entry in `.threads.unresolved`:
 
 Print the numbered list:
 
-```
+```text
 [FINDING 1] actionable — src/foo.ts:42 — "unused import" (coderabbitai[bot])
 [FINDING 2] already-fixed — src/bar.ts:10 — "missing null check" (coderabbitai[bot])
 [FINDING 3] outdated — src/deleted.ts:5 — file removed (greptile-apps[bot])
@@ -115,7 +115,7 @@ For each entry in `.check_runs.failing_runs` (blocking conclusions: `failure`, `
 
 Print per check:
 
-```
+```text
 [CI:FAIL] "lint" — 3 errors in src/foo.ts → fixing
 [CI:INFRA] "deploy-preview" — timed_out (transient)
 ```
@@ -308,7 +308,7 @@ After any rebase + force-push: `[MERGE] rebase complete, force-pushed (SHA: <new
 
 ## Step 7: Final summary
 
-```
+```text
 === fixpr complete ===
 PR:              #$PR_NUMBER ($BRANCH)
 Threads:         N total, M were unresolved

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -91,7 +91,7 @@ gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100"
 ### 1d. Print audit summary
 
 ```
-[AUDIT] Review threads: N total (M unresolved, K resolved, J outdated)
+[AUDIT] Review threads: N total — M unresolved, K resolved (J outdated across both categories)
 [AUDIT] CI checks: X total (P passing, F failing, I in-progress)
 ```
 

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -93,12 +93,12 @@ gh api --paginate "repos/$OWNER/$REPO/commits/$HEAD_SHA/check-runs?per_page=100"
 
 ### 1c. REST comment endpoints (for reply targets and comment IDs)
 
-Fetch all three endpoints with `per_page=100`. Paginate if `Link` header contains `rel="next"`.
+Fetch all three endpoints with `--paginate` so large PRs don't silently truncate review/comment data.
 
 ```bash
-gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100"
-gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100"
-gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100"
+gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100"
+gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100"
+gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100"
 ```
 
 ### 1d. Print audit summary

--- a/.claude/skills/fixpr/audit.sh
+++ b/.claude/skills/fixpr/audit.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# audit.sh — Gather all PR state into a single JSON file for the /fixpr skill.
+#
+# The skill's AI layer reads the JSON and does judgment work (classify findings,
+# fix code, reply/resolve threads). All mechanical GitHub API calls live here.
+#
+# Usage:
+#   audit.sh                     # Initial audit (no baseline timestamp)
+#   audit.sh --since <iso-8601>  # Verify pass — pre-classify bot comments since baseline
+#
+# Output: writes JSON to /tmp/fixpr-audit-<PR>-<epoch>.json and prints the path.
+
+set -euo pipefail
+
+SINCE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since)
+      SINCE="${2:-}"
+      if [[ -z "$SINCE" ]]; then
+        echo "ERROR: --since requires an ISO-8601 timestamp" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      # Print the leading `#` comment block (everything after the shebang, up to the first blank line).
+      # Delimiter-based extraction survives header edits without needing fixed line numbers.
+      awk 'NR == 1 { next } /^$/ { exit } { print }' "$0"
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ----------------------------------------------------------------------
+# 1. PR context
+# ----------------------------------------------------------------------
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [[ -z "$BRANCH" ]]; then
+  echo "ERROR: not on a git branch (detached HEAD?)" >&2
+  exit 3
+fi
+
+PR_JSON=$(gh pr view --json number,headRefName,headRefOid,state,url,mergeStateStatus,mergeable,reviewDecision 2>/dev/null || echo "")
+if [[ -z "$PR_JSON" ]]; then
+  echo "ERROR: no PR found for branch $BRANCH" >&2
+  exit 4
+fi
+
+# One jq pass extracts every field we need from PR_JSON.
+# Uses a `read` block rather than `mapfile` — macOS ships bash 3.2, which has no mapfile/readarray.
+# headRefOid is the authoritative current HEAD SHA — do NOT use .commits[-1].oid (depends on array order).
+{ IFS= read -r PR_NUMBER
+  IFS= read -r PR_STATE
+  IFS= read -r HEAD_SHA
+  IFS= read -r PR_URL
+  IFS= read -r MERGE_STATE
+  IFS= read -r MERGEABLE
+  IFS= read -r REVIEW_DECISION
+} < <(echo "$PR_JSON" | jq -r '
+  .number,
+  .state,
+  (.headRefOid // ""),
+  (.url // ""),
+  (.mergeStateStatus // ""),
+  (.mergeable // ""),
+  (.reviewDecision // "")')
+
+if [[ "$PR_STATE" != "OPEN" ]]; then
+  echo "ERROR: PR #$PR_NUMBER is $PR_STATE — nothing to audit" >&2
+  exit 5
+fi
+
+OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER="${OWNER_REPO%/*}"
+REPO="${OWNER_REPO#*/}"
+
+RUN_STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+OUT="/tmp/fixpr-audit-${PR_NUMBER}-$(date -u +%s).json"
+
+# ----------------------------------------------------------------------
+# 2. Review threads (GraphQL, paginated — authoritative for resolution)
+# Use -F cursor (not -f) so "null" is typed as GraphQL null on the first page.
+# ----------------------------------------------------------------------
+ALL_THREADS="[]"
+CURSOR="null"
+while :; do
+  RESP=$(gh api graphql -f query='query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            isOutdated
+            comments(first: 10) {
+              nodes {
+                id
+                databaseId
+                body
+                author { login }
+                path
+                line
+                originalLine
+                url
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }' -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUMBER" -F cursor="$CURSOR")
+  ALL_THREADS=$(jq -n --argjson acc "$ALL_THREADS" --argjson page "$RESP" \
+    '$acc + $page.data.repository.pullRequest.reviewThreads.nodes')
+  HAS_NEXT=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+  [[ "$HAS_NEXT" == "true" ]] || break
+  CURSOR=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+done
+
+UNRESOLVED=$(echo "$ALL_THREADS" | jq '[.[] | select(.isResolved == false)]')
+
+# ----------------------------------------------------------------------
+# 3. CI check-runs (paginated)
+# ----------------------------------------------------------------------
+CHECK_RUNS=$(gh api --paginate "repos/$OWNER/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
+  --jq '.check_runs[]' | jq -s '.')
+
+CR_SPLIT=$(echo "$CHECK_RUNS" | jq '
+  def is_blocking: . == "failure" or . == "timed_out" or . == "action_required" or . == "startup_failure" or . == "stale";
+  def is_passing: . == "success" or . == "neutral" or . == "skipped";
+  {
+    total: length,
+    passing: ([.[] | select(.conclusion | is_passing)] | length),
+    failing: ([.[] | select(.conclusion | is_blocking)] | length),
+    in_progress: ([.[] | select(.status != "completed")] | length),
+    failing_runs: [.[] | select(.conclusion | is_blocking) | {id, name, conclusion, title: .output.title, details_url, html_url}],
+    in_progress_runs: [.[] | select(.status != "completed") | {id, name, status}],
+    all: [.[] | {id, name, status, conclusion, title: .output.title}]
+  }
+')
+
+# ----------------------------------------------------------------------
+# 4. Commit statuses — latest per context, plus CR/Greptile bot rollup
+# ----------------------------------------------------------------------
+STATUSES=$(gh api --paginate "repos/$OWNER/$REPO/commits/$HEAD_SHA/statuses?per_page=100" | jq -s 'add // []')
+
+BOT_STATUSES=$(echo "$STATUSES" | jq '
+  [.[] | select(.context == "CodeRabbit" or .context == "Greptile")]
+  | group_by(.context)
+  | map({
+      key: .[0].context,
+      value: (sort_by(.updated_at) | last | {state, description, updated_at, target_url})
+    })
+  | from_entries
+')
+
+# ----------------------------------------------------------------------
+# 5. REST comment endpoints (paginated)
+# ----------------------------------------------------------------------
+REVIEWS=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" | jq -s 'add // []')
+INLINE=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100" | jq -s 'add // []')
+CONVO=$(gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100" | jq -s 'add // []')
+
+# ----------------------------------------------------------------------
+# 6. New-since-baseline classification (only when --since given)
+#    Classification rules are documented in SKILL.md Step 5b and must stay
+#    in sync with the regex branches below.
+#
+#    Branch ordering in classify is deliberate — do NOT reorder without reading this:
+#      1. Explicit-resolution overrides (addressed marker, "actionable comments posted: 0")
+#         are checked FIRST. They mean CR has marked the thread resolved regardless of
+#         any quoted earlier finding language still in the body.
+#      2. The specific "actionable comments posted: 0" check MUST precede the general
+#         "actionable comments posted" finding check — otherwise the general pattern
+#         swallows the zero case and a clean CR summary gets misclassified as a finding.
+#      3. Finding patterns (severity/badges/phrases/suggestions) come next.
+#      4. Weak-ack fallback (lgtm variants) last, so it can't hide a real finding.
+#      5. Default is finding — under-classifying is the failure mode this skill prevents.
+# ----------------------------------------------------------------------
+NEW_SINCE="null"
+if [[ -n "$SINCE" ]]; then
+  NEW_SINCE=$(jq -n \
+    --argjson reviews "$REVIEWS" \
+    --argjson inline "$INLINE" \
+    --argjson conversation "$CONVO" \
+    --arg since "$SINCE" \
+    '
+    def classify:
+      if . == null then {class: "acknowledgment", reason: "empty body"}
+      elif test("<!--\\s*<review_comment_addressed>\\s*-->"; "") then {class: "acknowledgment", reason: "addressed marker"}
+      elif test("actionable comments posted:\\s*0\\b"; "i") then {class: "acknowledgment", reason: "CR reports zero actionable"}
+      elif test("\\b(critical|major|minor|nitpick|p[0-2])\\b"; "i") then {class: "finding", reason: "severity keyword"}
+      elif test("🔴|🟠|🟡"; "") then {class: "finding", reason: "severity badge"}
+      elif test("actionable comments posted"; "i") then {class: "finding", reason: "actionable phrase"}
+      elif test("potential[_ ]issue|issues? found|findings?:"; "i") then {class: "finding", reason: "finding phrase"}
+      elif test("Prompt for AI Agent"; "i") then {class: "finding", reason: "CR fix prompt"}
+      elif test("```suggestion"; "m") then {class: "finding", reason: "suggestion block"}
+      elif test("\\b(lgtm|looks good|approved|confirmed|resolved)\\b"; "i") then {class: "acknowledgment", reason: "lgtm variant"}
+      else {class: "finding", reason: "default — no pattern matched"}
+      end;
+    def enrich($since; $tsfield):
+      [.[]
+       | select((.user.login == "coderabbitai[bot]" or .user.login == "greptile-apps[bot]")
+                and ((.[$tsfield] // "") > $since))
+       | {
+           id,
+           user: .user.login,
+           ts: .[$tsfield],
+           url: (.html_url // .url),
+           body,
+           classification: (.body | classify)
+         }];
+    {
+      reviews: ($reviews | enrich($since; "submitted_at")),
+      inline: ($inline | enrich($since; "created_at")),
+      conversation: ($conversation | enrich($since; "created_at"))
+    }
+    | . + {
+        finding_count: ([.reviews[], .inline[], .conversation[]] | map(select(.classification.class == "finding")) | length),
+        acknowledgment_count: ([.reviews[], .inline[], .conversation[]] | map(select(.classification.class == "acknowledgment")) | length)
+      }
+    ')
+fi
+
+# ----------------------------------------------------------------------
+# 7. Assemble final JSON
+# ----------------------------------------------------------------------
+jq -n \
+  --arg schema "1.0" \
+  --argjson pr_number "$PR_NUMBER" \
+  --arg branch "$BRANCH" \
+  --arg owner "$OWNER" \
+  --arg repo "$REPO" \
+  --arg head_sha "$HEAD_SHA" \
+  --arg pr_state "$PR_STATE" \
+  --arg pr_url "$PR_URL" \
+  --arg merge_state "$MERGE_STATE" \
+  --arg mergeable "$MERGEABLE" \
+  --arg review_decision "$REVIEW_DECISION" \
+  --arg run_started_at "$RUN_STARTED_AT" \
+  --arg since "$SINCE" \
+  --argjson threads_all "$ALL_THREADS" \
+  --argjson threads_unresolved "$UNRESOLVED" \
+  --argjson cr_split "$CR_SPLIT" \
+  --argjson statuses "$STATUSES" \
+  --argjson bot_statuses "$BOT_STATUSES" \
+  --argjson reviews "$REVIEWS" \
+  --argjson inline "$INLINE" \
+  --argjson conversation "$CONVO" \
+  --argjson new_since "$NEW_SINCE" \
+  '{
+    schema_version: $schema,
+    pr: {
+      number: $pr_number,
+      branch: $branch,
+      owner: $owner,
+      repo: $repo,
+      state: $pr_state,
+      url: $pr_url,
+      head_sha: $head_sha
+    },
+    run_started_at: $run_started_at,
+    since: (if $since == "" then null else $since end),
+    threads: {
+      total: ($threads_all | length),
+      resolved_count: ([$threads_all[] | select(.isResolved)] | length),
+      unresolved_count: ($threads_unresolved | length),
+      unresolved: $threads_unresolved,
+      all: $threads_all
+    },
+    check_runs: $cr_split,
+    commit_statuses: $statuses,
+    bot_statuses: $bot_statuses,
+    comments: {
+      reviews: $reviews,
+      inline: $inline,
+      conversation: $conversation
+    },
+    new_since_baseline: $new_since,
+    merge_state: {
+      mergeable: $mergeable,
+      mergeStateStatus: $merge_state,
+      reviewDecision: $review_decision
+    }
+  }' > "$OUT"
+
+echo "$OUT"

--- a/.claude/skills/fixpr/audit.sh
+++ b/.claude/skills/fixpr/audit.sh
@@ -115,7 +115,7 @@ while :; do
         }
       }
     }
-  }' -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUMBER" -F cursor="$CURSOR")
+  }' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER" -F cursor="$CURSOR")
   ALL_THREADS=$(jq -n --argjson acc "$ALL_THREADS" --argjson page "$RESP" \
     '$acc + $page.data.repository.pullRequest.reviewThreads.nodes')
   HAS_NEXT=$(echo "$RESP" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
@@ -192,7 +192,7 @@ if [[ -n "$SINCE" ]]; then
     --arg since "$SINCE" \
     '
     def classify:
-      if . == null then {class: "acknowledgment", reason: "empty body"}
+      if . == null or . == "" then {class: "acknowledgment", reason: "empty body"}
       elif test("<!--\\s*<review_comment_addressed>\\s*-->"; "") then {class: "acknowledgment", reason: "addressed marker"}
       elif test("actionable comments posted:\\s*0\\b"; "i") then {class: "acknowledgment", reason: "CR reports zero actionable"}
       elif test("\\b(critical|major|minor|nitpick|p[0-2])\\b"; "i") then {class: "finding", reason: "severity keyword"}


### PR DESCRIPTION
Closes #257

## Summary

Adds a new `/fixpr` skill that performs a single-pass audit and cleanup of the current branch's PR:

- Audits every review thread (via GraphQL `reviewThreads`) and every CI check-run
- Classifies unresolved findings as actionable / already-fixed / outdated
- Fixes all actionable findings + non-transient CI failures in one commit
- Replies to every thread and resolves via GraphQL `resolveReviewThread`
- Checks merge blockers (conflicts, branch behind main, human review requests)
- Reports final status: CLEAN / THREADS_STUCK / CI_PENDING / CI_FAILING / CONFLICTS / NEEDS_HUMAN_REVIEW

## Test plan

- [x] Skill file exists at `.claude/skills/fixpr/SKILL.md`
- [x] Skill uses GraphQL `reviewThreads` query (not just REST endpoints) for authoritative resolution status
- [x] Skill checks ALL CI check-runs (not just CodeRabbit)
- [x] Skill checks merge state (mergeable, mergeStateStatus, reviewDecision)
- [x] Skill resolves threads via GraphQL `resolveReviewThread` mutation with `minimizeComment` fallback
- [x] Skill reports a final status covering threads, CI, and merge blockers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Pull Request cleanup skill (/fixpr): audits unresolved review threads and CI failures, classifies issues, applies non-transient fixes in a single commit when needed, posts targeted replies and resolves threads (with bounded retries), re-audits after changes, evaluates mergeability, and reports a clear completion status.
  * Added a companion audit CLI tool that collects PR context and emits a structured JSON audit bundle for the skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->