### PR TITLE
fix(prompt): strengthen tilde fence directive

### DIFF
--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -10,6 +10,8 @@ argument-hint: "[#123 #124 ...] (issue numbers, or omit for PM auto-detect)"
 
 Analyze one or more GitHub issues, classify complexity, and produce a copy-paste-ready prompt with a model recommendation. The goal is quality-conservative right-sizing — never under-resource a task, but don't waste Opus 4.7 1M tokens on a typo fix.
 
+**MANDATORY OUTPUT FORMAT:** Every per-issue prompt block MUST open and close with `~~~` tilde fences. NEVER use backtick fences as the outer prompt-block delimiter.
+
 ## Step 0: Parse Arguments and Detect Context
 
 Parse `$ARGUMENTS` as space-separated issue references. Strip `#` prefixes to get bare issue numbers.
@@ -195,7 +197,7 @@ If all issues are subagent-eligible, skip the Tier Recommendation and prompt blo
 
 For single-issue input, there is one prompt block. For batch input, there are multiple prompt blocks, each independently copyable (i.e., self-contained with all context; this does not imply each block has its own tier). All blocks in a batch share the batch-level tier, so an individually Light issue's block may include Heavy-tier checkpoints when the batch tier is Heavy. **Batch tier is computed from thread-prompt issues only** — subagent candidates do not influence the batch tier.
 
-**Fence nesting rule:** Outer prompt blocks open and close with tilde fences (`~~~`). Inner code examples (bash commands, SQL, file paths, etc.) use the standard three backtick characters. Per CommonMark, a fenced block can only be closed by a fence using the **same character** as the opening fence — so a `~~~`-delimited outer block safely contains any number of ```` ``` ````-delimited inner blocks without collision. This is more robust than nested backtick fences (e.g., 4-backtick outer + 3-backtick inner) because some renderers (including recent versions of the Claude Mac app) close the outer fence at the first inner triple-backtick in violation of CommonMark's requirement that fences close only with matching fence characters of equal or greater length. Tilde outer fences sidestep that renderer bug entirely.
+**Fence nesting rule:** MUST use tilde fences (`~~~`) for all outer prompt blocks. Do NOT use backtick fences as outer delimiters. Inner code examples (bash commands, SQL, file paths, etc.) may use the standard three backtick characters because a `~~~`-delimited outer block is not closed by inner backticks; this keeps each full prompt block copyable as one unit in renderers that mishandle nested backtick fences.
 
 ### Subagent Candidates Template (PM auto-detect only)
 
@@ -224,6 +226,8 @@ Output the Tier Recommendation as plain text first (skip if all issues are subag
 
 Rationale: {1-line explanation of why this tier was selected, citing the dominant signal}
 ```
+
+**OUTPUT MUST USE `~~~` FENCES, NOT BACKTICKS.** The opening and closing lines of every per-issue prompt block must be exactly `~~~`.
 
 Then, for each issue, output a self-contained prompt block. Use tilde fences (`~~~`, shown here as the outer boundary):
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a top-level mandatory output-format directive requiring `~~~` outer fences for `/prompt` per-issue prompt blocks.
- Rewrites the fence nesting rule as an imperative MUST/DO NOT contract and removes the potentially confusing 4-backtick rejected-pattern example.
- Adds a standalone warning immediately before the output template so the generated prompt block remains tilde-fenced while preserving the existing prompt content.

Closes #382

## Test plan

- [x] `/prompt` output uses `~~~` outer fences (verify: inner backtick-fenced bash blocks do not break the outer fence)
  - Verified with a prompt-style issue #382 output fixture: the `~~~` outer block contains an inner ```bash block and closes only at the final `~~~`.
- [x] The full prompt block for any issue is copyable as one unit in the Claude Mac app
  - Verified the generated prompt-style block is a single tilde-fenced unit around all issue content and inner code examples.
- [x] No regression in prompt content (fence character is the only change)
  - Confirmed the template content remains unchanged; only directive prose around fence selection was strengthened.
- [x] `python3` assertion check for mandatory directives, removed rejected 4-backtick example, and expected template fences
- [x] `bash .github/scripts/rule-lint.sh` (passes; existing soft word-budget warning remains)
- [x] `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ac9c3a0-0899-4d02-8d7e-b38b956014a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ac9c3a0-0899-4d02-8d7e-b38b956014a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced prompt specification documentation with stricter formatting requirements and explicit structural guidelines. The comprehensive update consolidates and clarifies rules for block structure and delimiter usage, removes outdated technical references, and establishes clearer implementation standards to improve overall consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Force per-issue prompt blocks to use tilde fences**

### What Changed
- Per-issue prompt blocks now must open and close with `~~~` instead of backticks
- The fence rule is stated more directly so inner code examples can remain backtick-fenced without breaking the outer prompt block
- Added a clear warning right before the output template to keep the full prompt copyable as one unit

### Impact
`✅ Fewer broken prompt blocks in the Claude Mac app`
`✅ Copyable full prompts with inner code examples`
`✅ Clearer prompt formatting for issue outputs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=1QYad_uR0BepVVOP6iz3nqepfced-Ceil4lyr5QwxMY&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
