### PR TITLE
fix(scripts): unescape Python -c f-string quotes in ac-checkboxes.sh (#325)

### DIFF
--- a/.claude/scripts/ac-checkboxes.sh
+++ b/.claude/scripts/ac-checkboxes.sh
@@ -400,13 +400,13 @@ case "$RESULT" in
     exit 0
     ;;
   noop)
-    TICKED=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(f"0 ticked (of {d[\"items\"]} items — nothing to do)")' "$PY_OUT")
+    TICKED=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); n=d["items"]; print(f"0 ticked (of {n} items — nothing to do)")' "$PY_OUT")
     echo "$TICKED"
     exit 0
     ;;
   updated)
     BODY_PATH=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["body_path"])' "$PY_OUT")
-    TICKED=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(f"ticked {len(d[\"ticked\"])} of {d[\"items\"]} items: {d[\"ticked\"]}")' "$PY_OUT")
+    TICKED=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); t=d["ticked"]; n=d["items"]; print(f"ticked {len(t)} of {n} items: {t}")' "$PY_OUT")
     # gh pr edit --body-file reads the full body verbatim (preserves newlines).
     EDIT_ERR_FILE="$TMPDIR_AC/edit-stderr"
     if ! gh pr edit "$PR_NUMBER" --body-file "$BODY_PATH" >/dev/null 2>"$EDIT_ERR_FILE"; then


### PR DESCRIPTION
## Summary

- `.claude/scripts/ac-checkboxes.sh --all-pass` crashed with a Python `SyntaxError` after successfully ticking checkboxes, because `\"` inside bash single-quoted python literals passes through as a literal backslash-quote.
- Hoist dict lookups into locals on the two affected pretty-print invocations — the outer f-string `"..."` then never collides with inner key quotes. Matches the pattern already used on lines 386, 399, 408.

Closes #325

## Test plan

- [x] `--all-pass` on a PR with unchecked Test Plan items prints `ticked N of M items: [...]` with no SyntaxError
- [x] Checkboxes still get ticked in the PR body (`gh pr view --json body`)
- [x] `--all-pass` on a PR with all items already checked prints `0 ticked (of M items — nothing to do)` cleanly (noop path)
- [x] Local `coderabbit review --prompt-only` returns no findings (two clean passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal formatting changes made with no impact to user-facing behavior or output messages; all stdout messages and visible results remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->