### PR TITLE
feat(rules): heartbeat during batch file writes (#322)

### DIFF
--- a/.claude/rules/monitor-mode.md
+++ b/.claude/rules/monitor-mode.md
@@ -70,6 +70,12 @@ Canonical rule: CLAUDE.md #3 (5-minute max silence, non-negotiable).
 
 **Heartbeat enforcement:** A PostToolUse hook warns when >5 min have elapsed — on seeing it, stop and send a status message immediately.
 
+## File-Write Status Updates (MANDATORY)
+
+Extension of "Never batch status updates" (above). Long silent chains of file writes trip the silence detector even though work is progressing, and deprive the user of progress visibility.
+
+**Rule:** For operations touching 4+ files, emit a one-line status after every 3 writes/edits (e.g., "wrote 3/9: auth module done, starting handlers"). Batches of 1–3 don't need one. One message per chunk is enough — no extra timestamp needed if the turn-start one already fired. Applies to parent agents and subagents.
+
 ## Post-Compaction Recovery (MANDATORY)
 
 Context compaction wipes in-memory state. **Detection:** conversation starts with a summary block referencing prior work you don't remember.

--- a/.claude/skills/lessons/SKILL.md
+++ b/.claude/skills/lessons/SKILL.md
@@ -58,6 +58,8 @@ For each actionable, novel lesson:
 
 2. Add a pointer to `MEMORY.md` (the memory index at `~/.claude/projects/{project}/memory/MEMORY.md`) as a single bullet: `- [filename.md](filename.md) — one-line description`. If updating an existing memory, update the existing pointer instead of adding a duplicate.
 
+> **Heartbeat during batch writes:** If saving more than 3 memory files in a row, emit a one-line status message after every 3 writes per `monitor-mode.md` "File-Write Status Updates" (e.g., "Saved 3/5 lessons; continuing").
+
 ### Step 4: Output summary
 
 Present the lessons to the user in a concise format:

--- a/.claude/skills/lessons/SKILL.md
+++ b/.claude/skills/lessons/SKILL.md
@@ -58,7 +58,7 @@ For each actionable, novel lesson:
 
 2. Add a pointer to `MEMORY.md` (the memory index at `~/.claude/projects/{project}/memory/MEMORY.md`) as a single bullet: `- [filename.md](filename.md) — one-line description`. If updating an existing memory, update the existing pointer instead of adding a duplicate.
 
-> **Heartbeat during batch writes:** If saving more than 3 memory files in a row, emit a one-line status message after every 3 writes per `monitor-mode.md` "File-Write Status Updates" (e.g., "Saved 3/5 lessons; continuing").
+> **Heartbeat during batch writes:** When batching 4+ memory files, emit a one-line status message after every 3 writes per `monitor-mode.md` "File-Write Status Updates" (e.g., "Saved 3/5 lessons; continuing").
 
 ### Step 4: Output summary
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ These apply to EVERY message the parent agent sends to the user. No exceptions, 
 
 1. **Timestamp prefix.** Start every message with Eastern time (`Mon Mar 16 02:34 AM ET`). Get via: `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`. NEVER estimate timestamps — always run the `date` command.
 2. **Active monitoring declaration.** If monitoring background agents, state how many and which PRs at the end of every message.
-3. **5-minute heartbeat.** Never go >5 minutes without a status message. See `monitor-mode.md` "User Heartbeat" for detailed rules.
+3. **5-minute heartbeat.** Never go >5 minutes without a status message. During operations touching 4+ files, emit a one-line status after every 3 writes/edits (see `monitor-mode.md` "User Heartbeat" and "File-Write Status Updates" for details).
 4. **Dedicated monitor mode.** With active subagents, your ONLY job is orchestration — do NOT do substantive work. See `monitor-mode.md` "Dedicated Monitor Mode" for full rules.
 
 After context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `monitor-mode.md`) and report it WITH a timestamp.


### PR DESCRIPTION
## Summary

Adds a **File-Write Status Updates (MANDATORY)** section to `.claude/rules/monitor-mode.md` requiring a one-line status message after every 3 writes/edits when an operation touches 4+ files. Batches of 1–3 don't need one. Cross-referenced from `CLAUDE.md` non-negotiable #3.

This is the behavioral complement to the hook-level fixes in #318/#319/#320/#321: those fix the silence detector; this keeps the detector calibrated to actual work and gives the user live progress during long write chains.

**Rule placement:** colocated with existing heartbeat/status rules in `monitor-mode.md` (per CR's design-choice 1) — no new rule file, so no rule-files-table edit needed.

## Skill audit

| Skill | Batch-write behavior | Status |
|-------|---------------------|--------|
| `/subagent` | 1–2 files per phase (handoff + session-state) | ✅ Compliant (below threshold) |
| `/lessons` | N memory files per session (can exceed 3) | 🔧 Reminder added pointing to new rule |
| `/start-issue` | 2 `gh` ops (issue edit + comment) | ✅ Compliant (below threshold) |

**Skills named in issue body (`simplify`, `test scaffolding`, `batch-edit`) do not exist as `.claude/skills/*/SKILL.md` files** — CR's plan correctly identified this. The audit covered the actual batch-write skills in the codebase.

## Budget verification

- Word count: 12,383 / 14,000 (≤ 14,000 ✅)
- `monitor-mode.md`: 105 lines (≤ 150 soft cap ✅)

## Review loop notes

Local `coderabbit review --prompt-only` produced 2 rounds of valid findings (threshold clarity, wording consistency, terseness) which were fixed. A 3rd local pass hit the CR CLI rate limit twice in a row; per `cr-local-review.md` fallback rule, self-review was performed instead. GitHub CR/BugBot/Greptile will run on this PR as the authoritative merge gate.

## Test plan

- [x] Rule lives in the appropriate file (`.claude/rules/monitor-mode.md`) and counts against the 14,000-word rule budget
- [x] If standalone file, it's linked from the CLAUDE.md rule-files table (N/A — inside existing file)
- [x] Existing skills doing batch writes (`/subagent`, `/lessons`, `/start-issue`) audited for compliance and updated if violating
- [x] Word-count check passes: total ≤ 14,000

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified monitoring and progress-reporting: operations touching four or more files must emit one-line status updates after each group of three writes/edits.
  * Applied guidance across parent and subagent contexts and clarified behavior for batched “save to memory” steps (1–3 file batches exempt).
  * Expanded heartbeat guidance to ensure timely status visibility during long multi-file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->