### PR TITLE
Allow dotenv template suffixes in env guard

### DIFF
--- a/.claude/hooks/env-guard.py
+++ b/.claude/hooks/env-guard.py
@@ -7,7 +7,7 @@
 # Does NOT match: environment.ts, env-config.json, rails_env, my.env.backup.
 #
 # Allow-list: basenames matching `.env.<suffix>` where <suffix> (case-insensitive)
-# is in SAFE_ENV_SUFFIXES (example, sample, template, dist, tpl) are treated as
+# is in TEMPLATE_SUFFIXES (example, sample, template) are treated as
 # committed-to-repo templates and are NOT blocked. Everything else defaults to
 # deny — including bare `.env` and any unrecognized suffix.
 #
@@ -42,18 +42,7 @@ BLOCK_MSG = (
 ENV_BASENAME_RE = re.compile(r'(?:^|/)\.env(?:\.[A-Za-z0-9_-]+)?$')
 
 # Allow-list of suffixes that identify non-secret template/example files.
-# A basename of `.env.<suffix>` where <suffix> (case-insensitive) is in this
-# set is treated as a committed-to-repo template — safe to edit.
-# Everything else still defaults to deny.
-# To extend: add a lowercase suffix to this frozenset.
-SAFE_ENV_SUFFIXES = frozenset({'example', 'sample', 'template', 'dist', 'tpl'})
-
-# Matches the final suffix segment of a `.env.<suffix>` basename so we can
-# compare it against SAFE_ENV_SUFFIXES. The anchor on `(?:^|/)` ensures we
-# only look at basenames, not interior path segments.
-SAFE_ENV_TEMPLATE_RE = re.compile(
-    r'(?:^|/)\.env\.([A-Za-z0-9_-]+)$'
-)
+TEMPLATE_SUFFIXES = frozenset({'example', 'sample', 'template'})
 
 # Bash binaries that can mutate files. We only block a Bash command if one of
 # these appears AND the command also references a .env path. Non-mutating reads
@@ -75,21 +64,14 @@ def is_env_path(path: str) -> bool:
     if not path:
         return False
     p = path.strip().strip('"').strip("'").rstrip('/')
-    return bool(ENV_BASENAME_RE.search(p))
-
-
-def is_safe_env_template(path: str) -> bool:
-    """Return True iff `path` is a `.env.<suffix>` basename where <suffix>
-    (case-insensitive) is in the template allow-list. Returns False for bare
-    `.env`, unknown suffixes, and empty input.
-    """
-    if not path:
+    if not ENV_BASENAME_RE.search(p):
         return False
-    p = path.strip().strip('"').strip("'").rstrip('/')
-    m = SAFE_ENV_TEMPLATE_RE.search(p)
-    if not m:
-        return False
-    return m.group(1).lower() in SAFE_ENV_SUFFIXES
+    basename = p.rsplit('/', 1)[-1]
+    if '.' in basename[1:]:
+        suffix = basename.rsplit('.', 1)[-1].lower()
+        if suffix in TEMPLATE_SUFFIXES:
+            return False
+    return True
 
 
 def bash_targets_env(cmd: str) -> bool:
@@ -114,8 +96,7 @@ def bash_targets_env(cmd: str) -> bool:
         if redirect_m:
             has_write_op = True
             target = redirect_m.group(1)
-            # Safe-template targets (`>.env.example`) are not treated as env.
-            if is_env_path(target) and not is_safe_env_template(target):
+            if is_env_path(target):
                 has_env_token = True
             continue
         # Destructive binary (match on basename so `/bin/rm` still counts).
@@ -123,8 +104,8 @@ def bash_targets_env(cmd: str) -> bool:
         if base in DESTRUCTIVE_BINS:
             has_write_op = True
             continue
-        # Plain token that looks like a .env path. Skip safe templates.
-        if is_env_path(tok) and not is_safe_env_template(tok):
+        # Plain token that looks like a blocked .env path.
+        if is_env_path(tok):
             has_env_token = True
 
     return has_env_token and has_write_op
@@ -146,7 +127,7 @@ def main() -> int:
 
     if tool_name in ('Write', 'Edit', 'MultiEdit', 'NotebookEdit'):
         path = tool_input.get('file_path') or tool_input.get('notebook_path') or ''
-        if is_env_path(path) and not is_safe_env_template(path):
+        if is_env_path(path):
             blocked = True
             reason = f"{BLOCK_MSG} (tool={tool_name}, path={path})"
     elif tool_name == 'Bash':

--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -7,7 +7,7 @@
 ## Destructive Commands
 
 1. **NEVER delete, overwrite, move, or modify `.env` files** — anywhere, any repo. They contain irrecoverable secrets.
-   - **Template exception:** `.env.{example,sample,template,dist,tpl}` (case-insensitive) are committed, non-secret templates — safe to edit. Bare `.env`, `.env.local`, `.env.production`, and unrecognized suffixes stay blocked. Allow-list: `.claude/hooks/env-guard.py` (`SAFE_ENV_SUFFIXES`).
+   - **Template exception:** `.env.{example,sample,template}` (case-insensitive) are committed, non-secret templates — safe to edit. Bare `.env`, `.env.local`, `.env.production`, and unrecognized suffixes stay blocked. Allow-list: `.claude/hooks/env-guard.py` (`TEMPLATE_SUFFIXES`).
 2. **NEVER run `git clean` in ANY directory** — it deletes untracked files, including gitignored `.env`.
 3. **NEVER run destructive commands in the root repo:** `rm -rf`, `rm`, `git checkout .`, `git stash` (drops untracked), `git reset --hard`. Root stays clean on `main`.
 4. **NEVER `cd` to the root repo and run file operations.** Stay in your worktree. Safe root operations are read-only: `git worktree list`, `find`, file reads.
@@ -30,7 +30,7 @@ When spawning subagents, include this warning in the prompt AND always set `mode
 
 ```
 SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo.
-Exception: template files matching .env.<example|sample|template|dist|tpl>
+Exception: template files matching .env.<example|sample|template>
 (case-insensitive) are committed, non-secret, and safe to edit.
 Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm,
 git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your

--- a/tests/test_env_guard.py
+++ b/tests/test_env_guard.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Unit tests for .claude/hooks/env-guard.py."""
+
+import importlib.util
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+ENV_GUARD_PATH = REPO_ROOT / ".claude" / "hooks" / "env-guard.py"
+
+spec = importlib.util.spec_from_file_location("env_guard", ENV_GUARD_PATH)
+env_guard = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(env_guard)
+
+
+class EnvGuardPathTests(unittest.TestCase):
+    def test_is_env_path_allows_template_suffixes(self) -> None:
+        allowed = [
+            ".env.example",
+            ".env.sample",
+            ".env.template",
+            "path/to/.env.example",
+            "path/to/.env.sample",
+            "path/to/.env.template",
+            ".env.EXAMPLE",
+            "path/to/.env.SAMPLE",
+            "'path/to/.env.TEMPLATE'",
+        ]
+
+        for path in allowed:
+            with self.subTest(path=path):
+                self.assertFalse(env_guard.is_env_path(path))
+
+    def test_is_env_path_blocks_bare_and_non_template_suffixes(self) -> None:
+        blocked = [
+            ".env",
+            ".env.local",
+            ".env.production",
+            ".env.test",
+            ".env.ci",
+            ".env.development",
+            "path/to/.env",
+            "path/to/.env.local",
+            "path/to/.env.production",
+            "path/to/.env.test",
+            "path/to/.env.ci",
+            "path/to/.env.development",
+        ]
+
+        for path in blocked:
+            with self.subTest(path=path):
+                self.assertTrue(env_guard.is_env_path(path))
+
+    def test_is_env_path_ignores_non_dotenv_filenames(self) -> None:
+        ignored = [
+            "",
+            "environment.ts",
+            "env-config.json",
+            "rails_env",
+            "my.env.backup",
+            "path/to/.env.example/child",
+        ]
+
+        for path in ignored:
+            with self.subTest(path=path):
+                self.assertFalse(env_guard.is_env_path(path))
+
+
+class EnvGuardBashTests(unittest.TestCase):
+    def test_bash_targets_env_allows_template_suffixes(self) -> None:
+        allowed = [
+            "touch .env.example",
+            "rm path/to/.env.sample",
+            "printf x > .env.template",
+            "printf x > path/to/.env.EXAMPLE",
+        ]
+
+        for command in allowed:
+            with self.subTest(command=command):
+                self.assertFalse(env_guard.bash_targets_env(command))
+
+    def test_bash_targets_env_blocks_dotenv_and_non_template_suffixes(self) -> None:
+        blocked = [
+            "touch .env",
+            "rm path/to/.env.local",
+            "printf x > .env.production",
+            "printf x > path/to/.env.test",
+            "cp source path/to/.env.ci",
+            "mv source path/to/.env.development",
+        ]
+
+        for command in blocked:
+            with self.subTest(command=command):
+                self.assertTrue(env_guard.bash_targets_env(command))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Allow `.env.example`, `.env.sample`, and `.env.template` paths in `is_env_path` case-insensitively.
- Let `bash_targets_env` inherit the allowlist behavior directly from `is_env_path`.
- Update safety rules and add env-guard unit coverage for allowed and blocked cases.

Closes #301

## Test plan
- [x] `is_env_path` returns `False` for paths ending in the three template suffixes (example, sample, template)
- [x] `is_env_path` still returns `True` for the bare dotenv file and non-template suffixes (local, production, test, ci, development)
- [x] Directory-prefixed paths behave the same (`path/to/<file>`)
- [x] Case-insensitive: uppercase template suffixes are also allowed
- [x] `bash_targets_env` inherits the behavior (it calls `is_env_path`)
- [x] `.claude/rules/safety.md` updated to note the template allowlist
- [x] Unit tests added for both allowlisted and still-blocked cases
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f879d97-9f73-4a1c-9dcc-e8ca5f33fd98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f879d97-9f73-4a1c-9dcc-e8ca5f33fd98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Allow editing `.env.example`, `.env.sample`, and `.env.template` files**

### What Changed
- `.env.example`, `.env.sample`, and `.env.template` files are now treated as safe template files instead of blocked secret files
- This applies in direct file edits and when commands target those files from the shell
- The safety rule text now lists only the supported template suffixes
- Added coverage for allowed template files and still-blocked `.env` variants

### Impact
`✅ Fewer blocked edits for committed env templates`
`✅ Clearer handling of safe .env example files`
`✅ Safer shell commands around template env files`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=z3-Tg7jKZLEotHPRhc3IL7ehfKKIBS9UY1UvRhEXrX8&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
