### PR TITLE
Script adherence telemetry

### DIFF
--- a/.claude/hooks/script-bypass-detector.sh
+++ b/.claude/hooks/script-bypass-detector.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Script bypass detector — PreToolUse hook (matcher: Bash)
+#
+# Logs likely inline reimplementations of shared .claude/scripts helpers without
+# blocking the Bash command. This gives an outside signal when agents bypass
+# canonical scripts such as pr-state.sh or merge-gate.sh.
+#
+# Input  (stdin) : JSON with {tool_name, tool_input, cwd, ...}
+# Output (stdout): empty JSON object (non-blocking)
+# Exit code      : always 0 — never blocks tool execution
+#
+# Storage model:
+#   - Live TSV log: ~/.claude/script-bypass.log (NEVER in the skills worktree;
+#     session-start-sync.sh may reset worktrees, which would wipe live counters).
+#   - Format: timestamp UTC, cwd, matched pattern, suggested script, command
+#     truncated to 200 chars. Fields are tab-separated and single-line.
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+# Always emit empty JSON and never fail — this hook is non-blocking.
+trap 'printf "{}\n"; exit 0' EXIT
+
+SCRIPT_BYPASS_INPUT="$INPUT" python3 <<'PY' 2>/dev/null || true
+import json
+import os
+import re
+from datetime import datetime, timezone
+
+payload_raw = os.environ.get("SCRIPT_BYPASS_INPUT", "")
+try:
+    payload = json.loads(payload_raw)
+except Exception:
+    raise SystemExit(0)
+
+tool_name = payload.get("tool_name") or payload.get("toolName") or ""
+tool_input = payload.get("tool_input") or payload.get("toolInput") or {}
+if tool_name and tool_name != "Bash":
+    raise SystemExit(0)
+
+if isinstance(tool_input, dict):
+    command = tool_input.get("command") or ""
+elif isinstance(tool_input, str):
+    command = tool_input
+else:
+    command = ""
+
+if not command:
+    raise SystemExit(0)
+
+cwd = payload.get("cwd") or os.getcwd()
+
+sentinels = [
+    (
+        "gh api PR reviews/comments with per_page",
+        "pr-state.sh",
+        re.compile(r"gh\s+api.*repos/.*/pulls/[0-9]+/(reviews|comments).*per_page", re.S),
+    ),
+    (
+        "gh api check-runs blocking conclusions",
+        "merge-gate.sh",
+        re.compile(r"gh\s+api.*check-runs.*(failure|timed_out|action_required)", re.S),
+    ),
+    (
+        "resolveReviewThread mutation",
+        "resolve-review-threads.sh",
+        re.compile(r"resolveReviewThread", re.S),
+    ),
+    (
+        "CodeRabbit issue plan comment",
+        "cr-plan.sh",
+        re.compile(r"gh\s+issue\s+comment.*@coderabbitai\s+plan", re.S),
+    ),
+    (
+        "gh api PR reviews/commits jq length",
+        "cycle-count.sh",
+        re.compile(r"gh\s+api.*pulls/[0-9]+/(reviews|commits).*jq.*length", re.S),
+    ),
+    (
+        "git worktree porcelain piped to awk/sed",
+        "repo-root.sh",
+        re.compile(r"git\s+worktree\s+list\s+--porcelain.*\|.*\b(awk|sed)\b", re.S),
+    ),
+]
+
+matches = []
+for pattern_name, script_name, regex in sentinels:
+    if regex.search(command):
+        matches.append((pattern_name, script_name))
+
+has_date_window = re.search(r"\bdate\b.*(?:-v-|-d\b)", command, re.S)
+has_gh_query = re.search(r"\bgh\s+(?:search|api)\b", command, re.S)
+if has_date_window and has_gh_query:
+    matches.append(("date window combined with gh search/api", "gh-window.sh"))
+
+if not matches:
+    raise SystemExit(0)
+
+def single_line(value: str) -> str:
+    return re.sub(r"[\t\r\n]+", " ", str(value)).strip()
+
+timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+safe_cwd = single_line(cwd)
+safe_command = single_line(command)[:200]
+
+log_path = os.path.join(os.path.expanduser("~"), ".claude", "script-bypass.log")
+os.makedirs(os.path.dirname(log_path), exist_ok=True)
+
+with open(log_path, "a", encoding="utf-8") as log:
+    for pattern_name, script_name in matches:
+        fields = [
+            timestamp,
+            safe_cwd,
+            single_line(pattern_name),
+            script_name,
+            safe_command,
+        ]
+        log.write("\t".join(fields) + "\n")
+PY
+
+exit 0

--- a/.claude/scripts/ac-checkboxes.sh
+++ b/.claude/scripts/ac-checkboxes.sh
@@ -61,7 +61,7 @@
 # precisely — a bare `-e` would let any downstream failure surface as exit 1,
 # colliding with the "no Test Plan section" meaning.
 set -uo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 print_usage() {
   awk 'NR == 1 { next } /^$/ { exit } { print }' "$0"

--- a/.claude/scripts/ac-checkboxes.sh
+++ b/.claude/scripts/ac-checkboxes.sh
@@ -61,6 +61,7 @@
 # precisely — a bare `-e` would let any downstream failure surface as exit 1,
 # colliding with the "no Test Plan section" meaning.
 set -uo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 print_usage() {
   awk 'NR == 1 { next } /^$/ { exit } { print }' "$0"

--- a/.claude/scripts/audit-skill-usage.sh
+++ b/.claude/scripts/audit-skill-usage.sh
@@ -33,7 +33,7 @@
 #   1 — at least one skill is recommended for removal (60+ days unused)
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Help flag

--- a/.claude/scripts/audit-skill-usage.sh
+++ b/.claude/scripts/audit-skill-usage.sh
@@ -33,6 +33,7 @@
 #   1 — at least one skill is recommended for removal (60+ days unused)
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Help flag

--- a/.claude/scripts/ci-status.sh
+++ b/.claude/scripts/ci-status.sh
@@ -59,6 +59,7 @@
 # turn red too; the caller should fix the known failures first.
 
 set -uo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 FORMAT="json"
 INPUT=""

--- a/.claude/scripts/cr-plan.sh
+++ b/.claude/scripts/cr-plan.sh
@@ -28,7 +28,7 @@
 # See .claude/rules/issue-planning.md for the plan-merge workflow this feeds into.
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 usage() {
   sed -n '3,29p' "$0" | sed 's/^# \{0,1\}//'

--- a/.claude/scripts/cr-plan.sh
+++ b/.claude/scripts/cr-plan.sh
@@ -28,6 +28,7 @@
 # See .claude/rules/issue-planning.md for the plan-merge workflow this feeds into.
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 usage() {
   sed -n '3,29p' "$0" | sed 's/^# \{0,1\}//'

--- a/.claude/scripts/cycle-count.sh
+++ b/.claude/scripts/cycle-count.sh
@@ -52,7 +52,7 @@
 #      after an actionable review but before a later non-actionable one.
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 print_usage() {
   cat <<'EOF'

--- a/.claude/scripts/cycle-count.sh
+++ b/.claude/scripts/cycle-count.sh
@@ -52,6 +52,7 @@
 #      after an actionable review but before a later non-actionable one.
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 print_usage() {
   cat <<'EOF'

--- a/.claude/scripts/dirty-main-guard.sh
+++ b/.claude/scripts/dirty-main-guard.sh
@@ -65,6 +65,7 @@
 #   git -C "$ROOT" pull origin main --ff-only
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 print_help() {
   awk 'NR == 1 { next } /^$/ { exit } { sub(/^# ?/, ""); print }' "$0"

--- a/.claude/scripts/dirty-main-guard.sh
+++ b/.claude/scripts/dirty-main-guard.sh
@@ -65,7 +65,7 @@
 #   git -C "$ROOT" pull origin main --ff-only
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 print_help() {
   awk 'NR == 1 { next } /^$/ { exit } { sub(/^# ?/, ""); print }' "$0"

--- a/.claude/scripts/gh-window.sh
+++ b/.claude/scripts/gh-window.sh
@@ -41,7 +41,7 @@
 #   - `sed` — for the +HHMM → +HH:MM offset post-process.
 
 set -u
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 usage() {
   sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'

--- a/.claude/scripts/gh-window.sh
+++ b/.claude/scripts/gh-window.sh
@@ -41,6 +41,7 @@
 #   - `sed` — for the +HHMM → +HH:MM offset post-process.
 
 set -u
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 usage() {
   sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'

--- a/.claude/scripts/greptile-budget.sh
+++ b/.claude/scripts/greptile-budget.sh
@@ -73,7 +73,7 @@
 #   # -> {"date":"2026-04-16","reviews_used":3,"budget":40,"exhausted":false}
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 STATE_FILE="${HOME}/.claude/session-state.json"
 DEFAULT_BUDGET=40

--- a/.claude/scripts/greptile-budget.sh
+++ b/.claude/scripts/greptile-budget.sh
@@ -73,6 +73,7 @@
 #   # -> {"date":"2026-04-16","reviews_used":3,"budget":40,"exhausted":false}
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 STATE_FILE="${HOME}/.claude/session-state.json"
 DEFAULT_BUDGET=40

--- a/.claude/scripts/hhg-state.sh
+++ b/.claude/scripts/hhg-state.sh
@@ -52,6 +52,7 @@
 #   # (no stdout, exit 1)
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 print_help() {
   # Print the header comment block (from shebang's next line until the first

--- a/.claude/scripts/install-silence-watchdog.sh
+++ b/.claude/scripts/install-silence-watchdog.sh
@@ -2,7 +2,7 @@
 # Install the macOS launchd watchdog that monitors Claude heartbeat files.
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 LABEL="com.user.claude-silence-watchdog"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.claude/scripts/install-silence-watchdog.sh
+++ b/.claude/scripts/install-silence-watchdog.sh
@@ -2,6 +2,7 @@
 # Install the macOS launchd watchdog that monitors Claude heartbeat files.
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 LABEL="com.user.claude-silence-watchdog"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.claude/scripts/main-sync.sh
+++ b/.claude/scripts/main-sync.sh
@@ -86,6 +86,7 @@
 #   STATUS=$(bash .claude/scripts/main-sync.sh --repo "$ROOT_REPO")
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 # Collapse a captured git stderr blob into a single whitespace-normalized line
 # so the "failed: ..." status string honors the single-line stdout contract

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -50,7 +50,7 @@
 #   4 — gh / network / jq error
 
 set -uo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 # --------------------------------------------------------------------------
 # Arg parsing

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -46,6 +46,7 @@
 #   4 — gh / network / jq error
 
 set -uo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 # --------------------------------------------------------------------------
 # Arg parsing

--- a/.claude/scripts/off-peak-minute.sh
+++ b/.claude/scripts/off-peak-minute.sh
@@ -52,7 +52,7 @@
 #   echo "cron: \"$RANGE * * * *\"   # fires at :$MINUTE, :$(($MINUTE+10)), ..."
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 print_help() {
   # Print the header comment block (from shebang's next line until the first

--- a/.claude/scripts/off-peak-minute.sh
+++ b/.claude/scripts/off-peak-minute.sh
@@ -52,6 +52,7 @@
 #   echo "cron: \"$RANGE * * * *\"   # fires at :$MINUTE, :$(($MINUTE+10)), ..."
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 print_help() {
   # Print the header comment block (from shebang's next line until the first

--- a/.claude/scripts/pm-config-get.sh
+++ b/.claude/scripts/pm-config-get.sh
@@ -49,6 +49,7 @@
 #   pm-config-get.sh --section OKRs --file /path/to/pm-config.md
 
 set -uo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 print_help() {
   # Print the header comment block (PURPOSE through EXAMPLES and their bodies)

--- a/.claude/scripts/pm-config-get.sh
+++ b/.claude/scripts/pm-config-get.sh
@@ -49,7 +49,7 @@
 #   pm-config-get.sh --section OKRs --file /path/to/pm-config.md
 
 set -uo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 print_help() {
   # Print the header comment block (PURPOSE through EXAMPLES and their bodies)

--- a/.claude/scripts/pr-issue-ref.sh
+++ b/.claude/scripts/pr-issue-ref.sh
@@ -29,7 +29,7 @@
 #   ISSUE=$(pr-issue-ref.sh "$PR" || true)
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 print_usage() {
   cat <<'EOF'

--- a/.claude/scripts/pr-issue-ref.sh
+++ b/.claude/scripts/pr-issue-ref.sh
@@ -29,6 +29,7 @@
 #   ISSUE=$(pr-issue-ref.sh "$PR" || true)
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 print_usage() {
   cat <<'EOF'

--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -23,7 +23,7 @@
 #   5  gh/network error
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 # Wrap every `gh` invocation so any auth/network/API failure maps to exit code 5
 # (the documented "gh/network error" code in the CLI contract). Under `set -e`,

--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -23,6 +23,7 @@
 #   5  gh/network error
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 # Wrap every `gh` invocation so any auth/network/API failure maps to exit code 5
 # (the documented "gh/network error" code in the CLI contract). Under `set -e`,

--- a/.claude/scripts/repair-trust-all.sh
+++ b/.claude/scripts/repair-trust-all.sh
@@ -4,6 +4,7 @@
 # See .claude/rules/trust-dialog-fix.md for details.
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 if [[ $# -ne 0 ]]; then
   echo "Usage: $0"

--- a/.claude/scripts/repair-trust-all.sh
+++ b/.claude/scripts/repair-trust-all.sh
@@ -4,7 +4,7 @@
 # See .claude/rules/trust-dialog-fix.md for details.
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 if [[ $# -ne 0 ]]; then
   echo "Usage: $0"

--- a/.claude/scripts/repair-trust-single.sh
+++ b/.claude/scripts/repair-trust-single.sh
@@ -4,6 +4,7 @@
 # See .claude/rules/trust-dialog-fix.md for details.
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 if [[ $# -ne 1 ]]; then
   echo "Usage: $0 <absolute-project-path>"

--- a/.claude/scripts/repair-worktrees.sh
+++ b/.claude/scripts/repair-worktrees.sh
@@ -27,6 +27,7 @@
 #     (first entry) and explicitly excluded.
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 APPLY=0
 for arg in "$@"; do

--- a/.claude/scripts/repair-worktrees.sh
+++ b/.claude/scripts/repair-worktrees.sh
@@ -27,7 +27,7 @@
 #     (first entry) and explicitly excluded.
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 APPLY=0
 for arg in "$@"; do

--- a/.claude/scripts/reply-thread.sh
+++ b/.claude/scripts/reply-thread.sh
@@ -50,6 +50,7 @@
 # this script enforces.
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 REVIEWER=""
 BODY=""

--- a/.claude/scripts/repo-bootstrap.sh
+++ b/.claude/scripts/repo-bootstrap.sh
@@ -31,6 +31,7 @@
 #   - Read-only gh API calls are used for the branch-protection check.
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 MODE=""
 for arg in "$@"; do

--- a/.claude/scripts/repo-root.sh
+++ b/.claude/scripts/repo-root.sh
@@ -36,6 +36,7 @@
 #   ROOT_REPO=$(.claude/scripts/repo-root.sh "$SOME_WT") # from another worktree
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 # Self-extract the header block between BEGIN/END markers for --help.
 print_help() {

--- a/.claude/scripts/resolve-review-threads.sh
+++ b/.claude/scripts/resolve-review-threads.sh
@@ -25,6 +25,7 @@
 # See .claude/rules/cr-github-review.md "Processing CR Feedback" step 4.
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 AUTHORS="coderabbitai,cursor,greptile-apps"
 DRY_RUN=0

--- a/.claude/scripts/reviewer-of.sh
+++ b/.claude/scripts/reviewer-of.sh
@@ -89,6 +89,7 @@
 #   # -> unknown  (exit 1)
 
 set -uo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 STATE_FILE="${HOME}/.claude/session-state.json"
 

--- a/.claude/scripts/script-usage-report.sh
+++ b/.claude/scripts/script-usage-report.sh
@@ -7,6 +7,7 @@
 #
 # USAGE:
 #   script-usage-report.sh [--days N]
+#   script-usage-report.sh [--since Nd]
 #   script-usage-report.sh --help
 #
 # OUTPUT:
@@ -41,6 +42,30 @@ while [[ $# -gt 0 ]]; do
       ;;
     --days=*)
       DAYS="${1#--days=}"
+      shift
+      ;;
+    --since)
+      SINCE="${2:-}"
+      if [[ -z "$SINCE" ]]; then
+        echo "ERROR: --since requires a value like 7d" >&2
+        exit 2
+      fi
+      if [[ "$SINCE" =~ ^([0-9]+)d$ ]]; then
+        DAYS="${BASH_REMATCH[1]}"
+      else
+        echo "ERROR: --since must use Nd format, for example 7d" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --since=*)
+      SINCE="${1#--since=}"
+      if [[ "$SINCE" =~ ^([0-9]+)d$ ]]; then
+        DAYS="${BASH_REMATCH[1]}"
+      else
+        echo "ERROR: --since must use Nd format, for example 7d" >&2
+        exit 2
+      fi
       shift
       ;;
     -h|--help)

--- a/.claude/scripts/script-usage-report.sh
+++ b/.claude/scripts/script-usage-report.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# script-usage-report.sh — Summarize script adherence telemetry.
+#
+# PURPOSE:
+#   Reads ~/.claude/script-usage.log and ~/.claude/script-bypass.log, then
+#   reports script invocations, likely bypasses, and adherence ratios.
+#
+# USAGE:
+#   script-usage-report.sh [--days N]
+#   script-usage-report.sh --help
+#
+# OUTPUT:
+#   Human-readable table:
+#     Script | Invocations | Bypasses | Adherence %
+#   plus the top 5 bypass contexts grouped by cwd.
+#
+# LOG FORMATS:
+#   script-usage.log  : timestamp UTC, script basename, args
+#   script-bypass.log : timestamp UTC, cwd, matched pattern, suggested script,
+#                       command truncated to 200 chars
+#   Both logs are tab-separated and stored under ~/.claude/.
+
+set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+
+usage() {
+  sed -n '2,19p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+DAYS=7
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --days)
+      DAYS="${2:-}"
+      if [[ -z "$DAYS" ]]; then
+        echo "ERROR: --days requires a value" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --days=*)
+      DAYS="${1#--days=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! [[ "$DAYS" =~ ^[0-9]+$ ]] || [[ "$DAYS" -lt 1 ]]; then
+  echo "ERROR: --days must be a positive integer" >&2
+  exit 2
+fi
+
+python3 - "$DAYS" "$HOME/.claude/script-usage.log" "$HOME/.claude/script-bypass.log" <<'PY'
+import os
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+days = int(sys.argv[1])
+usage_path = sys.argv[2]
+bypass_path = sys.argv[3]
+cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+
+def parse_ts(value):
+    value = (value or "").strip()
+    if not value:
+        return None
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def in_window(ts_value):
+    parsed = parse_ts(ts_value)
+    return parsed is not None and parsed >= cutoff
+
+
+def best_effort_context(cwd):
+    cwd = cwd or "(unknown cwd)"
+    parts = [part for part in cwd.split(os.sep) if part]
+    if ".claude" in parts:
+        idx = parts.index(".claude")
+        if idx + 2 < len(parts) and parts[idx + 1] == "skills":
+            return f"skill:{parts[idx + 2]}"
+        if idx + 2 < len(parts) and parts[idx + 1] == "worktrees":
+            return f"worktree:{parts[idx + 2]}"
+    for marker in ("skills-worktree", "claude-code-config", "workspace"):
+        if marker in parts:
+            idx = parts.index(marker)
+            if idx + 1 < len(parts):
+                return f"{marker}/{parts[idx + 1]}"
+            return marker
+    return cwd
+
+
+usage_counts = Counter()
+bypass_counts = Counter()
+contexts = Counter()
+
+if os.path.exists(usage_path):
+    with open(usage_path, "r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            fields = line.split("\t")
+            if len(fields) < 2 or not in_window(fields[0]):
+                continue
+            script = fields[1].strip() or "(unknown)"
+            usage_counts[script] += 1
+
+if os.path.exists(bypass_path):
+    with open(bypass_path, "r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            fields = line.split("\t")
+            if len(fields) < 4 or not in_window(fields[0]):
+                continue
+            cwd = fields[1].strip() or "(unknown cwd)"
+            script = fields[3].strip() or "(unknown)"
+            bypass_counts[script] += 1
+            contexts[best_effort_context(cwd)] += 1
+
+scripts = sorted(set(usage_counts) | set(bypass_counts))
+total_usage = sum(usage_counts.values())
+total_bypass = sum(bypass_counts.values())
+total_events = total_usage + total_bypass
+overall = (total_usage / total_events * 100.0) if total_events else 0.0
+
+print(f"Script usage adherence report (last {days} day{'s' if days != 1 else ''})")
+print(f"Usage log : {usage_path}")
+print(f"Bypass log: {bypass_path}")
+print()
+print(f"{'Script':<32} {'Invocations':>12} {'Bypasses':>9} {'Adherence %':>12}")
+print("-" * 70)
+if scripts:
+    for script in scripts:
+        invocations = usage_counts[script]
+        bypasses = bypass_counts[script]
+        denominator = invocations + bypasses
+        adherence = (invocations / denominator * 100.0) if denominator else 0.0
+        print(f"{script:<32} {invocations:>12} {bypasses:>9} {adherence:>11.1f}%")
+else:
+    print(f"{'(no telemetry in window)':<32} {0:>12} {0:>9} {'n/a':>12}")
+print("-" * 70)
+print(f"{'TOTAL':<32} {total_usage:>12} {total_bypass:>9} {overall:>11.1f}%")
+print()
+print("Top bypass contexts")
+print("-------------------")
+if contexts:
+    for context, count in contexts.most_common(5):
+        print(f"{count:>5}  {context}")
+else:
+    print("No bypasses recorded in window.")
+PY

--- a/.claude/scripts/session-state.sh
+++ b/.claude/scripts/session-state.sh
@@ -89,6 +89,7 @@
 #   session-state.sh --set '.cr_quota.reviews_used=5'
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 STATE_FILE="${HOME}/.claude/session-state.json"
 

--- a/.claude/scripts/silence-watchdog.sh
+++ b/.claude/scripts/silence-watchdog.sh
@@ -5,6 +5,7 @@
 # even when Claude is stalled and no tool hook is firing. macOS-only v1.
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 LABEL="com.user.claude-silence-watchdog"
 HEARTBEAT_PREFIX="/tmp/claude-heartbeat-"

--- a/.claude/scripts/stale-cleanup.sh
+++ b/.claude/scripts/stale-cleanup.sh
@@ -67,6 +67,7 @@
 #   4  Environment error (cannot resolve repo, gh missing, etc.).
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 print_help() {
   awk 'NR == 1 { next } /^$/ { exit } { sub(/^# ?/, ""); print }' "$0"

--- a/.claude/scripts/uninstall-silence-watchdog.sh
+++ b/.claude/scripts/uninstall-silence-watchdog.sh
@@ -4,6 +4,7 @@
 # macOS-only v1. Linux/systemd support is intentionally out of scope.
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 LABEL="com.user.claude-silence-watchdog"
 PLIST_DEST="$HOME/Library/LaunchAgents/${LABEL}.plist"

--- a/.claude/scripts/workday.sh
+++ b/.claude/scripts/workday.sh
@@ -51,6 +51,7 @@
 #   bash .claude/scripts/workday.sh --holidays-for-year 2026
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Date helpers (cross-platform: BSD on macOS, GNU on Linux)

--- a/global-settings.json
+++ b/global-settings.json
@@ -41,6 +41,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/script-bypass-detector.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Write|Edit|NotebookEdit",
         "hooks": [
           {

--- a/setup-skills-worktree.sh
+++ b/setup-skills-worktree.sh
@@ -196,6 +196,7 @@ fi
 #   3. Run this script — it will register the hook in settings.json
 #
 HOOKS_MANIFEST=(
+  $'PreToolUse\tBash\tscript-bypass-detector.sh\t5'
   $'PreToolUse\tWrite|Edit|NotebookEdit\tworktree-guard.sh\t5'
   $'PreToolUse\tWrite|Edit|MultiEdit|NotebookEdit|Bash\tenv-guard.py\t5'
   $'Stop\t\tsilence-detector-ack.sh\t5'


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Instrument every `.claude/scripts/*.sh` invocation with a tab-separated UTC usage log entry in `~/.claude/script-usage.log`
- Add a non-blocking Bash PreToolUse bypass detector that logs sentinel matches to `~/.claude/script-bypass.log`
- Add `script-usage-report.sh` for weekly usage/bypass counts and adherence ratios, including `--days N` and `--since=Nd` windows

Closes #310

## Test plan
- [x] Every `.claude/scripts/*.sh` appends to `~/.claude/script-usage.log` on invocation
- [x] `~/.claude/script-usage.log` entries are single-line, tab-separated, ISO-8601 UTC timestamped
- [x] `script-bypass-detector.sh` installed and registered in `global-settings.json` with `Bash` matcher
- [x] Bypass detector never blocks Bash (always exits 0, emits `{}`)
- [x] Running a deliberate inline `gh api .../pulls/1/reviews?per_page=100` logs an entry in `~/.claude/script-bypass.log` naming `pr-state.sh`
- [x] Running `bash .claude/scripts/pr-state.sh 1` logs an entry in `~/.claude/script-usage.log`
- [x] `script-usage-report.sh` produces a readable summary with counts and a ratio
- [x] Hook storage uses `~/.claude/` not the skills-worktree (per `feedback_hook_storage_location.md`)
- [x] Follow-up issue created for the one-week review checkpoint (#311 already exists)

## Validation
- `python3` instrumentation scan: 30/30 `.claude/scripts/*.sh` files instrumented
- `bash -n .claude/scripts/*.sh .claude/hooks/script-bypass-detector.sh`
- `python3 -m json.tool global-settings.json`
- Manual hook fixture emitted `{}` and appended a `pr-state.sh` bypass entry
- `bash .claude/scripts/pr-state.sh 1` appended a usage entry
- `bash .claude/scripts/script-usage-report.sh --days 1`
- `bash .claude/scripts/script-usage-report.sh --since=7d`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35a53430-b8cf-44cd-a578-5986bd35f7a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35a53430-b8cf-44cd-a578-5986bd35f7a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Track shared script use and flag likely inline bypasses**

### What Changed
- Shared `.claude/scripts/*.sh` tools now record each run in a local usage log.
- A new non-blocking Bash hook records likely inline reimplementations of shared helpers, such as review lookup, merge checks, and thread resolution.
- A new report command summarizes usage vs. bypasses for a chosen time window and shows the most common bypass contexts.
- Usage logging was made non-fatal so telemetry does not break script runs if the local Claude folder or log file is unavailable.
- The new bypass hook is registered in the setup and settings files so it runs automatically.

### Impact
`✅ Clearer script adherence tracking`
`✅ Faster detection of shared-script bypasses`
`✅ Fewer tool failures from missing telemetry files`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=tsc8J38kYYCzfpwf3k9MQrzF9K1PPodSwTatdC5iq5k&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
