### PR TITLE
feat(fixpr): trigger missing AI reviewers after push

### DIFF
--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -167,7 +167,7 @@ echo "[REVIEWERS] waiting 120s for auto-triggered reviewers on ${PUSHED_SHA:0:7}
 sleep 120
 ```
 
-Detect activity from all 4 proactive reviewers on the pushed SHA. Check all three PR comment endpoints plus check-runs for activity after `$PUSHED_AT`:
+Detect activity from all 4 proactive reviewers on the pushed SHA. Check all three PR comment endpoints plus check-runs for activity after `$PUSHED_AT`. Conversation-level comments do not expose a `commit_id`, so they only count as activity on the pushed SHA when the body mentions the full SHA or short SHA; otherwise, use SHA-scoped reviews, inline comments, or check-runs to avoid treating a late summary from the previous SHA as coverage for the new one:
 
 ```bash
 REVIEWS=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" | jq -s 'add // []')
@@ -184,33 +184,41 @@ REVIEWER_ACTIVITY=$(jq -n \
   --argjson checks "$CHECK_RUNS" \
   '
   def recent($ts): ($ts // "") >= $pushed_at;
+  def matches_any($value; $needles):
+    ($value // "" | ascii_downcase) as $haystack
+    | any($needles[]; (. | ascii_downcase) as $needle | $haystack | contains($needle));
   def check_by($names):
     any($checks[]?;
       (((.name // "") as $name
         | (.app.slug // "") as $slug
         | (.app.name // "") as $app
-        | $names | index($name) or index($slug) or index($app)))
+        | (matches_any($name; $names) or matches_any($slug; $names) or matches_any($app; $names))))
       and recent(.started_at // .created_at // .completed_at));
+  def convo_by($login):
+    any($convo[]?;
+      .user.login == $login
+      and recent(.created_at)
+      and (((.body // "") | contains($sha)) or ((.body // "") | contains($sha[0:7]))));
   {
     coderabbit:
       (any($reviews[]?; .user.login == "coderabbitai[bot]" and .commit_id == $sha and recent(.submitted_at))
        or any($inline[]?; .user.login == "coderabbitai[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
-       or any($convo[]?; .user.login == "coderabbitai[bot]" and recent(.created_at))
+       or convo_by("coderabbitai[bot]")
        or check_by(["CodeRabbit", "coderabbitai"])),
     graphite:
       (any($reviews[]?; .user.login == "graphite-app[bot]" and .commit_id == $sha and recent(.submitted_at))
        or any($inline[]?; .user.login == "graphite-app[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
-       or any($convo[]?; .user.login == "graphite-app[bot]" and recent(.created_at))
+       or convo_by("graphite-app[bot]")
        or check_by(["Graphite", "graphite-app"])),
     codeant:
       (any($reviews[]?; .user.login == "codeant-ai[bot]" and .commit_id == $sha and recent(.submitted_at))
        or any($inline[]?; .user.login == "codeant-ai[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
-       or any($convo[]?; .user.login == "codeant-ai[bot]" and recent(.created_at))
+       or convo_by("codeant-ai[bot]")
        or check_by(["CodeAnt", "codeant-ai"])),
     cursor:
       (any($reviews[]?; .user.login == "cursor[bot]" and .commit_id == $sha and recent(.submitted_at))
        or any($inline[]?; .user.login == "cursor[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
-       or any($convo[]?; .user.login == "cursor[bot]" and recent(.created_at))
+       or convo_by("cursor[bot]")
        or check_by(["Cursor Bugbot", "cursor"])),
   }')
 ```
@@ -324,24 +332,45 @@ jq -r '
 
 **If `finding_count > 0`:** do NOT loop. Emit `NEW_FINDINGS` in Step 7 and stop. Re-running `/fixpr` captures a new `$RUN_STARTED_AT` and re-audits from Step 0, picking up the new findings.
 
-### 5c. CI (if a push was made)
+### 5c. CI (if a push was made; exclude review-bot check-runs from CI pending)
 
 The verify audit's `.check_runs` reflects the new HEAD.
 
 ```bash
 jq -r '.check_runs.all[] | "[CI] \(.name): \(.status)\(if .conclusion then " — \(.conclusion)" else "" end)"' "$VERIFY"
 
-FAILING=$(jq -r '.check_runs.failing' "$VERIFY")
-IN_PROGRESS=$(jq -r '.check_runs.in_progress' "$VERIFY")
+CI_CHECKS=$(jq '
+  def is_review_bot:
+    (.name // "" | ascii_downcase) as $name
+    | ($name | contains("coderabbit")
+       or contains("graphite")
+       or contains("codeant")
+       or contains("cursor bugbot"));
+  [.check_runs.all[] | select(is_review_bot | not)]
+' "$VERIFY")
+REVIEW_BOT_CHECKS=$(jq '
+  def is_review_bot:
+    (.name // "" | ascii_downcase) as $name
+    | ($name | contains("coderabbit")
+       or contains("graphite")
+       or contains("codeant")
+       or contains("cursor bugbot"));
+  [.check_runs.all[] | select(is_review_bot)]
+' "$VERIFY")
+
+FAILING=$(jq '[.[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "startup_failure" or .conclusion == "stale")] | length' <<<"$CI_CHECKS")
+IN_PROGRESS=$(jq '[.[] | select(.status != "completed")] | length' <<<"$CI_CHECKS")
+REVIEW_IN_PROGRESS=$(jq '[.[] | select(.status != "completed")] | length' <<<"$REVIEW_BOT_CHECKS")
 ```
 
-Decide from those two counts:
+Decide from the non-review CI counts before review-bot pending counts:
 
-- `IN_PROGRESS > 0` → emit `CI_PENDING` in Step 7. Re-run `/fixpr` after CI finishes.
+- `IN_PROGRESS > 0` on non-review-bot checks → emit `CI_PENDING` in Step 7. Re-run `/fixpr` after CI finishes.
+- `REVIEW_IN_PROGRESS > 0` with no non-review-bot CI pending/failing → defer to Step 5d and emit `REVIEW_PENDING`, not `CI_PENDING`.
 - `IN_PROGRESS == 0 && FAILING > 0` → read each entry in `.check_runs.failing_runs` from the VERIFY audit. Classify:
   - **deterministic** (lint/typecheck/test/build/security reports a real error) → emit `CI_FAILING` in Step 7 and stop. Re-run `/fixpr` so Steps 2–3 can retry the fix on the newly-visible error.
   - **transient** (runner timeout, startup failure, flaky external dep) → emit `CI_FAILING` in Step 7, note the specific checks, and continue to Step 6 — local fixes aren't possible and the user decides whether to retry.
-- `IN_PROGRESS == 0 && FAILING == 0` → CI clean on this SHA.
+- `IN_PROGRESS == 0 && FAILING == 0` → non-review-bot CI is clean on this SHA.
 
 Do NOT poll.
 
@@ -406,7 +435,7 @@ Status:          CLEAN | THREADS_STUCK | REVIEW_PENDING | CI_PENDING | CI_FAILIN
 - `THREADS_STUCK` — some threads could not be resolved via GraphQL (report which).
 - `REVIEW_PENDING` — 5d found a review-bot status/check-run still pending on the current HEAD, or a reviewer has not responded yet after Step 3b triggered it. Re-run `/fixpr` after it flips to a completed state. Do NOT declare CLEAN.
 - `NEW_FINDINGS` — 5b's `finding_count > 0`. Stop the run. A fresh `/fixpr` captures a new `$RUN_STARTED_AT` and re-audits from Step 0.
-- `CI_PENDING` — push was made, CI not yet complete. Re-run `/fixpr` after CI.
+- `CI_PENDING` — push was made, and non-review-bot CI is not yet complete. Re-run `/fixpr` after CI.
 - `CI_FAILING` — transient CI failures that cannot be fixed locally (report which).
 - `CONFLICTS` — merge conflicts could not be auto-resolved (needs manual intervention).
 - `BEHIND` — branch behind base, auto-rebased and force-pushed; now waiting for CI re-run. Re-run `/fixpr` after CI completes.

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -223,13 +223,26 @@ REVIEWER_ACTIVITY=$(jq -n \
   }')
 ```
 
-For each reviewer whose value is `false`, post exactly one dedicated PR-level trigger comment. Do not batch mentions; combined-mention comments fail to trigger reliably. Post these comments sequentially in this order, skipping reviewers that already auto-triggered:
+For each reviewer whose value is `false`, post exactly one dedicated PR-level trigger comment. Do not batch mentions; combined-mention comments fail to trigger reliably. Post these comments sequentially in this order, skipping reviewers that already auto-triggered. CodeRabbit is additionally capped at 2 manual `@coderabbitai full review` triggers per PR in the trailing hour:
 
 ```bash
 jq -r 'to_entries[] | "[REVIEWERS] \(.key): \(if .value then "auto-triggered" else "missing" end)"' <<<"$REVIEWER_ACTIVITY"
 
+CR_TRIGGER_COUNT_LAST_HOUR=$(gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100" | jq -s '
+  (add // [])
+  | map(select(
+      (.body // "") == "@coderabbitai full review"
+      and ((.created_at // "") >= (now - 3600 | strftime("%Y-%m-%dT%H:%M:%SZ")))
+    ))
+  | length
+')
+
 if [[ "$(jq -r '.coderabbit' <<<"$REVIEWER_ACTIVITY")" != "true" ]]; then
-  gh pr comment "$PR_NUMBER" --body "@coderabbitai full review"
+  if [[ "$CR_TRIGGER_COUNT_LAST_HOUR" -lt 2 ]]; then
+    gh pr comment "$PR_NUMBER" --body "@coderabbitai full review"
+  else
+    echo "[REVIEWERS] coderabbit trigger budget exhausted (>=2 in the last hour); skipping manual trigger"
+  fi
 fi
 if [[ "$(jq -r '.graphite' <<<"$REVIEWER_ACTIVITY")" != "true" ]]; then
   gh pr comment "$PR_NUMBER" --body "@graphite-app re-review"

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -352,7 +352,7 @@ The verify audit's `.check_runs` reflects the new HEAD.
 ```bash
 jq -r '.check_runs.all[] | "[CI] \(.name): \(.status)\(if .conclusion then " — \(.conclusion)" else "" end)"' "$VERIFY"
 
-CI_CHECKS=$(jq '
+CHECK_BUCKETS=$(jq '
   def is_review_bot:
     (.name // "" | ascii_downcase) as $name
     | (.app.slug // "" | ascii_downcase) as $slug
@@ -369,27 +369,13 @@ CI_CHECKS=$(jq '
          or contains("graphite")
          or contains("codeant")
          or contains("cursor"));
-  [.check_runs.all[] | select(is_review_bot | not)]
+  {
+    ci: [.check_runs.all[] | select(is_review_bot | not)],
+    review: [.check_runs.all[] | select(is_review_bot)]
+  }
 ' "$VERIFY")
-REVIEW_BOT_CHECKS=$(jq '
-  def is_review_bot:
-    (.name // "" | ascii_downcase) as $name
-    | (.app.slug // "" | ascii_downcase) as $slug
-    | (.app.name // "" | ascii_downcase) as $app
-    | ($name | contains("coderabbit")
-       or contains("graphite")
-       or contains("codeant")
-       or contains("cursor"))
-      or ($slug | contains("coderabbit")
-         or contains("graphite")
-         or contains("codeant")
-         or contains("cursor"))
-      or ($app | contains("coderabbit")
-         or contains("graphite")
-         or contains("codeant")
-         or contains("cursor"));
-  [.check_runs.all[] | select(is_review_bot)]
-' "$VERIFY")
+CI_CHECKS=$(jq '.ci' <<<"$CHECK_BUCKETS")
+REVIEW_BOT_CHECKS=$(jq '.review' <<<"$CHECK_BUCKETS")
 
 FAILING=$(jq '[.[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "startup_failure" or .conclusion == "stale")] | length' <<<"$CI_CHECKS")
 IN_PROGRESS=$(jq '[.[] | select(.status != "completed")] | length' <<<"$CI_CHECKS")

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -19,6 +19,7 @@ All mechanical GitHub API work — pagination, GraphQL queries, comment classifi
 | 1. Classify review findings | Judgment | AI reads JSON + source files |
 | 2. Classify CI failures | Judgment | AI reads `check-runs/<id>.output.summary` |
 | 3. Fix & push | Judgment | AI edits files, commits, pushes |
+| 3b. Trigger missing AI reviewers | Mechanical | wait 2 minutes, detect 4-bot activity on the new SHA, post one trigger comment per missing bot |
 | 4. Reply & resolve | Mechanical | `gh api` calls against IDs from the JSON |
 | 5. Verify | Mechanical | Re-run `pr-state.sh --since $RUN_STARTED_AT` |
 | 6. Merge blockers | Judgment | AI reads `.merge_state` from the JSON |
@@ -144,12 +145,96 @@ git add <modified files>
 git commit -m "fix: resolve all review findings and CI failures
 
 Fixes N review findings and M CI errors."
+PUSHED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 git push
 ```
 
 Print: `[PUSH] committed and pushed (SHA: $(git rev-parse --short HEAD))`.
 
 If nothing needed fixing (all already-fixed/outdated, CI all green), skip the commit/push.
+
+---
+
+## Step 3b: Trigger missing AI reviewers after a push
+
+Only run this step when Step 3 made a push. If Step 3 skipped the commit/push, skip this step too.
+
+Use the `$PUSHED_AT` captured immediately before `git push` in Step 3. Capturing it before the push avoids a race where a fast bot starts between push completion and the timestamp capture. After the push completes, wait exactly 2 minutes before checking reviewer status so auto-triggers have time to post activity:
+
+```bash
+PUSHED_SHA=$(git rev-parse HEAD)
+echo "[REVIEWERS] waiting 120s for auto-triggered reviewers on ${PUSHED_SHA:0:7}"
+sleep 120
+```
+
+Detect activity from all 4 proactive reviewers on the pushed SHA. Check all three PR comment endpoints plus check-runs for activity after `$PUSHED_AT`:
+
+```bash
+REVIEWS=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" | jq -s 'add // []')
+INLINE=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100" | jq -s 'add // []')
+CONVO=$(gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100" | jq -s 'add // []')
+CHECK_RUNS=$(gh api --paginate "repos/$OWNER/$REPO/commits/$PUSHED_SHA/check-runs?per_page=100" --jq '.check_runs[]' | jq -s '.')
+
+REVIEWER_ACTIVITY=$(jq -n \
+  --arg pushed_at "$PUSHED_AT" \
+  --arg sha "$PUSHED_SHA" \
+  --argjson reviews "$REVIEWS" \
+  --argjson inline "$INLINE" \
+  --argjson convo "$CONVO" \
+  --argjson checks "$CHECK_RUNS" \
+  '
+  def recent($ts): ($ts // "") >= $pushed_at;
+  def check_by($names):
+    any($checks[]?;
+      (((.name // "") as $name
+        | (.app.slug // "") as $slug
+        | (.app.name // "") as $app
+        | $names | index($name) or index($slug) or index($app)))
+      and recent(.started_at // .created_at // .completed_at));
+  {
+    coderabbit:
+      (any($reviews[]?; .user.login == "coderabbitai[bot]" and .commit_id == $sha and recent(.submitted_at))
+       or any($inline[]?; .user.login == "coderabbitai[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
+       or any($convo[]?; .user.login == "coderabbitai[bot]" and recent(.created_at))
+       or check_by(["CodeRabbit", "coderabbitai"])),
+    graphite:
+      (any($reviews[]?; .user.login == "graphite-app[bot]" and .commit_id == $sha and recent(.submitted_at))
+       or any($inline[]?; .user.login == "graphite-app[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
+       or any($convo[]?; .user.login == "graphite-app[bot]" and recent(.created_at))
+       or check_by(["Graphite", "graphite-app"])),
+    codeant:
+      (any($reviews[]?; .user.login == "codeant-ai[bot]" and .commit_id == $sha and recent(.submitted_at))
+       or any($inline[]?; .user.login == "codeant-ai[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
+       or any($convo[]?; .user.login == "codeant-ai[bot]" and recent(.created_at))
+       or check_by(["CodeAnt", "codeant-ai"])),
+    cursor:
+      (any($reviews[]?; .user.login == "cursor[bot]" and .commit_id == $sha and recent(.submitted_at))
+       or any($inline[]?; .user.login == "cursor[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
+       or any($convo[]?; .user.login == "cursor[bot]" and recent(.created_at))
+       or check_by(["Cursor Bugbot", "cursor"])),
+  }')
+```
+
+For each reviewer whose value is `false`, post exactly one dedicated PR-level trigger comment. Do not batch mentions; combined-mention comments fail to trigger reliably. Post these comments sequentially in this order, skipping reviewers that already auto-triggered:
+
+```bash
+jq -r 'to_entries[] | "[REVIEWERS] \(.key): \(if .value then "auto-triggered" else "missing" end)"' <<<"$REVIEWER_ACTIVITY"
+
+if [[ "$(jq -r '.coderabbit' <<<"$REVIEWER_ACTIVITY")" != "true" ]]; then
+  gh pr comment "$PR_NUMBER" --body "@coderabbitai full review"
+fi
+if [[ "$(jq -r '.graphite' <<<"$REVIEWER_ACTIVITY")" != "true" ]]; then
+  gh pr comment "$PR_NUMBER" --body "@graphite-app re-review"
+fi
+if [[ "$(jq -r '.codeant' <<<"$REVIEWER_ACTIVITY")" != "true" ]]; then
+  gh pr comment "$PR_NUMBER" --body "@codeant-ai review"
+fi
+if [[ "$(jq -r '.cursor' <<<"$REVIEWER_ACTIVITY")" != "true" ]]; then
+  gh pr comment "$PR_NUMBER" --body "@cursor review"
+fi
+```
+
+Cost/rate-limit note: `@codeant-ai review` and `@cursor review` may consume their respective review budgets, so skip them whenever auto-trigger activity is already present on the new SHA. Greptile is intentionally NOT part of this proactive trigger set; it remains last-resort only per `greptile.md`.
 
 ---
 
@@ -262,7 +347,7 @@ Do NOT poll.
 
 ### 5d. Review-bot commit statuses on the current HEAD
 
-CR and Greptile report review completion via commit *statuses*, not check-runs. `pending` means the bot is still analyzing the current HEAD — declaring CLEAN while pending is the exact failure mode this verify step was built to prevent.
+CR and Greptile report review completion via commit *statuses*, while Graphite, CodeAnt, and Cursor may report via check-runs. `pending` means a bot is still analyzing the current HEAD — declaring CLEAN while pending is the exact failure mode this verify step was built to prevent.
 
 ```bash
 jq -r '
@@ -270,12 +355,12 @@ jq -r '
 ' "$VERIFY"
 ```
 
-For each bot present:
+For each bot present in `.bot_statuses` or the current-head check-runs:
 
 - `state: success` → review completed on this SHA. Clean-pass signal.
-- `state: pending` → bot still running. **Do NOT declare CLEAN.** Emit `REVIEW_PENDING` and stop.
+- `state: pending` or check-run `status != "completed"` → bot still running. **Do NOT declare CLEAN.** Emit `REVIEW_PENDING` and stop.
 - `state: failure` / `error` with "rate limit" in `description` → CR rate-limited, fall back to Greptile per `cr-github-review.md`.
-- No CR/Greptile entry in `.bot_statuses` after a push → bot hasn't started. Re-run `/fixpr` after it does.
+- No activity from CodeRabbit, Graphite, CodeAnt, or Cursor after a pushed fix commit → the Step 3b trigger check should already have posted the reviewer-specific comment. Emit `REVIEW_PENDING` and re-run `/fixpr` after the reviewer responds.
 
 ---
 
@@ -317,9 +402,9 @@ Status:          CLEAN | THREADS_STUCK | REVIEW_PENDING | CI_PENDING | CI_FAILIN
 
 **Status definitions:**
 
-- `CLEAN` — **all four conditions simultaneously:** zero unresolved threads (5a), `new_since_baseline.finding_count == 0` (5b), every entry in `bot_statuses` is `success` on the current HEAD (5d), no merge blockers (6). Missing any one disqualifies `CLEAN` — pick the more specific status below.
+- `CLEAN` — **all four conditions simultaneously:** zero unresolved threads (5a), `new_since_baseline.finding_count == 0` (5b), every present review-bot status/check-run for the current HEAD is complete/successful (5d), no merge blockers (6). Missing any one disqualifies `CLEAN` — pick the more specific status below.
 - `THREADS_STUCK` — some threads could not be resolved via GraphQL (report which).
-- `REVIEW_PENDING` — 5d found a CR/Greptile status still `pending` on the current HEAD. Re-run `/fixpr` after it flips to `success`. Do NOT declare CLEAN.
+- `REVIEW_PENDING` — 5d found a review-bot status/check-run still pending on the current HEAD, or a reviewer has not responded yet after Step 3b triggered it. Re-run `/fixpr` after it flips to a completed state. Do NOT declare CLEAN.
 - `NEW_FINDINGS` — 5b's `finding_count > 0`. Stop the run. A fresh `/fixpr` captures a new `$RUN_STARTED_AT` and re-audits from Step 0.
 - `CI_PENDING` — push was made, CI not yet complete. Re-run `/fixpr` after CI.
 - `CI_FAILING` — transient CI failures that cannot be fixed locally (report which).

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -355,19 +355,39 @@ jq -r '.check_runs.all[] | "[CI] \(.name): \(.status)\(if .conclusion then " —
 CI_CHECKS=$(jq '
   def is_review_bot:
     (.name // "" | ascii_downcase) as $name
+    | (.app.slug // "" | ascii_downcase) as $slug
+    | (.app.name // "" | ascii_downcase) as $app
     | ($name | contains("coderabbit")
        or contains("graphite")
        or contains("codeant")
-       or contains("cursor bugbot"));
+       or contains("cursor"))
+      or ($slug | contains("coderabbit")
+         or contains("graphite")
+         or contains("codeant")
+         or contains("cursor"))
+      or ($app | contains("coderabbit")
+         or contains("graphite")
+         or contains("codeant")
+         or contains("cursor"));
   [.check_runs.all[] | select(is_review_bot | not)]
 ' "$VERIFY")
 REVIEW_BOT_CHECKS=$(jq '
   def is_review_bot:
     (.name // "" | ascii_downcase) as $name
+    | (.app.slug // "" | ascii_downcase) as $slug
+    | (.app.name // "" | ascii_downcase) as $app
     | ($name | contains("coderabbit")
        or contains("graphite")
        or contains("codeant")
-       or contains("cursor bugbot"));
+       or contains("cursor"))
+      or ($slug | contains("coderabbit")
+         or contains("graphite")
+         or contains("codeant")
+         or contains("cursor"))
+      or ($app | contains("coderabbit")
+         or contains("graphite")
+         or contains("codeant")
+         or contains("cursor"));
   [.check_runs.all[] | select(is_review_bot)]
 ' "$VERIFY")
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a `/fixpr` Step 3b that captures the push timestamp, waits 120 seconds, then checks reviewer activity for CodeRabbit, Graphite, CodeAnt, and Cursor on the new SHA.
- Document detection across PR reviews, inline comments, PR conversation comments, and current-head check-runs.
- Require sequential one-comment-per-missing-reviewer trigger comments with the exact bot-specific bodies, while skipping reviewers that already fired.
- Tighten follow-up handling so conversation-level comments need SHA evidence and review-bot checks do not get classified as regular CI pending.
- Cap manual CodeRabbit trigger comments at 2 per PR in the trailing hour before posting `@coderabbitai full review`.
- Recognize Cursor review-bot checks by check name, app slug, or app name so Cursor review status is not misclassified as regular CI.
- Share the review-bot check predicate through one check-bucket calculation to avoid drift between CI and review-bot arrays.

Closes #370

## Test plan
- [x] After a `/fixpr` push, the skill waits 2 minutes before checking reviewer status
- [x] Detection correctly identifies which of the 4 bots have posted activity on the new SHA
- [x] For missing reviewers, the skill posts 4 separate PR comments, one per bot, in sequence
- [x] Each comment contains exactly one of: `@coderabbitai full review`, `@graphite-app re-review`, `@codeant-ai review`, `@cursor review`
- [x] Reviewers that already auto-triggered are NOT re-pinged
- [x] Comments are posted in sequence (not batched), since combined-mention comments fail to trigger reliably

## Verification
- [x] `git diff --check`
- [x] Embedded reviewer-detection `jq` expression validated with empty endpoint/check-run inputs
- [x] Real PR dry-run smoke test on #375: detected CodeRabbit as auto-triggered and Graphite/CodeAnt/Cursor as missing; did not post trigger comments to avoid live bot/rate-limit side effects during implementation
- [x] `/fixpr` follow-up pass: fixed 2 reviewer findings, pushed `656b768`, and resolved both review threads
- [x] Verify audit after `656b768`: unresolved threads 0, new findings 0, failing CI 0
- [x] Synced to rebased remote `5f0928d`, fixed new CodeRabbit trigger-budget finding, pushed `7fd213f`, and resolved the reviewer thread
- [x] Verify audit after `7fd213f`: unresolved threads 0, new findings 0, failing CI 0, `rule-lint` success
- [x] Synced to rebased remote `9829e72`, fixed Cursor review-check classification finding, pushed `d70b6dc`, and resolved the reviewer thread
- [x] Verify audit after `d70b6dc`: unresolved threads 0, new findings 0, failing CI 0, `rule-lint` success
- [x] Fixed review-bot predicate duplication, pushed `7370042`, and resolved the reviewer thread
- [x] Verify audit after `7370042`: unresolved threads 0, new findings 0, failing CI 0, `rule-lint` success, CodeRabbit success
- [ ] `coderabbit review --prompt-only` (blocked: `coderabbit` CLI not installed in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fdb9f9d-426c-42fe-a21f-cc74391d2f90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fdb9f9d-426c-42fe-a21f-cc74391d2f90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Post-push step waits 120s, detects per-PR review-bot activity, and posts one trigger comment per missing bot in a fixed order; CodeRabbit manual full-review triggers capped per trailing hour.

* **Improvements**
  * Status logic refined: review-bot check-runs excluded from CI_PENDING and tracked separately; REVIEW_PENDING fires for pending or missing review-bot signals; review completion can come from commit statuses or check-runs; status texts updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Trigger missing AI reviewers after a push**

### What Changed
- After a `/fixpr` push, the workflow now waits 2 minutes, checks the new commit for activity from CodeRabbit, Graphite, CodeAnt, and Cursor, and posts one follow-up trigger comment for each reviewer that did not respond.
- It now avoids treating review-bot activity as regular CI work, so pending review checks no longer block the run as a CI failure.
- CodeRabbit follow-up comments are limited to 2 per PR in the last hour, which prevents repeated manual re-pings.

### Impact
`✅ Fewer missing AI review follow-ups`
`✅ Fewer false CI pending states`
`✅ Less repeated CodeRabbit re-pinging`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=1MOx7qpriSkGaHwZva9hx_ZLDkvI5nelzBbLYQqpFgQ&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
