### PR TITLE
feat(hooks): add pre-commit hook blocking commits on root/main (#323)

### DIFF
--- a/.claude/git-hooks/pre-commit
+++ b/.claude/git-hooks/pre-commit
@@ -1,0 +1,58 @@
+#!/bin/bash
+# pre-commit — Block commits on `main` in the root checkout.
+#
+# Worktree discipline: the root repo is a bookmark, never a workspace. All
+# code changes happen in worktrees on feature branches. This hook enforces
+# that at the git level so human and agent commits are caught uniformly.
+#
+# Behavior:
+#   - On a branch other than `main`: allow (exit 0).
+#   - Detached HEAD: allow (no branch = no main).
+#   - On `main` in a worktree: allow — rare, but not this hook's concern.
+#   - On `main` in the root checkout: reject with guidance.
+#
+# Bypass: `git commit --no-verify` still works for genuine emergencies.
+#
+# Installed by setup.sh into .git/hooks/pre-commit.
+
+set -u
+
+branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+
+# Detached HEAD or anything non-main: allow.
+if [[ "$branch" != "main" ]]; then
+  exit 0
+fi
+
+# Root vs. worktree: in the root checkout the `.git` entry at the work-tree
+# root is a DIRECTORY; in a linked worktree it is a FILE containing
+# `gitdir: ...`. `git rev-parse --git-dir` always returns a real directory
+# path (in worktrees it resolves to `<main>/.git/worktrees/<name>`) and so is
+# not usable for this distinction — we check the entry type directly.
+toplevel="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+# Bare repo / no working tree: nothing to commit in, allow (hook wouldn't run
+# in a bare repo anyway).
+if [[ -z "$toplevel" ]]; then
+  exit 0
+fi
+
+if [[ -d "$toplevel/.git" ]]; then
+  cat >&2 <<'ERR'
+❌ Blocked: committing to `main` in the root checkout is forbidden.
+
+The root repo is a bookmark, never a workspace. All code changes happen in
+worktrees on feature branches.
+
+Create a worktree:
+  git worktree add ../<name> -b issue-N-short-description
+
+Or use the EnterWorktree tool in Claude Code.
+
+Bypass with `git commit --no-verify` only for genuine emergencies.
+ERR
+  exit 1
+fi
+
+# `.git` is a file → we are inside a worktree. Allow.
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) "Hook Lifecycle" and "Hook Auto-Registrat
 
 ## Git Pre-commit Hook (Worktree Enforcement)
 
-`setup.sh` installs `.claude/git-hooks/pre-commit` into `.git/hooks/pre-commit` on first run (and keeps it in sync on later runs when unchanged). The hook rejects commits made on `main` in the root checkout so the "never work on main" rule is enforced at the git level for every committer — human, Claude, Cursor, Codex, or a random terminal session.
+`setup.sh` installs `.claude/git-hooks/pre-commit` into the shared git hooks directory on first run (and reuses it on later runs when unchanged). When this hook is installed and not bypassed, it rejects commits made on `main` in the root checkout, enforcing the "never work on main" rule at the git level for any committer — human, Claude, Cursor, Codex, or a random terminal session.
 
 - **Blocks:** `git commit` while on `main` in the root checkout.
 - **Allows:** any other branch, detached HEAD, and commits on `main` inside a worktree (rare but not this hook's concern).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,15 @@ Hooks live in `.claude/hooks/` and run automatically during Claude Code sessions
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) "Hook Lifecycle" and "Hook Auto-Registration" for details on event types and the registration flow.
 
+## Git Pre-commit Hook (Worktree Enforcement)
+
+`setup.sh` installs `.claude/git-hooks/pre-commit` into `.git/hooks/pre-commit` on first run (and keeps it in sync on later runs when unchanged). The hook rejects commits made on `main` in the root checkout so the "never work on main" rule is enforced at the git level for every committer — human, Claude, Cursor, Codex, or a random terminal session.
+
+- **Blocks:** `git commit` while on `main` in the root checkout.
+- **Allows:** any other branch, detached HEAD, and commits on `main` inside a worktree (rare but not this hook's concern).
+- **Bypass:** `git commit --no-verify` still works for genuine emergencies — left functional on purpose.
+- **User customization:** if `.git/hooks/pre-commit` already exists with different content, `setup.sh` warns and leaves your hook in place.
+
 ## Modifying CLAUDE.md
 
 - CLAUDE.md is the **executive summary** — high-level non-negotiables and pointers to rule files. Target: **≤ 1,000 words**.

--- a/setup.sh
+++ b/setup.sh
@@ -350,15 +350,32 @@ fi
 echo "Step 8: Installing Git pre-commit hook..."
 
 HOOK_SRC="$SCRIPT_DIR/.claude/git-hooks/pre-commit"
-HOOK_DST="$SCRIPT_DIR/.git/hooks/pre-commit"
+
+# Resolve the shared hooks dir via Git metadata so setup.sh works from the
+# root checkout OR from a linked worktree (where `.git` is a file, not a
+# directory). We deliberately use --git-common-dir, not --git-path hooks:
+# in a worktree the latter points at the per-worktree hooks directory, and
+# a pre-commit hook installed there would not block commits on `main` in
+# the root checkout — the whole point of this hook.
+GIT_COMMON_DIR="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir 2>/dev/null || true)"
+if [[ -z "$GIT_COMMON_DIR" ]]; then
+  step_fail "Git pre-commit hook" "Not inside a git repository: $SCRIPT_DIR"
+  exit 1
+fi
+# --git-common-dir can return a relative path; resolve to absolute.
+if [[ "$GIT_COMMON_DIR" != /* ]]; then
+  GIT_COMMON_DIR="$SCRIPT_DIR/$GIT_COMMON_DIR"
+fi
+HOOKS_DIR="$GIT_COMMON_DIR/hooks"
+HOOK_DST="$HOOKS_DIR/pre-commit"
 
 if [[ ! -f "$HOOK_SRC" ]]; then
   step_fail "Git pre-commit hook" "Source hook not found: $HOOK_SRC"
   exit 1
 fi
 
-if [[ ! -d "$SCRIPT_DIR/.git/hooks" ]]; then
-  step_fail "Git pre-commit hook" "Hooks directory missing: $SCRIPT_DIR/.git/hooks"
+if [[ ! -d "$HOOKS_DIR" ]]; then
+  step_fail "Git pre-commit hook" "Hooks directory missing: $HOOKS_DIR"
   exit 1
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -345,6 +345,40 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Step 8: Install Git pre-commit hook (blocks commits on root/main)
+# ---------------------------------------------------------------------------
+echo "Step 8: Installing Git pre-commit hook..."
+
+HOOK_SRC="$SCRIPT_DIR/.claude/git-hooks/pre-commit"
+HOOK_DST="$SCRIPT_DIR/.git/hooks/pre-commit"
+
+if [[ ! -f "$HOOK_SRC" ]]; then
+  step_fail "Git pre-commit hook" "Source hook not found: $HOOK_SRC"
+  exit 1
+fi
+
+if [[ ! -d "$SCRIPT_DIR/.git/hooks" ]]; then
+  step_fail "Git pre-commit hook" "Hooks directory missing: $SCRIPT_DIR/.git/hooks"
+  exit 1
+fi
+
+if [[ ! -e "$HOOK_DST" ]]; then
+  cp "$HOOK_SRC" "$HOOK_DST"
+  chmod +x "$HOOK_DST"
+  echo "  Installed pre-commit hook."
+  step_pass "Git pre-commit hook"
+elif cmp -s "$HOOK_SRC" "$HOOK_DST"; then
+  chmod +x "$HOOK_DST"
+  echo "  Pre-commit hook already installed — no changes."
+  step_pass "Git pre-commit hook"
+else
+  echo "  WARNING: $HOOK_DST exists but differs from $HOOK_SRC." >&2
+  echo "           Leaving user hook in place. Merge manually if you want our rule." >&2
+  echo "           Inspect with: diff -u \"$HOOK_DST\" \"$HOOK_SRC\"" >&2
+  step_pass "Git pre-commit hook (user customization preserved)"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Closes #323

## Summary

Adds a git-level pre-commit hook that rejects commits on `main` in the root checkout, enforcing the "never work on main" worktree-discipline rule for every committer (human, Claude, Cursor, Codex, or any terminal session).

- **`.claude/git-hooks/pre-commit`** — source hook. Checks the current branch via `git symbolic-ref --short HEAD`; if not `main`, exits 0. Otherwise inspects the `.git` entry at the work-tree root: directory → root checkout → block with guidance; file → linked worktree → allow. Detached HEAD allowed (no branch = no main). `--no-verify` bypass is a git-native contract and is left functional on purpose.
- **`setup.sh` Step 8** — idempotent install into `.git/hooks/pre-commit`. Uses `cmp -s` to detect identical content and skip re-copy; if the file exists but differs (user customization), warns with a `diff -u` hint and leaves it in place.
- **`CONTRIBUTING.md`** — short section documenting the hook behavior, allowed/blocked cases, and the `--no-verify` bypass.

## Design choices

- **`.claude/git-hooks/` directory** (not `.claude/hooks/`) to keep Git hooks separate from Claude Code hooks — two different hook systems with different contracts.
- **`.git` directory-vs-file detection** is more reliable than `git rev-parse --git-dir`, which in worktrees resolves to a real directory (`<main>/.git/worktrees/<name>`) and so doesn't distinguish root from worktree.
- **Copy install** (not symlink) — standard for git hooks; portable and survives `setup.sh` re-runs.

## Test plan

Ran manual smoke tests by invoking the hook directly (the hook is a pure function of `git symbolic-ref` and the `.git` entry type, so no destructive commit is needed):

- [x] `setup.sh` installs `.git/hooks/pre-commit` in the root checkout (idempotent) — verified: fresh install copies; `cmp -s` skips re-install; different content preserved with diff hint.
- [x] Hook rejects commits on `main` in the root checkout — Test B: `cd <root> && bash .claude/git-hooks/pre-commit` → exit 1 + guidance message.
- [x] Hook allows commits on any other branch — Test A: on feature-branch worktree → exit 0.
- [x] Hook allows commits on `main` inside a worktree — Test C: fresh `git worktree add -f /tmp/<name> main` → exit 0.
- [x] Error message points user at the fix (worktree + branch name convention) — message includes `git worktree add ../<name> -b issue-N-short-description` and EnterWorktree guidance.
- [x] `--no-verify` bypass documented and left functional (don't try to block it) — git-native contract; hook contains nothing that would defeat it. Documented in CONTRIBUTING.md and the hook's own header comment.
- [x] Manual smoke test: commit on root/main → blocked; commit on root/feature-branch → allowed; commit in a worktree → allowed — all verified above. (Bonus: Test D — detached HEAD → exit 0.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Git pre-commit hook that blocks direct commits to main when working in the repository root; commits on other branches, worktrees, and detached HEAD are allowed. Bypass via `git commit --no-verify`.

* **Documentation**
  * Added docs and setup steps describing hook installation, behavior, and how existing user hooks are preserved or reported during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->