### PR TITLE
fix(polling): wire /fixpr as poll-then-fix body; merge gate is sole exit

### DIFF
--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -220,11 +220,12 @@ Before exiting, follow this checklist literally:
 
 1. If you pushed any commit during this phase: wait for the reviewer to respond to the new SHA. Full timeouts per `cr-github-review.md`: 7 min for CR, 5 min for BugBot, 5 min for Greptile.
 2. If the response arrives with findings: invoke `/fixpr` to handle them **in this same phase** before exiting. Do not kick the can to a replacement unless you hit token exhaustion (see "Token Exhaustion Protocol" below).
-3. Only exit with `OUTCOME: clean` or `OUTCOME: merge_ready` when the merge gate is met per `cr-merge-gate.md` ("Polling exit criterion" and Step 1) — specifically one of:
+3. Exit with `OUTCOME: merge_ready` ONLY when the merge gate is met per `cr-merge-gate.md` ("Polling exit criterion" and Step 1) on the current HEAD — specifically one of:
    - 2 consecutive clean CR passes on the current HEAD (CR path)
    - 1 clean BugBot pass on the current HEAD (BugBot path)
    - Greptile severity gate passed (Greptile path)
-4. If findings landed that you can't fix in this phase (token budget, scope): exit with `OUTCOME: fixes_pushed` (if you pushed) or `OUTCOME: exhaustion` — NEVER `clean`.
+4. Exit with `OUTCOME: clean` ONLY when this round had no new findings AND no commit was pushed in this phase AND the merge gate is NOT yet fully satisfied (e.g., only 1 of 2 required CR passes). This signals the parent to launch a replacement Phase B to poll for the confirmation pass — do NOT advance to Phase C.
+5. If findings landed that you can't fix in this phase (token budget, scope): exit with `OUTCOME: fixes_pushed` (if you pushed) or `OUTCOME: exhaustion` — NEVER `clean` or `merge_ready`.
 
 ## Exit Report (MANDATORY — print as final output)
 
@@ -240,11 +241,11 @@ NEXT_PHASE: <C or B>
 HANDOFF_FILE: {{HANDOFF_FILE}}
 ```
 
-**Valid OUTCOME values for Phase B:**
-- `clean` — merge gate met per `cr-merge-gate.md` on current HEAD, no findings, no pushes pending reviewer response (set `NEXT_PHASE: C`)
-- `fixes_pushed` — fixed findings and pushed, reviewer response pending on new SHA (set `NEXT_PHASE: B` for replacement)
-- `merge_ready` — merge gate satisfied, all checks green, reviewer has weighed in on current SHA (set `NEXT_PHASE: C`)
-- `exhaustion` — token budget low, replacement needed (set `NEXT_PHASE: B`)
+**Valid OUTCOME values for Phase B (mutually exclusive):**
+- `merge_ready` — merge gate satisfied on current HEAD per `cr-merge-gate.md` (Step 1). This is the **single Phase C terminal** (set `NEXT_PHASE: C`).
+- `clean` — review loop clean on current HEAD (no findings this round, no pushes pending) but merge gate NOT yet satisfied (e.g., 1 of 2 required CR passes). Keep polling for the confirmation pass (set `NEXT_PHASE: B`).
+- `fixes_pushed` — fixed findings and pushed; reviewer response pending on new SHA (set `NEXT_PHASE: B` for replacement).
+- `exhaustion` — token budget low; replacement needed (set `NEXT_PHASE: B`).
 
 ## Token Exhaustion Protocol
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -212,6 +212,20 @@ On completion, read-modify-write `{{HANDOFF_FILE}}`:
 - **Deduplicate:** `string[]` fields by exact value; `findings_dismissed` by `.id`
 - Preserve unknown fields (forward compatibility)
 
+## Exit criteria — merge gate ONLY (MANDATORY)
+
+**You may NOT exit with `OUTCOME: clean` just because the current instant has no unresolved threads.** "0 unresolved threads right now" is a snapshot, not a merge-gate signal. After your last push in this phase, the HEAD SHA changed — every reviewer re-runs, and new findings commonly arrive 5–7 minutes later.
+
+Before exiting, follow this checklist literally:
+
+1. If you pushed any commit during this phase: wait for the reviewer to respond to the new SHA. Full timeouts per `cr-github-review.md`: 7 min for CR, 5 min for BugBot, 5 min for Greptile.
+2. If the response arrives with findings: invoke `/fixpr` to handle them **in this same phase** before exiting. Do not kick the can to a replacement unless you hit token exhaustion (see "Token Exhaustion Protocol" below).
+3. Only exit with `OUTCOME: clean` or `OUTCOME: merge_ready` when the merge gate is met per `cr-merge-gate.md` ("Polling exit criterion" and Step 1) — specifically one of:
+   - 2 consecutive clean CR passes on the current HEAD (CR path)
+   - 1 clean BugBot pass on the current HEAD (BugBot path)
+   - Greptile severity gate passed (Greptile path)
+4. If findings landed that you can't fix in this phase (token budget, scope): exit with `OUTCOME: fixes_pushed` (if you pushed) or `OUTCOME: exhaustion` — NEVER `clean`.
+
 ## Exit Report (MANDATORY — print as final output)
 
 ```text
@@ -227,9 +241,9 @@ HANDOFF_FILE: {{HANDOFF_FILE}}
 ```
 
 **Valid OUTCOME values for Phase B:**
-- `clean` — review passed with no findings (set `NEXT_PHASE: C`)
-- `fixes_pushed` — fixed findings and pushed, needs re-review (set `NEXT_PHASE: B` for replacement)
-- `merge_ready` — merge gate satisfied, all checks green (set `NEXT_PHASE: C`)
+- `clean` — merge gate met per `cr-merge-gate.md` on current HEAD, no findings, no pushes pending reviewer response (set `NEXT_PHASE: C`)
+- `fixes_pushed` — fixed findings and pushed, reviewer response pending on new SHA (set `NEXT_PHASE: B` for replacement)
+- `merge_ready` — merge gate satisfied, all checks green, reviewer has weighed in on current SHA (set `NEXT_PHASE: C`)
 - `exhaustion` — token budget low, replacement needed (set `NEXT_PHASE: B`)
 
 ## Token Exhaustion Protocol

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -33,12 +33,12 @@ On startup, check for the handoff file:
 
 ## Before Requesting Any New Review (MANDATORY)
 
-Before triggering `@coderabbitai full review` or entering the polling loop:
+Run the session-start / pre-review comment audit per `cr-github-review.md` ("Session-start / pre-review comment audit"):
 
-1. **Scan all existing review comments** on the PR (all three endpoints, `per_page=100`)
-2. **Identify unresolved findings** from `coderabbitai[bot]`, `cursor[bot]`, or `greptile-apps[bot]` that have no reply confirming a fix and point to unchanged code
-3. **If unresolved findings exist: fix them first.** Read, fix, commit, push, reply to each thread. The assigned reviewer auto-reviews the new push (CR and BugBot auto-trigger; Greptile requires explicit `@greptileai`). Do NOT request a fresh review on top of unaddressed feedback.
-4. **If all addressed:** Proceed with polling or review request.
+1. Fetch all 3 comment endpoints with `per_page=100`.
+2. Identify any unresolved findings from `coderabbitai[bot]`, `cursor[bot]`, or `greptile-apps[bot]`.
+3. **If ANY unresolved findings exist: invoke `/fixpr`.** `/fixpr` fixes, commits once, pushes, replies to every thread, resolves via GraphQL. Do NOT fix manually and do NOT request a new review on top of unaddressed feedback.
+4. **STOP condition:** do not proceed to the polling loop (or request a new review) until step 3 completes.
 
 ## CodeRabbit Review Path (when `reviewer` = `cr`)
 

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -33,7 +33,7 @@ Each poll cycle, for every open PR owned by this session, query everything liste
 
 If **ANY** of the conditions below hold, invoke `/fixpr` and do NOT request a new review until `/fixpr` completes:
 
-1. New findings from any bot (CR / BugBot / Greptile) since the last poll watermark
+1. New findings from any bot (CR / BugBot / Greptile) since the last poll watermark — i.e., bot comments that arrived after the watermark, not pre-existing unresolved threads still awaiting reviewer ack
 2. Any check-run with a blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`)
 3. `mergeStateStatus == "BEHIND"` (branch behind base, auto-rebase; `/fixpr` handles it)
 4. `mergeable == "CONFLICTING"` (merge conflicts; `/fixpr` handles rebase + surfaces blockers)

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -1,15 +1,49 @@
 ## GitHub CodeRabbit Review Loop (Fallback)
 - note code rabbit is called cr or CR for short
 
-> **Always:** Poll all 3 endpoints + check-runs every cycle. Use `per_page=100`. Filter by `coderabbitai[bot]`. Batch fixes into one commit. Reply to every thread. Resolve threads via GraphQL. **Enter the polling loop immediately after push — do NOT ask.**
+> **NEVER declare a PR done immediately after pushing a fix commit.** Every push triggers a new CR/BugBot/Greptile review — you MUST continue polling until you see the reviewer's response to the new SHA. "0 unresolved threads right now" ≠ merge gate met. The merge gate lives in `cr-merge-gate.md` and is the ONLY valid polling exit condition.
+
+> **Always:** Poll all 3 endpoints + check-runs every cycle. Use `per_page=100`. Filter by `coderabbitai[bot]`. Batch fixes into one commit. Reply to every thread. Resolve threads via GraphQL. **Enter the polling loop immediately after push — do NOT ask.** Invoke `/fixpr` when any trigger condition fires (see "Per-cycle check" below).
 > **Ask first:** Merging — always ask the user. **Nothing else in this workflow requires permission.**
-> **Never:** Poll only 1-2 endpoints. Use bare `coderabbitai` without `[bot]`. Push per-finding. Trigger `@coderabbitai full review` more than twice per PR per hour. Trigger Greptile proactively (only on CR failure). Merge without meeting the merge gate (see `cr-merge-gate.md` for the authoritative definition). **Ask "want me to poll?" or "should I process this feedback?" — just do it.**
+> **Never:** Poll only 1-2 endpoints. Use bare `coderabbitai` without `[bot]`. Push per-finding. Trigger `@coderabbitai full review` more than twice per PR per hour. Trigger Greptile proactively (only on CR failure). Merge without meeting the merge gate (see `cr-merge-gate.md` for the authoritative definition). **Exit polling on "nothing unresolved right now" — the only valid exit is the merge gate.** **Ask "want me to poll?" or "should I process this feedback?" — just do it.**
 
 > **This is the fallback review workflow.** It runs after you push and create a PR. If the local review loop was thorough, CR should find few or no issues here. But edge cases exist (e.g., CI-only context, cross-file interactions the local review missed), so always let this loop run.
 
 **Prerequisite:** Before entering this loop, check if the repo uses CodeRabbit (look for `.coderabbit.yaml` at the repo root, or check if CodeRabbit has ever commented on PRs via `gh api repos/{owner}/{repo}/pulls --jq '.[].number' | head -5 | xargs -I{} gh api repos/{owner}/{repo}/pulls/{}/reviews --jq '.[].user.login' | grep -q 'coderabbitai\[bot\]'`). If CodeRabbit is not configured for the repo, skip this workflow.
 
 After pushing a commit to a PR, **automatically** enter the CR review loop. Do not ask "want me to poll for reviews?" — polling is mandatory and immediate.
+
+### Session-start / pre-review comment audit (MANDATORY)
+
+Run this checklist BEFORE the first poll tick AND before triggering any new review (`@coderabbitai full review`, `@cursor review`, `@greptileai`). Applies on fresh push, session resume, and post-compaction re-entry. The "Before Requesting Any New Review" block is this section — there is no other.
+
+> **Why:** A subagent that requests a fresh review on top of an unresolved thread wastes a review cycle and makes the bot look broken — CR reasonably asks "why the new review when the last one had unresolved comments?" This is the #2 subagent failure mode.
+
+1. Fetch **all 3 comment endpoints** on the PR with `per_page=100`:
+   - `repos/{owner}/{repo}/pulls/{N}/reviews`
+   - `repos/{owner}/{repo}/pulls/{N}/comments`
+   - `repos/{owner}/{repo}/issues/{N}/comments`
+2. Identify any unresolved findings from `coderabbitai[bot]`, `cursor[bot]`, or `greptile-apps[bot]` (no reply confirming a fix, code unchanged since the comment, not marked outdated/resolved).
+3. **If ANY unresolved findings exist: invoke `/fixpr` now.** `/fixpr` fixes, commits once, pushes, replies to every thread, resolves via GraphQL. Do NOT request a new review on top of unaddressed feedback.
+4. **STOP condition:** do not proceed to the polling loop (or request a new review) until step 3 completes — either no unresolved findings, or `/fixpr` finished a pass.
+
+### Per-cycle check (every 60 seconds)
+
+Each poll cycle, for every open PR owned by this session, query:
+
+1. All 3 comment endpoints (`pulls/{N}/reviews`, `pulls/{N}/comments`, `issues/{N}/comments`), each with `per_page=100`
+2. All check-runs on the current HEAD SHA (resolve SHA dynamically — `gh pr view N --json commits --jq '.commits[-1].oid'` — do NOT cache it across cycles)
+3. `mergeable` and `mergeStateStatus` via `gh pr view N --json mergeable,mergeStateStatus`
+
+If **ANY** of the following conditions hold, invoke `/fixpr` and do NOT request a new review until `/fixpr` completes:
+
+- New findings from any bot (CR / BugBot / Greptile) since the last poll watermark
+- Any check-run with a blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`)
+- `mergeStateStatus == "BEHIND"` (branch behind base, auto-rebase; `/fixpr` handles it)
+- `mergeable == "CONFLICTING"` (merge conflicts; `/fixpr` handles rebase + surfaces blockers)
+- An unresolved review thread exists **after** the last fix-commit push (reviewer hasn't yet caught up — keep polling, invoke `/fixpr` on new findings)
+
+**Exit polling ONLY when the merge gate (`cr-merge-gate.md`) is met.** "0 unresolved threads right now" is NOT an exit condition — see the trap note at the top of this file. After any `/fixpr` push, reset the watermark and keep polling for the reviewer's response to the new SHA.
 
 ### Rate Limits & Behavior (Pro Tier)
 - **8 PR reviews/hour** (each push or `@coderabbitai full review` consumes one), **50 chat interactions/hour**.
@@ -37,10 +71,10 @@ After pushing a commit to a PR, **automatically** enter the CR review loop. Do n
 **Check ALL check-runs every poll cycle — not just CodeRabbit.** CI failures (test, lint, build, audit, gitleaks) are independent of CR review status. Query `repos/{owner}/{repo}/commits/{SHA}/check-runs?per_page=100` and inspect `{name, status, conclusion}`. Full command: `.claude/reference/cr-polling-commands.md`.
 
 **Rules:**
-- **Blocking conclusions:** `failure`, `timed_out`, `action_required`, `startup_failure`, `stale`. If ANY check-run has one of these, **investigate immediately.** (`cancelled`, `neutral`, `skipped` are non-blocking.) Read the output via `gh api repos/{owner}/{repo}/check-runs/{CHECK_RUN_ID} --jq .output.summary`.
-  - Test/lint/build failure: fix, commit, push before continuing the review loop.
-  - Transient/infra failure (e.g., `timed_out`, `startup_failure`): note it, retry with a no-op commit if needed.
-- CI failures block merge independently of CR — a PR with passing CR but failing tests is not merge-ready. Report pass/fail summary to the user: "CI: 5/6 passed, `test` failed — investigating."
+- **Blocking conclusions:** `failure`, `timed_out`, `action_required`, `startup_failure`, `stale`. If ANY check-run has one of these, **invoke `/fixpr` immediately — no permission required.** (`cancelled`, `neutral`, `skipped` are non-blocking.) `/fixpr` reads the output via `gh api repos/{owner}/{repo}/check-runs/{CHECK_RUN_ID} --jq .output.summary` and fixes deterministic failures.
+  - Test/lint/build failure: `/fixpr` fixes, commits, pushes. Do NOT resume polling until CI is green on the new SHA.
+  - Transient/infra failure (e.g., `timed_out`, `startup_failure`): `/fixpr` flags it; cannot auto-fix, user decides retry.
+- CI failures block merge independently of CR — a PR with passing CR but failing tests is not merge-ready. Report pass/fail summary: "CI: 5/6 passed, `test` failed — invoking `/fixpr`."
 
 ### Timeout & Fallback — Three-Tier Review Chain
 
@@ -53,23 +87,6 @@ When CR fails (rate-limited or 7-min timeout), check BugBot before Greptile. Bug
 - **Sticky assignment:** CR fail → BugBot owns the PR. If BugBot also fails → Greptile owns permanently. Do not switch back up the chain.
 - **If all three fail** (CR rate-limited + BugBot 5-min timeout + Greptile 5-min timeout): fall back to **self-review**. Self-review does NOT satisfy the merge gate.
 - Tell the user which fallback was used and why.
-
-### Before Requesting Any New Review (MANDATORY — applies to ALL agents)
-
-> **THE #2 SUBAGENT FAILURE MODE:** A new subagent picks up a PR, sees it needs a review, and immediately posts `@coderabbitai full review` — while the PR still has unresolved findings from the previous round sitting right above the request. CR sees this and reasonably asks "why are you requesting a new review when the last one had unresolved comments?" This wastes a review cycle and makes the bot look broken.
-
-**Before triggering `@coderabbitai full review` or entering the polling loop, ALWAYS do this first:**
-
-1. **Scan all existing review comments on the PR** by fetching all three endpoints:
-   - `repos/{owner}/{repo}/pulls/{N}/comments?per_page=100` (inline comments)
-   - `repos/{owner}/{repo}/pulls/{N}/reviews?per_page=100` (review-level comments)
-   - `repos/{owner}/{repo}/issues/{N}/comments?per_page=100` (PR conversation)
-2. **Identify unresolved findings** — any comment from `coderabbitai[bot]`, `cursor[bot]`, or `greptile-apps[bot]` that:
-   - Has no reply confirming a fix
-   - Points to code that hasn't been changed since the comment was posted
-   - Is not marked as resolved/outdated
-3. **If unresolved findings exist: fix them first.** Read the findings, fix the code, commit, push, reply to each thread — then let CR auto-review the new push. Do NOT request a fresh review on top of unaddressed feedback.
-4. **If all findings are already addressed:** Verify by reading the current code, then proceed with requesting a review.
 
 ### Processing CR Feedback
 1. Fetch latest CR comments via `gh api`, verify each finding against the actual file

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -29,13 +29,9 @@ Run this checklist BEFORE the first poll tick AND before triggering any new revi
 
 ### Per-cycle check (every 60 seconds)
 
-Each poll cycle, for every open PR owned by this session, query:
+Each poll cycle, for every open PR owned by this session, query everything listed in the "Polling" section below.
 
-1. All 3 comment endpoints (`pulls/{N}/reviews`, `pulls/{N}/comments`, `issues/{N}/comments`), each with `per_page=100`
-2. All check-runs on the current HEAD SHA (resolve SHA dynamically — `gh pr view N --json commits --jq '.commits[-1].oid'` — do NOT cache it across cycles)
-3. `mergeable` and `mergeStateStatus` via `gh pr view N --json mergeable,mergeStateStatus`
-
-If **ANY** of conditions 1–4 below hold, invoke `/fixpr` and do NOT request a new review until `/fixpr` completes:
+If **ANY** of the conditions below hold, invoke `/fixpr` and do NOT request a new review until `/fixpr` completes:
 
 1. New findings from any bot (CR / BugBot / Greptile) since the last poll watermark
 2. Any check-run with a blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`)
@@ -59,6 +55,7 @@ If **ANY** of conditions 1–4 below hold, invoke `/fixpr` and do NOT request a 
   1. `repos/{owner}/{repo}/pulls/{N}/reviews` — review objects
   2. `repos/{owner}/{repo}/pulls/{N}/comments` — inline diff comments
   3. `repos/{owner}/{repo}/issues/{N}/comments` — PR conversation (summary, ack, general findings). Missing this endpoint causes indefinite polling on clean passes.
+- **Check merge metadata every cycle.** Query `mergeable` and `mergeStateStatus` via `gh pr view N --json mergeable,mergeStateStatus` — these drive `/fixpr` trigger conditions 3 and 4.
 - **Check commit status every cycle.** Query `repos/{owner}/{repo}/commits/{SHA}/check-runs` filtered to `name == "CodeRabbit"`; fallback: `/statuses` filtered to `context ~ "CodeRabbit"`. Full commands: `.claude/reference/cr-polling-commands.md`.
   - **Completion signal:** `status: "completed"` + `conclusion: "success"` = review done. Definitive signal.
   - **Fast-path rate limit:** check-run `conclusion: "failure"` with "rate limit" in `output.title`, OR status `state: "failure"`/`"error"` with "rate limit" in `description` — **check BugBot first** (see `bugbot.md`). If BugBot already posted a review, use it. If not, wait up to 5 min **from push time** for BugBot. If BugBot also times out, trigger Greptile. Sticky assignment applies at each tier.

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -35,13 +35,14 @@ Each poll cycle, for every open PR owned by this session, query:
 2. All check-runs on the current HEAD SHA (resolve SHA dynamically — `gh pr view N --json commits --jq '.commits[-1].oid'` — do NOT cache it across cycles)
 3. `mergeable` and `mergeStateStatus` via `gh pr view N --json mergeable,mergeStateStatus`
 
-If **ANY** of the following conditions hold, invoke `/fixpr` and do NOT request a new review until `/fixpr` completes:
+If **ANY** of conditions 1–4 below hold, invoke `/fixpr` and do NOT request a new review until `/fixpr` completes:
 
-- New findings from any bot (CR / BugBot / Greptile) since the last poll watermark
-- Any check-run with a blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`)
-- `mergeStateStatus == "BEHIND"` (branch behind base, auto-rebase; `/fixpr` handles it)
-- `mergeable == "CONFLICTING"` (merge conflicts; `/fixpr` handles rebase + surfaces blockers)
-- An unresolved review thread exists **after** the last fix-commit push (reviewer hasn't yet caught up — keep polling, invoke `/fixpr` on new findings)
+1. New findings from any bot (CR / BugBot / Greptile) since the last poll watermark
+2. Any check-run with a blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`)
+3. `mergeStateStatus == "BEHIND"` (branch behind base, auto-rebase; `/fixpr` handles it)
+4. `mergeable == "CONFLICTING"` (merge conflicts; `/fixpr` handles rebase + surfaces blockers)
+
+> **Unresolved threads are NOT a trigger.** If unresolved threads remain after the last fix-commit push, keep polling for reviewer catch-up. See conditions 1–4 above.
 
 **Exit polling ONLY when the merge gate (`cr-merge-gate.md`) is met.** "0 unresolved threads right now" is NOT an exit condition — see the trap note at the top of this file. After any `/fixpr` push, reset the watermark and keep polling for the reviewer's response to the new SHA.
 
@@ -80,9 +81,7 @@ If **ANY** of the following conditions hold, invoke `/fixpr` and do NOT request 
 
 **Review chain:** CR (primary) → BugBot (second tier, free) → Greptile (last resort, paid) → self-review (emergency).
 
-BugBot auto-runs on every push — poll for its reviews alongside CR. When CR fails, check BugBot before triggering Greptile.
-
-When CR fails (rate-limited or 7-min timeout), check BugBot before Greptile. BugBot's 5-min timeout runs from push time, concurrent with CR's window. See `bugbot.md` for full BugBot behavior and `greptile.md` for Greptile trigger conditions.
+BugBot auto-runs on every push — poll for its reviews alongside CR. When CR fails (rate-limited or 7-min timeout), check BugBot before triggering Greptile; BugBot's 5-min timeout runs from push time, concurrent with CR's window. See `bugbot.md` and `greptile.md` for timing and trigger details.
 
 - **Sticky assignment:** CR fail → BugBot owns the PR. If BugBot also fails → Greptile owns permanently. Do not switch back up the chain.
 - **If all three fail** (CR rate-limited + BugBot 5-min timeout + Greptile 5-min timeout): fall back to **self-review**. Self-review does NOT satisfy the merge gate.

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -2,11 +2,11 @@
 - note code rabbit is called cr or CR for short
 
 > **NEVER declare a PR done immediately after pushing a fix commit.** Every push triggers a new CR/BugBot/Greptile review — you MUST continue polling until you see the reviewer's response to the new SHA. "0 unresolved threads right now" ≠ merge gate met. The merge gate lives in `cr-merge-gate.md` and is the ONLY valid polling exit condition.
-
+>
 > **Always:** Poll all 3 endpoints + check-runs every cycle. Use `per_page=100`. Filter by `coderabbitai[bot]`. Batch fixes into one commit. Reply to every thread. Resolve threads via GraphQL. **Enter the polling loop immediately after push — do NOT ask.** Invoke `/fixpr` when any trigger condition fires (see "Per-cycle check" below).
 > **Ask first:** Merging — always ask the user. **Nothing else in this workflow requires permission.**
 > **Never:** Poll only 1-2 endpoints. Use bare `coderabbitai` without `[bot]`. Push per-finding. Trigger `@coderabbitai full review` more than twice per PR per hour. Trigger Greptile proactively (only on CR failure). Merge without meeting the merge gate (see `cr-merge-gate.md` for the authoritative definition). **Exit polling on "nothing unresolved right now" — the only valid exit is the merge gate.** **Ask "want me to poll?" or "should I process this feedback?" — just do it.**
-
+>
 > **This is the fallback review workflow.** It runs after you push and create a PR. If the local review loop was thorough, CR should find few or no issues here. But edge cases exist (e.g., CI-only context, cross-file interactions the local review missed), so always let this loop run.
 
 **Prerequisite:** Before entering this loop, check if the repo uses CodeRabbit (look for `.coderabbit.yaml` at the repo root, or check if CodeRabbit has ever commented on PRs via `gh api repos/{owner}/{repo}/pulls --jq '.[].number' | head -5 | xargs -I{} gh api repos/{owner}/{repo}/pulls/{}/reviews --jq '.[].user.login' | grep -q 'coderabbitai\[bot\]'`). If CodeRabbit is not configured for the repo, skip this workflow.

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -3,7 +3,17 @@
 > **This is the single authoritative definition of the merge gate.** All other rule files reference this file instead of duplicating it.
 > **Always:** Verify merge gate before any merge. Verify CI. Verify AC checkboxes against code. Ask user before merging.
 > **Ask first:** Merging — always ask the user.
-> **Never:** Merge without meeting the gate. Merge with failing CI. Merge with unchecked AC boxes.
+> **Never:** Merge without meeting the gate. Merge with failing CI. Merge with unchecked AC boxes. Stop polling because "nothing is unresolved right now" — see "Polling exit criterion" below.
+
+## Polling exit criterion
+
+The ONLY valid reason to stop polling an open PR is: this file's merge gate has been met — specifically, one of:
+
+1. **2 consecutive clean CR passes** on the current HEAD SHA (CR-only path, Step 1 below).
+2. **1 clean BugBot pass** on the current HEAD SHA (BugBot path, Step 1 below).
+3. **Greptile severity gate passed** (sticky-Greptile path — clean review, or only P1/P2 fixed, or P0 fixed + re-review clean — Step 1 below).
+
+"0 unresolved threads right now" is a transient snapshot, NOT an exit condition. After pushing a fix commit (whether by the loop directly or by `/fixpr`), the HEAD SHA changes and every reviewer re-runs — continue polling for the reviewer's response to the new SHA until one of the three conditions above holds.
 
 ## Step 1 — Confirm reviews are clean (merge gate)
 

--- a/.claude/rules/phase-protocols.md
+++ b/.claude/rules/phase-protocols.md
@@ -42,7 +42,8 @@ Block header is `EXIT_REPORT`; fields (one per line, colon-separated, no extra w
 
 1. **Parse the exit report.** No exit report = silent failure.
 2. **Branch on OUTCOME:**
-   - `clean` or `merge_ready` → proceed to step 3 (launch Phase C)
+   - `merge_ready` → proceed to step 3 (launch Phase C). This is the single Phase-C-advancing terminal.
+   - `clean` → launch replacement Phase B within 60s to poll for the confirmation pass (review loop is clean but merge gate not yet fully satisfied — e.g., 1 of 2 required CR passes). Update `session-state.json` (keep phase as B). Report to user with timestamp. **STOP — do not execute steps 3-6.**
    - `fixes_pushed` → launch replacement Phase B within 60s. Update `session-state.json` (record new HEAD SHA, keep phase as B). Report to user with timestamp. **STOP — do not execute steps 3-6.**
    - `exhaustion` → launch replacement Phase B within 60s. Update `session-state.json` (record remaining work, keep phase as B). Report to user with timestamp. **STOP — do not execute steps 3-6.**
 3. **Verify review state via GitHub API.** Confirm the merge gate is met per the authoritative definition in `cr-merge-gate.md` (Step 1). If verification fails, launch replacement Phase B instead of Phase C — STOP.
@@ -50,7 +51,7 @@ Block header is `EXIT_REPORT`; fields (one per line, colon-separated, no extra w
 5. **Update `session-state.json`.** Record phase transition and HEAD SHA.
 6. **Report to user (with timestamp).**
 
-**Phase C launch is the highest-priority action after Phase B reports clean.**
+**Phase C launch is the highest-priority action after Phase B reports `merge_ready`.**
 
 ## Phase C Completion Protocol (MANDATORY)
 

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -77,7 +77,7 @@ If agent definitions are unavailable (e.g., repo without `.claude/agents/`):
 | BugBot timeout (5 min, CR already failed) | Trigger Greptile | **Always do** |
 | All three reviewers down | Self-review for risk reduction | **Always do** |
 | Phase A subagent completes | Parent launches Phase B within 60s | **Always do** |
-| Phase B reports clean | Parent launches Phase C | **Always do** |
+| Phase B reports merge_ready | Parent launches Phase C | **Always do** |
 | Merge gate met | Verify AC checkboxes against code | **Always do** |
 | AC verified, all boxes checked | Ask user about merging | **Ask first** |
 | Subagent failed (crash / no handoff state) | Report failure, ask about respawn | **Ask first** |
@@ -108,7 +108,7 @@ The 32K limit is the binding constraint. Give each subagent ONE clear phase with
 **Orchestration rules:**
 - Parent launches Phase A subagents (can run in parallel across PRs)
 - Phase A complete → parent launches Phase B immediately (see `phase-protocols.md`)
-- Phase B clean → parent launches Phase C
+- Phase B merge_ready → parent launches Phase C
 - Soft limit: 3-4 active CR-polled PRs to reduce throttling
 - Track CR quota: 7+ reviews/hour means expect Greptile as primary reviewer
 

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -297,7 +297,7 @@ jq -r '.merge_state | "[MERGE] mergeable=\(.mergeable), status=\(.mergeStateStat
 |-------|---------------|--------|
 | `mergeable` | `CONFLICTING` | Rebase onto main: `git fetch origin main && git rebase origin/main`. Fix conflicts, continue, force-push. |
 | `mergeable` | `UNKNOWN` | GitHub still computing — note and re-run `/fixpr` later. |
-| `mergeStateStatus` | `BEHIND` | Rebase onto main: `git fetch origin main && git rebase origin/main`. No conflict-resolution step needed (`BEHIND` means no conflicts — just stale). Force-push. Wait for CI to re-run before verifying merge gate. |
+| `mergeStateStatus` | `BEHIND` | Rebase onto main: `git fetch origin main && git rebase origin/main`. If conflicts arise mid-rebase (replaying commits individually can conflict even when a three-way merge wouldn't), resolve them the same way as `CONFLICTING` above, then `git rebase --continue`. Force-push. Wait for CI to re-run before verifying merge gate. |
 | `mergeStateStatus` | `BLOCKED` | Required checks/reviews missing — already covered by 5c/5d, but report any residual. |
 | `mergeStateStatus` | `UNSTABLE` | A non-required check pending/failing — typically CR/Greptile on the new SHA. If 5d emitted `REVIEW_PENDING`, stop with that status. |
 | `reviewDecision` | `CHANGES_REQUESTED` | A human reviewer requested changes — report; cannot auto-resolve. |

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -297,7 +297,7 @@ jq -r '.merge_state | "[MERGE] mergeable=\(.mergeable), status=\(.mergeStateStat
 |-------|---------------|--------|
 | `mergeable` | `CONFLICTING` | Rebase onto main: `git fetch origin main && git rebase origin/main`. Fix conflicts, continue, force-push. |
 | `mergeable` | `UNKNOWN` | GitHub still computing — note and re-run `/fixpr` later. |
-| `mergeStateStatus` | `BEHIND` | Rebase + force-push. |
+| `mergeStateStatus` | `BEHIND` | Rebase onto main: `git fetch origin main && git rebase origin/main`. No conflict-resolution step needed (`BEHIND` means no conflicts — just stale). Force-push. Wait for CI to re-run before verifying merge gate. |
 | `mergeStateStatus` | `BLOCKED` | Required checks/reviews missing — already covered by 5c/5d, but report any residual. |
 | `mergeStateStatus` | `UNSTABLE` | A non-required check pending/failing — typically CR/Greptile on the new SHA. If 5d emitted `REVIEW_PENDING`, stop with that status. |
 | `reviewDecision` | `CHANGES_REQUESTED` | A human reviewer requested changes — report; cannot auto-resolve. |
@@ -320,7 +320,7 @@ CI checks:       P total, Q were failing
   - Transient:   S (cannot fix locally)
 Merge state:     mergeable=..., status=..., review=...
 Push:            <sha> or "no push needed"
-Status:          CLEAN | THREADS_STUCK | REVIEW_PENDING | CI_PENDING | CI_FAILING | CONFLICTS | NEEDS_HUMAN_REVIEW | NEW_FINDINGS
+Status:          CLEAN | THREADS_STUCK | REVIEW_PENDING | CI_PENDING | CI_FAILING | CONFLICTS | BEHIND | NEEDS_HUMAN_REVIEW | NEW_FINDINGS
 ```
 
 **Status definitions:**
@@ -332,4 +332,5 @@ Status:          CLEAN | THREADS_STUCK | REVIEW_PENDING | CI_PENDING | CI_FAILIN
 - `CI_PENDING` — push was made, CI not yet complete. Re-run `/fixpr` after CI.
 - `CI_FAILING` — transient CI failures that cannot be fixed locally (report which).
 - `CONFLICTS` — merge conflicts could not be auto-resolved (needs manual intervention).
+- `BEHIND` — branch behind base, auto-rebased and force-pushed; now waiting for CI re-run. Re-run `/fixpr` after CI completes.
 - `NEEDS_HUMAN_REVIEW` — a human reviewer requested changes (cannot auto-resolve).

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -357,10 +357,11 @@ When a Phase B subagent returns:
 
 1. **Parse exit report.**
 2. **Branch on OUTCOME:**
-   - `clean` or `merge_ready` -> launch Phase C within 60s.
+   - `merge_ready` -> launch Phase C within 60s.
+   - `clean` -> launch replacement Phase B within 60s (confirmation pass — merge gate not yet verified on current HEAD).
    - `fixes_pushed` -> launch replacement Phase B within 60s.
    - `exhaustion` -> launch replacement Phase B within 60s.
-3. **Verify review state via GitHub API** for `clean`/`merge_ready`.
+3. **Verify review state via GitHub API** for `merge_ready`.
 4. **Update `session-state.json`.**
 5. **Report to user** with timestamp.
 


### PR DESCRIPTION
## Summary

Fixes two related failure modes in the GitHub review polling loop:

- **#255** — poll detects issues (unscanned comments on session start, CI failures, `BEHIND` base) but doesn't auto-fix them
- **#260** — agent stops polling after pushing a fix commit, conflating "0 unresolved threads right now" with "merge gate met"

**Solution:** replace poll-then-nudge with **poll-then-`/fixpr`**. Polling's only valid exit is "merge gate met" (per `cr-merge-gate.md`) — never "nothing unresolved right now."

Closes #255
Closes #260

## Changes

- **`.claude/rules/cr-github-review.md`**
  - Top-of-file trap: "NEVER declare a PR done immediately after pushing a fix commit."
  - New `Session-start / pre-review comment audit (MANDATORY)` — numbered checklist with explicit STOP before the polling loop; consolidates the former "Before Requesting Any New Review" section to eliminate duplication
  - New `Per-cycle check (every 60 seconds)` — 3 queries + 5 `/fixpr` trigger conditions (new findings, blocking CI, `BEHIND`, `CONFLICTING`, unresolved-after-push)
  - CI Health Check now invokes `/fixpr` immediately on blocking conclusions — no permission required

- **`.claude/rules/cr-merge-gate.md`**
  - New `Polling exit criterion` section above Step 1 — the merge gate is the **only** valid stop
  - Added to Never list: "Stop polling because 'nothing is unresolved right now'"

- **`.claude/skills/fixpr/SKILL.md`**
  - Enriched `BEHIND` handler: rebase onto main, force-push, wait for CI to re-run
  - Added `BEHIND` to status dashboard + definitions (alongside `CONFLICTING`, `BLOCKED`, `UNSTABLE`)

- **`.claude/agents/phase-b-reviewer.md`**
  - New `Exit criteria — merge gate ONLY (MANDATORY)` section — subagent cannot exit `clean`/`merge_ready` on a transient snapshot; must verify the merge gate on the current HEAD
  - OUTCOME descriptions rewritten to require merge-gate verification

## Test plan

- [x] #255 AC1 — session-start comment audit runs before polling, with a STOP condition if unresolved findings exist
- [x] #255 AC2 — `mergeStateStatus: BEHIND` is detected per-cycle and triggers `/fixpr` for auto-rebase
- [x] #255 AC3 — CI failures (blocking conclusions) trigger `/fixpr` autonomously; no permission required
- [x] #255 AC4 — numbered checklists with explicit STOP conditions replace prose prescriptions
- [x] #260 AC1 — top-of-file trap in `cr-github-review.md` bars declaring done after push
- [x] #260 AC2 — `cr-merge-gate.md` has a `Polling exit criterion` section making the merge gate the sole valid stop
- [x] #260 AC3 — `phase-b-reviewer.md` exit criteria require merge-gate verification on current HEAD
- [x] Word budget: CLAUDE.md + `.claude/rules/*.md` under 14,000 words

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Phase B tightened: only "merge_ready" advances to Phase C; "clean" now spawns a replacement Phase B for confirmation.
  * Mandatory session-start pre-review audit and per-cycle (60s) checks that block new review requests and auto-invoke the automated fix workflow for unresolved findings, CI blockers, or merge-state issues.
  * Prohibits declaring a PR done immediately after pushing fixes; polling continues until explicit merge-gate conditions are met.
  * Clarified merge-gate exit criteria and added explicit rebase/force-push + CI wait guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->