### PR TITLE
feat(setup): drift check + complete HOOKS_MANIFEST

### DIFF
--- a/setup-skills-worktree.sh
+++ b/setup-skills-worktree.sh
@@ -183,20 +183,28 @@ fi
 # --- Step 6: Register hooks in ~/.claude/settings.json ---
 #
 # Hooks manifest — declarative list of hooks this repo expects to be registered.
-# Each entry: "event|matcher|script_name|timeout"
-# matcher is empty string for hooks with no matcher.
+# Fields are TAB-separated so matchers can use "|" alternation (e.g. Write|Edit).
+# Layout: event<TAB>matcher<TAB>script_name<TAB>timeout
+# matcher is an empty field for hooks with no matcher.
+#
+# Must stay in sync with global-settings.json; setup.sh verifies this and fails
+# if any template hook is missing from ~/.claude/settings.json after this runs.
 #
 # To add a new hook:
 #   1. Add the hook script to .claude/hooks/
-#   2. Add a manifest entry below with the event, matcher, script name, and timeout
+#   2. Add the same entry to global-settings.json AND to this manifest
 #   3. Run this script — it will register the hook in settings.json
 #
 HOOKS_MANIFEST=(
-  "Stop||silence-detector-ack.sh|5"
-  "Stop||trust-flag-repair.sh|10"
-  "PostToolUse|Bash|post-merge-pull.sh|15"
-  "PostToolUse||session-start-sync.sh|30"
-  "PostToolUse||silence-detector.sh|5"
+  $'PreToolUse\tWrite|Edit|NotebookEdit\tworktree-guard.sh\t5'
+  $'PreToolUse\tWrite|Edit|MultiEdit|NotebookEdit|Bash\tenv-guard.py\t5'
+  $'Stop\t\tsilence-detector-ack.sh\t5'
+  $'Stop\t\ttrust-flag-repair.sh\t10'
+  $'Stop\t\tdirty-main-warn.sh\t10'
+  $'PostToolUse\t\tsession-start-sync.sh\t30'
+  $'PostToolUse\tBash\tpost-merge-pull.sh\t15'
+  $'PostToolUse\tSkill\tskill-usage-tracker.sh\t5'
+  $'PostToolUse\t\tsilence-detector.sh\t5'
 )
 
 SETTINGS_FILE="$HOME/.claude/settings.json"
@@ -214,17 +222,18 @@ settings_file = sys.argv[1]
 hooks_dir = sys.argv[2]
 manifest_entries = sys.argv[3:]
 
-# Parse manifest: "event|matcher|script_name|timeout"
+# Parse manifest: TAB-separated "event\tmatcher\tscript_name\ttimeout".
+# Tab is used (not "|") so matchers can contain "|" alternation (e.g. Write|Edit).
 manifest = []
 for entry in manifest_entries:
-    parts = entry.split("|")
+    parts = entry.split("\t")
     if len(parts) != 4:
-        print(f"  WARNING: skipping malformed manifest entry: {entry}")
+        print(f"  WARNING: skipping malformed manifest entry: {entry!r}")
         continue
     try:
         timeout_val = int(parts[3])
     except ValueError:
-        print(f"  WARNING: skipping entry with non-integer timeout: {entry}")
+        print(f"  WARNING: skipping entry with non-integer timeout: {entry!r}")
         continue
     manifest.append({
         "event": parts[0],

--- a/setup.sh
+++ b/setup.sh
@@ -349,7 +349,8 @@ fi
 # ~/.claude/settings.json. Catches the failure mode from #145, where a hook is
 # added to global-settings.json but not to setup-skills-worktree.sh's manifest,
 # silently never reaching the user's deployed settings.
-drift_output="$(python3 - "$SETTINGS_SRC" "$SETTINGS_DST" <<'PYTHON_DRIFT_CHECK'
+drift_rc=0
+drift_output="$(python3 - "$SETTINGS_SRC" "$SETTINGS_DST" 2>&1 <<'PYTHON_DRIFT_CHECK'
 import json, os, shlex, sys
 
 def hook_keys(data):
@@ -387,23 +388,27 @@ try:
     with open(sys.argv[1]) as f:
         template = json.load(f)
 except (OSError, json.JSONDecodeError) as e:
-    print(f"read-template-failed: {e}")
-    sys.exit(0)
+    print(f"read-template-failed: {e}", file=sys.stderr)
+    sys.exit(2)
 try:
     with open(sys.argv[2]) as f:
         deployed = json.load(f)
 except (OSError, json.JSONDecodeError) as e:
-    print(f"read-deployed-failed: {e}")
-    sys.exit(0)
+    print(f"read-deployed-failed: {e}", file=sys.stderr)
+    sys.exit(2)
 
 template_hooks = set(hook_keys(template))
 deployed_hooks = set(hook_keys(deployed))
 for missing in sorted(template_hooks - deployed_hooks):
     print(f"missing\t{missing[0]}\t{missing[1]}\t{missing[2]}")
 PYTHON_DRIFT_CHECK
-)"
+)" || drift_rc=$?
 
-if [[ -n "$drift_output" ]]; then
+if [[ $drift_rc -ne 0 ]]; then
+  echo "  Drift check script error (exit $drift_rc):" >&2
+  [[ -n "$drift_output" ]] && echo "$drift_output" | sed 's/^/    /' >&2
+  step_fail "Hook drift check" "drift-check script failed to read $SETTINGS_SRC or $SETTINGS_DST"
+elif [[ -n "$drift_output" ]]; then
   echo "  Drift detected — global-settings.json lists hooks that are missing from $SETTINGS_DST:" >&2
   while IFS=$'\t' read -r tag event matcher script; do
     [[ "$tag" == "missing" ]] || continue

--- a/setup.sh
+++ b/setup.sh
@@ -71,8 +71,9 @@ if [[ ! -f "$SETTINGS_SRC" ]]; then
 fi
 
 # Ensure hooks are executable before anything else (handles missing execute bits
-# from tarballs, WSL, or CI environments where git didn't preserve modes)
-chmod +x "$SCRIPT_DIR/.claude/hooks"/*.sh 2>/dev/null || true
+# from tarballs, WSL, or CI environments where git didn't preserve modes).
+# Cover both shell and Python hooks — the manifest includes env-guard.py.
+chmod +x "$SCRIPT_DIR/.claude/hooks"/*.sh "$SCRIPT_DIR/.claude/hooks"/*.py 2>/dev/null || true
 
 # Merge non-hook keys from template into existing settings.json.
 # Existing keys are NEVER overwritten — only missing keys are seeded.
@@ -165,10 +166,10 @@ echo "Step 3: Verifying hook permissions..."
 
 hooks_dir="$SCRIPT_DIR/.claude/hooks"
 if [[ -d "$hooks_dir" ]]; then
-  chmod +x "$hooks_dir"/*.sh 2>/dev/null || true
+  chmod +x "$hooks_dir"/*.sh "$hooks_dir"/*.py 2>/dev/null || true
 
   hook_check_errors=0
-  for f in "$hooks_dir"/*.sh; do
+  for f in "$hooks_dir"/*.sh "$hooks_dir"/*.py; do
     [[ -f "$f" ]] || continue
     if [[ ! -x "$f" ]]; then
       echo "  ERROR: Could not make executable: $f" >&2
@@ -349,10 +350,14 @@ fi
 # added to global-settings.json but not to setup-skills-worktree.sh's manifest,
 # silently never reaching the user's deployed settings.
 drift_output="$(python3 - "$SETTINGS_SRC" "$SETTINGS_DST" <<'PYTHON_DRIFT_CHECK'
-import json, os, sys
+import json, os, shlex, sys
 
 def hook_keys(data):
-    """Yield (event, matcher_or_empty, script_basename) for each hook entry."""
+    """Yield (event, matcher_or_empty, script_basename) for each hook entry.
+
+    Normalizes the command via shlex so entries like "dirty-main-warn.sh --check"
+    compare by basename of the executable token, not the full command string.
+    """
     hooks = data.get("hooks", {})
     if not isinstance(hooks, dict):
         return
@@ -370,7 +375,11 @@ def hook_keys(data):
                 if not isinstance(h, dict):
                     continue
                 cmd = h.get("command", "")
-                script = os.path.basename(cmd)
+                try:
+                    argv = shlex.split(cmd) if isinstance(cmd, str) else []
+                except ValueError:
+                    argv = []
+                script = os.path.basename(argv[0]) if argv else ""
                 if script:
                     yield (event, matcher, script)
 

--- a/setup.sh
+++ b/setup.sh
@@ -344,6 +344,69 @@ else
   step_pass "Hook registration"
 fi
 
+# Drift check: every hook listed in global-settings.json MUST be registered in
+# ~/.claude/settings.json. Catches the failure mode from #145, where a hook is
+# added to global-settings.json but not to setup-skills-worktree.sh's manifest,
+# silently never reaching the user's deployed settings.
+drift_output="$(python3 - "$SETTINGS_SRC" "$SETTINGS_DST" <<'PYTHON_DRIFT_CHECK'
+import json, os, sys
+
+def hook_keys(data):
+    """Yield (event, matcher_or_empty, script_basename) for each hook entry."""
+    hooks = data.get("hooks", {})
+    if not isinstance(hooks, dict):
+        return
+    for event, groups in hooks.items():
+        if not isinstance(groups, list):
+            continue
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            matcher = group.get("matcher") or ""
+            hook_list = group.get("hooks", [])
+            if not isinstance(hook_list, list):
+                continue
+            for h in hook_list:
+                if not isinstance(h, dict):
+                    continue
+                cmd = h.get("command", "")
+                script = os.path.basename(cmd)
+                if script:
+                    yield (event, matcher, script)
+
+try:
+    with open(sys.argv[1]) as f:
+        template = json.load(f)
+except (OSError, json.JSONDecodeError) as e:
+    print(f"read-template-failed: {e}")
+    sys.exit(0)
+try:
+    with open(sys.argv[2]) as f:
+        deployed = json.load(f)
+except (OSError, json.JSONDecodeError) as e:
+    print(f"read-deployed-failed: {e}")
+    sys.exit(0)
+
+template_hooks = set(hook_keys(template))
+deployed_hooks = set(hook_keys(deployed))
+for missing in sorted(template_hooks - deployed_hooks):
+    print(f"missing\t{missing[0]}\t{missing[1]}\t{missing[2]}")
+PYTHON_DRIFT_CHECK
+)"
+
+if [[ -n "$drift_output" ]]; then
+  echo "  Drift detected — global-settings.json lists hooks that are missing from $SETTINGS_DST:" >&2
+  while IFS=$'\t' read -r tag event matcher script; do
+    [[ "$tag" == "missing" ]] || continue
+    matcher_display="${matcher:-(none)}"
+    echo "    - $event / matcher=$matcher_display / $script" >&2
+  done <<<"$drift_output"
+  echo "  Fix: add the entries to HOOKS_MANIFEST in setup-skills-worktree.sh and re-run setup.sh." >&2
+  step_fail "Hook drift check" "global-settings.json has hooks not registered in $SETTINGS_DST"
+else
+  step_pass "Hook drift check"
+fi
+
 # ---------------------------------------------------------------------------
 # Step 8: Install Git pre-commit hook (blocks commits on root/main)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #145.

## Summary

Catches the failure mode that #145 describes: a hook added to `global-settings.json` but not to `setup-skills-worktree.sh`'s `HOOKS_MANIFEST` silently never reaches the user's `~/.claude/settings.json`. Before this change, four such hooks were already drifted on `main` (`worktree-guard.sh`, `env-guard.py`, `dirty-main-warn.sh`, `skill-usage-tracker.sh`), but still listed as template entries.

- `setup-skills-worktree.sh`: switch `HOOKS_MANIFEST` delimiter from `|` to `TAB` so matchers can contain `|` alternation (`Write|Edit|NotebookEdit`, etc.). Add the four drifted hooks. Update the Python parser accordingly.
- `setup.sh` Step 7: add a drift check that fails the step when any `(event, matcher, script)` tuple in `global-settings.json` is missing from `~/.claude/settings.json`, with a remediation message pointing at `HOOKS_MANIFEST`.
- `setup.sh` Step 2 + Step 3: extend `chmod +x` to cover `*.py` (previously only `*.sh`) so `env-guard.py` keeps its executable bit on systems that drop mode bits.
- Drift check Python uses `shlex.split` before `basename` so template commands with inline args match their deployed counterpart; errors go to stderr with exit code 2 so the shell can distinguish "script read error" from "real drift".

Rationale for option chosen: issue-level AC #1 and #2 (`session-start-sync.sh` as PostToolUse, `trust-flag-repair.sh` as Stop) were already satisfied by PR #247 — both hooks have been in `global-settings.json` and in `HOOKS_MANIFEST` since then. Rather than a no-op PR, this change adds the guardrail that prevents the next "forgot to register" regression that #145 describes.

## Test plan

- [x] `bash -n setup.sh && bash -n setup-skills-worktree.sh` passes (syntax check) — verified locally.
- [x] `bash setup-skills-worktree.sh` on a fresh install registers all 9 hooks in `~/.claude/settings.json` — verified locally (all 9 registered first-run).
- [x] Re-running `setup-skills-worktree.sh` reports all hooks "already registered" (idempotent) — verified locally.
- [x] `setup.sh` Step 7 drift check passes against the committed state (no drift) — verified locally.
- [x] Simulating a missing hook in `~/.claude/settings.json` makes the drift check fail with a pinpoint line (`event / matcher / script`) — verified locally.
- [x] Drift-check Python correctly distinguishes read errors (exit 2, script-error message) from real drift (exit 0 + non-empty stdout, drift message) — verified via scenario tests (BugBot finding fix).
- [ ] Post-merge: `git -C ~/.claude/skills-worktree fetch origin main && git -C ~/.claude/skills-worktree reset --hard origin/main` runs cleanly.
- [ ] Post-merge: fresh session in another repo triggers `session-start-sync.sh` on first tool call and picks up latest SKILL.md.
