### PR TITLE
feat(wrap+pm-update): move stale-cleanup out of /wrap into /pm-update (#338)

### DIFF
--- a/.claude/scripts/stale-cleanup.sh
+++ b/.claude/scripts/stale-cleanup.sh
@@ -546,6 +546,25 @@ for entry in "${STALE_WORKTREES[@]}"; do
   fi
   if out="$("${GIT[@]}" worktree remove "$p" 2>&1)"; then
     echo "removed: worktree $p"
+    # The branch this worktree was holding was NOT classified as a stale
+    # local branch (parse_worktrees adds every worktree's branch to
+    # CHECKED_OUT_BRANCHES, so during classification stale-worktree
+    # branches were skipped as "checked out"). Now that the worktree is
+    # gone, attempt to delete the branch too — gated by the same safety
+    # checks the local-branch loop uses (protected names, open PR).
+    # `git branch -D` is non-fatal on unknown branches, so failures here
+    # don't abort the script; we surface them via the FAILURES counter
+    # only when the branch actually exists and refuses deletion.
+    if [[ -n "$b" ]] && ! is_protected "$b" && ! has_open_pr "$b"; then
+      if "${GIT[@]}" show-ref --verify --quiet "refs/heads/$b"; then
+        if branch_out="$("${GIT[@]}" branch -D "$b" 2>&1)"; then
+          echo "removed: local branch $b (was on stale worktree $p)"
+        else
+          echo "failed: local branch $b (after worktree $p removed) — $branch_out"
+          FAILURES=$(( FAILURES + 1 ))
+        fi
+      fi
+    fi
   else
     echo "failed: worktree $p — $out"
     FAILURES=$(( FAILURES + 1 ))

--- a/.claude/scripts/stale-cleanup.sh
+++ b/.claude/scripts/stale-cleanup.sh
@@ -1,0 +1,548 @@
+#!/usr/bin/env bash
+# stale-cleanup.sh — Detect and optionally remove stale worktrees and branches.
+#
+# PURPOSE
+#   Replaces the self-cleanup that /wrap used to do (worktree removal + branch
+#   deletion in the running session). Runs out-of-band as part of /pm-update so
+#   the active session never deletes itself. Detects three classes of stale
+#   refs on the root repo:
+#     1. Local worktrees whose HEAD commit is older than STALE_DAYS.
+#     2. Local branches whose tip commit is older than STALE_DAYS.
+#     3. Remote branches (refs/remotes/origin/*) whose tip commit is older
+#        than STALE_DAYS.
+#
+#   Default mode is --check (dry-run). --apply performs the deletions only
+#   for items that pass every safety check below. Nothing is ever deleted in
+#   --check mode.
+#
+# SAFETY CHECKS (always applied; cannot be bypassed)
+#   Worktrees:
+#     - Skip the main worktree (root repo).
+#     - Skip the worktree the caller is currently inside (resolved from $PWD).
+#     - Skip if the worktree has uncommitted tracked changes (git diff).
+#     - Skip if the worktree's branch has an open PR.
+#   Local branches:
+#     - Skip protected names: main, master, develop.
+#     - Skip the current branch in any worktree (git refuses anyway).
+#     - Skip branches checked out in any worktree.
+#     - Skip branches with an open PR.
+#   Remote branches:
+#     - Skip protected names: main, master, develop, HEAD.
+#     - Skip branches with an open PR.
+#
+# CONFIGURATION
+#   STALE_DAYS — env var, default 7. Tip commits older than this are stale.
+#
+# USAGE
+#   stale-cleanup.sh --check                    # dry-run (default)
+#   stale-cleanup.sh --apply                    # delete stale items
+#   stale-cleanup.sh --check --json             # machine-readable output
+#   stale-cleanup.sh --help | -h
+#
+#   --check    Report stale items without deleting. Exit 0 if none, 1 if any.
+#   --apply    Delete stale items that pass safety checks. Exit 0 on success
+#              (or no stale items), 2 on partial failure.
+#   --json     Emit a JSON object instead of human-readable text.
+#
+# OUTPUT (human-readable, default)
+#   Stale worktrees (older than 7 days):
+#     <path> (branch <branch>, last commit <YYYY-MM-DD>)
+#     ...
+#   Stale local branches (older than 7 days):
+#     <branch> (last commit <YYYY-MM-DD>)
+#   Stale remote branches (older than 7 days):
+#     origin/<branch> (last commit <YYYY-MM-DD>)
+#   Skipped (with reason):
+#     <name> — <reason>
+#
+#   On --apply, each successful deletion is logged as "removed: <thing>" and
+#   each failure as "failed: <thing> — <reason>".
+#
+# EXIT STATUS
+#   0  No stale items, or --apply succeeded for all stale items.
+#   1  --check found one or more stale items.
+#   2  --apply hit one or more deletion failures (other items may have
+#      succeeded — see output).
+#   3  Usage error.
+#   4  Environment error (cannot resolve repo, gh missing, etc.).
+
+set -euo pipefail
+
+print_help() {
+  awk 'NR == 1 { next } /^$/ { exit } { sub(/^# ?/, ""); print }' "$0"
+}
+
+usage_error() {
+  echo "stale-cleanup.sh: $1" >&2
+  echo "Run with --help for usage." >&2
+  exit 3
+}
+
+MODE="check"
+JSON=0
+MODE_SET=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    --check|--apply)
+      if (( MODE_SET == 1 )); then
+        usage_error "--check and --apply are mutually exclusive"
+      fi
+      MODE="${1#--}"
+      MODE_SET=1
+      shift
+      ;;
+    --json)
+      JSON=1
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      usage_error "unknown flag: $1"
+      ;;
+    *)
+      usage_error "unexpected positional argument: $1"
+      ;;
+  esac
+done
+
+STALE_DAYS="${STALE_DAYS:-7}"
+if ! [[ "$STALE_DAYS" =~ ^[0-9]+$ ]] || (( STALE_DAYS < 1 )); then
+  echo "error: STALE_DAYS must be a positive integer (got: $STALE_DAYS)" >&2
+  exit 3
+fi
+
+NOW="$(date +%s)"
+THRESHOLD=$(( NOW - STALE_DAYS * 86400 ))
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT_SH="$SCRIPT_DIR/repo-root.sh"
+if [[ ! -x "$REPO_ROOT_SH" ]]; then
+  echo "error: repo-root.sh not found or not executable at $REPO_ROOT_SH" >&2
+  exit 4
+fi
+
+ROOT=""
+if ! ROOT="$("$REPO_ROOT_SH" "$SCRIPT_DIR" 2>/dev/null)"; then
+  echo "error: could not resolve root repo" >&2
+  exit 4
+fi
+if [[ -z "$ROOT" || ! -d "$ROOT" ]]; then
+  echo "error: resolved root repo is empty or missing" >&2
+  exit 4
+fi
+
+GIT=(git -C "$ROOT")
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found — open-PR safety check requires it" >&2
+  exit 4
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq not found — required for parsing gh JSON output and emit_json" >&2
+  exit 4
+fi
+
+PROTECTED_BRANCHES=("main" "master" "develop")
+is_protected() {
+  local b="$1"
+  for p in "${PROTECTED_BRANCHES[@]}"; do
+    [[ "$b" == "$p" ]] && return 0
+  done
+  return 1
+}
+
+# Cache open-PR head refs once. `gh pr list --json headRefName` caps at 1000
+# per call (gh's hard limit), so we paginate via `--search "is:open"` with
+# created-time pagination by walking pages until we get a short page back.
+# For typical repos (dozens to low-hundreds of open PRs) this is one round
+# trip; for a repo with thousands of open PRs it stays correct without
+# silently dropping entries.
+OPEN_PR_BRANCHES=""
+gh_pr_page() {
+  # gh pr list with --json forces non-interactive mode; --limit 1000 is the
+  # max gh accepts per call. We use the search API via --search to enable
+  # cursor-style pagination through `created:<timestamp` filters.
+  local cursor="$1"
+  local query="state:open"
+  if [[ -n "$cursor" ]]; then
+    query="$query created:<$cursor"
+  fi
+  gh pr list --search "$query" --limit 1000 --json headRefName,createdAt 2>/dev/null
+}
+fetch_open_prs() {
+  local cursor=""
+  local prev_cursor=""
+  local accumulated=""
+  while :; do
+    local page
+    page="$(gh_pr_page "$cursor")" || break
+    [[ "$page" == "[]" || -z "$page" ]] && break
+    local refs
+    refs="$(printf '%s' "$page" | jq -r '.[].headRefName' 2>/dev/null || true)"
+    if [[ -n "$refs" ]]; then
+      if [[ -z "$accumulated" ]]; then
+        accumulated="$refs"
+      else
+        accumulated="$accumulated"$'\n'"$refs"
+      fi
+    fi
+    # Page < 1000 entries means no more results.
+    local count
+    count="$(printf '%s' "$page" | jq 'length' 2>/dev/null || echo 0)"
+    (( count < 1000 )) && break
+    # Advance cursor to the oldest createdAt we just saw.
+    prev_cursor="$cursor"
+    cursor="$(printf '%s' "$page" | jq -r '[.[].createdAt] | min' 2>/dev/null || echo "")"
+    [[ -z "$cursor" || "$cursor" == "null" ]] && break
+    # Guard against pathological case where 1000+ PRs share the same
+    # createdAt timestamp — without this check we'd refetch the same page
+    # forever. In practice 1000 collisions is impossible (timestamps have
+    # second resolution and PR creation is rate-limited), but the bound
+    # makes the loop demonstrably terminating.
+    if [[ "$cursor" == "$prev_cursor" ]]; then
+      break
+    fi
+  done
+  printf '%s' "$accumulated"
+}
+OPEN_PR_BRANCHES="$(fetch_open_prs)"
+has_open_pr() {
+  local b="$1"
+  [[ -z "$OPEN_PR_BRANCHES" ]] && return 1
+  printf '%s\n' "$OPEN_PR_BRANCHES" | grep -Fxq "$b"
+}
+
+# Resolve "where am I right now?" so we never delete the caller's own worktree
+# even if its HEAD commit happens to be older than STALE_DAYS (e.g., long-lived
+# branch the user is actively working on).
+CALLER_PWD="$(pwd -P 2>/dev/null || pwd)"
+caller_in_worktree() {
+  local wt="$1"
+  # Resolve symlinks in both paths so we compare canonicalized forms.
+  local wt_real
+  wt_real="$(cd "$wt" 2>/dev/null && pwd -P || echo "$wt")"
+  [[ "$CALLER_PWD" == "$wt_real" || "$CALLER_PWD" == "$wt_real"/* ]]
+}
+
+# Compatibility note: macOS ships bash 3.2, which has no associative arrays.
+# Worktree records are stored as one delimited line per worktree in WORKTREES,
+# and CHECKED_OUT_BRANCHES is a newline-joined string of branch names. We look
+# up by linear scan / grep — fine for the dozens-of-worktrees scale we expect.
+#
+# Records use the ASCII unit separator (US, 0x1f) as the field delimiter
+# instead of `|` — git refnames and filesystem paths can both contain `|`
+# but never US, so parsing stays unambiguous regardless of input shape.
+US=$'\x1f'
+WORKTREES=()           # each entry: "is_main<US>path<US>branch<US>head_ts"
+CHECKED_OUT_BRANCHES="" # newline-separated list of branches checked out anywhere
+
+# `git worktree list --porcelain` emits records separated by blank lines:
+#   worktree <path>
+#   HEAD <sha>
+#   branch refs/heads/<name>      (or `detached`)
+parse_worktrees() {
+  local cur_path="" cur_branch="" cur_head=""
+  # `first` is intentionally accessible to the nested flush() below via bash's
+  # dynamic scoping — flush() flips it to 0 after recording the first record
+  # so subsequent records are tagged as non-main worktrees. Don't promote
+  # `first` to global without also updating flush().
+  local first=1
+  flush() {
+    if [[ -n "$cur_path" ]]; then
+      local is_main=0
+      if (( first == 1 )); then is_main=1; first=0; fi
+      WORKTREES+=("${is_main}${US}${cur_path}${US}${cur_branch}${US}${cur_head}")
+      if [[ -n "$cur_branch" ]]; then
+        if [[ -z "$CHECKED_OUT_BRANCHES" ]]; then
+          CHECKED_OUT_BRANCHES="$cur_branch"
+        else
+          CHECKED_OUT_BRANCHES="$CHECKED_OUT_BRANCHES"$'\n'"$cur_branch"
+        fi
+      fi
+    fi
+    cur_path=""; cur_branch=""; cur_head=""
+  }
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ -z "$line" ]]; then
+      flush
+      continue
+    fi
+    case "$line" in
+      "worktree "*) cur_path="${line#worktree }" ;;
+      "HEAD "*)
+        local sha="${line#HEAD }"
+        # Empty fallback (NOT 0) — 0 would compare as "ancient" against
+        # THRESHOLD and force the worktree to be classified stale even
+        # though we couldn't read its HEAD. Classification skips entries
+        # with empty/non-numeric ts and logs the worktree.
+        cur_head="$("${GIT[@]}" log -1 --format=%ct "$sha" 2>/dev/null || echo "")"
+        ;;
+      "branch refs/heads/"*) cur_branch="${line#branch refs/heads/}" ;;
+      "detached") cur_branch="" ;;
+    esac
+  done < <("${GIT[@]}" worktree list --porcelain)
+  flush
+}
+
+parse_worktrees
+
+is_branch_checked_out() {
+  local b="$1"
+  [[ -z "$CHECKED_OUT_BRANCHES" ]] && return 1
+  printf '%s\n' "$CHECKED_OUT_BRANCHES" | grep -Fxq "$b"
+}
+
+# Classify each worktree. Stale ⇔ not main, not the caller's, no uncommitted
+# tracked changes, branch has no open PR, HEAD older than threshold.
+STALE_WORKTREES=()
+SKIPPED_WORKTREES=()
+for record in "${WORKTREES[@]}"; do
+  IFS="$US" read -r is_main wt branch ts <<<"$record"
+  if (( is_main == 1 )); then
+    SKIPPED_WORKTREES+=("${wt}${US}main worktree")
+    continue
+  fi
+  if caller_in_worktree "$wt"; then
+    SKIPPED_WORKTREES+=("${wt}${US}caller's current worktree")
+    continue
+  fi
+  if [[ ! -d "$wt" ]]; then
+    SKIPPED_WORKTREES+=("${wt}${US}directory missing — run 'git worktree prune'")
+    continue
+  fi
+  # Tracked-only dirty detection inside the worktree.
+  if ! git -C "$wt" diff --quiet 2>/dev/null \
+     || ! git -C "$wt" diff --cached --quiet 2>/dev/null; then
+    SKIPPED_WORKTREES+=("${wt}${US}uncommitted tracked changes")
+    continue
+  fi
+  if [[ -n "$branch" ]] && has_open_pr "$branch"; then
+    SKIPPED_WORKTREES+=("${wt}${US}open PR on branch $branch")
+    continue
+  fi
+  # Unreadable HEAD (`git log -1 --format=%ct` failed): conservatively
+  # skip rather than treating as ancient and deleting.
+  if [[ -z "$ts" ]] || ! [[ "$ts" =~ ^[0-9]+$ ]]; then
+    SKIPPED_WORKTREES+=("${wt}${US}HEAD unreadable — cannot determine staleness")
+    continue
+  fi
+  if (( ts > THRESHOLD )); then
+    continue  # fresh — not stale, not skipped (just normal)
+  fi
+  STALE_WORKTREES+=("${wt}${US}${branch}${US}${ts}")
+done
+
+# Local branches: any refs/heads entry whose tip is older than threshold.
+STALE_LOCAL_BRANCHES=()
+SKIPPED_LOCAL_BRANCHES=()
+while IFS="$US" read -r branch ts; do
+  [[ -z "$branch" ]] && continue
+  if is_protected "$branch"; then
+    SKIPPED_LOCAL_BRANCHES+=("${branch}${US}protected")
+    continue
+  fi
+  if is_branch_checked_out "$branch"; then
+    SKIPPED_LOCAL_BRANCHES+=("${branch}${US}checked out in a worktree")
+    continue
+  fi
+  if has_open_pr "$branch"; then
+    SKIPPED_LOCAL_BRANCHES+=("${branch}${US}open PR")
+    continue
+  fi
+  if (( ts > THRESHOLD )); then
+    continue
+  fi
+  STALE_LOCAL_BRANCHES+=("${branch}${US}${ts}")
+done < <("${GIT[@]}" for-each-ref --format="%(refname:short)${US}%(committerdate:unix)" refs/heads/)
+
+# Remote branches under origin/. Skip the symbolic origin/HEAD and protected
+# names. We do NOT auto-fetch — that's a network operation the caller can run
+# explicitly before invoking this script. Stale state on a stale fetch is
+# still real signal.
+STALE_REMOTE_BRANCHES=()
+SKIPPED_REMOTE_BRANCHES=()
+while IFS="$US" read -r ref ts; do
+  [[ -z "$ref" ]] && continue
+  # ref is e.g. "origin/feature-x"; strip leading origin/.
+  case "$ref" in
+    origin/HEAD) continue ;;
+    origin/*) branch="${ref#origin/}" ;;
+    *) continue ;;
+  esac
+  if is_protected "$branch"; then
+    SKIPPED_REMOTE_BRANCHES+=("${ref}${US}protected")
+    continue
+  fi
+  if has_open_pr "$branch"; then
+    SKIPPED_REMOTE_BRANCHES+=("${ref}${US}open PR")
+    continue
+  fi
+  if (( ts > THRESHOLD )); then
+    continue
+  fi
+  STALE_REMOTE_BRANCHES+=("${ref}${US}${ts}")
+done < <("${GIT[@]}" for-each-ref --format="%(refname:short)${US}%(committerdate:unix)" refs/remotes/origin/)
+
+ts_to_date() {
+  # Portable across BSD/GNU date: read a unix ts on stdin, emit YYYY-MM-DD.
+  local ts="$1"
+  if date -r "$ts" +%Y-%m-%d 2>/dev/null; then return; fi
+  date -d "@$ts" +%Y-%m-%d 2>/dev/null || echo "?"
+}
+
+emit_text() {
+  echo "Stale threshold: ${STALE_DAYS} days (commits before $(ts_to_date "$THRESHOLD"))"
+  echo
+  if (( ${#STALE_WORKTREES[@]} == 0 )); then
+    echo "Stale worktrees: none"
+  else
+    echo "Stale worktrees:"
+    for entry in "${STALE_WORKTREES[@]}"; do
+      IFS="$US" read -r p b t <<<"$entry"
+      printf '  %s (branch %s, last commit %s)\n' "$p" "${b:-detached}" "$(ts_to_date "$t")"
+    done
+  fi
+  if (( ${#STALE_LOCAL_BRANCHES[@]} == 0 )); then
+    echo "Stale local branches: none"
+  else
+    echo "Stale local branches:"
+    for entry in "${STALE_LOCAL_BRANCHES[@]}"; do
+      IFS="$US" read -r b t <<<"$entry"
+      printf '  %s (last commit %s)\n' "$b" "$(ts_to_date "$t")"
+    done
+  fi
+  if (( ${#STALE_REMOTE_BRANCHES[@]} == 0 )); then
+    echo "Stale remote branches: none"
+  else
+    echo "Stale remote branches:"
+    for entry in "${STALE_REMOTE_BRANCHES[@]}"; do
+      IFS="$US" read -r r t <<<"$entry"
+      printf '  %s (last commit %s)\n' "$r" "$(ts_to_date "$t")"
+    done
+  fi
+  local skipped_total=$(( ${#SKIPPED_WORKTREES[@]} + ${#SKIPPED_LOCAL_BRANCHES[@]} + ${#SKIPPED_REMOTE_BRANCHES[@]} ))
+  if (( skipped_total > 0 )); then
+    echo
+    echo "Skipped (safety):"
+    for entry in "${SKIPPED_WORKTREES[@]}"; do
+      IFS="$US" read -r p reason <<<"$entry"
+      printf '  worktree %s — %s\n' "$p" "$reason"
+    done
+    for entry in "${SKIPPED_LOCAL_BRANCHES[@]}"; do
+      IFS="$US" read -r b reason <<<"$entry"
+      printf '  branch %s — %s\n' "$b" "$reason"
+    done
+    for entry in "${SKIPPED_REMOTE_BRANCHES[@]}"; do
+      IFS="$US" read -r r reason <<<"$entry"
+      printf '  remote %s — %s\n' "$r" "$reason"
+    done
+  fi
+}
+
+emit_json() {
+  local wt_json="[]" lb_json="[]" rb_json="[]"
+  local sw_json="[]" sl_json="[]" sr_json="[]"
+  if (( ${#STALE_WORKTREES[@]} > 0 )); then
+    wt_json="$(printf '%s\n' "${STALE_WORKTREES[@]}" \
+      | jq -Rn --arg D "$US" '[inputs | split($D) | {path:.[0], branch:.[1], last_commit_ts:(.[2]|tonumber)}]')"
+  fi
+  if (( ${#STALE_LOCAL_BRANCHES[@]} > 0 )); then
+    lb_json="$(printf '%s\n' "${STALE_LOCAL_BRANCHES[@]}" \
+      | jq -Rn --arg D "$US" '[inputs | split($D) | {branch:.[0], last_commit_ts:(.[1]|tonumber)}]')"
+  fi
+  if (( ${#STALE_REMOTE_BRANCHES[@]} > 0 )); then
+    rb_json="$(printf '%s\n' "${STALE_REMOTE_BRANCHES[@]}" \
+      | jq -Rn --arg D "$US" '[inputs | split($D) | {ref:.[0], last_commit_ts:(.[1]|tonumber)}]')"
+  fi
+  if (( ${#SKIPPED_WORKTREES[@]} > 0 )); then
+    sw_json="$(printf '%s\n' "${SKIPPED_WORKTREES[@]}" \
+      | jq -Rn --arg D "$US" '[inputs | split($D) | {path:.[0], reason:.[1]}]')"
+  fi
+  if (( ${#SKIPPED_LOCAL_BRANCHES[@]} > 0 )); then
+    sl_json="$(printf '%s\n' "${SKIPPED_LOCAL_BRANCHES[@]}" \
+      | jq -Rn --arg D "$US" '[inputs | split($D) | {branch:.[0], reason:.[1]}]')"
+  fi
+  if (( ${#SKIPPED_REMOTE_BRANCHES[@]} > 0 )); then
+    sr_json="$(printf '%s\n' "${SKIPPED_REMOTE_BRANCHES[@]}" \
+      | jq -Rn --arg D "$US" '[inputs | split($D) | {ref:.[0], reason:.[1]}]')"
+  fi
+  jq -n --argjson wt "$wt_json" --argjson lb "$lb_json" --argjson rb "$rb_json" \
+        --argjson sw "$sw_json" --argjson sl "$sl_json" --argjson sr "$sr_json" \
+        --arg threshold_days "$STALE_DAYS" \
+        --arg threshold_ts "$THRESHOLD" \
+        '{stale_days:($threshold_days|tonumber),
+          threshold_ts:($threshold_ts|tonumber),
+          stale_worktrees:$wt,
+          stale_local_branches:$lb,
+          stale_remote_branches:$rb,
+          skipped_worktrees:$sw,
+          skipped_local_branches:$sl,
+          skipped_remote_branches:$sr}'
+}
+
+if [[ "$MODE" == "check" ]]; then
+  if (( JSON == 1 )); then emit_json; else emit_text; fi
+  total=$(( ${#STALE_WORKTREES[@]} + ${#STALE_LOCAL_BRANCHES[@]} + ${#STALE_REMOTE_BRANCHES[@]} ))
+  if (( total > 0 )); then exit 1; fi
+  exit 0
+fi
+
+# --apply: delete each stale item, recording outcomes.
+FAILURES=0
+emit_text
+echo
+
+for entry in "${STALE_WORKTREES[@]}"; do
+  IFS="$US" read -r p b _ <<<"$entry"
+  # TOCTOU re-check: between classification (Phase --check) and apply, the
+  # user may have started editing the worktree or opened a PR on its
+  # branch. Re-run the same safety checks used during classification and
+  # skip if anything has changed — losing user work to a stale dry-run is
+  # a much bigger problem than skipping a deletion.
+  if [[ -d "$p" ]] && { ! git -C "$p" diff --quiet 2>/dev/null \
+       || ! git -C "$p" diff --cached --quiet 2>/dev/null; }; then
+    echo "skipped: worktree $p (became dirty after dry-run)"
+    continue
+  fi
+  if [[ -n "$b" ]] && has_open_pr "$b"; then
+    echo "skipped: worktree $p (open PR on branch $b appeared after dry-run)"
+    continue
+  fi
+  if out="$("${GIT[@]}" worktree remove "$p" 2>&1)"; then
+    echo "removed: worktree $p"
+  else
+    echo "failed: worktree $p — $out"
+    FAILURES=$(( FAILURES + 1 ))
+  fi
+done
+
+for entry in "${STALE_LOCAL_BRANCHES[@]}"; do
+  IFS="$US" read -r b _ <<<"$entry"
+  if out="$("${GIT[@]}" branch -D "$b" 2>&1)"; then
+    echo "removed: local branch $b"
+  else
+    echo "failed: local branch $b — $out"
+    FAILURES=$(( FAILURES + 1 ))
+  fi
+done
+
+for entry in "${STALE_REMOTE_BRANCHES[@]}"; do
+  IFS="$US" read -r ref _ <<<"$entry"
+  branch="${ref#origin/}"
+  if out="$("${GIT[@]}" push origin --delete "$branch" 2>&1)"; then
+    echo "removed: remote branch $branch"
+  else
+    echo "failed: remote branch $branch — $out"
+    FAILURES=$(( FAILURES + 1 ))
+  fi
+done
+
+if (( FAILURES > 0 )); then exit 2; fi
+exit 0

--- a/.claude/scripts/stale-cleanup.sh
+++ b/.claude/scripts/stale-cleanup.sh
@@ -165,16 +165,24 @@ is_protected() {
 # trip; for a repo with thousands of open PRs it stays correct without
 # silently dropping entries.
 OPEN_PR_BRANCHES=""
+GH_TMPERR=""
+trap 'rm -f "$GH_TMPERR"' EXIT
+GH_TMPERR="$(mktemp -t stale-cleanup-gh-stderr.XXXXXX)"
+
 gh_pr_page() {
   # gh pr list with --json forces non-interactive mode; --limit 1000 is the
   # max gh accepts per call. We use the search API via --search to enable
   # cursor-style pagination through `created:<timestamp` filters.
+  # Stderr is captured (not silenced) so fetch_open_prs can distinguish
+  # "no PRs" from "gh failed" — silently swallowing errors here would
+  # let the open-PR safety check return false for every branch and
+  # delete branches that actually have open PRs.
   local cursor="$1"
   local query="state:open"
   if [[ -n "$cursor" ]]; then
     query="$query created:<$cursor"
   fi
-  gh pr list --search "$query" --limit 1000 --json headRefName,createdAt 2>/dev/null
+  gh pr list --search "$query" --limit 1000 --json headRefName,createdAt 2>"$GH_TMPERR"
 }
 fetch_open_prs() {
   local cursor=""
@@ -182,10 +190,20 @@ fetch_open_prs() {
   local accumulated=""
   while :; do
     local page
-    page="$(gh_pr_page "$cursor")" || break
-    [[ "$page" == "[]" || -z "$page" ]] && break
+    if ! page="$(gh_pr_page "$cursor")"; then
+      echo "error: gh pr list failed — refusing to run with an unverified open-PR set" >&2
+      sed 's/^/  gh: /' "$GH_TMPERR" >&2 || true
+      exit 4
+    fi
+    [[ -z "$page" ]] && break
+    local count
+    if ! count="$(printf '%s' "$page" | jq 'length')"; then
+      echo "error: gh pr list returned non-JSON output — refusing to proceed" >&2
+      exit 4
+    fi
+    (( count == 0 )) && break
     local refs
-    refs="$(printf '%s' "$page" | jq -r '.[].headRefName' 2>/dev/null || true)"
+    refs="$(printf '%s' "$page" | jq -r '.[].headRefName')"
     if [[ -n "$refs" ]]; then
       if [[ -z "$accumulated" ]]; then
         accumulated="$refs"
@@ -194,12 +212,10 @@ fetch_open_prs() {
       fi
     fi
     # Page < 1000 entries means no more results.
-    local count
-    count="$(printf '%s' "$page" | jq 'length' 2>/dev/null || echo 0)"
     (( count < 1000 )) && break
     # Advance cursor to the oldest createdAt we just saw.
     prev_cursor="$cursor"
-    cursor="$(printf '%s' "$page" | jq -r '[.[].createdAt] | min' 2>/dev/null || echo "")"
+    cursor="$(printf '%s' "$page" | jq -r '[.[].createdAt] | min')"
     [[ -z "$cursor" || "$cursor" == "null" ]] && break
     # Guard against pathological case where 1000+ PRs share the same
     # createdAt timestamp — without this check we'd refetch the same page
@@ -499,6 +515,10 @@ FAILURES=0
 emit_text
 echo
 
+# Empty-array guard: under `set -u`, expanding "${ARR[@]}" on an empty
+# array errors with `unbound variable` on bash 3.2 (macOS system bash).
+# Skip the loop entirely when the category has no stale items.
+if (( ${#STALE_WORKTREES[@]} > 0 )); then
 for entry in "${STALE_WORKTREES[@]}"; do
   IFS="$US" read -r p b _ <<<"$entry"
   # TOCTOU re-check: between classification (Phase --check) and apply, the
@@ -522,7 +542,9 @@ for entry in "${STALE_WORKTREES[@]}"; do
     FAILURES=$(( FAILURES + 1 ))
   fi
 done
+fi
 
+if (( ${#STALE_LOCAL_BRANCHES[@]} > 0 )); then
 for entry in "${STALE_LOCAL_BRANCHES[@]}"; do
   IFS="$US" read -r b _ <<<"$entry"
   # TOCTOU re-check: same defense as worktrees — a PR opened between
@@ -538,7 +560,9 @@ for entry in "${STALE_LOCAL_BRANCHES[@]}"; do
     FAILURES=$(( FAILURES + 1 ))
   fi
 done
+fi
 
+if (( ${#STALE_REMOTE_BRANCHES[@]} > 0 )); then
 for entry in "${STALE_REMOTE_BRANCHES[@]}"; do
   IFS="$US" read -r ref _ <<<"$entry"
   branch="${ref#origin/}"
@@ -554,6 +578,7 @@ for entry in "${STALE_REMOTE_BRANCHES[@]}"; do
     FAILURES=$(( FAILURES + 1 ))
   fi
 done
+fi
 
 if (( FAILURES > 0 )); then exit 2; fi
 exit 0

--- a/.claude/scripts/stale-cleanup.sh
+++ b/.claude/scripts/stale-cleanup.sh
@@ -447,18 +447,27 @@ emit_text() {
   if (( skipped_total > 0 )); then
     echo
     echo "Skipped (safety):"
-    for entry in "${SKIPPED_WORKTREES[@]}"; do
-      IFS="$US" read -r p reason <<<"$entry"
-      printf '  worktree %s — %s\n' "$p" "$reason"
-    done
-    for entry in "${SKIPPED_LOCAL_BRANCHES[@]}"; do
-      IFS="$US" read -r b reason <<<"$entry"
-      printf '  branch %s — %s\n' "$b" "$reason"
-    done
-    for entry in "${SKIPPED_REMOTE_BRANCHES[@]}"; do
-      IFS="$US" read -r r reason <<<"$entry"
-      printf '  remote %s — %s\n' "$r" "$reason"
-    done
+    # Per-array guards: under bash 3.2 + set -u, expanding "${ARR[@]}" on
+    # an empty array crashes — even when at least one of the three has
+    # items. Same pattern used by --apply and emit_json.
+    if (( ${#SKIPPED_WORKTREES[@]} > 0 )); then
+      for entry in "${SKIPPED_WORKTREES[@]}"; do
+        IFS="$US" read -r p reason <<<"$entry"
+        printf '  worktree %s — %s\n' "$p" "$reason"
+      done
+    fi
+    if (( ${#SKIPPED_LOCAL_BRANCHES[@]} > 0 )); then
+      for entry in "${SKIPPED_LOCAL_BRANCHES[@]}"; do
+        IFS="$US" read -r b reason <<<"$entry"
+        printf '  branch %s — %s\n' "$b" "$reason"
+      done
+    fi
+    if (( ${#SKIPPED_REMOTE_BRANCHES[@]} > 0 )); then
+      for entry in "${SKIPPED_REMOTE_BRANCHES[@]}"; do
+        IFS="$US" read -r r reason <<<"$entry"
+        printf '  remote %s — %s\n' "$r" "$reason"
+      done
+    fi
   fi
 }
 

--- a/.claude/scripts/stale-cleanup.sh
+++ b/.claude/scripts/stale-cleanup.sh
@@ -525,6 +525,12 @@ done
 
 for entry in "${STALE_LOCAL_BRANCHES[@]}"; do
   IFS="$US" read -r b _ <<<"$entry"
+  # TOCTOU re-check: same defense as worktrees — a PR opened between
+  # dry-run and apply must not lose its branch.
+  if has_open_pr "$b"; then
+    echo "skipped: local branch $b (open PR appeared after dry-run)"
+    continue
+  fi
   if out="$("${GIT[@]}" branch -D "$b" 2>&1)"; then
     echo "removed: local branch $b"
   else
@@ -536,6 +542,11 @@ done
 for entry in "${STALE_REMOTE_BRANCHES[@]}"; do
   IFS="$US" read -r ref _ <<<"$entry"
   branch="${ref#origin/}"
+  # TOCTOU re-check for remote-branch deletion.
+  if has_open_pr "$branch"; then
+    echo "skipped: remote branch $branch (open PR appeared after dry-run)"
+    continue
+  fi
   if out="$("${GIT[@]}" push origin --delete "$branch" 2>&1)"; then
     echo "removed: remote branch $branch"
   else

--- a/.claude/skills/pm-update/SKILL.md
+++ b/.claude/skills/pm-update/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: pm-update
-description: Re-scan the current repo and update `.claude/pm-config.md` with fresh infrastructure and architecture detection while preserving user-edited sections (Role, OKRs, Team, Notes, Dependency Rules, Workflow Rules). Use this after major milestones, new service integrations, or significant directory restructuring. Triggers on "pm update", "update pm config", "refresh pm config", "rescan repo".
+description: Re-scan the current repo and update `.claude/pm-config.md` with fresh infrastructure and architecture detection while preserving user-edited sections (Role, OKRs, Team, Notes, Dependency Rules, Workflow Rules), then run a stale-cleanup pass to prune long-abandoned worktrees and branches. Use this after major milestones, new service integrations, or significant directory restructuring. Triggers on "pm update", "update pm config", "refresh pm config", "rescan repo".
 ---
 
-Re-scan the current repo and update `.claude/pm-config.md`. Auto-generated sections (Infrastructure, Architecture) are regenerated from the repo's current state. User-edited sections are preserved verbatim.
+Re-scan the current repo and update `.claude/pm-config.md`, then sweep stale worktrees and branches. Auto-generated config sections (Infrastructure, Architecture) are regenerated from the repo's current state; user-edited sections are preserved verbatim. After the config write, the stale-cleanup pass surfaces (and optionally removes) worktrees and branches that have aged past the threshold.
 
 ## Section classification
 
@@ -118,9 +118,9 @@ Reconstruct `.claude/pm-config.md` using the fixed schema order below (regardles
 
 Write back to `.claude/pm-config.md`.
 
-## Step 7: Report changes
+## Step 7: Report config changes
 
-Output a summary showing what changed:
+Output a summary showing what changed in the config:
 
 ```
 ## PM Config Updated
@@ -133,4 +133,59 @@ Output a summary showing what changed:
 - Architecture: {brief diff — e.g., "detected new api/ directory"}
 ```
 
-If nothing changed in the auto-generated sections, say so: "Infrastructure and Architecture are unchanged — config is up to date."
+If nothing changed in the auto-generated sections, say so: "Infrastructure and Architecture are unchanged — config is up to date." Either way, proceed to Step 8 — config staleness and worktree/branch staleness are independent.
+
+## Step 8: Stale worktree + branch cleanup
+
+`/wrap` no longer self-removes the running worktree or deletes its branch (issue #338). Stale cleanup is `/pm-update`'s job — invoke `.claude/scripts/stale-cleanup.sh` to detect and (after user confirmation) prune long-abandoned refs.
+
+### Step 8.1: Run the dry-run pass
+
+Always run `--check` first. The script never deletes in this mode.
+
+```bash
+.claude/scripts/stale-cleanup.sh --check
+RC=$?
+```
+
+`stale-cleanup.sh` reports three categories — stale worktrees, stale local branches, stale remote branches — plus a "Skipped (safety)" list with the reason each item was protected (main worktree, caller's current worktree, uncommitted changes, open PR, protected branch name, branch checked out in a worktree). See `.claude/scripts/stale-cleanup.sh --help` for the full safety-check contract.
+
+Threshold defaults to 7 days; override with `STALE_DAYS=N` if the user requests a different cutoff.
+
+### Step 8.2: Show the report and ask before deleting
+
+Show the user the stdout from Step 8.1 verbatim. Then:
+
+- **If `RC == 0`:** No stale items — say "No stale worktrees or branches detected." Done.
+- **If `RC == 1`:** Stale items exist. Ask the user: "Apply the stale cleanup above? (worktrees removed, local + remote branches deleted)" Wait for confirmation. Never run `--apply` autonomously — every deletion is destructive and the dry-run is the user's only chance to spot a false positive.
+- **If `RC == 3`:** Usage error (invalid flag, bad `STALE_DAYS`). Print the script's `--help` output and stop — this indicates a bug in this skill's invocation, not a real-state problem.
+- **If `RC == 4`:** Environment error (no `gh`, no `jq`, can't resolve repo). Surface stderr to the user and stop.
+- **Other non-zero exits:** Surface stderr and stop.
+
+### Step 8.3: Apply (only on user confirmation)
+
+If the user approves, run `--apply`:
+
+```bash
+.claude/scripts/stale-cleanup.sh --apply
+APPLY_RC=$?
+```
+
+The script re-runs the same detection (in case the repo state changed between Steps 8.1 and 8.3), re-emits the report, and then attempts each deletion. Each successful deletion logs `removed: <thing>`; each failure logs `failed: <thing> — <reason>` and continues.
+
+- **`APPLY_RC == 0`:** All deletions succeeded.
+- **`APPLY_RC == 2`:** One or more deletions failed — surface the `failed:` lines from stdout. Do not retry automatically; some failures (e.g., network errors on remote-branch deletion) need user intervention.
+
+### Step 8.4: Final report
+
+Append a cleanup summary to the Step 7 report:
+
+```
+**Stale cleanup:**
+- {N} worktrees removed
+- {M} local branches deleted
+- {K} remote branches deleted
+- {F} failures (see log)
+```
+
+If the user declined `--apply`, report: "Stale cleanup: dry-run only — no changes applied."

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -1,23 +1,25 @@
 ---
 name: wrap
-description: End-of-session command — verify no unresolved findings, squash merge, detect follow-ups, extract lessons, and clean up the worktree.
+description: End-of-session command — verify no unresolved findings, squash merge, sync main, detect follow-ups, and extract lessons.
 ---
 
-Wrap up the current PR and session. This is the "we're done here" command that handles everything from final verification through worktree cleanup.
+Wrap up the current PR and session. This is the "we're done here" command that handles final verification through merge, root-main sync, follow-up detection, and lessons.
+
+`/wrap` does **not** delete the running worktree or its branch — leaving the thread alive so it can keep working. Stale worktrees and stale local/remote branches are reaped out-of-band by `/pm-update`, which calls `.claude/scripts/stale-cleanup.sh`.
 
 ## When to use /wrap vs /merge
 
-- Use **/wrap** at end-of-session. Handles merge + follow-up detection + lessons + worktree cleanup in one command.
-- Use **/merge** for a quick mid-session merge when you'll keep working. Skips the cleanup steps and only runs outside worktrees.
-- /wrap includes everything /merge does, plus the cleanup. Don't run both.
+- Use **/wrap** at end-of-session. Handles merge + root-main sync + follow-up detection + lessons.
+- Use **/merge** for a quick mid-session merge when you'll keep working. Skips follow-up detection and lessons.
+- /wrap includes everything /merge does, plus follow-ups and lessons. Don't run both.
 
 ## Execution Model
 
-`/wrap` is a set-and-forget command. Once invoked, it runs all 5 phases end-to-end without mid-run confirmation prompts. It stops early only for explicit stop conditions (for example: no PR on current branch, unresolved findings, failed merge gate, CI failure, AC verification failure, or rebase detected).
+`/wrap` is a set-and-forget command. Once invoked, it runs all 4 phases end-to-end without mid-run confirmation prompts. It stops early only for explicit stop conditions (for example: no PR on current branch, unresolved findings, failed merge gate, CI failure, AC verification failure, or rebase detected).
 
 > **Always:** Execute all phases end-to-end; proceed immediately between phases when no blocker exists.
 > **Ask first:** Never — all phases are autonomous once /wrap is invoked.
-> **Never:** Stop to ask "should I continue?" between phases; insert confirmation prompts for non-blocker transitions.
+> **Never:** Stop to ask "should I continue?" between phases; insert confirmation prompts for non-blocker transitions. Delete the running worktree or its branch — that's `/pm-update`'s job, not /wrap's.
 
 ### Phase Transition Autonomy
 
@@ -26,8 +28,7 @@ Wrap up the current PR and session. This is the "we're done here" command that h
 | Phase 1 complete (no unresolved findings) | Begin Phase 2 | **Always do** |
 | Phase 2 complete | Begin Phase 3 | **Always do** |
 | Phase 3 follow-ups processed | Begin Phase 4 | **Always do** |
-| Phase 4 lessons complete (or skipped as trivial) | Begin Phase 5 | **Always do** |
-| Phase 5 cleanup complete | Output Step 5.3 final report | **Always do** |
+| Phase 4 lessons complete (or skipped as trivial) | Output final report | **Always do** |
 | Unresolved reviewer findings detected (Phase 1) | Stop and report | **Stop and report** |
 | Merge gate not met (Phase 2.1) | Stop and report | **Stop and report** |
 | AC checkbox verification fails (Phase 2.2) | Stop and report | **Stop and report** |
@@ -94,13 +95,6 @@ GATE_EXIT=$?
 - Exit `3` → PR not found; skip to Phase 3 as described above.
 - Exit `2`/`4` → script or gh error; surface the stderr message.
 
-Also extract and store the feature branch name and base branch for use in Phase 5 cleanup:
-
-```bash
-BRANCH_NAME=$(gh pr view --json headRefName --jq '.headRefName')
-BASE_BRANCH=$(gh pr view --json baseRefName --jq '.baseRefName')
-```
-
 ### Step 2.2: Verify acceptance criteria
 
 Use the shared `ac-checkboxes.sh` helper to parse and tick Test Plan items:
@@ -160,7 +154,7 @@ gh api "repos/{owner}/{repo}/check-runs/{CHECK_RUN_ID}" --jq '.output.summary'
 gh pr merge --squash
 ```
 
-Do NOT use `--delete-branch` here. That flag attempts local branch deletion while the worktree is still active, which fails because git refuses to delete a branch checked out in any worktree. Branch cleanup is handled explicitly in Phase 5 after the worktree is removed.
+Do NOT use `--delete-branch`. The current worktree is still checked out on the feature branch — git refuses to delete a branch held by a worktree, and `/wrap` no longer touches the worktree at all. The branch is cleaned up out-of-band by `/pm-update` once it ages past the stale threshold (see `.claude/scripts/stale-cleanup.sh`).
 
 ### Step 2.5: Sync root repo main (aggressive reset)
 
@@ -169,7 +163,7 @@ After merging, aggressively align the root repo's local `main` with `origin/main
 1. **Quarantine any dirty state** on root main via `dirty-main-guard.sh --quarantine` (creates a `recovery/dirty-main-*` branch if needed — nothing is lost).
 2. **Aggressively reset** root main to `origin/main` via `main-sync.sh --reset`. This fetches origin, aborts loudly if local main has unpushed commits (belt-and-suspenders for bypasses of the `#323` pre-commit hook), and otherwise `git reset --hard origin/main`.
 
-**Capture both status lines for the final report in Step 5.3.**
+**Capture both status lines for the final report in Phase 4.**
 
 ```bash
 # /wrap runs from inside a worktree. dirty-main-guard.sh resolves the root
@@ -203,7 +197,7 @@ See `.claude/scripts/main-sync.sh --help` and `.claude/scripts/dirty-main-guard.
 
 **If `MAIN_SYNC_STATUS` starts with `aborted:`** (local main has unpushed commits that didn't come from origin), do NOT attempt recovery automatically. Surface the full status line in the final report so the user can run `git log origin/main..main` against the root repo and decide. The PR merge itself has already succeeded — main-sync failure does not un-merge anything.
 
-Store `MAIN_SYNC_STATUS` and `QUARANTINE_STATUS` for the final report — both values MUST appear in Step 5.3 output.
+Store `MAIN_SYNC_STATUS` and `QUARANTINE_STATUS` for the final report at the end of Phase 4.
 
 ## Phase 3: Follow-Up Detection and Creation
 
@@ -355,7 +349,7 @@ Calculate a complexity signal:
 
 ### Step 4.2: Run lessons (or skip)
 
-**If trivial:** Output "Clean session — no lessons to capture." and skip to Phase 5.
+**If trivial:** Output "Clean session — no lessons to capture." and skip to Step 4.3 (final report).
 
 **If non-trivial:** Reflect on the session:
 
@@ -381,39 +375,9 @@ Present the summary:
 - <things noted but not actionable>
 ```
 
-After lessons (or skip): proceed immediately to Phase 5 — do not ask.
+After lessons (or skip): emit the final report below — do not ask.
 
-## Phase 5: Worktree Cleanup
-
-### Step 5.1: Remove the worktree
-
-Use `ExitWorktree` with `action: "remove"` to delete the worktree directory. This must happen **before** local branch deletion — git refuses to delete a branch that is currently checked out in any worktree.
-
-If `ExitWorktree` reports uncommitted changes, discard them — by this point all meaningful work has been merged.
-
-### Step 5.2: Delete the local branch
-
-After the worktree is removed, the branch is no longer checked out anywhere and can be safely deleted. Run on the root repo:
-
-```bash
-CURRENT_ROOT_BRANCH=$(git -C "$ROOT_REPO" branch --show-current)
-if [ "$CURRENT_ROOT_BRANCH" = "$BRANCH_NAME" ]; then
-  git -C "$ROOT_REPO" checkout "$BASE_BRANCH" || echo "Warning: could not checkout $BASE_BRANCH before deleting $BRANCH_NAME"
-fi
-git -C "$ROOT_REPO" branch -D "$BRANCH_NAME" || echo "Warning: local branch deletion failed (may already be deleted) — skipping"
-```
-
-Use `-D` (force) rather than `-d` — squash merges rewrite history so the branch commits are not reachable from `main`, and `-d` will always fail post-squash.
-
-If this fails (branch already deleted or never existed locally), treat as non-fatal.
-
-The remote branch is deleted by GitHub's auto-delete-on-merge setting. If that is not enabled, delete it manually — treat failure as non-fatal (branch may already be deleted, or permissions/network may prevent it):
-
-```bash
-git -C "$ROOT_REPO" push origin --delete "$BRANCH_NAME" || echo "Warning: remote branch deletion failed (may already be deleted) — skipping"
-```
-
-### Step 5.3: Final report
+### Step 4.3: Final report
 
 ```
 ## Wrap-Up Complete
@@ -421,8 +385,8 @@ git -C "$ROOT_REPO" push origin --delete "$BRANCH_NAME" || echo "Warning: remote
 - **PR #{N}** merged ({title})
 - **Main quarantine** {QUARANTINE_STATUS from Step 2.5 — e.g. "clean" (literal output of `dirty-main-guard.sh --check` on a clean main), "quarantined: recovery/dirty-main-20260424-003012 (uncommitted)", or "no-op: main is clean" (only produced if `--quarantine` ran on an already-clean tree)}
 - **Main branch** {MAIN_SYNC_STATUS from Step 2.5 — e.g. "reset abc1234 → def5678", "up to date (abc1234)", "aborted: local main has 1 unpushed commit(s) — inspect: git log origin/main..main, resolve manually before re-running", or "failed: ..."}
-- **Branch** deleted
 - **Follow-ups:** {summary or "none"}
 - **Lessons:** {summary or "clean session"}
-- **Worktree** removed
 ```
+
+The worktree and feature branch are intentionally left in place. They are reaped out-of-band by `/pm-update`'s stale-cleanup pass once they age past the threshold (default 7 days, configurable via `STALE_DAYS`). See `.claude/scripts/stale-cleanup.sh --help`.


### PR DESCRIPTION
## **User description**
## Summary
- Strip Phase 5 from `/wrap` so it stops self-deleting the running worktree + branch — the running thread stays alive after merge.
- Add `.claude/scripts/stale-cleanup.sh` (dry-run by default, `--apply` for deletions, configurable `STALE_DAYS`) that detects stale local worktrees, local branches, and remote branches with extensive safety checks (main/master/develop are protected, caller's own worktree, dirty worktrees, branches with open PRs, branches checked out anywhere).
- Wire `/pm-update` Step 8 to invoke the helper after the config rescan and gate `--apply` behind explicit user confirmation.

Closes #338

## Test plan
- [x] `/wrap` no longer removes the running worktree (Phase 5.1 removed)
- [x] `/wrap` no longer deletes the running local or remote branch (Phase 5.2 removed)
- [x] `/wrap` still merges the PR, syncs root `main`, runs follow-up detection, and runs lessons (Phases 1–4 + Step 2.5 preserved)
- [x] A stale-cleanup helper exists at `.claude/scripts/stale-cleanup.sh` that detects: (a) stale local worktrees, (b) stale local branches, (c) stale remote branches
- [x] Stale threshold is configurable (env var `STALE_DAYS`, default 7)
- [x] Safe-checks prevent removing in-use worktrees (uncommitted tracked changes), the current branch, branches with open PRs, and protected branches (`main`, `master`, `develop`)
- [x] Helper supports a default dry-run mode (`--check`) that reports without deleting, and an explicit `--apply` mode that performs the deletions
- [x] `/pm-update` invokes the stale-cleanup helper after the config rescan and surfaces the dry-run report to the user before any `--apply` is offered

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Move stale worktree and branch cleanup into `/pm-update` and keep `/wrap` from deleting the active session

### What Changed
- `/wrap` no longer removes the running worktree or deletes its branch after merge, so the session stays alive
- `/pm-update` now runs a stale-cleanup pass that finds old worktrees, local branches, and remote branches, then asks before removing them
- The cleanup pass skips protected branches, worktrees with changes, checked-out branches, the current worktree, and branches with open pull requests
- Cleanup defaults to a dry run, with deletion only after explicit user approval, and the age threshold can be changed with `STALE_DAYS`

### Impact
`✅ Fewer self-deleting wrap sessions`
`✅ Safer cleanup of abandoned worktrees`
`✅ Fewer accidental branch deletions` 


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=TwU3wQDxjtN2-ZTe2Z73wOieaqZPD-4YQQCa0Abqj90&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
