### PR TITLE
feat(prompt): update model roster to 4.7/4.6, drop effort field

### DIFF
--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -159,7 +159,9 @@ When `PM_AUTO_DETECT=true`, partition the classified issues into two groups usin
 |--------|---------------------------|
 | `file_count` | 0–1 |
 | `ac_count` | ≤ 3 |
-| `dependency_count_per_issue` | 0 (count only dependencies referencing or referenced by this specific issue, not the batch total) |
+
+| `dependency_count` | 0 (count only dependencies referencing or referenced by this specific issue, not the batch total) |
+
 | `touches_rules` | `false` |
 | `touches_claude_md` | `false` |
 | `has_orchestration_keywords` | `false` |

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -1,15 +1,14 @@
 ---
 name: prompt
-description: Analyze GitHub issues to assess complexity, classify effort tier, recommend model selection, and generate tailored prompts with pre-extracted context. Use when starting work, planning sprints, estimating effort, right-sizing model choice, or analyzing issue batches. When called with no args in a PM thread, auto-detects suggested issues and partitions subagent candidates from thread prompts.
+description: Analyze GitHub issues to assess complexity, recommend a model tier, and generate tailored prompts with pre-extracted context. Use when starting work, planning sprints, right-sizing model choice, or analyzing issue batches. When called with no args in a PM thread, auto-detects suggested issues and partitions subagent candidates from thread prompts.
 triggers:
   - analyze issue
   - generate prompt
-  - estimate effort
   - complexity check
 argument-hint: "[#123 #124 ...] (issue numbers, or omit for PM auto-detect)"
 ---
 
-Analyze one or more GitHub issues, classify complexity, and produce a copy-paste-ready prompt with a model/effort recommendation. The goal is quality-conservative right-sizing — never under-resource a task, but don't waste Opus 4.6 1M tokens on a typo fix.
+Analyze one or more GitHub issues, classify complexity, and produce a copy-paste-ready prompt with a model recommendation. The goal is quality-conservative right-sizing — never under-resource a task, but don't waste Opus 4.7 1M tokens on a typo fix.
 
 ## Step 0: Parse Arguments and Detect Context
 
@@ -120,7 +119,7 @@ Apply this decision tree. When signals conflict, choose the **higher** tier (con
 
 **Batch handling rule:** First classify each issue independently to produce a per-issue tier (`issue_tier`). Then compute a batch tier from the most complex `issue_tier` in the set. A batch of 3 issues where one is Heavy makes the batch tier Heavy. The batch tier is used for thread-prompt output formatting and checkpoint inheritance, while per-issue decisions (like Step 5.5 subagent partitioning) must use `issue_tier`.
 
-### Heavy — Opus 4.6 1M / High effort
+### Heavy — Opus 4.7 1M
 
 Assign Heavy if ANY of these are true:
 - `touches_rules` is true (rule files are highest-stakes)
@@ -130,7 +129,7 @@ Assign Heavy if ANY of these are true:
 - `file_count > 5`
 - `dependency_count > 2`
 
-### Standard — Opus 4.6 / Medium effort
+### Standard — Opus 4.7
 
 Assign Standard if ANY of these are true (and Heavy was not triggered):
 - `file_count` is 2–5
@@ -139,20 +138,11 @@ Assign Standard if ANY of these are true (and Heavy was not triggered):
 - Issue body is >200 words with structural patterns (includes a user story, describes a new feature via keywords like "implement", "add", "support")
 - `is_multi_issue` with mixed complexity (at least one non-trivial issue that didn't trigger Heavy)
 
-### Quick — Haiku 4.5 / Low effort
+### Light — Sonnet 4.6
 
-Assign Quick only if ALL of these are true (evaluated before Light to prevent Light's broader conditions from preempting):
-- `scope_keywords` is non-empty AND every element is exclusively from: "typo", "rename", "comment", "formatting"
+Assign Light if ANY of these are true (and Heavy/Standard were not triggered):
 - `file_count` is 0–1
-- `ac_count` ≤ 2
-- `dependency_count` is 0
-- No orchestration, rule, or skill signals
-
-### Light — Sonnet 4.6 / Medium effort
-
-Assign Light if ANY of these are true (and Heavy/Standard/Quick were not triggered):
-- `file_count` is 0–1
-- `scope_keywords` include "config", "doc update", "README"
+- `scope_keywords` include "typo", "rename", "comment", "formatting", "config", "doc update", "README"
 - Issue describes a straightforward single-file addition or modification
 
 ### Fallback
@@ -173,7 +163,7 @@ When `PM_AUTO_DETECT=true`, partition the classified issues into two groups usin
 | `touches_rules` | `false` |
 | `touches_claude_md` | `false` |
 | `has_orchestration_keywords` | `false` |
-| `issue_tier` | Quick or Light |
+| `issue_tier` | Light |
 
 Use per-issue signal values from Steps 4–5, including `issue_tier` (the per-issue tier from the classification decision tree — not the batch tier). Do not use batch-aggregated values for per-issue gating. Apply the table as a gate: if ANY signal exceeds its threshold, the issue is **not** subagent-eligible.
 
@@ -228,7 +218,7 @@ Output the Tier Recommendation as plain text first (skip if all issues are subag
 ```
 ## Tier Recommendation
 
-**{TIER_NAME}** — {MODEL} / {EFFORT} effort
+**{TIER_NAME}** — {MODEL}
 
 Rationale: {1-line explanation of why this tier was selected, citing the dominant signal}
 ```

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -157,9 +157,9 @@ When `PM_AUTO_DETECT=true`, partition the classified issues into two groups usin
 
 | Signal | Subagent-eligible threshold |
 |--------|---------------------------|
-| `file_count` | 0–2 |
+| `file_count` | 0–1 |
 | `ac_count` | ≤ 3 |
-| `dependency_count` | 0 (for that issue — count only dependencies referencing or referenced by this specific issue, not the batch total) |
+| `dependency_count_per_issue` | 0 (count only dependencies referencing or referenced by this specific issue, not the batch total) |
 | `touches_rules` | `false` |
 | `touches_claude_md` | `false` |
 | `has_orchestration_keywords` | `false` |

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -249,7 +249,7 @@ Then, for each issue, output a self-contained prompt block. Use tilde fences (`~
 {- For any tier involving PRs: "Read `.claude/rules/cr-github-review.md` for polling endpoints and thread resolution, and `.claude/rules/cr-merge-gate.md` for the authoritative merge gate (1 explicit CR APPROVED review on current HEAD SHA, with SHA freshness + explicit-approval-only)."}
 {- For any tier involving CR local review: "Read `.claude/rules/cr-local-review.md` — specifically the fix loop and exit criteria (1 clean pass)."}
 {- For issue creation: "Read `.claude/rules/issue-planning.md` — specifically the planning flow and plan merge step."}
-{- For Light/Quick tiers with no protocol involvement: "No special protocol rules needed — standard coding workflow."}
+{- For Light tier with no protocol involvement: "No special protocol rules needed — standard coding workflow."}
 
 ---
 

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -331,4 +331,40 @@ When called with no args in a PM thread, auto-detects recently suggested issues,
 ```
 Falls back to asking: "Which issue(s) should I analyze?"
 
+### Sample output
+
+For an issue with `touches_skill=true` and `ac_count=4`, the skill emits the Tier Recommendation as plain text first, then a self-contained prompt block in a tilde fence. The recommendation rendered to the chat looks like:
+
+> **Standard** — Opus 4.7
+>
+> Rationale: touches_skill=true (modifies a file under .claude/skills/) drives Standard.
+
+The prompt block that follows:
+
+~~~
+### Issue #110: {Title}
+
+**Acceptance Criteria:**
+{checklist items from the issue body}
+
+**Dependencies:** {relationships, or "None detected"}
+
+**Labels:** {comma-separated, or "None"}
+
+---
+
+## Pre-extracted Context
+
+### Files to read/modify
+{files from CR plan, or exploration note}
+
+### Relevant rules
+{rule files relevant to the tier}
+
+---
+
+## CR Implementation Plan
+{CR plan verbatim, or "No CodeRabbit implementation plan available."}
+~~~
+
 **Note:** This skill produces a recommendation. The user decides whether to follow the tier suggestion. When in doubt, the skill errs toward the higher tier — it's better to slightly over-resource than to get instruction adherence failures on a complex task.


### PR DESCRIPTION
## **User description**
## Summary

- Replaces all `Opus 4.6` / `Opus 4.6 1M` references in `.claude/skills/prompt/SKILL.md` with the new roster: Heavy → **Opus 4.7 1M**, Standard → **Opus 4.7**, Light → **Sonnet 4.6**.
- Collapses the **Quick** tier into Light (no Haiku from `/prompt` per direction) — Light's `scope_keywords` list now includes the former Quick keywords (`typo`, `rename`, `comment`, `formatting`).
- Removes all `/ {EFFORT} effort` language from tier headers and the output template (`{TIER_NAME} — {MODEL}` is now the format).
- Updates frontmatter `description` (drops "classify effort tier" / "estimating effort") and removes the `estimate effort` trigger alias.

Closes #308

## Sample run

Running the updated skill against issue #308 itself:

- Signals: `file_count = 1`, `ac_count = 7`, `touches_skill = true`, `dependency_count = 0`, no orchestration / rule / CLAUDE.md keywords.
- Decision tree: `touches_skill` triggers **Standard** (Heavy not triggered).

Output (Tier Recommendation + sample prompt block — model names present, no effort field):

```
## Tier Recommendation

**Standard** — Opus 4.7

Rationale: touches_skill=true (modifies a file under .claude/skills/) drives Standard.
```

~~~
### Issue #308: Update /prompt skill — new model roster (Opus 4.7 / 4.7 1M / Sonnet 4.6), remove effort config

**Acceptance Criteria:**
- [x] All Opus 4.6 references replaced
- [x] All / {EFFORT} effort language removed
- [x] Output template updated to drop the effort field
- [x] Description line updated
- [x] Frontmatter description / alias list updated if it mentions effort classification
- [x] grep returns no matches after the change
- [x] Sample run produces a prompt block with new model names and no effort field

**Dependencies:** None detected

**Labels:** None

## Pre-extracted Context

### Files to read/modify
- .claude/skills/prompt/SKILL.md (only file in scope)

### Relevant rules
- For any tier involving CR local review: Read .claude/rules/cr-local-review.md.
- For any tier involving PRs: Read .claude/rules/cr-github-review.md and .claude/rules/cr-merge-gate.md.
~~~

The block above contains the new model name (`Opus 4.7`) and contains **no** `effort` field — both required by the AC.

## Test plan

- [x] All `Opus 4.6` references in `.claude/skills/prompt/SKILL.md` replaced with the new roster
- [x] All `/ {EFFORT} effort` language removed from tier headers and the output template
- [x] Output template updated to drop the effort field
- [x] Description line updated — no "Opus 4.6 1M" reference, no "effort" framing
- [x] Frontmatter `description` / alias list updated (no effort classification)
- [x] `grep -inE 'opus 4\.6|/ .* effort|haiku' .claude/skills/prompt/SKILL.md` returns no matches
- [x] Sample run on a real issue produces a prompt block with the new model names and no effort field (see Sample run above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed effort estimation from the skill interface and triggers
  * Simplified tiering to Heavy, Standard, and Light and updated model assignments
  * Removed Quick tier and consolidated tier logic to model-only categories
  * Broadened Light eligibility via expanded scope keywords (config, docs, README, typos, etc.)
  * Tightened per-issue partitioning so only Light is eligible and refined dependency/file gating
  * Tier recommendations no longer display effort values

* **Documentation**
  * Added a sample output section illustrating the updated tier recommendation and prompt structure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Update the /prompt skill to use the new model roster and remove effort-based wording

### What Changed
- Replaces the old model names with Opus 4.7 1M, Opus 4.7, and Sonnet 4.6, and removes the effort field from the recommendation output
- Collapses the old Quick tier into Light, so small cleanup tasks now fall under the Light path
- Removes effort-focused wording from the skill description and triggers
- Adds a sample output section showing the recommendation format and the prompt block users should expect

### Impact
`✅ Clearer model recommendations`
`✅ Fewer effort-based prompts`
`✅ Easier-to-follow /prompt output`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Z8DWktm5cBTkOAkjv7Ouqy6zAMXj-p-vQ39slVskUUU&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
