### PR TITLE
feat(phase-c): explicit numbered procedural gates for CI + thread resolution (#211)

### DIFF
--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -41,7 +41,11 @@ gh pr view {{PR_NUMBER}} --json state,title,mergeStateStatus,commits
 
 ## Step 1: Verify Merge Gate (and CI)
 
-Run the shared merge-gate verifier. It implements the three-path gate from `.claude/rules/cr-merge-gate.md` (CR 1-clean-approval on current HEAD, BugBot 1-clean, Greptile severity-gated), plus the CI-must-pass check and the BEHIND check.
+Run the shared merge-gate verifier. It implements the three-path gate from `.claude/rules/cr-merge-gate.md` (CR 1-clean-approval on current HEAD, BugBot 1-clean, Greptile severity-gated), plus these explicit pre-merge gates — each is a hard STOP if not satisfied:
+
+- **Gate 1a — CI terminal state.** All check-runs `status: "completed"` with no blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`). In-progress checks BLOCK — do NOT present the merge prompt; wait and re-poll.
+- **Gate 1b — All review threads resolved.** Every thread `isResolved: true` via GraphQL `reviewThreads(first: 100)` (REST misses cursor/copilot bot threads). Any unresolved thread BLOCKS regardless of author.
+- **Gate 1c — BEHIND check.** `mergeStateStatus != BEHIND`.
 
 ```bash
 # Prefer the handoff's reviewer field; fall back to reviewer-of.sh (session-state

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -70,7 +70,7 @@ Every thread must be `isResolved: true` via GraphQL `reviewThreads` (REST misses
 
 ## Step 2 — Verify every Test Plan checkbox (MANDATORY — do NOT skip)
 
-> This is the **immediate next step** after CI passes (Step 1b). Do not ask the user about merging until this is done.
+> After Step 1c passes (`merge-gate.sh` enforces resolved threads), verify AC before merge.
 >
 > 1. Fetch the PR body via `gh pr view N --json body`
 > 2. Parse **every** checkbox in the **Test plan** section of the PR description

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -66,15 +66,7 @@ This applies to ALL merge paths: manual `gh pr merge`, the `/merge` skill, the `
 
 ## Step 1c — All Review Threads Resolved (NON-NEGOTIABLE)
 
-Before any merge, every review thread on the PR must be `isResolved: true`. Use the GraphQL `reviewThreads` endpoint — REST endpoints miss bot threads (cursor/copilot — see memory `feedback_premerge_all_threads.md`). `merge-gate.sh` enforces this universally (any unresolved thread blocks, regardless of author). Manual fallback:
-
-```bash
-gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{isResolved}}}}}' \
-  -F o="$OWNER" -F r="$REPO" -F n="$PR" \
-  | jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
-```
-
-**If the count is > 0: DO NOT MERGE.** Reply + resolve via `resolveReviewThread` mutation (see `cr-github-review.md` "Processing CR Feedback"), then re-check.
+Every thread must be `isResolved: true` via GraphQL `reviewThreads` (REST misses cursor/copilot bots). `merge-gate.sh` enforces this — any unresolved thread blocks, regardless of author. **If any unresolved: DO NOT MERGE.** Reply + `resolveReviewThread`, then re-check.
 
 ## Step 2 — Verify every Test Plan checkbox (MANDATORY — do NOT skip)
 

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -64,6 +64,18 @@ Before running `gh pr merge` on ANY PR, verify ALL CI check-runs are complete an
 
 This applies to ALL merge paths: manual `gh pr merge`, the `/merge` skill, the `/wrap` skill, and Phase C merge prep.
 
+## Step 1c — All Review Threads Resolved (NON-NEGOTIABLE)
+
+Before any merge, every review thread on the PR must be `isResolved: true`. Use the GraphQL `reviewThreads` endpoint — REST endpoints miss bot threads (cursor/copilot — see memory `feedback_premerge_all_threads.md`). `merge-gate.sh` enforces this universally (any unresolved thread blocks, regardless of author). Manual fallback:
+
+```bash
+gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{isResolved}}}}}' \
+  -F o="$OWNER" -F r="$REPO" -F n="$PR" \
+  | jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
+```
+
+**If the count is > 0: DO NOT MERGE.** Reply + resolve via `resolveReviewThread` mutation (see `cr-github-review.md` "Processing CR Feedback"), then re-check.
+
 ## Step 2 — Verify every Test Plan checkbox (MANDATORY — do NOT skip)
 
 > This is the **immediate next step** after CI passes (Step 1b). Do not ask the user about merging until this is done.

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -286,18 +286,20 @@ if [[ "$CI_FAILING" -gt 0 ]]; then
   MISSING+=("CI has $CI_FAILING failing check-run(s): $BLOCKING_NAMES")
 fi
 
+# Universal unresolved-thread gate (#211) — applies to all paths regardless of
+# author. Catches threads from any reviewer (CR, BugBot, Greptile, Copilot,
+# human) that the per-path author-scoped checks would miss.
+UNRESOLVED_TOTAL=$(echo "$THREADS_JSON" | jq -r '
+  [.data.repository.pullRequest.reviewThreads.nodes[]?
+    | select(.isResolved == false)]
+  | length')
+if [[ "$UNRESOLVED_TOTAL" -gt 0 ]]; then
+  MISSING+=("$UNRESOLVED_TOTAL unresolved review thread(s) — resolve via GraphQL before merge")
+fi
+
 # Path-specific checks.
 case "$REVIEWER" in
   cr)
-    # Unresolved CR threads (GraphQL — any thread with a coderabbitai[bot] comment and isResolved=false).
-    UNRESOLVED_CR=$(echo "$THREADS_JSON" | jq -r '
-      [.data.repository.pullRequest.reviewThreads.nodes[]?
-        | select(.isResolved == false)
-        | select(any(.comments.nodes[]?; .author.login == "coderabbitai[bot]"))]
-      | length')
-    if [[ "$UNRESOLVED_CR" -gt 0 ]]; then
-      MISSING+=("$UNRESOLVED_CR unresolved CR thread(s)")
-    fi
 
     # CodeRabbit check-run status on current HEAD.
     CR_CHECK=$(echo "$CHECK_RUNS_JSON" | jq -c '[.check_runs[]? | select(.name == "CodeRabbit")] | first // empty')
@@ -356,17 +358,8 @@ case "$REVIEWER" in
     ;;
 
   bugbot)
-    # Unresolved BugBot (cursor[bot]) threads.
-    UNRESOLVED_BB=$(echo "$THREADS_JSON" | jq -r '
-      [.data.repository.pullRequest.reviewThreads.nodes[]?
-        | select(.isResolved == false)
-        | select(any(.comments.nodes[]?; .author.login == "cursor[bot]"))]
-      | length')
-    if [[ "$UNRESOLVED_BB" -gt 0 ]]; then
-      MISSING+=("$UNRESOLVED_BB unresolved BugBot thread(s)")
-    fi
-
     # Need at least 1 BugBot review on current HEAD, with no actionable findings.
+    # Unresolved BugBot threads are caught by the universal unresolved-thread gate above.
     BB_REVIEWS_ON_HEAD=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
       [.[]? | select(.user.login == "cursor[bot]" and .commit_id == $sha)] | length')
 

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -383,12 +383,9 @@ case "$REVIEWER" in
     ;;
 
   greptile)
-    # Severity-gated. Clean = no unresolved Greptile threads and no "P0" badges outstanding.
-    UNRESOLVED_G=$(echo "$THREADS_JSON" | jq -r '
-      [.data.repository.pullRequest.reviewThreads.nodes[]?
-        | select(.isResolved == false)
-        | select(any(.comments.nodes[]?; .author.login == "greptile-apps[bot]"))]
-      | length')
+    # Severity-gated. Greptile-specific count handling is intentionally NOT here —
+    # the universal unresolved-thread gate above already reports the count for any
+    # unresolved thread. This path adds severity context (P0 vs P1/P2) only.
 
     # Latest Greptile review.
     LATEST_G=$(echo "$REVIEWS_JSON" | jq -c '
@@ -398,23 +395,26 @@ case "$REVIEWER" in
     if [[ -z "$LATEST_G" ]]; then
       MISSING+=("no Greptile review yet")
     else
-      # Look at the Greptile review body + its inline findings for P0 badges.
+      # Did the latest Greptile review include a P0 finding (in its body or its
+      # inline comments)? Used for severity-gated logic below.
       G_BODY=$(echo "$LATEST_G" | jq -r '.body // ""')
       G_SUBMITTED=$(echo "$LATEST_G" | jq -r '.submitted_at // ""')
       G_INLINE_BODIES=$(echo "$PR_COMMENTS_JSON" | jq -r --arg ts "$G_SUBMITTED" '
         [.[]? | select(.user.login == "greptile-apps[bot]" and .created_at >= $ts) | .body] | join("\n---\n")')
-
-      # Count P0 vs P1/P2 findings from the review + its inline comments. Greptile uses
-      # "P0"/"P1"/"P2" badges in comment bodies (see .claude/rules/greptile.md).
       P0_COUNT=$( { echo "$G_BODY"; echo "$G_INLINE_BODIES"; } | grep -oE '\bP0\b' | wc -l | tr -d ' ')
 
-      if [[ "$UNRESOLVED_G" -gt 0 ]]; then
-        if [[ "$P0_COUNT" -gt 0 ]]; then
-          MISSING+=("$UNRESOLVED_G unresolved Greptile thread(s) with P0 finding(s) — need re-review after fix")
-        else
-          MISSING+=("$UNRESOLVED_G unresolved Greptile thread(s) (P1/P2 — fix and reply to close)")
-        fi
-      elif [[ "$P0_COUNT" -gt 0 ]]; then
+      # Are there unresolved Greptile-authored threads? If so, P0 vs P1/P2 changes
+      # whether a re-review is required after fixing.
+      UNRESOLVED_G=$(echo "$THREADS_JSON" | jq -r '
+        [.data.repository.pullRequest.reviewThreads.nodes[]?
+          | select(.isResolved == false)
+          | select(any(.comments.nodes[]?; .author.login == "greptile-apps[bot]"))]
+        | length')
+
+      if [[ "$UNRESOLVED_G" -gt 0 && "$P0_COUNT" -gt 0 ]]; then
+        # Universal gate already reports the count; add severity-aware advice only.
+        MISSING+=("Greptile threads include P0 finding(s) — need clean re-review after fix")
+      elif [[ "$UNRESOLVED_G" -eq 0 && "$P0_COUNT" -gt 0 ]]; then
         # Threads are resolved but the latest (most recent) Greptile review had P0.
         # Since LATEST_G is already the last review by submitted_at, a clean re-review
         # would BE the latest review and wouldn't have P0. So if we're here, no clean


### PR DESCRIPTION
## **User description**
## Summary

Promotes Phase C's pre-merge checks from prose to **explicit numbered procedural gates** so the merge prompt is gated on (1) all CI check-runs at terminal status and (2) every review thread resolved via GraphQL — not just the assigned reviewer's threads.

- `merge-gate.sh` — universal unresolved-thread check (any author) blocks the gate. Drops redundant per-reviewer author-scoped checks for CR/BugBot. Greptile keeps its severity-aware messaging.
- `cr-merge-gate.md` — new **Step 1c — All Review Threads Resolved (NON-NEGOTIABLE)** with the GraphQL query and a hard STOP condition.
- `phase-c-merger.md` — Step 1 lists the gates as explicit numbered subgates (1a CI terminal, 1b thread resolution, 1c BEHIND).

GraphQL `reviewThreads` is the canonical source — REST endpoints miss cursor/copilot bot threads (per memory `feedback_premerge_all_threads.md`).

Closes #211

## Test plan

- [ ] `merge-gate.sh` syntax check passes (`bash -n`)
- [ ] `merge-gate.sh` reports `met: false` with `"N unresolved review thread(s)"` in `missing` when any thread `isResolved: false`, regardless of author
- [ ] `merge-gate.sh` reports `met: true` only when all check-runs are `status: completed` with non-blocking conclusions AND all threads resolved AND reviewer-path conditions met
- [ ] `cr-merge-gate.md` Step 1c is a numbered procedural step with explicit STOP condition (not buried in prose)
- [ ] `phase-c-merger.md` Step 1 lists gates 1a/1b/1c as numbered subgates
- [ ] Word budget under 14,000 across CLAUDE.md + .claude/rules/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Stricter pre-merge gating: CI checks must reach a final state and the branch must not be behind before merges proceed.
  * All pull request review threads must be fully resolved (detected via the API) and unresolved threads will block merging.
  * Unified review-thread handling and clearer severity-aware messaging for review feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Make merge checks block on any unresolved review thread and avoid duplicate Greptile counts**

### What Changed
- Merge checks now stop when any review thread is still open, including threads from bot or human reviewers, instead of only looking at reviewer-specific threads
- The merge guide now calls out the pre-merge steps as explicit numbered gates: CI must finish, all review threads must be resolved, and the branch must not be behind
- Greptile checks now add only severity context when needed, so unresolved-thread counts are reported once instead of twice

### Impact
`✅ Fewer merges with unresolved review comments`
`✅ Clearer pre-merge checks`
`✅ Less duplicate merge-blocking messages`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=PG0eCLMTCU-R6evqoV5A2Z0n0mmP0Jvi0jy9C1zr0Ls&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
