### PR TITLE
feat(reviewers): bump AI reviewer polling timeouts (CR 7→12, BugBot 5→10, Greptile 5→10)

### DIFF
--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -90,7 +90,7 @@ If check-runs show `conclusion: "failure"` with `output.title` containing "rate 
 
 ### CR Timeout (Slow Path)
 
-If CR has not delivered a review after **12 minutes** of polling → **check if BugBot (`cursor[bot]`) already posted a review** (BugBot's 10-min window from push has already expired at this point). If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review exists → run the Greptile Daily Budget Check below: if budget allows, trigger Greptile immediately (do NOT wait another 10 min); if budget exhausted, fall back to self-review and report the blocker. Sticky assignment applies at each tier. Polling cadence stays 60 s; a clean CR check-run completion short-circuits earlier — exit immediately on completion, do not keep polling to 12 min.
+If CR has not delivered a review after **12 minutes** of polling → **check if BugBot (`cursor[bot]`) already posted a review** (BugBot's 10-min window from push has already expired at this point). If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review exists → run the Greptile Daily Budget Check below: if budget allows, trigger Greptile immediately (do NOT wait another 10 min); if budget exhausted, fall back to self-review and report the blocker. Sticky assignment applies at each tier. Polling cadence stays 60 s; a clean CR check-run completion short-circuits the timeout wait, but Phase B must still verify the merge gate (explicit `APPROVED` review on current HEAD SHA per `cr-merge-gate.md` Step 1) before exiting — completion alone is not approval.
 
 > **MANDATORY budget gate on both paths above.** The Greptile Daily Budget Check in the "Greptile Review Path" section below is NOT optional — it applies to every `@greptileai` trigger point, including CR fallbacks. Never post `@greptileai` without running the check first.
 
@@ -98,7 +98,7 @@ If CR has not delivered a review after **12 minutes** of polling → **check if 
 
 1 clean CR approval on the current HEAD SHA satisfies the gate. An "approval" means a CR review object with `state: "APPROVED"` AND `commit_id == <current HEAD SHA>`. Ack comments, empty thread snapshots, and CR check-run completion alone do NOT exit polling — see `cr-merge-gate.md` "Step 1" for the full explicit-approval and SHA-freshness rules.
 
-If no approval lands on the current SHA within the 12-minute timeout, re-trigger `@coderabbitai full review` once. After 2 failed re-triggers on the same SHA, fall through to the BugBot/Greptile fallback chain. Never trigger `@coderabbitai full review` more than twice per PR per hour.
+If no approval lands on the current SHA within the 12-minute timeout, re-trigger `@coderabbitai full review` (max 2 re-triggers per PR per hour). If both re-triggers fail on the same SHA, fall through to the BugBot/Greptile fallback chain.
 
 ## BugBot Review Path (when `reviewer` = `bugbot`)
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -86,11 +86,11 @@ jq '.comments.conversation | map(select(.user.login == "coderabbitai[bot]"))' "$
 
 ### Rate-Limit Fast Path
 
-If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **check if BugBot (`cursor[bot]`) already posted a review** on any of the 3 endpoints. If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review yet, continue polling for BugBot until 5 minutes from push time have elapsed (do NOT start a new 5-minute timer now — the window runs concurrently with CR's, so some or all of it may have already passed). When BugBot times out, run the Greptile Daily Budget Check below: if budget allows, trigger Greptile; if exhausted, fall back to self-review and report the blocker.
+If check-runs show `conclusion: "failure"` with `output.title` containing "rate limit" (case-insensitive), OR commit statuses show rate-limit language → **escalate immediately, regardless of elapsed minutes.** Rate-limit signals override CR's 12-minute timeout — do not wait it out. **Check if BugBot (`cursor[bot]`) already posted a review** on any of the 3 endpoints. If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review yet, continue polling for BugBot until 10 minutes from push time have elapsed (do NOT start a new 10-minute timer now — the window runs concurrently with CR's, so some or all of it may have already passed). When BugBot times out, run the Greptile Daily Budget Check below: if budget allows, trigger Greptile; if exhausted, fall back to self-review and report the blocker.
 
 ### CR Timeout (Slow Path)
 
-If CR has not delivered a review after **7 minutes** of polling → **check if BugBot (`cursor[bot]`) already posted a review** (BugBot's 5-min window from push has already expired at this point). If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review exists → run the Greptile Daily Budget Check below: if budget allows, trigger Greptile immediately (do NOT wait another 5 min); if budget exhausted, fall back to self-review and report the blocker. Sticky assignment applies at each tier.
+If CR has not delivered a review after **12 minutes** of polling → **check if BugBot (`cursor[bot]`) already posted a review** (BugBot's 10-min window from push has already expired at this point). If yes, use BugBot review (set `reviewer: bugbot`, sticky assignment). If no BugBot review exists → run the Greptile Daily Budget Check below: if budget allows, trigger Greptile immediately (do NOT wait another 10 min); if budget exhausted, fall back to self-review and report the blocker. Sticky assignment applies at each tier. Polling cadence stays 60 s; a clean CR check-run completion short-circuits earlier — exit immediately on completion, do not keep polling to 12 min.
 
 > **MANDATORY budget gate on both paths above.** The Greptile Daily Budget Check in the "Greptile Review Path" section below is NOT optional — it applies to every `@greptileai` trigger point, including CR fallbacks. Never post `@greptileai` without running the check first.
 
@@ -98,7 +98,7 @@ If CR has not delivered a review after **7 minutes** of polling → **check if B
 
 1 clean CR approval on the current HEAD SHA satisfies the gate. An "approval" means a CR review object with `state: "APPROVED"` AND `commit_id == <current HEAD SHA>`. Ack comments, empty thread snapshots, and CR check-run completion alone do NOT exit polling — see `cr-merge-gate.md` "Step 1" for the full explicit-approval and SHA-freshness rules.
 
-If no approval lands on the current SHA within the 7-minute timeout, re-trigger `@coderabbitai full review` once. After 2 failed re-triggers on the same SHA, fall through to the BugBot/Greptile fallback chain. Never trigger `@coderabbitai full review` more than twice per PR per hour.
+If no approval lands on the current SHA within the 12-minute timeout, re-trigger `@coderabbitai full review` once. After 2 failed re-triggers on the same SHA, fall through to the BugBot/Greptile fallback chain. Never trigger `@coderabbitai full review` more than twice per PR per hour.
 
 ## BugBot Review Path (when `reviewer` = `bugbot`)
 
@@ -110,7 +110,7 @@ Same shared `$STATE` bundle as the CR path. Filter by `.user.login == "cursor[bo
 
 **Completion:** check-run `status: "completed"` (any conclusion — BugBot uses `neutral` for reviews with findings). Also check for review objects from `cursor[bot]`.
 
-**Timeout:** 5 minutes from push. If no BugBot review after 5 min, run the Greptile Daily Budget Check below: if budget allows, trigger Greptile; if exhausted, fall back to self-review and report the blocker.
+**Timeout:** 10 minutes from push. Polling cadence stays 60 s; a `Cursor Bugbot` check-run with `status: "completed"` short-circuits the wait — exit polling as soon as the review lands, do not keep polling to 10 min. If no BugBot review after 10 min, run the Greptile Daily Budget Check below: if budget allows, trigger Greptile; if exhausted, fall back to self-review and report the blocker.
 
 ### BugBot Merge Gate
 
@@ -127,7 +127,7 @@ Use the shared helper — it tries the inline reply endpoint first, falls back t
 
 ### Re-Reviews
 
-After fixing BugBot findings and pushing, BugBot auto-reviews the new push. If auto-review doesn't fire within 5 min, trigger manually: `gh pr comment {{PR_NUMBER}} --body "@cursor review"`
+After fixing BugBot findings and pushing, BugBot auto-reviews the new push. If auto-review doesn't fire within 10 min, trigger manually: `gh pr comment {{PR_NUMBER}} --body "@cursor review"`
 
 ## Greptile Review Path (when `reviewer` = `greptile`)
 
@@ -151,7 +151,7 @@ Post a comment: `gh pr comment {{PR_NUMBER}} --body "@greptileai"`
 
 ### Polling
 
-Same shared `$STATE` bundle, filter by `.user.login == "greptile-apps[bot]"` across `.comments.reviews`, `.comments.inline`, `.comments.conversation`. Timeout: 5 minutes. Completion: review comments or 👍 emoji. Failure: 😕 emoji.
+Same shared `$STATE` bundle, filter by `.user.login == "greptile-apps[bot]"` across `.comments.reviews`, `.comments.inline`, `.comments.conversation`. Timeout: 10 minutes. Polling cadence stays 60 s — exit immediately when the review lands, do not keep polling to 10 min. Completion: review comments or 👍 emoji. Failure: 😕 emoji.
 
 ### Severity Classification (P0/P1/P2)
 
@@ -212,11 +212,11 @@ On completion, read-modify-write `{{HANDOFF_FILE}}`:
 
 ## Exit criteria — merge gate ONLY (MANDATORY)
 
-**You may NOT exit with `OUTCOME: clean` just because the current instant has no unresolved threads.** "0 unresolved threads right now" is a snapshot, not a merge-gate signal. After your last push in this phase, the HEAD SHA changed — every reviewer re-runs, and new findings commonly arrive 5–7 minutes later.
+**You may NOT exit with `OUTCOME: clean` just because the current instant has no unresolved threads.** "0 unresolved threads right now" is a snapshot, not a merge-gate signal. After your last push in this phase, the HEAD SHA changed — every reviewer re-runs, and new findings commonly arrive 10–12 minutes later.
 
 Before exiting, follow this checklist literally:
 
-1. If you pushed any commit during this phase: wait for the reviewer to respond to the new SHA. Full timeouts per `cr-github-review.md`: 7 min for CR, 5 min for BugBot, 5 min for Greptile.
+1. If you pushed any commit during this phase: wait for the reviewer to respond to the new SHA. Full timeouts per `cr-github-review.md`: 12 min for CR, 10 min for BugBot, 10 min for Greptile.
 2. If the response arrives with findings: invoke `/fixpr` to handle them **in this same phase** before exiting. Do not kick the can to a replacement unless you hit token exhaustion (see "Token Exhaustion Protocol" below).
 3. Exit with `OUTCOME: merge_ready` ONLY when the merge gate is met per `cr-merge-gate.md` ("Polling exit criterion" and Step 1) on the current HEAD — specifically one of:
    - 1 explicit clean CR approval on the current HEAD SHA (CR path — approval's `commit_id` must match current HEAD)

--- a/.claude/reference/cr-polling-commands.md
+++ b/.claude/reference/cr-polling-commands.md
@@ -18,7 +18,7 @@ gh api "repos/{owner}/{repo}/commits/{SHA}/statuses" \
 
 **Completion signal:** `status: "completed"` + `conclusion: "success"` = review done.
 
-**Fast-path rate-limit signal:** check-run with `conclusion: "failure"` and `output.title` containing "rate limit" (case-insensitive), OR status `state: "failure"`/`"error"` with `description` containing "rate limit" → check BugBot (`cursor[bot]`) first. If BugBot already posted a review, use it. If not, wait up to 5 min for BugBot. If BugBot also times out, trigger Greptile (see `bugbot.md`).
+**Fast-path rate-limit signal:** check-run with `conclusion: "failure"` and `output.title` containing "rate limit" (case-insensitive), OR status `state: "failure"`/`"error"` with `description` containing "rate limit" → escalate immediately regardless of elapsed minutes (do not wait out CR's 12-min ceiling); check BugBot (`cursor[bot]`) first. If BugBot already posted a review, use it. If not, wait up to 10 min for BugBot. If BugBot also times out, trigger Greptile (see `bugbot.md`).
 
 ## CI Health Check — every poll cycle
 

--- a/.claude/reference/phase-decomposition.md
+++ b/.claude/reference/phase-decomposition.md
@@ -14,7 +14,7 @@ Canonical reference for per-phase subagent procedures. Used by agent definitions
 
 1. Read handoff file on startup (GitHub API fallback if missing)
 2. Before ANY `@greptileai` trigger, check daily budget (see `greptile.md`)
-3. CR path: poll for review (fast-path → check BugBot → 5-min BugBot timeout → Greptile trigger). BugBot path: poll for BugBot review on the 3 endpoints. Greptile path: poll for existing Greptile review; only re-trigger `@greptileai` for P0 findings (max 3 reviews/PR).
+3. CR path: poll for review (fast-path → check BugBot → 10-min BugBot timeout → Greptile trigger). BugBot path: poll for BugBot review on the 3 endpoints. Greptile path: poll for existing Greptile review; only re-trigger `@greptileai` for P0 findings (max 3 reviews/PR).
 4. Greptile findings: classify P0/P1/P2, fix all, commit, push, reply. Re-trigger only for P0 (max 3 reviews/PR).
 5. CR gate: verify an explicit `state: "APPROVED"` CR review exists on the current HEAD SHA (stale approvals don't count — re-trigger if the latest approval's `commit_id` is not HEAD)
 6. Update handoff file. Deduplicate: `string[]` by exact value, `findings_dismissed` by `.id`.

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -19,7 +19,7 @@ BugBot is the **second-tier** AI code reviewer — free, auto-triggers on every 
 
 Poll alongside CR every 60 seconds on all three endpoints (same pattern — `pulls/{N}/reviews`, `pulls/{N}/comments`, `issues/{N}/comments` with `per_page=100`). Filter by `.user.login == "cursor[bot]"`.
 
-**Timeout:** 10 minutes **from push time** (not from CR failure detection). BugBot auto-triggers at push, so its timeout runs concurrently with CR's 12-minute window — BugBot's 10 fits inside CR's 12. Cadence stays 60 s; a `Cursor Bugbot` `status: "completed"` short-circuits the wait. If CR's 12-min timeout fires and BugBot hasn't posted, BugBot's 10-min window has already expired — trigger Greptile immediately (see `greptile.md` "When to Trigger Greptile"). Do NOT wait another 10 minutes.
+**Timeout:** 10 minutes **from push time** (not from CR failure detection). BugBot auto-triggers at push, so its timeout runs concurrently with CR's 12-minute window (BugBot's 10 fits inside CR's 12). Cadence stays 60 s; `Cursor Bugbot` `status: "completed"` short-circuits the wait. If CR's 12-min timeout fires and BugBot hasn't posted, BugBot's 10-min window has already expired — trigger Greptile immediately (see `greptile.md`). Do NOT wait another 10 min.
 
 **Completion signal:** BugBot creates a CI check-run named `Cursor Bugbot` that transitions to `status: "completed"` when the review finishes. The `conclusion` field is `neutral` when BugBot posted findings (still counts as a completed review — `neutral` is not a failure). Completion can also be detected via BugBot review comments appearing on any of the three endpoints.
 

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -19,15 +19,15 @@ BugBot is the **second-tier** AI code reviewer — free, auto-triggers on every 
 
 Poll alongside CR every 60 seconds on all three endpoints (same pattern — `pulls/{N}/reviews`, `pulls/{N}/comments`, `issues/{N}/comments` with `per_page=100`). Filter by `.user.login == "cursor[bot]"`.
 
-**Timeout:** 5 minutes **from push time** (not from CR failure detection). Since BugBot auto-triggers at push time, its timeout runs concurrently with CR's 7-minute window. If the 7-minute CR timeout fires and BugBot hasn't posted a review, BugBot's 5-minute window has already expired — trigger Greptile immediately (see `greptile.md` "When to Trigger Greptile"). Do NOT wait another 5 minutes.
+**Timeout:** 10 minutes **from push time** (not from CR failure detection). BugBot auto-triggers at push, so its timeout runs concurrently with CR's 12-minute window — BugBot's 10 fits inside CR's 12. Cadence stays 60 s; a `Cursor Bugbot` `status: "completed"` short-circuits the wait. If CR's 12-min timeout fires and BugBot hasn't posted, BugBot's 10-min window has already expired — trigger Greptile immediately (see `greptile.md` "When to Trigger Greptile"). Do NOT wait another 10 minutes.
 
 **Completion signal:** BugBot creates a CI check-run named `Cursor Bugbot` that transitions to `status: "completed"` when the review finishes. The `conclusion` field is `neutral` when BugBot posted findings (still counts as a completed review — `neutral` is not a failure). Completion can also be detected via BugBot review comments appearing on any of the three endpoints.
 
 ## When BugBot Becomes the Active Reviewer
 
 BugBot becomes the active reviewer (`reviewer: bugbot`) when:
-1. **CR fails** (rate-limited or 7-min timeout) AND BugBot has already posted a review, OR
-2. **CR fails** AND BugBot posts a review within its 5-minute window
+1. **CR fails** (rate-limited or 12-min timeout) AND BugBot has already posted a review, OR
+2. **CR fails** AND BugBot posts a review within its 10-minute window
 
 **Sticky assignment:** Once a PR is assigned to BugBot (CR failed, BugBot responded), it stays on BugBot unless BugBot also fails — then Greptile takes over permanently.
 
@@ -47,4 +47,4 @@ Verify all findings against actual code. Fix all valid findings in one commit, p
 
 ## Re-Reviews
 
-After fixing BugBot findings, BugBot auto-reviews the new push (since auto-trigger is ON). No need to manually trigger `@cursor review` unless the auto-review didn't fire within 5 minutes — then post `@cursor review` as a manual trigger.
+After fixing BugBot findings, BugBot auto-reviews the new push (since auto-trigger is ON). No need to manually trigger `@cursor review` unless the auto-review didn't fire within 10 minutes — then post `@cursor review` as a manual trigger.

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -60,11 +60,11 @@ If **ANY** of the conditions below hold, invoke `/fixpr` and do NOT request a ne
 - **Check merge metadata every cycle.** Query `mergeable` and `mergeStateStatus` via `gh pr view N --json mergeable,mergeStateStatus` — these drive `/fixpr` trigger conditions 3 and 4.
 - **Check commit status every cycle.** Query `repos/{owner}/{repo}/commits/{SHA}/check-runs` filtered to `name == "CodeRabbit"`; fallback: `/statuses` filtered to `context ~ "CodeRabbit"`. Full commands: `.claude/reference/cr-polling-commands.md`.
   - **Completion signal:** `status: "completed"` + `conclusion: "success"` = review done. Definitive signal.
-  - **Fast-path rate limit:** check-run `conclusion: "failure"` with "rate limit" in `output.title`, OR status `state: "failure"`/`"error"` with "rate limit" in `description` — **escalate immediately, regardless of elapsed minutes.** Rate-limit signals override the timeout: do not wait out CR's 12-minute window. **Check BugBot first** (see `bugbot.md`). If BugBot already posted a review, use it. If not, wait up to 10 min **from push time** for BugBot. If BugBot also times out, trigger Greptile. Sticky assignment applies at each tier.
+  - **Fast-path rate limit:** check-run `conclusion: "failure"` with "rate limit" in `output.title`, OR status `state: "failure"`/`"error"` with "rate limit" in `description` — **escalate immediately**, regardless of elapsed minutes (overrides CR's 12-min timeout). Check BugBot first (see `bugbot.md`); if absent, wait up to 10 min from push for BugBot, then Greptile. Sticky assignment applies at each tier.
   - **Ack ≠ completion.** "Actions performed — Full review triggered" = CR started. "CodeRabbit — Review completed" CI check = CR finished.
 - **CR username:** `coderabbitai[bot]` (with `[bot]` suffix). Filter by `.user.login == "coderabbitai[bot]"` — NOT bare `coderabbitai`.
 - **Watermark:** Track highest review ID from `pulls/{N}/reviews`. New reviews can have inline comment IDs lower than previous reviews (different ID sequences). For `issues/{N}/comments`, track by comment ID.
-- **Hard timeout: 12 minutes.** Cadence stays 60 s; a clean CR `status: "completed"` exits polling immediately — don't keep polling to 12 min after completion. No CR review after 12 min → check BugBot (see `bugbot.md`). If BugBot already posted a review, use it. If not, trigger Greptile immediately (BugBot's 10-min window has already elapsed). Sticky assignment applies at each tier.
+- **Hard timeout: 12 minutes.** Cadence 60 s; a CR `status: "completed"` exits polling immediately. No CR review after 12 min → check BugBot (see `bugbot.md`); if absent, trigger Greptile immediately (BugBot's 10-min window already elapsed). Sticky assignment applies.
 
 ### CI Health Check (MANDATORY — every poll cycle)
 
@@ -80,7 +80,7 @@ If **ANY** of the conditions below hold, invoke `/fixpr` and do NOT request a ne
 
 **Review chain:** CR (primary) → BugBot (second tier, free) → Greptile (last resort, paid) → self-review (emergency).
 
-BugBot auto-runs on every push — poll for its reviews alongside CR. When CR fails (rate-limited or 12-min timeout), check BugBot before triggering Greptile; BugBot's 10-min timeout runs from push time, concurrent with CR's window (BugBot's 10 still fits inside CR's 12). See `bugbot.md` and `greptile.md` for timing and trigger details.
+BugBot auto-runs on every push — poll alongside CR. When CR fails (rate-limited or 12-min timeout), check BugBot before triggering Greptile; BugBot's 10-min timeout runs concurrent with CR's 12 (BugBot's 10 fits inside CR's 12). See `bugbot.md` and `greptile.md` for timing and trigger details.
 
 - **Sticky assignment:** CR fail → BugBot owns the PR. If BugBot also fails → Greptile owns permanently. Do not switch back up the chain.
 - **If all three fail** (CR rate-limited + BugBot 10-min timeout + Greptile 10-min timeout): fall back to **self-review**. Self-review does NOT satisfy the merge gate.

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -60,11 +60,11 @@ If **ANY** of the conditions below hold, invoke `/fixpr` and do NOT request a ne
 - **Check merge metadata every cycle.** Query `mergeable` and `mergeStateStatus` via `gh pr view N --json mergeable,mergeStateStatus` — these drive `/fixpr` trigger conditions 3 and 4.
 - **Check commit status every cycle.** Query `repos/{owner}/{repo}/commits/{SHA}/check-runs` filtered to `name == "CodeRabbit"`; fallback: `/statuses` filtered to `context ~ "CodeRabbit"`. Full commands: `.claude/reference/cr-polling-commands.md`.
   - **Completion signal:** `status: "completed"` + `conclusion: "success"` = review done. Definitive signal.
-  - **Fast-path rate limit:** check-run `conclusion: "failure"` with "rate limit" in `output.title`, OR status `state: "failure"`/`"error"` with "rate limit" in `description` — **check BugBot first** (see `bugbot.md`). If BugBot already posted a review, use it. If not, wait up to 5 min **from push time** for BugBot. If BugBot also times out, trigger Greptile. Sticky assignment applies at each tier.
+  - **Fast-path rate limit:** check-run `conclusion: "failure"` with "rate limit" in `output.title`, OR status `state: "failure"`/`"error"` with "rate limit" in `description` — **escalate immediately, regardless of elapsed minutes.** Rate-limit signals override the timeout: do not wait out CR's 12-minute window. **Check BugBot first** (see `bugbot.md`). If BugBot already posted a review, use it. If not, wait up to 10 min **from push time** for BugBot. If BugBot also times out, trigger Greptile. Sticky assignment applies at each tier.
   - **Ack ≠ completion.** "Actions performed — Full review triggered" = CR started. "CodeRabbit — Review completed" CI check = CR finished.
 - **CR username:** `coderabbitai[bot]` (with `[bot]` suffix). Filter by `.user.login == "coderabbitai[bot]"` — NOT bare `coderabbitai`.
 - **Watermark:** Track highest review ID from `pulls/{N}/reviews`. New reviews can have inline comment IDs lower than previous reviews (different ID sequences). For `issues/{N}/comments`, track by comment ID.
-- **Hard timeout: 7 minutes.** No CR review after 7 min → check BugBot (see `bugbot.md`). If BugBot already posted a review, use it. If not, trigger Greptile immediately (BugBot's 5-min window from push has already elapsed). Sticky assignment applies at each tier.
+- **Hard timeout: 12 minutes.** Cadence stays 60 s; a clean CR `status: "completed"` exits polling immediately — don't keep polling to 12 min after completion. No CR review after 12 min → check BugBot (see `bugbot.md`). If BugBot already posted a review, use it. If not, trigger Greptile immediately (BugBot's 10-min window has already elapsed). Sticky assignment applies at each tier.
 
 ### CI Health Check (MANDATORY — every poll cycle)
 
@@ -80,10 +80,10 @@ If **ANY** of the conditions below hold, invoke `/fixpr` and do NOT request a ne
 
 **Review chain:** CR (primary) → BugBot (second tier, free) → Greptile (last resort, paid) → self-review (emergency).
 
-BugBot auto-runs on every push — poll for its reviews alongside CR. When CR fails (rate-limited or 7-min timeout), check BugBot before triggering Greptile; BugBot's 5-min timeout runs from push time, concurrent with CR's window. See `bugbot.md` and `greptile.md` for timing and trigger details.
+BugBot auto-runs on every push — poll for its reviews alongside CR. When CR fails (rate-limited or 12-min timeout), check BugBot before triggering Greptile; BugBot's 10-min timeout runs from push time, concurrent with CR's window (BugBot's 10 still fits inside CR's 12). See `bugbot.md` and `greptile.md` for timing and trigger details.
 
 - **Sticky assignment:** CR fail → BugBot owns the PR. If BugBot also fails → Greptile owns permanently. Do not switch back up the chain.
-- **If all three fail** (CR rate-limited + BugBot 5-min timeout + Greptile 5-min timeout): fall back to **self-review**. Self-review does NOT satisfy the merge gate.
+- **If all three fail** (CR rate-limited + BugBot 10-min timeout + Greptile 10-min timeout): fall back to **self-review**. Self-review does NOT satisfy the merge gate.
 - Tell the user which fallback was used and why.
 
 ### Processing CR Feedback

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -28,11 +28,11 @@ The merge gate depends on which reviewer owns the PR:
   - "0 unresolved threads right now" without an APPROVED review on the current SHA.
   - Absence of findings in the first N minutes after triggering (CR can run slowly or time out).
   - CR check-run `status: "completed"` without an accompanying APPROVED review object on the current SHA.
-- **Re-trigger policy (unchanged):** if no approval on the current SHA within the 7-minute polling timeout, re-trigger `@coderabbitai full review` once. Max 2 explicit triggers per PR per hour. After 2 failed re-triggers on the same SHA, fall back to BugBot → Greptile → self-review per the three-tier chain.
+- **Re-trigger policy (unchanged):** if no approval on the current SHA within the 12-minute polling timeout, re-trigger `@coderabbitai full review` once. Max 2 explicit triggers per PR per hour. After 2 failed re-triggers on the same SHA, fall back to BugBot → Greptile → self-review per the three-tier chain. Rate-limit signals override the timeout — escalate immediately on a rate-limit signal regardless of elapsed minutes.
 
 **BugBot path** (CR failed, BugBot responded, Greptile was never triggered — sticky assignment, see `bugbot.md`):
 - 1 clean BugBot review on the current HEAD SHA satisfies the gate (BugBot's completion signals are reliable).
-- After fixing BugBot findings, BugBot auto-reviews the new push. If auto-review doesn't fire within 5 min, trigger manually via `@cursor review`.
+- After fixing BugBot findings, BugBot auto-reviews the new push. If auto-review doesn't fire within 10 min, trigger manually via `@cursor review`.
 - Stay on BugBot — do not switch back to CR. Ignore late CR reviews.
 
 **Greptile path** (Greptile was triggered at any point — both CR and BugBot failed — sticky assignment, see `greptile.md`):
@@ -43,7 +43,7 @@ The merge gate depends on which reviewer owns the PR:
 - Stay on Greptile — do not switch back to CR or BugBot. Ignore any late CR/BugBot reviews.
 - Max 3 Greptile reviews per PR (initial + up to 2 P0 re-reviews). At 3 with persistent P0, self-review and report blocker.
 
-**If CR, BugBot, and Greptile are all down** (CR rate-limited/timed out + BugBot 5-min timeout + Greptile 5-min timeout): perform a self-review for risk reduction. A clean self-review does NOT satisfy the merge gate — report the blocker to the user.
+**If CR, BugBot, and Greptile are all down** (CR rate-limited/timed out + BugBot 10-min timeout + Greptile 10-min timeout): perform a self-review for risk reduction. A clean self-review does NOT satisfy the merge gate — report the blocker to the user.
 
 - **How to detect a clean CR approval:** After triggering `@coderabbitai full review`, watch for these signals in order:
   1. **Ack (review started):** CR posts an issue comment (on `issues/{N}/comments`) with "Actions performed — Full review triggered." This means CR **started** the review — it is NOT a completion signal and NOT an approval.

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -28,7 +28,7 @@ The merge gate depends on which reviewer owns the PR:
   - "0 unresolved threads right now" without an APPROVED review on the current SHA.
   - Absence of findings in the first N minutes after triggering (CR can run slowly or time out).
   - CR check-run `status: "completed"` without an accompanying APPROVED review object on the current SHA.
-- **Re-trigger policy (unchanged):** if no approval on the current SHA within the 12-minute polling timeout, re-trigger `@coderabbitai full review` once. Max 2 explicit triggers per PR per hour. After 2 failed re-triggers on the same SHA, fall back to BugBot → Greptile → self-review per the three-tier chain. Rate-limit signals override the timeout — escalate immediately on a rate-limit signal regardless of elapsed minutes.
+- **Re-trigger policy:** if no approval on the current SHA within the 12-min timeout, re-trigger `@coderabbitai full review` once. Max 2 triggers per PR per hour. Rate-limit signals override the timeout — escalate immediately. After 2 failed re-triggers on the same SHA, fall back BugBot → Greptile → self-review.
 
 **BugBot path** (CR failed, BugBot responded, Greptile was never triggered — sticky assignment, see `bugbot.md`):
 - 1 clean BugBot review on the current HEAD SHA satisfies the gate (BugBot's completion signals are reliable).

--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -55,8 +55,8 @@ Applies to 2nd/3rd triggers only; initial trigger requires only the budget check
 
 **Greptile is last-resort only.** Never trigger it before both CR AND BugBot have failed. It is only triggered when both upstream reviewers fail for a specific PR:
 
-1. **CR rate-limit + BugBot timeout:** CR is rate-limited (fast-path) AND BugBot has not posted a review within 10 minutes → trigger Greptile. Rate-limit signals override the timeout — CR's 12-minute ceiling does NOT delay this fallback; escalate the moment a rate-limit signal appears (waiting only on BugBot's 10).
-2. **CR timeout + BugBot timeout:** CR has not delivered a review within 12 minutes AND BugBot has not posted a review within 10 minutes → trigger Greptile.
+1. **CR rate-limit + BugBot timeout:** CR is rate-limited (fast-path) AND BugBot has not posted within 10 min → trigger Greptile. Rate-limit signals override CR's 12-min ceiling (escalate immediately, wait only on BugBot's 10).
+2. **CR timeout + BugBot timeout:** no CR review within 12 min AND no BugBot review within 10 min → trigger Greptile.
 
 In both cases, always check if BugBot (`cursor[bot]`) already posted a review before triggering Greptile — BugBot auto-runs on every push, so it may have responded while you were waiting for CR.
 
@@ -68,7 +68,7 @@ In both cases, always check if BugBot (`cursor[bot]`) already posted a review be
 
 Poll every 60 seconds on all three endpoints (same pattern as CR — `pulls/{N}/reviews`, `pulls/{N}/comments`, `issues/{N}/comments` with `per_page=100`). Filter by `greptile-apps[bot]`.
 
-**Timeout:** 10 minutes. Polling cadence stays 60 s — the longer ceiling does not slow checks. **Completion:** 👍 or review comments = done (exit polling immediately on completion; do not keep polling to 10 min). 😕 = failed. No signal after 10 min = timeout.
+**Timeout:** 10 minutes. Cadence stays 60 s. **Completion:** 👍 or review comments = done (exit immediately). 😕 = failed. No signal after 10 min = timeout.
 
 ## Processing Greptile Findings
 

--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -55,8 +55,8 @@ Applies to 2nd/3rd triggers only; initial trigger requires only the budget check
 
 **Greptile is last-resort only.** Never trigger it before both CR AND BugBot have failed. It is only triggered when both upstream reviewers fail for a specific PR:
 
-1. **CR rate-limit + BugBot timeout:** CR is rate-limited (fast-path) AND BugBot has not posted a review within 5 minutes → trigger Greptile.
-2. **CR timeout + BugBot timeout:** CR has not delivered a review within 7 minutes AND BugBot has not posted a review within 5 minutes → trigger Greptile.
+1. **CR rate-limit + BugBot timeout:** CR is rate-limited (fast-path) AND BugBot has not posted a review within 10 minutes → trigger Greptile. Rate-limit signals override the timeout — CR's 12-minute ceiling does NOT delay this fallback; escalate the moment a rate-limit signal appears (waiting only on BugBot's 10).
+2. **CR timeout + BugBot timeout:** CR has not delivered a review within 12 minutes AND BugBot has not posted a review within 10 minutes → trigger Greptile.
 
 In both cases, always check if BugBot (`cursor[bot]`) already posted a review before triggering Greptile — BugBot auto-runs on every push, so it may have responded while you were waiting for CR.
 
@@ -68,7 +68,7 @@ In both cases, always check if BugBot (`cursor[bot]`) already posted a review be
 
 Poll every 60 seconds on all three endpoints (same pattern as CR — `pulls/{N}/reviews`, `pulls/{N}/comments`, `issues/{N}/comments` with `per_page=100`). Filter by `greptile-apps[bot]`.
 
-**Timeout:** 5 minutes. **Completion:** 👍 or review comments = done. 😕 = failed. No signal after 5 min = timeout.
+**Timeout:** 10 minutes. Polling cadence stays 60 s — the longer ceiling does not slow checks. **Completion:** 👍 or review comments = done (exit polling immediately on completion; do not keep polling to 10 min). 😕 = failed. No signal after 10 min = timeout.
 
 ## Processing Greptile Findings
 

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -65,8 +65,8 @@ If agent definitions are unavailable (e.g., repo without `.claude/agents/`):
 | Branch pushed | Create PR via `gh pr create` | **Always do** |
 | PR created/updated | Enter GitHub review polling loop (60s cycle) | **Always do** |
 | CR/BugBot/Greptile posts findings | Fix all valid findings, commit, push, reply to threads | **Always do** |
-| CR rate-limited (fast-path) | Escalate immediately regardless of elapsed minutes; check BugBot review; if absent, wait up to 10 min for BugBot | **Always do** |
-| CR timeout (12 min) | Check BugBot review; if absent, trigger Greptile immediately (BugBot's 10-min window from push has already elapsed) | **Always do** |
+| CR rate-limited (fast-path) | Escalate immediately; check BugBot, else wait up to 10 min from push | **Always do** |
+| CR timeout (12 min) | Check BugBot; if absent, trigger Greptile immediately (BugBot's 10-min window already elapsed) | **Always do** |
 | BugBot timeout (10 min, CR already failed) | Trigger Greptile | **Always do** |
 | All three reviewers down | Self-review for risk reduction | **Always do** |
 | Phase A subagent completes | Parent launches Phase B within 60s | **Always do** |

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -65,9 +65,9 @@ If agent definitions are unavailable (e.g., repo without `.claude/agents/`):
 | Branch pushed | Create PR via `gh pr create` | **Always do** |
 | PR created/updated | Enter GitHub review polling loop (60s cycle) | **Always do** |
 | CR/BugBot/Greptile posts findings | Fix all valid findings, commit, push, reply to threads | **Always do** |
-| CR rate-limited (fast-path) | Check BugBot review; if absent, wait 5 min for BugBot | **Always do** |
-| CR timeout (7 min) | Check BugBot review; if absent, trigger Greptile immediately (BugBot's 5-min window from push has already elapsed) | **Always do** |
-| BugBot timeout (5 min, CR already failed) | Trigger Greptile | **Always do** |
+| CR rate-limited (fast-path) | Escalate immediately regardless of elapsed minutes; check BugBot review; if absent, wait up to 10 min for BugBot | **Always do** |
+| CR timeout (12 min) | Check BugBot review; if absent, trigger Greptile immediately (BugBot's 10-min window from push has already elapsed) | **Always do** |
+| BugBot timeout (10 min, CR already failed) | Trigger Greptile | **Always do** |
 | All three reviewers down | Self-review for risk reduction | **Always do** |
 | Phase A subagent completes | Parent launches Phase B within 60s | **Always do** |
 | Phase B reports merge_ready | Parent launches Phase C | **Always do** |

--- a/.claude/skills/continue/SKILL.md
+++ b/.claude/skills/continue/SKILL.md
@@ -181,7 +181,7 @@ gh api "repos/{owner}/{repo}/commits/$SHA/statuses" \
 - CR has finished reviewing. Check for findings (Step 7).
 
 **Review pending:** If no completion signal and no rate-limit signal:
-- `[ACTION]` — CR review is still pending. Polling every 60 seconds (12-minute timeout). Polling cadence stays 60 s; a clean CR check-run completion short-circuits earlier — exit immediately on completion, do not keep polling to 12 min.
+- `[ACTION]` — CR review is still pending. Polling every 60 seconds (12-minute timeout). A clean CR check-run completion short-circuits the timeout wait — but the merge gate still requires an explicit `APPROVED` review on the current HEAD SHA (per `cr-merge-gate.md` Step 1); completion alone does not satisfy it.
 - Poll all 3 endpoints each cycle for new comments from `coderabbitai[bot]`.
 - Check for rate-limit signals on every poll cycle. Rate-limit signals override the timeout — escalate immediately regardless of elapsed minutes.
 - After 12 minutes with no review content and no rate-limit signal: `[ACTION]` — CR timed out. Check BugBot (same query as rate-limit path above). If BugBot has posted a review, persist `--sticky bugbot` and go to the BugBot section. If BugBot has also timed out (≥10 min since push), fall through to Greptile.
@@ -209,10 +209,7 @@ gh api "repos/{owner}/{repo}/commits/$SHA/check-runs" \
 - BugBot has posted findings on `$SHA` → `[DONE]` — BugBot review received. Process findings (Step 7). After fixes are pushed, BugBot auto-reviews the new push; return to this section on the new SHA.
 - BugBot has posted a clean review (check-run `completed` with no finding comments) on `$SHA` → `[DONE]` — merge gate met (1 clean pass is sufficient for the BugBot path). Proceed to merge verification.
 - No BugBot response AND <10 min since push → `[ACTION]` — Polling for BugBot (10-min timeout from push). Poll every 60 s.
-- No BugBot response AND ≥10 min since push → BugBot timed out. Trigger manual re-review once; if still silent after another 10 min, fall through to Greptile:
-  ```bash
-  gh pr comment "$PR_NUM" --body "@cursor review"
-  ```
+- No BugBot response AND ≥10 min since push → BugBot timed out. Fall through to Greptile immediately (after the Greptile budget gate). Do NOT extend the wait by triggering a manual `@cursor review` retry — the 10-min window from push is the hard timeout.
 - Stay on BugBot — do not switch back to CR. Ignore late CR reviews. Only escalate to Greptile if BugBot also fails.
 
 ### If PR is on Greptile:

--- a/.claude/skills/continue/SKILL.md
+++ b/.claude/skills/continue/SKILL.md
@@ -169,8 +169,8 @@ gh api "repos/{owner}/{repo}/commits/$SHA/statuses" \
     ```bash
     .claude/scripts/reviewer-of.sh "$PR_NUM" --sticky bugbot
     ```
-  - BugBot has NOT posted AND <5 min since push → `[ACTION]` — Waiting up to 5 min for BugBot's auto-review. Poll every 60 s.
-  - BugBot has NOT posted AND ≥5 min since push → BugBot timed out. Fall through to Greptile:
+  - BugBot has NOT posted AND <10 min since push → `[ACTION]` — Waiting up to 10 min for BugBot's auto-review. Poll every 60 s.
+  - BugBot has NOT posted AND ≥10 min since push → BugBot timed out. Fall through to Greptile:
     ```bash
     gh pr comment "$PR_NUM" --body "@greptileai"
     .claude/scripts/reviewer-of.sh "$PR_NUM" --sticky greptile
@@ -181,10 +181,10 @@ gh api "repos/{owner}/{repo}/commits/$SHA/statuses" \
 - CR has finished reviewing. Check for findings (Step 7).
 
 **Review pending:** If no completion signal and no rate-limit signal:
-- `[ACTION]` — CR review is still pending. Polling every 60 seconds (7-minute timeout).
+- `[ACTION]` — CR review is still pending. Polling every 60 seconds (12-minute timeout). Polling cadence stays 60 s; a clean CR check-run completion short-circuits earlier — exit immediately on completion, do not keep polling to 12 min.
 - Poll all 3 endpoints each cycle for new comments from `coderabbitai[bot]`.
-- Check for rate-limit signals on every poll cycle.
-- After 7 minutes with no review content and no rate-limit signal: `[ACTION]` — CR timed out. Check BugBot (same query as rate-limit path above). If BugBot has posted a review, persist `--sticky bugbot` and go to the BugBot section. If BugBot has also timed out (≥5 min since push), fall through to Greptile.
+- Check for rate-limit signals on every poll cycle. Rate-limit signals override the timeout — escalate immediately regardless of elapsed minutes.
+- After 12 minutes with no review content and no rate-limit signal: `[ACTION]` — CR timed out. Check BugBot (same query as rate-limit path above). If BugBot has posted a review, persist `--sticky bugbot` and go to the BugBot section. If BugBot has also timed out (≥10 min since push), fall through to Greptile.
 
 ### If PR is on BugBot:
 
@@ -208,8 +208,8 @@ gh api "repos/{owner}/{repo}/commits/$SHA/check-runs" \
 
 - BugBot has posted findings on `$SHA` → `[DONE]` — BugBot review received. Process findings (Step 7). After fixes are pushed, BugBot auto-reviews the new push; return to this section on the new SHA.
 - BugBot has posted a clean review (check-run `completed` with no finding comments) on `$SHA` → `[DONE]` — merge gate met (1 clean pass is sufficient for the BugBot path). Proceed to merge verification.
-- No BugBot response AND <5 min since push → `[ACTION]` — Polling for BugBot (5-min timeout from push). Poll every 60 s.
-- No BugBot response AND ≥5 min since push → BugBot timed out. Trigger manual re-review once; if still silent after another 5 min, fall through to Greptile:
+- No BugBot response AND <10 min since push → `[ACTION]` — Polling for BugBot (10-min timeout from push). Poll every 60 s.
+- No BugBot response AND ≥10 min since push → BugBot timed out. Trigger manual re-review once; if still silent after another 10 min, fall through to Greptile:
   ```bash
   gh pr comment "$PR_NUM" --body "@cursor review"
   ```
@@ -228,8 +228,8 @@ gh api --paginate "repos/{owner}/{repo}/issues/{N}/comments?per_page=100" \
 ```
 
 - If Greptile has posted findings: `[DONE]` — Greptile review received. Process findings (Step 7).
-- If no Greptile response: `[ACTION]` — Polling for Greptile (5-minute timeout).
-  - If no response after 5 minutes: `[BLOCKED]` — Greptile timed out. Performing self-review as fallback. Note: self-review does NOT satisfy merge gate.
+- If no Greptile response: `[ACTION]` — Polling for Greptile (10-minute timeout). Polling cadence stays 60 s; exit immediately when the review lands, do not keep polling to 10 min.
+  - If no response after 10 minutes: `[BLOCKED]` — Greptile timed out. Performing self-review as fallback. Note: self-review does NOT satisfy merge gate.
 
 ---
 
@@ -311,7 +311,7 @@ Branch on the exit code:
 
 - `0` → `[DONE]` — Merge gate satisfied. Proceed to Step 9 (AC verification).
 - `1` → `[ACTION]` — Gate not met. Parse `missing` from the JSON output and act accordingly:
-  - CR path with **"need 1 explicit CR APPROVED review on HEAD"**: if the current SHA is still within the 7-minute CR polling window, return to **Step 6** and keep polling — do NOT re-trigger yet. Only after the 7-minute timeout, and only within the 2-trigger-per-hour budget, post `@coderabbitai full review` once and return to **Step 6**.
+  - CR path with **"need 1 explicit CR APPROVED review on HEAD"**: if the current SHA is still within the 12-minute CR polling window, return to **Step 6** and keep polling — do NOT re-trigger yet. Only after the 12-minute timeout, and only within the 2-trigger-per-hour budget, post `@coderabbitai full review` once and return to **Step 6**.
   - CR path with **"CR approval on HEAD ... retracted by later CHANGES_REQUESTED"**: CR retracted approval. Return to **Step 7** to process the findings. Re-trigger only after fixes are pushed (the new SHA invalidates prior reviews regardless).
   - CR path with **"CodeRabbit check-run not green on HEAD"** or **"latest CR review on HEAD requests changes"**: CR has findings; return to **Step 7** to process them.
   - BugBot path with **"no BugBot review on HEAD"**: BugBot hasn't reviewed the current HEAD yet; return to **Step 6** to poll for the review.

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -357,7 +357,7 @@ If missing, reconstruct state from GitHub API.
 4. Poll for CR review every 60s on all 3 endpoints. Filter by coderabbitai[bot].
 5. Check commit status for CR completion signal and rate-limit fast-path.
 6. If CR rate-limited (fast-path): trigger Greptile immediately (budget check first).
-7. If 7 minutes with no CR review: trigger Greptile (budget check first).
+7. If 12 minutes with no CR review: trigger Greptile (budget check first). Polling cadence stays 60 s; a clean CR check-run completion short-circuits the wait. Rate-limit signals override the timeout — escalate immediately on a rate-limit signal regardless of elapsed minutes.
 8. Process findings: fix all valid ones in ONE commit, push once, reply to every thread, resolve threads via GraphQL.
 9. Merge gate:
    - CR-only: 1 explicit CR APPROVED review on the current HEAD SHA (commit_id must match HEAD; acks / check-run completion alone do NOT count).


### PR DESCRIPTION
## **User description**
## Summary
- Bump CR hard timeout 7→12 min, BugBot 5→10 min, Greptile 5→10 min across rules, agents, skills, and reference docs.
- Preserve fast-path: rate-limit signals override the longer timeout — escalate immediately regardless of elapsed minutes.
- Reaffirm 60s polling cadence and check-run completion short-circuit on every path (don't keep polling to the ceiling once a review lands).
- BugBot's 10 still fits inside CR's 12 — sticky-assignment chain works as before.

## Why
Per memory `feedback_bugbot_auto_trigger_unreliable.md`, BugBot reviews routinely take 8–12 min, not the 1–3 min the old timeout assumed. CR's 7 min is also too short — long files / cold queues exceed it. The bumped windows match observed turnaround so genuinely-running reviews are not falsely declared "timed out" and forced down the fallback chain.

## Files touched
Rules: `cr-github-review.md`, `bugbot.md`, `greptile.md`, `cr-merge-gate.md`, `subagent-orchestration.md`
Agents: `phase-b-reviewer.md`
Skills: `continue/SKILL.md`, `subagent/SKILL.md`
Reference: `cr-polling-commands.md`, `phase-decomposition.md`

Closes #316

## Test plan
- [x] CR hard timeout bumped to 12 min in `cr-github-review.md`
- [x] BugBot timeout bumped to 10 min in `bugbot.md`
- [x] Greptile timeout bumped to 10 min in `greptile.md`
- [x] All trigger conditions referencing these values updated consistently (grep `5 min`, `7 min`, `5 minutes`, `7 minutes` returns zero stale review-timeout hits)
- [x] Fast-path rate-limit escalation language preserved — explicit statement that longer timeout doesn't delay rate-limit fallback
- [x] Polling cadence (60s) and check-run short-circuit behavior explicitly reaffirmed
- [x] No stale references in `.claude/scripts/`, agent definitions, or reference docs
- [x] BugBot's 10-min window fits inside CR's 12-min window (chain still consistent)
- [x] Word budget for CLAUDE.md + rules under 14000

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Extend AI reviewer wait times and keep rate-limit fallbacks immediate**

### What Changed
- CodeRabbit, BugBot, and Greptile now wait longer before timing out, so reviews are less likely to be treated as failed while they are still running.
- When a rate-limit signal appears, the flow now escalates right away instead of waiting for the full timeout window.
- BugBot and Greptile polling now stops as soon as a review completes, and the manual retry window for BugBot is longer.
- The review and merge rules were updated so the same timeout behavior is used consistently across the reviewer chain.

### Impact
`✅ Fewer false reviewer timeouts`
`✅ Faster recovery from rate-limit failures`
`✅ Fewer unnecessary fallback reviews`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=KZ-sS2h-HeVii5sMJmkkeyDwOth7h8bwix0O6Wm6LU4&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
