### PR TITLE
feat(rules): scheduling-reliability — mandate /loop for recurring polls

### DIFF
--- a/.claude/reference/scheduling-failure-modes.md
+++ b/.claude/reference/scheduling-failure-modes.md
@@ -1,0 +1,64 @@
+# Scheduling Failure Modes — Observed Patterns
+
+> Reference material for `.claude/rules/scheduling-reliability.md`. Each pattern is recorded as a case study so that future sessions (and future rule edits) have concrete symptoms to match against.
+
+The common thread: **between-turn scheduling has no in-turn observer.** Once the next tick fails to fire, there is no agent turn in which the 5-minute heartbeat hook can warn. The user is the first detector. These patterns exist to shorten the detection loop — recognize the symptom, re-establish with `/loop`, and stop re-committing the same class of error.
+
+## Pattern 1 — First-Tick-Fires-Then-Drops
+
+**Symptom.** The agent sets up a poll ("I'll check back in 5 minutes") and the first tick fires on schedule. The second tick never arrives. The user eventually prompts: "what happened to the polling?" or "did you check?"
+
+**Root cause.** Hand-rolled one-shot chains require the agent to call `ScheduleWakeup` (or equivalent) at the end of *every* turn. Any turn where the agent forgets the re-arm, or where the re-arm call silently errors, ends the chain. The first tick often works because the setup is fresh in-context; subsequent ticks are cold and the re-arm is easy to drop.
+
+**Fix.** Replace with `/loop N <command>`. The runtime owns the cadence; the agent never has to remember.
+
+## Pattern 2 — Cold-Cache Fragility on Long Intervals
+
+**Symptom.** Polling with an interval >5 minutes (especially >10–30 min) exhibits flakier tick behavior than short-interval polling in the same session — partial completion, missed state updates, or skipped re-arms.
+
+**Root cause.** The Anthropic prompt-cache TTL is ~5 minutes. Any tick that fires after the TTL elapses is a cold-cache turn. Cold turns are more vulnerable to:
+- Losing in-memory context that the re-arm logic depended on
+- Partial completion if the model is under pressure on the cold turn
+- Subtle drift in what "the last watermark" meant
+
+**Fix.** For genuinely long intervals, use `CronCreate` — it fires a fresh invocation with a self-contained prompt, so there is no in-memory state to lose. For short intervals (≤5 min), `/loop` stays warm and avoids the problem entirely. Don't optimize cadence inside a flaky chain — fix the chain by switching primitive.
+
+## Pattern 3 — Silent Re-Schedule Failures
+
+**Symptom.** Same as Pattern 1 (user must prompt to discover the drop), but the re-schedule call was actually made — it just failed.
+
+**Root causes observed:**
+- **Malformed `prompt` parameter** — e.g., an autonomous sentinel that the runtime does not recognize, or a prompt string with embedded tool-call syntax that the validator rejects.
+- **`delaySeconds` outside the clamp** — `ScheduleWakeup` clamps `[60, 3600]`. A call with `30` or `7200` is silently clamped; a call with a non-numeric value errors.
+- **Runtime rejection not surfaced to user** — the tool-call error is visible to the agent but not to the user, so if the agent exits without a heartbeat, the user never learns.
+
+**Fix.** `/loop` eliminates the failure surface — there is no re-schedule call to fail. If a one-shot primitive is still in use (rare), the agent MUST verify the scheduling call returned cleanly before exiting the turn, and must surface any error in a user-visible heartbeat.
+
+## Pattern 4 — Scheduler Promise With No Scheduler
+
+**Symptom.** The agent says "I'll check back in N minutes" in user-facing text but never actually issues a scheduling call. The promise is rhetorical. No tick ever fires.
+
+**Root cause.** The agent described the intent but omitted the tool call — a pure output-vs-action mismatch. Often triggered when the agent is summarizing and conflates "I will" with "I did."
+
+**Fix.** Before any message that commits to a future check-back, the same turn must contain an active `/loop` (or `CronCreate`) call. If no scheduler is armed, do not promise one — say "ping me when you want the status" instead.
+
+## Detection Heuristics
+
+Treat any of these as a scheduling failure until proven otherwise:
+
+- User says "your polling didn't fire" / "what happened to the check?" / "you said you'd come back"
+- User prompts for status after the promised tick time with no intervening agent message
+- `session-state.json` records a polling context but `CronList` has no matching job and no `/loop` is visible
+- Post-compaction recovery finds a `polling_failures` entry or a `monitoring_active: true` flag with no live schedule
+
+Recovery is always the same: apologize briefly, issue `/loop`, record the incident, continue.
+
+## Canonical Incident — 2026-04-20 Dropped PM Tick
+
+**Context.** During a PM monitoring session, the agent promised "I'll check back at 12:02 PM ET" after a prior successful tick at 11:57 AM. The 12:02 tick never fired. The user prompted at 12:11 PM: "did you check?" — the silent 9-minute gap was the detection signal.
+
+**Root cause (diagnosed post-hoc).** The 11:57 turn ran substantive work and exited without re-arming `ScheduleWakeup`. No error was surfaced because no re-schedule call was made. The 5-minute heartbeat hook could not fire because there was no subsequent turn.
+
+**Fix applied.** Re-established via `/loop 5m /status`. No further drops in that session.
+
+**Lesson.** Documented in memory (`feedback_schedulewakeup_silent_drop.md`) so future sessions recognize the pattern on the first instance rather than the Nth.

--- a/.claude/reference/session-state-schema.json
+++ b/.claude/reference/session-state-schema.json
@@ -12,6 +12,9 @@
   "active_agents": [
     {"id": "a3f8d26fa75eddcb3", "task": "PR #623 Phase C", "launched": "2026-03-16T15:55:00Z"}
   ],
+  "polling_failures": [
+    {"detected_at": "2026-03-16T15:58:00Z", "context": "PM tick dropped at 11:57 AM ET", "recovery": "restarted via /loop 5m /status"}
+  ],
   "_token_exhaustion_example": {
     "phase": "B",
     "needs": "continue_polling",

--- a/.claude/rules/handoff-files.md
+++ b/.claude/rules/handoff-files.md
@@ -17,7 +17,7 @@
 
 Full example JSON (including the token-exhaustion handoff shape): `.claude/reference/session-state-schema.json`.
 
-Top-level keys: `last_updated`, `monitoring_active`, `root_repo`, `prs` (map of PR number → `{phase, head_sha, reviewer, needs}`), `cr_quota` (`{reviews_used, window_start}`), `greptile_daily` (`{reviews_used, date, budget}`), `active_agents` (array of `{id, task, launched}`).
+Top-level keys: `last_updated`, `monitoring_active`, `root_repo`, `prs` (map of PR number → `{phase, head_sha, reviewer, needs}`), `cr_quota` (`{reviews_used, window_start}`), `greptile_daily` (`{reviews_used, date, budget}`), `active_agents` (array of `{id, task, launched}`), `polling_failures` (array of `{detected_at, context, recovery}` — dropped scheduler chains; see `.claude/rules/scheduling-reliability.md` "Failure Recovery").
 
 Write on phase transitions (A→B, B→C) and key state-change events (agent launched, completed, review received). Use `.claude/scripts/session-state.sh --set <jq-path>=<value> [--set ...]` for surgical writes — it preserves sibling fields, batches multiple `--set` flags into one atomic temp+mv, and refreshes `.last_updated` automatically. Use `--get <jq-path>` for reads. Avoid hand-rolling `jq … > tmp && mv tmp file` blocks for this file.
 

--- a/.claude/rules/monitor-mode.md
+++ b/.claude/rules/monitor-mode.md
@@ -68,7 +68,7 @@ Canonical rule: CLAUDE.md #3 (5-minute max silence, non-negotiable).
 3. **After completing any multi-step operation:** immediately send a status update.
 4. **Never batch status updates.** Report incrementally.
 
-**Heartbeat enforcement:** A PostToolUse hook warns when >5 min have elapsed — on seeing it, stop and send a status message immediately.
+**Heartbeat enforcement:** A PostToolUse hook warns when >5 min have elapsed — on seeing it, stop and send a status message immediately. The hook only fires **during** turns, so it cannot detect a dropped scheduler chain between turns. For polling that survives the gap between turns, see `scheduling-reliability.md`.
 
 ## File-Write Status Updates (MANDATORY)
 

--- a/.claude/rules/scheduling-reliability.md
+++ b/.claude/rules/scheduling-reliability.md
@@ -1,0 +1,56 @@
+# Scheduling Reliability — Polling That Doesn't Die Silently
+
+> **Always:** Use `/loop` for any user-facing "poll every N / check every N / watch for X" request. Run the pre-exit checklist on every wake-up turn. Record polling state in `session-state.json`.
+> **Ask first:** Never — scheduling reliability is autonomous.
+> **Never:** Hand-roll a chain of one-shot `ScheduleWakeup` (or equivalent) calls for a recurring user-facing poll. Promise to "check back in N minutes" without backing it with an active `/loop` or `CronCreate` job. Exit a wake-up turn without confirming the next tick is scheduled.
+
+The 5-minute heartbeat rule (CLAUDE.md #3, `monitor-mode.md`) catches silence **during** turns. It cannot detect a polling chain that died between turns — once `ScheduleWakeup` stops firing, there is no turn for the hook to warn in. This rule closes that gap.
+
+## Tool Selection Decision Tree
+
+Pick the primitive based on what the user asked for:
+
+| User request / context | Primitive | Why |
+|------------------------|-----------|-----|
+| "Poll every N", "check every N", "watch for X", "keep running /skill" | **`/loop`** | Runtime manages the cadence — the agent cannot forget to re-schedule |
+| ≥3 concurrent autonomous polls, or the job must survive across sessions | **`CronCreate`** | Durable, fleet-managed, fires even when REPL is idle |
+| One-shot "wake me up in N minutes for X" with no recurrence | `ScheduleWakeup` (or equivalent single-shot primitive) | Single tick is exactly what the primitive guarantees |
+
+> **Default for any recurring user-facing poll is `/loop`.** Only drop to `CronCreate` when `/loop` doesn't fit (cross-session durability, multi-task fleet). Never drop to a hand-rolled one-shot chain.
+
+## Forbidden Pattern: Hand-Rolled One-Shot Chains
+
+**Do not** promise a recurring poll and implement it as: "run the work this turn, then call `ScheduleWakeup` at the end to fire the next tick." That pattern requires the model to remember — and successfully execute — the re-schedule on every turn. Two silent failure modes:
+
+1. **Model forgets to re-schedule.** No error, no warning, no turn fires — the loop is simply gone.
+2. **Re-schedule call fails silently.** Malformed `prompt`, rejected `delaySeconds`, bad sentinel — same end state: no next tick.
+
+Both failures are invisible to the in-turn heartbeat hook because there is no next turn for it to run in. The user discovers it only by pinging: "what happened to the polling you promised?"
+
+**Correct replacement:** issue `/loop N <command>` once. The runtime owns the cadence. If the user wants to stop it, they say "stop polling" or interrupt it — the agent never has to re-arm it.
+
+## Mandatory Pre-Exit Checklist for Polling Turns
+
+Before the end of any turn that is part of a polling loop (whether fired by `/loop`, `CronCreate`, or a legacy `ScheduleWakeup` chain), verify **all three** items below. Missing any one = blocking error — do not exit until it is fixed.
+
+1. **Next tick scheduled?**
+   - `/loop`: verify the loop is still active. If you invoked a skill that may have displaced the loop, confirm `/loop` is re-armed (or that the runtime auto-resumes it).
+   - `CronCreate`: confirm the job still exists via `CronList` — a prior `CronDelete` or 7-day expiry may have removed it.
+   - Legacy `ScheduleWakeup` chain: confirm this turn made the next-tick call **and** that the call returned without error. If the call was skipped or errored, switch the chain to `/loop` now.
+2. **User heartbeat sent this turn?** A visible message with a timestamp, summarizing what the tick did and what is next. See `monitor-mode.md` "User Heartbeat". A tick that did no user-visible work is still a tick — report it briefly so the user sees the poll is alive.
+3. **Monitoring state recorded?** Update `~/.claude/session-state.json` with the tick timestamp, the next expected tick, and any watermarks (last-seen review ID, last HEAD SHA, etc.) that the next tick will consume. See `handoff-files.md` for the schema. A crashed poll that the next session can reconstruct from `session-state.json` is recoverable; one that left no trace is not.
+
+## Failure Recovery
+
+If the user says "what happened to the polling?" / "your check didn't fire" / anything that implies a dropped tick:
+
+1. **Acknowledge the drop** — do not argue or hand-wave. The silent failure is the symptom, the promise to poll was the commitment.
+2. **Re-establish with `/loop`**, not with another hand-rolled chain. State the cadence and the command: "Restarting with `/loop 5m /status` — the runtime owns the cadence now, so it won't drop again."
+3. **Record the incident** — add a line to `session-state.json` (`polling_failures` array, if not already present) so post-compaction recovery can see the pattern.
+4. **If this is a new failure mode** (not already documented in `.claude/reference/scheduling-failure-modes.md`), append it to that file after the session ends.
+
+## Related
+
+- `monitor-mode.md` — in-turn heartbeat and monitor loop (complements this file: heartbeats catch silence during turns; this file catches silence between turns)
+- `.claude/reference/scheduling-failure-modes.md` — canonical list of observed failure modes with case studies
+- `handoff-files.md` — `session-state.json` schema, including the polling-state fields this file requires

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -283,6 +283,8 @@ After Step 1 presents assignments/suggestions, detect whether any **active cloud
 
 Resume mode passes through this step too — polling needs to be re-established after context turnover.
 
+**Primitive selection (MANDATORY):** For any user-initiated "poll every N" request, `/loop` is **mandatory** — not just recommended. `CronCreate` is reserved for PM-initiated autonomous monitoring across ≥3 concurrent threads or cross-session durability. Hand-rolled one-shot `ScheduleWakeup` chains are forbidden for recurring polls — they drop silently when the model forgets to re-schedule. For the full decision tree and the pre-exit checklist that every polling turn must run, see `.claude/rules/scheduling-reliability.md`.
+
 ### 2.1: Detect active threads
 
 An active cloud thread is an open issue (assigned to `$GH_USER` if set, otherwise any) where ANY of:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ These apply to EVERY message the parent agent sends to the user. No exceptions, 
 1. **Timestamp prefix.** Start every message with Eastern time (`Mon Mar 16 02:34 AM ET`). Get via: `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`. NEVER estimate timestamps — always run the `date` command.
 2. **Active monitoring declaration.** If monitoring background agents, state how many and which PRs at the end of every message.
 3. **5-minute heartbeat.** Never go >5 minutes without a status message. During operations touching 4+ files, emit a one-line status after every 3 writes/edits (see `monitor-mode.md` "User Heartbeat" and "File-Write Status Updates" for details).
-4. **`/loop` for recurring polls.** Any user request phrased as "poll every N / check every N / watch for X" must be backed by `/loop` (or `CronCreate` for cross-session durability) — never a hand-rolled chain of one-shot wake-ups. See `scheduling-reliability.md` for the decision tree and pre-exit checklist.
+4. **`/loop` for recurring polls.** Any user request phrased as "poll every N / check every N / watch for X" must be backed by `/loop` (or `CronCreate` for ≥3 concurrent autonomous polls and/or cross-session durability) — never a hand-rolled chain of one-shot wake-ups. See `scheduling-reliability.md` for the decision tree and pre-exit checklist.
 5. **Dedicated monitor mode.** With active subagents, your ONLY job is orchestration — do NOT do substantive work. See `monitor-mode.md` "Dedicated Monitor Mode" for full rules.
 
 After context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `monitor-mode.md`) and report it WITH a timestamp.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,8 @@ These apply to EVERY message the parent agent sends to the user. No exceptions, 
 1. **Timestamp prefix.** Start every message with Eastern time (`Mon Mar 16 02:34 AM ET`). Get via: `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`. NEVER estimate timestamps — always run the `date` command.
 2. **Active monitoring declaration.** If monitoring background agents, state how many and which PRs at the end of every message.
 3. **5-minute heartbeat.** Never go >5 minutes without a status message. During operations touching 4+ files, emit a one-line status after every 3 writes/edits (see `monitor-mode.md` "User Heartbeat" and "File-Write Status Updates" for details).
-4. **Dedicated monitor mode.** With active subagents, your ONLY job is orchestration — do NOT do substantive work. See `monitor-mode.md` "Dedicated Monitor Mode" for full rules.
+4. **`/loop` for recurring polls.** Any user request phrased as "poll every N / check every N / watch for X" must be backed by `/loop` (or `CronCreate` for cross-session durability) — never a hand-rolled chain of one-shot wake-ups. See `scheduling-reliability.md` for the decision tree and pre-exit checklist.
+5. **Dedicated monitor mode.** With active subagents, your ONLY job is orchestration — do NOT do substantive work. See `monitor-mode.md` "Dedicated Monitor Mode" for full rules.
 
 After context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `monitor-mode.md`) and report it WITH a timestamp.
 
@@ -82,6 +83,7 @@ Detailed workflow rules are split into topic-specific files in `.claude/rules/`:
 | `greptile.md` | Greptile last-resort reviewer + CR/BugBot fallback + self-review fallback |
 | `subagent-orchestration.md` | Subagent spawning, phase transition autonomy table, token exhaustion, phase A/B/C decomposition |
 | `monitor-mode.md` | Dedicated monitor mode, monitor loop, heartbeats, health monitoring, post-compaction recovery |
+| `scheduling-reliability.md` | `/loop` vs one-shot decision tree, forbidden hand-rolled chains, pre-exit checklist for polling turns |
 | `handoff-files.md` | Handoff file schema, session-state.json format, lifecycle (create/update/delete) |
 | `phase-protocols.md` | Structured exit report format, Phase A/B/C completion protocol checklists |
 | `safety.md` | Destructive command prohibitions, .env protection, subagent safety warnings |


### PR DESCRIPTION
## Summary

Close the gap between the in-turn heartbeat hook and between-turn scheduler reliability. Hand-rolled `ScheduleWakeup` chains silently drop after the first tick — the fix is to default to `/loop` for any user-facing "poll every N" request, with a pre-exit checklist every polling turn must run.

- Adds `.claude/rules/scheduling-reliability.md` (tool selection decision tree, forbidden hand-rolled chains, mandatory pre-exit checklist, failure recovery) and wires it into `CLAUDE.md` as rule #4 + rules-table entry.
- `pm/SKILL.md` Step 2 now makes `/loop` **mandatory** for user-initiated polling; `CronCreate` is reserved for autonomous PM monitoring across ≥3 threads or cross-session durability.
- Adds `.claude/reference/scheduling-failure-modes.md` with four observed patterns, detection heuristics, and the canonical 2026-04-20 dropped-tick incident as a case study.
- Adds memory note `feedback_schedulewakeup_silent_drop.md` + `MEMORY.md` index entry so future sessions recognize the pattern on first instance.
- `monitor-mode.md` User Heartbeat section clarifies the hook only fires during turns and cross-refs the new rule.

## Test plan

- [x] `.claude/rules/scheduling-reliability.md` exists with all four required sections: Tool Selection Decision Tree, Forbidden Pattern, Mandatory Pre-Exit Checklist, Failure Recovery
- [x] `CLAUDE.md` top-of-file numbered list includes a new rule referencing `/loop` for recurring polls; existing #1/#3 cross-references in other rule files still resolve
- [x] `CLAUDE.md` Rule Files table contains a `scheduling-reliability.md` row
- [x] `.claude/rules/monitor-mode.md` User Heartbeat section notes the hook's between-turn gap and cross-refs `scheduling-reliability.md`
- [x] `.claude/skills/pm/SKILL.md` Step 2 marks `/loop` as **mandatory** for user-initiated polls with cross-ref to `scheduling-reliability.md`
- [x] `.claude/reference/scheduling-failure-modes.md` exists with four failure-mode patterns, detection heuristics, and the 2026-04-20 canonical incident
- [x] `feedback_schedulewakeup_silent_drop.md` memory file exists and has a one-line entry in `MEMORY.md`
- [x] Rules word budget under 14,000 words: `{ cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } | wc -w`
- [x] New rule file under 150-line soft cap

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a reference on recurring polling failure modes with a canonical incident and recovery steps (acknowledge missed tick, restart with /loop, record incident).
  * Published a scheduling reliability ruleset: require /loop for user-facing recurring polls, reserve CronCreate for durable/PM-initiated monitoring, forbid chaining one-shot wakeups, and add a per-turn pre-exit checklist.
  * Clarified monitor-mode heartbeat limits and extended session-state schema to record polling_failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->