### PR TITLE
feat(wrap): aggressive main reset after merge (#324)

### DIFF
--- a/.claude/scripts/main-sync.sh
+++ b/.claude/scripts/main-sync.sh
@@ -18,35 +18,57 @@
 #   reports without re-parsing.
 #
 # USAGE
-#   main-sync.sh [--repo <path>]
+#   main-sync.sh [--repo <path>] [--reset]
 #   main-sync.sh --help | -h
 #
 #   --repo <path>   Operate on the git repo rooted at <path> (uses `git -C`).
 #                   Defaults to the current working directory.
+#   --reset         Aggressive post-merge sync: fetch origin/main, abort if
+#                   local main has unpushed commits, else `git reset --hard
+#                   origin/main`. Used by /wrap to guarantee local main
+#                   matches origin after merge. Without --reset, the script
+#                   falls back to the cautious `git pull --ff-only` path.
 #
 # OUTPUT (single stdout line, always — multi-line git stderr is collapsed)
 #   updated <before7> → <after7>       Fast-forward pulled new commits.
+#   reset <before7> → <after7>         --reset advanced main to origin/main.
 #   up to date (<sha7>)                Already at origin/main.
 #   skipped: tracked files have uncommitted changes — run manually: <cmd>
 #                                       Off-main with dirty tree; no-op.
-#                                       (On-main dirty trees are NOT skipped —
-#                                       pull --ff-only handles them natively.)
+#                                       (On-main dirty trees are NOT skipped
+#                                       in the default path — pull --ff-only
+#                                       handles them natively. --reset DOES
+#                                       check tracked changes on main because
+#                                       `reset --hard` is destructive.)
+#   aborted: local main has <N> unpushed commit(s) — inspect: git log origin/main..main, resolve manually before re-running
+#                                       --reset refused to clobber unpushed
+#                                       commits. Belt-and-suspenders for any
+#                                       bypass of the root/main pre-commit
+#                                       hook (#323). Run the suggested
+#                                       `git log` to see what's local.
 #   failed: not inside a git working tree — <rev-parse output>
 #                                       --repo (or cwd) is not a git repo.
 #   failed: could not inspect working tree state (git diff rc=<N>, ...)
 #                                       `git diff` itself errored (rc>1).
 #   failed: could not checkout main — <git output>
 #                                       Not on main and checkout refused.
+#   failed: git fetch origin main — <git output>
+#                                       --reset fetch step failed.
+#   failed: could not compare HEAD to origin/main — <git output>
+#                                       --reset rev-list step failed.
+#   failed: could not reset main to origin/main — <git output>
+#                                       --reset reset step failed.
 #   failed: <git pull output>           Pull refused (non-ff, network, etc.).
 #
-#   The "updated" arrow is rendered as U+2192 RIGHTWARDS ARROW to match the
-#   existing prose in merge/wrap skills.
+#   The arrow is rendered as U+2192 RIGHTWARDS ARROW to match the existing
+#   prose in merge/wrap skills.
 #
 # EXIT STATUS
-#   0  Success — pull succeeded (updated or already up to date).
+#   0  Success — pull or reset succeeded (updated, reset, or up to date).
 #   1  Skipped — uncommitted changes blocked the sync.
-#   2  Failed — checkout main failed or pull --ff-only failed.
+#   2  Failed — checkout main, fetch, rev-list, pull, or reset failed.
 #   3  Usage error (unknown flag, missing --repo value, bad path).
+#   4  Aborted — --reset refused because local main has unpushed commits.
 #
 # EXAMPLES
 #   # Default: operate on the current working directory's repo.
@@ -80,6 +102,7 @@ usage_error() {
 }
 
 REPO=""
+RESET_MODE=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help)
@@ -95,6 +118,10 @@ while [[ $# -gt 0 ]]; do
     --repo=*)
       REPO="${1#--repo=}"
       [[ -n "$REPO" ]] || usage_error "--repo value cannot be empty"
+      shift
+      ;;
+    --reset)
+      RESET_MODE=1
       shift
       ;;
     --)
@@ -179,6 +206,67 @@ if [[ "$CURRENT_BRANCH" != "main" ]]; then
 fi
 
 BEFORE_SHA=$("${GIT[@]}" rev-parse HEAD 2>/dev/null || true)
+
+if (( RESET_MODE == 1 )); then
+  # --reset mode: fetch, verify safety, then hard-reset to origin/main.
+  # `git reset --hard` is a sanctioned exception to safety.md's destructive-
+  # command prohibitions, guarded by:
+  #   (a) the dirty-tree check below (pull --ff-only's tolerance of dirty
+  #       on-main trees does NOT apply — reset --hard clobbers them),
+  #   (b) the ahead-of-origin check below (belt-and-suspenders for any
+  #       bypass of the root/main pre-commit hook from #323).
+  # Expected composition: /wrap runs dirty-main-guard --quarantine on the
+  # root repo before calling this, so the dirty check here should be a
+  # formality on the happy path.
+  unstaged_rc=0
+  "${GIT[@]}" diff --quiet 2>/dev/null || unstaged_rc=$?
+  staged_rc=0
+  "${GIT[@]}" diff --cached --quiet 2>/dev/null || staged_rc=$?
+  if (( unstaged_rc > 1 || staged_rc > 1 )); then
+    echo "failed: could not inspect working tree state (git diff rc=$unstaged_rc, git diff --cached rc=$staged_rc)"
+    exit 2
+  fi
+  if (( unstaged_rc == 1 || staged_rc == 1 )); then
+    echo "skipped: tracked files have uncommitted changes — run manually: $MANUAL_CMD"
+    exit 1
+  fi
+
+  if ! FETCH_OUTPUT=$("${GIT[@]}" fetch origin main 2>&1); then
+    echo "failed: git fetch origin main — $(to_one_line "$FETCH_OUTPUT")"
+    exit 2
+  fi
+
+  if ! AHEAD_RAW=$("${GIT[@]}" rev-list --count origin/main..HEAD 2>&1); then
+    echo "failed: could not compare HEAD to origin/main — $(to_one_line "$AHEAD_RAW")"
+    exit 2
+  fi
+  # Fail loud if the count can't be parsed — silently treating "?" as 0
+  # would proceed to reset --hard with unknown state, which is exactly what
+  # the ahead check exists to prevent.
+  AHEAD_TRIMMED="$(printf '%s' "$AHEAD_RAW" | tr -d '[:space:]')"
+  if ! [[ "$AHEAD_TRIMMED" =~ ^[0-9]+$ ]]; then
+    echo "failed: could not parse ahead count from rev-list — $(to_one_line "$AHEAD_RAW")"
+    exit 2
+  fi
+  AHEAD="$AHEAD_TRIMMED"
+  if (( AHEAD > 0 )); then
+    echo "aborted: local main has $AHEAD unpushed commit(s) — inspect: git log origin/main..main, resolve manually before re-running"
+    exit 4
+  fi
+
+  if ! RESET_OUTPUT=$("${GIT[@]}" reset --hard origin/main 2>&1); then
+    echo "failed: could not reset main to origin/main — $(to_one_line "$RESET_OUTPUT")"
+    exit 2
+  fi
+  AFTER_SHA=$("${GIT[@]}" rev-parse HEAD 2>/dev/null || true)
+  if [[ "$BEFORE_SHA" == "$AFTER_SHA" ]]; then
+    echo "up to date (${AFTER_SHA:0:7})"
+  else
+    echo "reset ${BEFORE_SHA:0:7} → ${AFTER_SHA:0:7}"
+  fi
+  exit 0
+fi
+
 if PULL_OUTPUT=$("${GIT[@]}" pull origin main --ff-only 2>&1); then
   AFTER_SHA=$("${GIT[@]}" rev-parse HEAD 2>/dev/null || true)
   if [[ "$BEFORE_SHA" == "$AFTER_SHA" ]]; then

--- a/.claude/scripts/main-sync.sh
+++ b/.claude/scripts/main-sync.sh
@@ -34,12 +34,19 @@
 #   reset <before7> → <after7>         --reset advanced main to origin/main.
 #   up to date (<sha7>)                Already at origin/main.
 #   skipped: tracked files have uncommitted changes — run manually: <cmd>
-#                                       Off-main with dirty tree; no-op.
-#                                       (On-main dirty trees are NOT skipped
-#                                       in the default path — pull --ff-only
-#                                       handles them natively. --reset DOES
-#                                       check tracked changes on main because
-#                                       `reset --hard` is destructive.)
+#                                       Default path, off-main with dirty
+#                                       tree; no-op. <cmd> is the
+#                                       checkout+pull recovery. (On-main
+#                                       dirty trees are NOT skipped in the
+#                                       default path — pull --ff-only handles
+#                                       them natively.)
+#   skipped: tracked files have uncommitted changes — run .claude/scripts/dirty-main-guard.sh --quarantine, then re-run main-sync.sh --reset
+#                                       --reset path, dirty tree on main.
+#                                       `reset --hard` would clobber them,
+#                                       so we redirect to dirty-main-guard
+#                                       (which preserves state to a recovery
+#                                       branch) rather than the default
+#                                       `pull --ff-only` hint.
 #   aborted: local main has <N> unpushed commit(s) — inspect: git log origin/main..main, resolve manually before re-running
 #                                       --reset refused to clobber unpushed
 #                                       commits. Belt-and-suspenders for any
@@ -227,7 +234,12 @@ if (( RESET_MODE == 1 )); then
     exit 2
   fi
   if (( unstaged_rc == 1 || staged_rc == 1 )); then
-    echo "skipped: tracked files have uncommitted changes — run manually: $MANUAL_CMD"
+    # In --reset mode, the right recovery is dirty-main-guard (which
+    # preserves state to a recovery branch), NOT `pull --ff-only` — the
+    # caller invoked --reset specifically to hard-reset, and pull --ff-only
+    # would neither rescue the uncommitted work nor perform the intended
+    # reset. Point users at the guard instead.
+    echo "skipped: tracked files have uncommitted changes — run .claude/scripts/dirty-main-guard.sh --quarantine, then re-run main-sync.sh --reset"
     exit 1
   fi
 

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -162,30 +162,48 @@ gh pr merge --squash
 
 Do NOT use `--delete-branch` here. That flag attempts local branch deletion while the worktree is still active, which fails because git refuses to delete a branch checked out in any worktree. Branch cleanup is handled explicitly in Phase 5 after the worktree is removed.
 
-### Step 2.5: Sync root repo main
+### Step 2.5: Sync root repo main (aggressive reset)
 
-After merging, update the root repo's local `main` so subsequent sessions branch from the latest code. **Capture the result for the final report in Step 5.3.**
+After merging, aggressively align the root repo's local `main` with `origin/main` so subsequent sessions branch from the latest code with zero drift. The sequence is:
+
+1. **Quarantine any dirty state** on root main via `dirty-main-guard.sh --quarantine` (creates a `recovery/dirty-main-*` branch if needed — nothing is lost).
+2. **Aggressively reset** root main to `origin/main` via `main-sync.sh --reset`. This fetches origin, aborts loudly if local main has unpushed commits (belt-and-suspenders for bypasses of the `#323` pre-commit hook), and otherwise `git reset --hard origin/main`.
+
+**Capture both status lines for the final report in Step 5.3.**
 
 ```bash
-# .claude/scripts/main-sync.sh --repo <path> writes the status line to
-# stdout and exits 0 OK / 1 skipped (uncommitted) / 2 failed
-# (checkout/pull). /wrap runs from inside a worktree, so we resolve the
-# root repo explicitly and pass it via --repo. A non-zero exit from the
-# helper is not a hard error here — the status line is captured for the
-# final report regardless.
+# /wrap runs from inside a worktree. dirty-main-guard.sh resolves the root
+# repo itself via repo-root.sh — no --repo flag needed. main-sync.sh does
+# accept --repo, so we pass the resolved root explicitly.
 ROOT_REPO=$(.claude/scripts/repo-root.sh 2>/dev/null || true)
 MAIN_SYNC_STATUS=""
+QUARANTINE_STATUS=""
 if [ -z "$ROOT_REPO" ] || [ ! -d "$ROOT_REPO" ]; then
   MAIN_SYNC_STATUS="failed: could not determine root repo path"
 else
-  MAIN_SYNC_STATUS=$(bash .claude/scripts/main-sync.sh --repo "$ROOT_REPO" 2>&1 || true)
+  # Quarantine first so the reset below never clobbers uncommitted work.
+  # --check is read-only (exit 0 clean / 1 dirty); --quarantine is non-
+  # destructive (preserves state to a recovery branch). A non-zero exit
+  # from either is captured for the report but does not short-circuit —
+  # main-sync.sh --reset has its own guards.
+  if .claude/scripts/dirty-main-guard.sh --check >/dev/null 2>&1; then
+    QUARANTINE_STATUS="clean"
+  else
+    QUARANTINE_STATUS=$(.claude/scripts/dirty-main-guard.sh --quarantine 2>&1 || true)
+  fi
+  # --reset: fetch → abort-if-ahead → reset --hard origin/main. Exits 0
+  # success / 1 skipped / 2 failed / 4 aborted (unpushed commits on main).
+  MAIN_SYNC_STATUS=$(bash .claude/scripts/main-sync.sh --reset --repo "$ROOT_REPO" 2>&1 || true)
 fi
+echo "Main quarantine: $QUARANTINE_STATUS"
 echo "Main sync: $MAIN_SYNC_STATUS"
 ```
 
-See `.claude/scripts/main-sync.sh --help` for the full contract.
+See `.claude/scripts/main-sync.sh --help` and `.claude/scripts/dirty-main-guard.sh --help` for the full contracts.
 
-Store `MAIN_SYNC_STATUS` for the final report — this value MUST appear in Step 5.3 output.
+**If `MAIN_SYNC_STATUS` starts with `aborted:`** (local main has unpushed commits that didn't come from origin), do NOT attempt recovery automatically. Surface the full status line in the final report so the user can run `git log origin/main..main` against the root repo and decide. The PR merge itself has already succeeded — main-sync failure does not un-merge anything.
+
+Store `MAIN_SYNC_STATUS` and `QUARANTINE_STATUS` for the final report — both values MUST appear in Step 5.3 output.
 
 ## Phase 3: Follow-Up Detection and Creation
 
@@ -401,7 +419,8 @@ git -C "$ROOT_REPO" push origin --delete "$BRANCH_NAME" || echo "Warning: remote
 ## Wrap-Up Complete
 
 - **PR #{N}** merged ({title})
-- **Main branch** {MAIN_SYNC_STATUS from Step 2.5 — e.g. "updated abc1234 → def5678", "up to date (abc1234)", or "failed: ..."}
+- **Main quarantine** {QUARANTINE_STATUS from Step 2.5 — e.g. "clean" (literal output of `dirty-main-guard.sh --check` on a clean main), "quarantined: recovery/dirty-main-20260424-003012 (uncommitted)", or "no-op: main is clean" (only produced if `--quarantine` ran on an already-clean tree)}
+- **Main branch** {MAIN_SYNC_STATUS from Step 2.5 — e.g. "reset abc1234 → def5678", "up to date (abc1234)", "aborted: local main has 1 unpushed commit(s) — inspect: git log origin/main..main, resolve manually before re-running", or "failed: ..."}
 - **Branch** deleted
 - **Follow-ups:** {summary or "none"}
 - **Lessons:** {summary or "clean session"}


### PR DESCRIPTION
Closes #324.

## Summary

- Extend `.claude/scripts/main-sync.sh` with a `--reset` flag: fetch `origin/main`, abort loudly if local main has unpushed commits, else `git reset --hard origin/main`. New exit code `4` for the abort path; status line points to `git log origin/main..main` for manual inspection.
- Update `/wrap` Step 2.5 to call `dirty-main-guard.sh --quarantine` (preserves any stray state to a recovery branch) before `main-sync.sh --reset` (guaranteed origin-matching reset). Step 5.3 final report surfaces both statuses.
- The ahead-of-origin abort is belt-and-suspenders for any `--no-verify` bypass of the #323 pre-commit hook. Tree-dirty is caught by the composition above or by `--reset`'s own dirty check.

## Safety composition

1. Pre-commit hook (#323) — blocks new commits on root/main.
2. Dirty-main guard (#334) — quarantines uncommitted state to `recovery/dirty-main-*`.
3. `main-sync.sh --reset` (this PR) — fetches, refuses if ahead, else hard-reset.

`git reset --hard` is a sanctioned exception to `safety.md`, guarded by all three checks above.

## Smoke test evidence

Three scenarios exercised in a sandbox repo (bare `origin.git` + working clone):

| Scenario | Setup | Result | Exit |
|----------|-------|--------|------|
| Normal (no-op) | Local main == origin/main | `up to date (0d7b6cb)` | 0 |
| Behind (fast-forward via reset) | Origin advanced by one commit | `reset 0d7b6cb → d317c78` | 0 |
| Ahead (loud abort) | One local-only commit via `--no-verify` | `aborted: local main has 1 unpushed commit(s) — inspect: git log origin/main..main, resolve manually before re-running` | 4 |
| Bonus: dirty tree | Uncommitted tracked change | `skipped: tracked files have uncommitted changes — run manually: ...` | 1 |

## Local CodeRabbit review

- Pass 1: 2 findings (1 potential_issue, 1 nitpick). Fixed potential_issue (SKILL.md status-string mismatch). Rejected nitpick (helper extraction) per CLAUDE.md anti-premature-abstraction guidance.
- Pass 2: 2 nitpicks. Accepted one (tighter AHEAD integer validation — small, aligned with loud-abort spirit). Rejected helper extraction again.
- Pass 3: CR CLI rate-limited (4-min wait). Fell through to self-review per `cr-local-review.md`.

## Test plan

- [x] `main-sync.sh --reset` fetches `origin/main` before touching local main
- [x] `main-sync.sh --reset` aborts loudly (exit 4) if local main has commits not on origin
- [x] `main-sync.sh --reset` hard-resets local main to `origin/main` when safe (clean + not ahead)
- [x] Abort message tells user exactly how to inspect (`git log origin/main..main`)
- [x] Logic lives in the shared `.claude/scripts/main-sync.sh` script
- [x] `/wrap` Step 2.5 calls `dirty-main-guard.sh --quarantine` then `main-sync.sh --reset`
- [x] `/wrap` Step 5.3 final report surfaces both `QUARANTINE_STATUS` and `MAIN_SYNC_STATUS`
- [x] Smoke test — normal scenario (no-op reset) documented
- [x] Smoke test — behind scenario (fast-forward via reset) documented
- [x] Smoke test — ahead scenario (loud abort with exit 4) documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores & Infrastructure**
  * Enhanced main branch synchronization with improved safety mechanisms including dirty state verification before syncing.
  * Refined error handling and status reporting with new variants for reset operations and conflict detection.
  * Updated workflow guidance to flag critical synchronization states for manual review rather than automatic recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->