### PR TITLE
Make issue planning a procedural gate

### DIFF
--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -10,16 +10,17 @@
 
 1. **Draft the issue locally** — write the title, body, acceptance criteria, and relevant context. Do NOT post it yet.
 2. **Create the issue** — post via `gh issue create`. A GitHub Actions workflow (`.github/workflows/cr-plan-on-issue.yml`) automatically comments `@coderabbitai plan` on every new issue. The workflow skips bot-created issues; do not manually post `@coderabbitai plan` unless the workflow failed (visible in the Actions tab).
-3. **Read the issue and comments** — run `gh issue view N --comments` and check for an implementation plan comment from `coderabbitai`.
+3. **Check for an existing CR implementation plan** — run `.claude/scripts/cr-plan.sh N` and treat exit code `0` as "substantive plan found." This uses the canonical filter for `coderabbitai` issue comments and ignores ack-only or short replies.
 4. **If no CR plan exists, request or poll for one:**
-   - If a workflow-triggered `@coderabbitai plan` request already exists, poll that request every 60 seconds for up to 5 minutes.
-   - If no request exists, or the workflow clearly failed, post `@coderabbitai plan` on the issue and poll every 60 seconds for up to 5 minutes.
-   - If no response appears after 5 minutes: log "CR plan unavailable" and continue. This fallback applies only to CR's plan; it does not skip Claude's plan or the issue-body merge below.
+   - If a workflow-triggered `@coderabbitai plan` request already exists, run `.claude/scripts/cr-plan.sh N --poll 5`.
+   - If no request exists, or the workflow clearly failed, post `@coderabbitai plan` on the issue, then run `.claude/scripts/cr-plan.sh N --poll 5`.
+   - If the substantive-filtered poll times out after 5 minutes: log "CR plan unavailable" and continue. This fallback applies only to CR's plan; it does not skip Claude's plan or the issue-body merge below.
 5. **Build Claude's plan** — explore the codebase and design an implementation approach. Claude's own plan is always required regardless of CR availability.
 6. **Merge plans into the issue body** — create **one canonical document** for the coding agent to work from:
    - If CR posted a plan: compare CR's plan against Claude's plan. Incorporate anything CR identified that Claude missed (files, edge cases, risks). Pick the best ideas from each.
    - If CR did not post a plan: use Claude's plan as-is.
    - Edit the issue body — fetch the current body first, then write back both the original content and the plan:
+
    ```bash
    current_body="$(gh issue view N --json body --jq .body)"
    gh issue edit N --body "${current_body}
@@ -27,16 +28,21 @@
    ## Implementation Plan
    <merged plan here>"
    ```
+
    `gh issue edit --body` replaces the entire body — you must fetch-concatenate-edit to append.
 7. **GATE: Verify the issue body contains the implementation plan before coding.**
+
    ```bash
    gh issue view N --json body --jq '.body' | grep -q '## Implementation Plan'
    ```
+
    If the command fails: **STOP** — you skipped steps 5-6. Go back and merge Claude's plan into the issue body before coding.
 8. **Comment confirming the merge.**
+
    ```bash
    gh issue comment N --body "Implementation plan merged into issue body (<source>). Ready for implementation."
    ```
+
    Use "Claude's analysis + CodeRabbit's recommendations" when CR contributed, or "Claude's analysis only — CodeRabbit plan was not available" when it didn't.
 9. **Start coding only after the gate passes** — create the feature branch (`issue-N-short-description`), read the issue body (not scattered comments) for the canonical implementation plan, implement the changes, then run the Local CodeRabbit Review Loop (see `cr-local-review.md`) and its Post-Clean checklist.
 

--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -11,9 +11,9 @@
 1. **Draft the issue locally** — write the title, body, acceptance criteria, and relevant context. Do NOT post it yet.
 2. **Create the issue** — post via `gh issue create`. A GitHub Actions workflow (`.github/workflows/cr-plan-on-issue.yml`) automatically comments `@coderabbitai plan` on every new issue. The workflow skips bot-created issues; do not manually post `@coderabbitai plan` unless the workflow failed (visible in the Actions tab).
 3. **Read the issue and comments** — run `gh issue view N --comments` and check for an implementation plan comment from `coderabbitai`.
-4. **If no CR plan exists, request and poll for one:**
-   - Post `@coderabbitai plan` on the issue.
-   - Poll every 60 seconds for up to 5 minutes for a comment from `coderabbitai`.
+4. **If no CR plan exists, request or poll for one:**
+   - If a workflow-triggered `@coderabbitai plan` request already exists, poll that request every 60 seconds for up to 5 minutes.
+   - If no request exists, or the workflow clearly failed, post `@coderabbitai plan` on the issue and poll every 60 seconds for up to 5 minutes.
    - If no response appears after 5 minutes: log "CR plan unavailable" and continue. This fallback applies only to CR's plan; it does not skip Claude's plan or the issue-body merge below.
 5. **Build Claude's plan** — explore the codebase and design an implementation approach. Claude's own plan is always required regardless of CR availability.
 6. **Merge plans into the issue body** — create **one canonical document** for the coding agent to work from:

--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -4,34 +4,22 @@
 > **Ask first:** Never — issue creation and planning are autonomous.
 > **Never:** Skip the issue. Start coding without a plan. Post the plan as scattered comments instead of editing the issue body.
 
-## 1. Draft the issue locally
-- Write the title, body, acceptance criteria, and any relevant context
-- Do NOT post it yet
-
-## 2. Create the issue
-- Post via `gh issue create`
-- A GitHub Actions workflow (`.github/workflows/cr-plan-on-issue.yml`) automatically comments `@coderabbitai plan` on every new issue. The workflow skips bot-created issues.
-- Do not manually post `@coderabbitai plan` unless the workflow failed (visible in the Actions tab).
-
-## 3. Check for CR's implementation plan
+## Issue Planning Flow — Procedural Checklist
 
 > **Username note:** Use `coderabbitai` (no `[bot]` suffix) for issue comments; PR reviews use `coderabbitai[bot]`.
 
-Issue age determines the polling strategy:
-- **Older than 10 minutes:** Check comments for a plan from `coderabbitai`. If missing, post `@coderabbitai plan` and poll up to 5 minutes.
-- **Less than 10 minutes old:** Poll every 60 seconds for a comment from `coderabbitai`. Timeout after 10 minutes from issue creation time.
-- **No response after timeout:** Log "CR plan unavailable" and continue — Claude's plan (step 4) is always required regardless.
-
-## 4. Build Claude's plan
-- Explore the codebase and design an implementation plan (use plan mode)
-- Draft the plan internally — do not post it yet
-
-## 5. Merge plans into the issue body
-This creates **one canonical document** for the coding agent to work from:
-
-1. **If CR posted a plan:** Compare CR's plan against Claude's plan. Incorporate anything CR identified that Claude missed (files, edge cases, risks). Pick the best ideas from each.
-2. **If CR did not post a plan:** Use Claude's plan as-is.
-3. **Edit the issue body** — fetch the current body first, then write back both the original content and the plan:
+1. **Draft the issue locally** — write the title, body, acceptance criteria, and relevant context. Do NOT post it yet.
+2. **Create the issue** — post via `gh issue create`. A GitHub Actions workflow (`.github/workflows/cr-plan-on-issue.yml`) automatically comments `@coderabbitai plan` on every new issue. The workflow skips bot-created issues; do not manually post `@coderabbitai plan` unless the workflow failed (visible in the Actions tab).
+3. **Read the issue and comments** — run `gh issue view N --comments` and check for an implementation plan comment from `coderabbitai`.
+4. **If no CR plan exists, request and poll for one:**
+   - Post `@coderabbitai plan` on the issue.
+   - Poll every 60 seconds for up to 5 minutes for a comment from `coderabbitai`.
+   - If no response appears after 5 minutes: log "CR plan unavailable" and continue. This fallback applies only to CR's plan; it does not skip Claude's plan or the issue-body merge below.
+5. **Build Claude's plan** — explore the codebase and design an implementation approach. Claude's own plan is always required regardless of CR availability.
+6. **Merge plans into the issue body** — create **one canonical document** for the coding agent to work from:
+   - If CR posted a plan: compare CR's plan against Claude's plan. Incorporate anything CR identified that Claude missed (files, edge cases, risks). Pick the best ideas from each.
+   - If CR did not post a plan: use Claude's plan as-is.
+   - Edit the issue body — fetch the current body first, then write back both the original content and the plan:
    ```bash
    current_body="$(gh issue view N --json body --jq .body)"
    gh issue edit N --body "${current_body}
@@ -40,16 +28,16 @@ This creates **one canonical document** for the coding agent to work from:
    <merged plan here>"
    ```
    `gh issue edit --body` replaces the entire body — you must fetch-concatenate-edit to append.
+7. **GATE: Verify the issue body contains the implementation plan before coding.**
+   ```bash
+   gh issue view N --json body --jq '.body' | grep -q '## Implementation Plan'
+   ```
+   If the command fails: **STOP** — you skipped steps 5-6. Go back and merge Claude's plan into the issue body before coding.
+8. **Comment confirming the merge.**
+   ```bash
+   gh issue comment N --body "Implementation plan merged into issue body (<source>). Ready for implementation."
+   ```
+   Use "Claude's analysis + CodeRabbit's recommendations" when CR contributed, or "Claude's analysis only — CodeRabbit plan was not available" when it didn't.
+9. **Start coding only after the gate passes** — create the feature branch (`issue-N-short-description`), read the issue body (not scattered comments) for the canonical implementation plan, implement the changes, then run the Local CodeRabbit Review Loop (see `cr-local-review.md`) and its Post-Clean checklist.
 
-## 6. Comment confirming the merge
-```
-gh issue comment N --body "Implementation plan merged into issue body (<source>). Ready for implementation."
-```
-Use "Claude's analysis + CodeRabbit's recommendations" when CR contributed, or "Claude's analysis only — CodeRabbit plan was not available" when it didn't.
-
-## 7. Begin implementation
-1. **Create the feature branch** (`issue-N-short-description`).
-2. **Read the issue body** (not scattered comments) for the canonical implementation plan.
-3. **Implement the changes.**
-4. **Run the Local CodeRabbit Review Loop** (see `cr-local-review.md`) — one clean pass required before pushing.
-5. **Execute the post-clean checklist** (see `cr-local-review.md` "Post-Clean" section) — commit, push, create PR, enter GitHub review loop.
+> Do NOT jump to step 9 without passing step 7. The `## Implementation Plan` section in the issue body is the canonical spec for the coding work.


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Convert the issue planning flow into a numbered procedural checklist.
- Require bounded CR plan polling with a fallback that only applies to the CR plan.
- Add a verifiable `grep` gate for `## Implementation Plan` before coding can begin.
- Use `.claude/scripts/cr-plan.sh` so CR plan detection requires substantive comments, not ack-only bot replies.

Closes #152

## Test plan

- [x] Issue Planning Flow uses numbered checklist format
- [x] Verifiable gate before "start coding" step
- [x] CR plan polling has explicit timeout with fallback (not a skip-entirely escape)
- [x] "proceed without it" only applies to CR's plan, not to the entire planning step
- [x] Claude's own plan is always required regardless of CR availability
- [x] Rule corpus word budget remains under the 11K cap
- [x] `git diff --check` passes
- [x] Local CodeRabbit review attempted; self-review fallback used if CLI unavailable
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8615ca99-f820-4cd2-857f-137230fc4d1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8615ca99-f820-4cd2-857f-137230fc4d1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Make issue planning follow a required checklist with a verified plan gate**

### What Changed
- Issue planning now follows a numbered sequence from drafting the issue to starting implementation.
- Coding can begin only after the issue body contains an `## Implementation Plan` section, with a check that stops the flow if it is missing.
- CR plan lookup now treats only substantive plans as valid, ignores short acknowledgement replies, and uses a 5-minute timeout before continuing without CR input.
- The issue body is now the single source of truth for the implementation plan, and the workflow posts a confirmation comment after the plan is merged.

### Impact
`✅ Fewer starts without an approved plan`
`✅ Clearer issue-to-code handoff`
`✅ Reduced confusion from bot acknowledgements`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=A5PrgW2I0xQDHBHQw9Cxxnkm1lc7xDhvRro8OwGwlj4&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
