### PR TITLE
fix(subagents): clean up Phase A worktree + defensive Phase B checkout (#249)

### DIFF
--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -31,6 +31,21 @@ On startup, check for the handoff file:
 1. **If `{{HANDOFF_FILE}}` exists:** Parse and validate (`schema_version`, `pr_number`, `phase_completed`). Extract `head_sha`, `reviewer`, `threads_replied`, `threads_resolved`, `findings_fixed` to avoid duplicate work. Log: "Loaded handoff file from Phase A."
 2. **If missing or invalid:** Fall back to GitHub API reconstruction — fetch all 3 comment endpoints with `per_page=100`. Log: "No handoff file found, reconstructing state from GitHub API."
 
+### Defensive Branch Checkout (MANDATORY)
+
+Before any code operations, check out the feature branch using a **uniquely-named local branch** that tracks the remote. This is lock-free even if a stale Phase A worktree is still holding the feature branch:
+
+```bash
+git fetch origin <branch>
+git checkout -b phase-b-<branch> origin/<branch>
+# ... poll, fix, commit ...
+git push origin HEAD:<branch>
+```
+
+Creating a differently-named local branch (`phase-b-<branch>`) avoids the git "branch '<branch>' is already checked out at '<path>'" error. Pushing with `HEAD:<branch>` sends commits to the correct remote branch regardless of the local name.
+
+**Why MANDATORY (not just redundant):** the parent's worktree cleanup in `phase-protocols.md` (Phase A step 4) can fail or race in ways Phase B cannot observe — a crashed Phase A that never returned a result, `git worktree remove --force` failing on permissions or in-flight file handles, a concurrent Phase B launch while the first still holds the branch, or prune leaving dangling refs. This defensive checkout is the single reliable guarantee that Phase B acquires the branch; the parent cleanup is a best-effort hygiene step layered on top.
+
 ## Before Requesting Any New Review (MANDATORY)
 
 Run the session-start / pre-review comment audit per `cr-github-review.md` ("Session-start / pre-review comment audit"):

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -37,12 +37,12 @@ Before any code operations, check out the feature branch using a **uniquely-name
 
 ```bash
 git fetch origin <branch>
-git checkout -b phase-b-<branch> origin/<branch>
+git checkout -B phase-b-<branch> origin/<branch>
 # ... poll, fix, commit ...
 git push origin HEAD:<branch>
 ```
 
-Creating a differently-named local branch (`phase-b-<branch>`) avoids the git "branch '<branch>' is already checked out at '<path>'" error. Pushing with `HEAD:<branch>` sends commits to the correct remote branch regardless of the local name.
+Creating a differently-named local branch (`phase-b-<branch>`) avoids the git "branch '<branch>' is already checked out at '<path>'" error. Use `-B` (uppercase) — it creates the branch on first launch and resets it to `origin/<branch>` on replacement launches (three of four Phase B outcomes — `clean`, `fixes_pushed`, `exhaustion` — trigger replacement, so this path is common; lowercase `-b` would fail with "branch already exists"). Pushing with `HEAD:<branch>` sends commits to the correct remote branch regardless of the local name.
 
 **Why MANDATORY (not just redundant):** the parent's worktree cleanup in `phase-protocols.md` (Phase A step 4) can fail or race in ways Phase B cannot observe — a crashed Phase A that never returned a result, `git worktree remove --force` failing on permissions or in-flight file handles, a concurrent Phase B launch while the first still holds the branch, or prune leaving dangling refs. This defensive checkout is the single reliable guarantee that Phase B acquires the branch; the parent cleanup is a best-effort hygiene step layered on top.
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -37,12 +37,13 @@ Before any code operations, check out the feature branch using a **uniquely-name
 
 ```bash
 git fetch origin <branch>
-git checkout -B phase-b-<branch> origin/<branch>
+LOCAL="phase-b-<branch>-$(date +%s)"
+git checkout -b "$LOCAL" origin/<branch>
 # ... poll, fix, commit ...
 git push origin HEAD:<branch>
 ```
 
-The differently-named local branch avoids the "branch already checked out" error; `-B` (uppercase) is idempotent — creates on first launch, resets to `origin/<branch>` on replacements (three of four Phase B outcomes trigger replacements); `HEAD:<branch>` pushes to the right remote regardless of local name. MANDATORY because parent cleanup (`phase-protocols.md` Phase A step 4) can silently fail or race — Phase A crash, permission/file-handle errors, concurrent launches, dangling refs after prune — and Phase B cannot observe those failures. This checkout is the single reliable guarantee; parent cleanup is best-effort hygiene layered on top.
+Using a **unique per-launch local name** (timestamp suffix) sidesteps git's worktree branch lock — the lock is per-branch across all worktrees, so even `-B` can't override it when an old Phase B worktree still holds the branch (three of four Phase B outcomes trigger replacements). A fresh local name per launch is lock-free by construction. `HEAD:<branch>` pushes to the right remote regardless of local name. MANDATORY because parent cleanup (`phase-protocols.md` Phase A step 4) covers only Phase A; Phase B replacements are uncleaned today, and parent cleanup anywhere can silently fail or race (crash, permissions, concurrent launches). This checkout is the single reliable guarantee Phase B acquires the branch.
 
 ## Before Requesting Any New Review (MANDATORY)
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -42,9 +42,7 @@ git checkout -B phase-b-<branch> origin/<branch>
 git push origin HEAD:<branch>
 ```
 
-Creating a differently-named local branch (`phase-b-<branch>`) avoids the git "branch '<branch>' is already checked out at '<path>'" error. Use `-B` (uppercase) — it creates the branch on first launch and resets it to `origin/<branch>` on replacement launches (three of four Phase B outcomes — `clean`, `fixes_pushed`, `exhaustion` — trigger replacement, so this path is common; lowercase `-b` would fail with "branch already exists"). Pushing with `HEAD:<branch>` sends commits to the correct remote branch regardless of the local name.
-
-**Why MANDATORY (not just redundant):** the parent's worktree cleanup in `phase-protocols.md` (Phase A step 4) can fail or race in ways Phase B cannot observe — a crashed Phase A that never returned a result, `git worktree remove --force` failing on permissions or in-flight file handles, a concurrent Phase B launch while the first still holds the branch, or prune leaving dangling refs. This defensive checkout is the single reliable guarantee that Phase B acquires the branch; the parent cleanup is a best-effort hygiene step layered on top.
+The differently-named local branch avoids the "branch already checked out" error; `-B` (uppercase) is idempotent — creates on first launch, resets to `origin/<branch>` on replacements (three of four Phase B outcomes trigger replacements); `HEAD:<branch>` pushes to the right remote regardless of local name. MANDATORY because parent cleanup (`phase-protocols.md` Phase A step 4) can silently fail or race — Phase A crash, permission/file-handle errors, concurrent launches, dangling refs after prune — and Phase B cannot observe those failures. This checkout is the single reliable guarantee; parent cleanup is best-effort hygiene layered on top.
 
 ## Before Requesting Any New Review (MANDATORY)
 

--- a/.claude/rules/phase-protocols.md
+++ b/.claude/rules/phase-protocols.md
@@ -27,7 +27,7 @@ Block header is `EXIT_REPORT`; fields (one per line, colon-separated, no extra w
 1. **Parse the exit report.** Extract `PR_NUMBER`, `HEAD_SHA`, `OUTCOME`, `REVIEWER`, `NEXT_PHASE`. No exit report = silent failure — report to user, check GitHub API.
 2. **Branch on OUTCOME:**
    - `pushed_fixes` or `no_findings` → proceed to step 3
-   - `exhaustion` → launch replacement Phase A within 60s. Report to user. **STOP — do not execute steps 3-8.**
+   - `exhaustion` → **run step 4 (worktree cleanup) now**, then launch replacement Phase A within 60s. Report to user. **STOP — do not execute steps 3, 5-8.** (Cleanup is mandatory even on exhaustion — Phase A has no defensive checkout, so the replacement will hit "branch already checked out" if the old worktree's lock persists.)
 3. **Verify the push.** `gh pr view N --json commits --jq '.commits[-1].oid'` — confirm SHA matches. Mismatch = silent failure.
 4. **Clean up the Phase A worktree.** Remove it with `git worktree remove <path> --force` (required for uncommitted state). On failure, fall back to `git worktree prune`. Cleanup releases the branch lock for Phase B. Phase B's defensive checkout (see `phase-b-reviewer.md`) handles residual lock failures via a distinct local branch name.
 5. **Verify handoff file.** Check `~/.claude/handoffs/pr-{N}-handoff.json` exists with `phase_completed: "A"`. If missing, reconstruct and write it yourself.

--- a/.claude/rules/phase-protocols.md
+++ b/.claude/rules/phase-protocols.md
@@ -27,12 +27,13 @@ Block header is `EXIT_REPORT`; fields (one per line, colon-separated, no extra w
 1. **Parse the exit report.** Extract `PR_NUMBER`, `HEAD_SHA`, `OUTCOME`, `REVIEWER`, `NEXT_PHASE`. No exit report = silent failure — report to user, check GitHub API.
 2. **Branch on OUTCOME:**
    - `pushed_fixes` or `no_findings` → proceed to step 3
-   - `exhaustion` → launch replacement Phase A within 60s. Report to user. **STOP — do not execute steps 3-7.**
+   - `exhaustion` → launch replacement Phase A within 60s. Report to user. **STOP — do not execute steps 3-8.**
 3. **Verify the push.** `gh pr view N --json commits --jq '.commits[-1].oid'` — confirm SHA matches. Mismatch = silent failure.
-4. **Verify handoff file.** Check `~/.claude/handoffs/pr-{N}-handoff.json` exists with `phase_completed: "A"`. If missing, reconstruct and write it yourself.
-5. **Launch Phase B within 60 seconds.** Check if reviewers already posted findings (fetch all 3 comment endpoints, `per_page=100`). Include findings and handoff file path in prompt. If throttled, tell user and auto-retry.
-6. **Update `session-state.json`.** Record phase transition and HEAD SHA.
-7. **Report to user.** "Phase A complete for PR #N — fixes pushed (SHA `abc1234`). Phase B launched."
+4. **Clean up the Phase A worktree.** Remove it with `git worktree remove <path> --force` (required for uncommitted state). On failure, fall back to `git worktree prune`. Cleanup releases the branch lock for Phase B. Phase B's defensive checkout (see `phase-b-reviewer.md`) handles residual lock failures via a distinct local branch name.
+5. **Verify handoff file.** Check `~/.claude/handoffs/pr-{N}-handoff.json` exists with `phase_completed: "A"`. If missing, reconstruct and write it yourself.
+6. **Launch Phase B within 60 seconds.** Check if reviewers already posted findings (fetch all 3 comment endpoints, `per_page=100`). Include findings and handoff file path in prompt. If throttled, tell user and auto-retry.
+7. **Update `session-state.json`.** Record phase transition and HEAD SHA.
+8. **Report to user.** "Phase A complete for PR #N — fixes pushed (SHA `abc1234`). Phase B launched."
 
 **Phase B launch is the highest-priority action after Phase A reports.** Do not start other work until Phase B is launched for every completed Phase A.
 

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -103,13 +103,13 @@ Subagents have a 32K output token limit. When approaching exhaustion:
 
 The 32K limit is the binding constraint. Give each subagent ONE clear phase with explicit exit criteria — no exploratory instructions. Detailed per-phase procedures live in the agent definitions (`.claude/agents/phase-{a,b,c}-*.md`); if agent definitions are unavailable, use `.claude/reference/phase-decomposition.md`.
 
-- **Phase A: Fix + Push** (heaviest) — fix findings, commit once, push once, reply to threads, write handoff, EXIT.
+- **Phase A: Fix + Push** (heaviest) — fix findings, commit once, push once, reply to threads, write handoff, EXIT. The parent removes Phase A's worktree before launching Phase B (see `phase-protocols.md` Phase A step 4).
 - **Phase B: Review Loop** (lighter) — poll/trigger reviewer, fix new findings, update handoff, EXIT.
 - **Phase C: Merge Prep** (lightest) — verify merge gate per `cr-merge-gate.md` + AC, report readiness, EXIT. Do not delete handoff.
 
 **Orchestration rules:**
 - Parent launches Phase A subagents (can run in parallel across PRs)
-- Phase A complete → parent launches Phase B immediately (see `phase-protocols.md`)
+- Phase A complete → parent removes the Phase A worktree (releases branch lock), then launches Phase B immediately (see `phase-protocols.md` Phase A Completion Protocol for the authoritative cleanup step)
 - Phase B merge_ready → parent launches Phase C
 - Soft limit: 3-4 active CR-polled PRs to reduce throttling
 - Track CR quota: 7+ reviews/hour means expect Greptile as primary reviewer

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -103,7 +103,7 @@ Subagents have a 32K output token limit. When approaching exhaustion:
 
 The 32K limit is the binding constraint. Give each subagent ONE clear phase with explicit exit criteria — no exploratory instructions. Detailed per-phase procedures live in the agent definitions (`.claude/agents/phase-{a,b,c}-*.md`); if agent definitions are unavailable, use `.claude/reference/phase-decomposition.md`.
 
-- **Phase A: Fix + Push** (heaviest) — fix findings, commit once, push once, reply to threads, write handoff, EXIT. The parent removes Phase A's worktree before launching Phase B (see `phase-protocols.md` Phase A step 4).
+- **Phase A: Fix + Push** (heaviest) — fix findings, commit once, push once, reply to threads, write handoff, EXIT (parent cleanup detailed in Orchestration rules below).
 - **Phase B: Review Loop** (lighter) — poll/trigger reviewer, fix new findings, update handoff, EXIT.
 - **Phase C: Merge Prep** (lightest) — verify merge gate per `cr-merge-gate.md` + AC, report readiness, EXIT. Do not delete handoff.
 


### PR DESCRIPTION
## Summary

- Phase A subagents run in `isolation: "worktree"` — each holds a branch lock. Without explicit cleanup, Phase B cannot check out the feature branch.
- Parent now removes the Phase A worktree before launching Phase B (`phase-protocols.md` Phase A step 4).
- Phase B uses a uniquely-named local branch (`git checkout -b phase-b-<branch>-$(date +%s) origin/<branch>`) that's lock-free even on replacement launches, pushes with `HEAD:<branch>` (`phase-b-reviewer.md`).
- `subagent-orchestration.md` now documents parent cleanup as a first-class orchestration step.

Closes #249

## Test plan

- [x] `phase-protocols.md` Phase A Completion Protocol includes worktree cleanup step (now step 4, renumbered)
- [x] Phase B agent definition (`phase-b-reviewer.md`) uses defensive branch checkout (`git checkout -b` + `git push origin HEAD:`)
- [x] `subagent-orchestration.md` "Task Decomposition" Phase A section mentions worktree cleanup as parent responsibility
- [x] Rule file word count stays within 14,000-word budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)