### PR TITLE
feat(env-guard): allow .env.<template-suffix> writes via allow-list

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -66,7 +66,9 @@ Agent tool call:
            Handoff file: ~/.claude/handoffs/pr-618-handoff.json
 
            SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere,
-           any repo. Do NOT run git clean in ANY directory. Do NOT run destructive
+           any repo. Exception: template files matching .env.<example|sample|template
+           |dist|tpl> (case-insensitive) are committed, non-secret, and safe to edit.
+           Do NOT run git clean in ANY directory. Do NOT run destructive
            commands (rm -rf, rm, git checkout ., git stash, git reset --hard) in the
            root repo directory. Stay in your worktree directory at all times.
 

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -17,7 +17,7 @@ The parent agent provides these values in your prompt:
 
 ## Safety Rules (NON-NEGOTIABLE)
 
-- NEVER delete, overwrite, move, or modify `.env` files — anywhere, any repo.
+- NEVER delete, overwrite, move, or modify `.env` files — anywhere, any repo. **Exception:** template files with basename `.env.<example|sample|template|dist|tpl>` (case-insensitive) are committed, non-secret, and safe to edit.
 - NEVER run `git clean` in ANY directory.
 - NEVER run destructive commands (`rm -rf`, `rm`, `git checkout .`, `git stash`, `git reset --hard`) in the root repo directory.
 - Stay in your worktree directory at all times.

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -18,7 +18,7 @@ The parent agent provides:
 
 ## Safety Rules (NON-NEGOTIABLE)
 
-- NEVER delete, overwrite, move, or modify `.env` files — anywhere, any repo.
+- NEVER delete, overwrite, move, or modify `.env` files — anywhere, any repo. **Exception:** template files with basename `.env.<example|sample|template|dist|tpl>` (case-insensitive) are committed, non-secret, and safe to edit.
 - NEVER run `git clean` in ANY directory.
 - NEVER run destructive commands (`rm -rf`, `rm`, `git checkout .`, `git stash`, `git reset --hard`) in the root repo directory.
 - Stay in your worktree directory at all times.

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -19,7 +19,7 @@ The parent agent provides:
 
 ## Safety Rules (NON-NEGOTIABLE)
 
-- NEVER delete, overwrite, move, or modify `.env` files.
+- NEVER delete, overwrite, move, or modify `.env` files. **Exception:** template files with basename `.env.<example|sample|template|dist|tpl>` (case-insensitive) are committed, non-secret, and safe to edit.
 - NEVER run `git clean` in ANY directory.
 - NEVER run destructive commands in the root repo directory.
 - Stay in your worktree directory at all times.

--- a/.claude/agents/pm-worker.md
+++ b/.claude/agents/pm-worker.md
@@ -16,7 +16,7 @@ The parent agent provides task-specific context in your prompt:
 
 ## Safety Rules (NON-NEGOTIABLE)
 
-- NEVER delete, overwrite, move, or modify `.env` files — anywhere, any repo.
+- NEVER delete, overwrite, move, or modify `.env` files — anywhere, any repo. **Exception:** template files with basename `.env.<example|sample|template|dist|tpl>` (case-insensitive) are committed, non-secret, and safe to edit.
 - NEVER run `git clean` in ANY directory.
 - NEVER run destructive commands (`rm -rf`, `rm`, `git checkout .`, `git stash`, `git reset --hard`) in the root repo directory.
 - Stay in your worktree directory at all times.

--- a/.claude/hooks/env-guard.py
+++ b/.claude/hooks/env-guard.py
@@ -6,6 +6,11 @@
 # Matches basenames: .env, .env.local, .env.production, .env.test, .env.ci, etc.
 # Does NOT match: environment.ts, env-config.json, rails_env, my.env.backup.
 #
+# Allow-list: basenames matching `.env.<suffix>` where <suffix> (case-insensitive)
+# is in SAFE_ENV_SUFFIXES (example, sample, template, dist, tpl) are treated as
+# committed-to-repo templates and are NOT blocked. Everything else defaults to
+# deny — including bare `.env` and any unrecognized suffix.
+#
 # Hook protocol: reads tool-invocation JSON from stdin. Exit code 2 with a
 # message on stderr blocks the tool call and surfaces the reason to the agent.
 #
@@ -36,6 +41,20 @@ BLOCK_MSG = (
 # `rails_env`, and `my.env.bak` do NOT match.
 ENV_BASENAME_RE = re.compile(r'(?:^|/)\.env(?:\.[A-Za-z0-9_-]+)?$')
 
+# Allow-list of suffixes that identify non-secret template/example files.
+# A basename of `.env.<suffix>` where <suffix> (case-insensitive) is in this
+# set is treated as a committed-to-repo template — safe to edit.
+# Everything else still defaults to deny.
+# To extend: add a lowercase suffix to this frozenset.
+SAFE_ENV_SUFFIXES = frozenset({'example', 'sample', 'template', 'dist', 'tpl'})
+
+# Matches the final suffix segment of a `.env.<suffix>` basename so we can
+# compare it against SAFE_ENV_SUFFIXES. The anchor on `(?:^|/)` ensures we
+# only look at basenames, not interior path segments.
+SAFE_ENV_TEMPLATE_RE = re.compile(
+    r'(?:^|/)\.env\.([A-Za-z0-9_-]+)$'
+)
+
 # Bash binaries that can mutate files. We only block a Bash command if one of
 # these appears AND the command also references a .env path. Non-mutating reads
 # like `cat .env` or `grep X .env` are not blocked by the hook — using the Read
@@ -59,6 +78,20 @@ def is_env_path(path: str) -> bool:
     return bool(ENV_BASENAME_RE.search(p))
 
 
+def is_safe_env_template(path: str) -> bool:
+    """Return True iff `path` is a `.env.<suffix>` basename where <suffix>
+    (case-insensitive) is in the template allow-list. Returns False for bare
+    `.env`, unknown suffixes, and empty input.
+    """
+    if not path:
+        return False
+    p = path.strip().strip('"').strip("'").rstrip('/')
+    m = SAFE_ENV_TEMPLATE_RE.search(p)
+    if not m:
+        return False
+    return m.group(1).lower() in SAFE_ENV_SUFFIXES
+
+
 def bash_targets_env(cmd: str) -> bool:
     if not cmd:
         return False
@@ -80,7 +113,9 @@ def bash_targets_env(cmd: str) -> bool:
         redirect_m = EMBEDDED_REDIRECT_RE.search(tok)
         if redirect_m:
             has_write_op = True
-            if is_env_path(redirect_m.group(1)):
+            target = redirect_m.group(1)
+            # Safe-template targets (`>.env.example`) are not treated as env.
+            if is_env_path(target) and not is_safe_env_template(target):
                 has_env_token = True
             continue
         # Destructive binary (match on basename so `/bin/rm` still counts).
@@ -88,8 +123,8 @@ def bash_targets_env(cmd: str) -> bool:
         if base in DESTRUCTIVE_BINS:
             has_write_op = True
             continue
-        # Plain token that looks like a .env path.
-        if is_env_path(tok):
+        # Plain token that looks like a .env path. Skip safe templates.
+        if is_env_path(tok) and not is_safe_env_template(tok):
             has_env_token = True
 
     return has_env_token and has_write_op
@@ -111,7 +146,7 @@ def main() -> int:
 
     if tool_name in ('Write', 'Edit', 'MultiEdit', 'NotebookEdit'):
         path = tool_input.get('file_path') or tool_input.get('notebook_path') or ''
-        if is_env_path(path):
+        if is_env_path(path) and not is_safe_env_template(path):
             blocked = True
             reason = f"{BLOCK_MSG} (tool={tool_name}, path={path})"
     elif tool_name == 'Bash':

--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -9,6 +9,7 @@ Prevent accidental `.env` deletion and other destructive operations from the rep
 ## Absolute Rules (no exceptions)
 
 1. **NEVER delete, overwrite, move, or modify `.env` files.** Not in root, not in worktrees, not anywhere, not in any repo. `.env` files contain secrets and credentials that cannot be recovered.
+   - **Template exception (allow-list):** basenames matching `.env.<suffix>` where `<suffix>` (case-insensitive) is `example`, `sample`, `template`, `dist`, or `tpl` are committed-to-repo templates with no secrets. These are safe to edit. Everything else — bare `.env`, `.env.local`, `.env.production`, any unrecognized suffix — stays blocked. The allow-list lives in `.claude/hooks/env-guard.py` (`SAFE_ENV_SUFFIXES`); extend it there.
 2. **NEVER run `git clean` in ANY directory.** It removes untracked files — including `.env` files that are in `.gitignore`.
 3. **NEVER run destructive file commands in the root repo directory.** This includes `rm -rf`, `rm`, `git checkout .`, `git stash` (which can drop untracked files), and `git reset --hard`. All work happens in worktrees — the root repo stays untouched on `main`.
 4. **NEVER `cd` to the root repo and run file operations there.** Stay in your assigned worktree directory at all times. The only safe root-repo operations are read-only: `git worktree list`, `find` for locating directories, reading files.
@@ -19,6 +20,8 @@ When spawning subagents, include this warning in the prompt AND always set `mode
 
 ```
 SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo.
+Exception: template files matching .env.<example|sample|template|dist|tpl>
+(case-insensitive) are committed, non-secret, and safe to edit.
 Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm,
 git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your
 worktree directory at all times.

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -27,6 +27,8 @@ Use the custom agent definitions in `.claude/agents/` instead of manually readin
 
    ```text
    SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo.
+   Exception: template files matching .env.<example|sample|template|dist|tpl>
+   (case-insensitive) are committed, non-secret, and safe to edit.
    Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm,
    git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your
    worktree directory at all times.

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -92,7 +92,7 @@ Spawn one subagent per valid PR using the Agent tool. All subagents run in paral
 - The repo owner/name (must substitute `{owner}/{repo}` in all API paths — `gh api` does not auto-detect)
 - The strategic context fetched in Step 1 (OKRs or README/milestones)
 - Which strategic source was used (`okrs` or `readme_fallback`)
-- A safety warning block: `SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo. Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm, git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your worktree directory at all times. This is a read-only review skill — do not edit any source files.`
+- A safety warning block: `SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo. Exception: template files matching .env.<example|sample|template|dist|tpl> (case-insensitive) are committed, non-secret, and safe to edit. Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm, git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your worktree directory at all times. This is a read-only review skill — do not edit any source files.`
 - The full subagent instructions below with parent-resolved placeholders substituted (`{NUMBER}`, `{STRATEGIC_CONTEXT_DISCLOSURE}`). Note: `{ISSUE_NUMBER}` is resolved by the subagent at runtime when it parses linked issues — do not substitute it in the parent.
 
 ### Subagent Instructions (include verbatim in each subagent prompt)

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -189,6 +189,8 @@ Body:
 
 ## SAFETY WARNING
 SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo.
+Exception: template files matching .env.<example|sample|template|dist|tpl>
+(case-insensitive) are committed, non-secret, and safe to edit.
 Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm,
 git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your
 worktree directory at all times.
@@ -378,6 +380,8 @@ Read ~/.claude/handoffs/pr-{PR_NUMBER}-handoff.json first.
 
 ## SAFETY WARNING
 SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo.
+Exception: template files matching .env.<example|sample|template|dist|tpl>
+(case-insensitive) are committed, non-secret, and safe to edit.
 Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm,
 git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your
 worktree directory at all times.


### PR DESCRIPTION
## Summary

- Adds an allow-list (`SAFE_ENV_SUFFIXES`) to the `.env` guard hook so basenames matching `.env.<example|sample|template|dist|tpl>` (case-insensitive) pass through, while bare `.env` and unrecognized suffixes stay blocked.
- Default-deny posture preserved — only 5 explicit suffixes are allow-listed; extending the list is a one-line change to the constant.
- Canonical rule in `.claude/rules/safety.md` updated; subagent warning text synchronized across `rules/`, `agents/`, and `skills/` so embedded prompts stay consistent.

Closes #303

## Why

Agents were forced to request a user override to edit files like `services/scoring-service/.env.example` — a committed, secret-free template. Blocking these adds friction and trains agents to ask permission for safe operations. The fix narrows the block to actual secret-bearing `.env` files while keeping the rule simple to reason about.

## What changed

| File | Change |
|------|--------|
| `.claude/hooks/env-guard.py` | Add `SAFE_ENV_SUFFIXES` constant + `is_safe_env_template()` helper; exempt safe templates in the Write/Edit branch and in `bash_targets_env()` |
| `.claude/rules/safety.md` | Absolute Rule #1 refined; Subagent Warning block gets an Exception line |
| `.claude/rules/subagent-orchestration.md` | Warning block synced |
| `.claude/agents/README.md` | Spawn example warning synced |
| `.claude/agents/{phase-a-fixer, phase-b-reviewer, phase-c-merger, pm-worker}.md` | Bullet-form `.env` rule gets an Exception clause |
| `.claude/skills/subagent/SKILL.md` | Both warning blocks synced |
| `.claude/skills/pr-review-help/SKILL.md` | Inline warning sentence synced |

## Test plan

Hook behavior (verified locally by importing the module and exercising `is_env_path` + `is_safe_env_template` + `bash_targets_env`; full matrix in the plan on #303):

- [x] Write-tool path: `.env.example` allowed (exit 0)
- [x] Write-tool path: `.env.EXAMPLE` allowed (case-insensitive)
- [x] Write-tool path: `.env.Template`, `.env.sample`, `.env.dist`, `.env.tpl` allowed
- [x] Write-tool path: `services/svc/.env.example` allowed (path prefix handled)
- [x] Write-tool path: bare `.env` blocked (exit 2)
- [x] Write-tool path: `.env.local`, `.env.production` blocked
- [x] Write-tool path: multi-dot basenames (`.env.example.bak`, `my.env.backup`) pass through unblocked — this is the pre-existing `ENV_BASENAME_RE` scope, documented in the hook header; my change doesn't expand or shrink it
- [x] Write-tool path: unrelated files (`environment.ts`, `rails_env`) still pass through
- [x] Bash: destructive verb against `.env.example` allowed (e.g., `cp .env.example deploy/.env.example`, `chmod 644 .env.example`)
- [x] Bash: destructive verb against `.env.local` still blocked (e.g., `rm .env.local`, `chmod 600 .env.production`)
- [x] Bash: `echo X >.env` blocked; `echo X >.env.example` allowed
- [x] Canonical rule in `.claude/rules/safety.md` includes the Exception clause
- [x] Subagent warning text (block + bullet forms) includes the Exception across all 9 embedded locations
- [x] `SAFE_ENV_SUFFIXES` is the single source of truth — extending the list requires only editing that frozenset
- [x] Rule file word budget still under 14,000 (verified: 12,837)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated safety guidelines to permit editing of committed, non-secret template environment files with names matching `.env.<example|sample|template|dist|tpl>` (case-insensitive), while preserving restrictions on other `.env` files.

* **Chores**
  * Implemented validation logic to enforce the template environment file exception across safety checks, enabling safe editing of configuration templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
