### PR TITLE
Fix merge gate for code-owner bot approvals

### DIFF
--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -50,6 +50,12 @@ The merge gate depends on which reviewer owns the PR:
 
 **CR detection order:** ack means started; CodeRabbit check-run success means complete; only an APPROVED review object on current HEAD satisfies the gate. Once Step 1 passes, proceed immediately to Step 1b.
 
+### Code-owner bots
+
+Some repos list CR (`@coderabbitai`) or Greptile (`@greptile-apps`) in `CODEOWNERS`. When branch protection has `require_code_owner_reviews`, that bot's `APPROVED` review on the current HEAD SHA satisfies the code-owner approval requirement. Do not ask the PR author or repo owner to self-approve — GitHub does not allow author self-approval and the bot approval is the terminal unblock when fresh.
+
+Because `CODEOWNERS` varies by repo, this is a runtime check. `.claude/scripts/merge-gate.sh` reads `CODEOWNERS`, `.github/CODEOWNERS`, or `docs/CODEOWNERS`; when CR or Greptile is a code owner it also requires GitHub `reviewDecision == "APPROVED"` on the current PR head. If branch protection is `BLOCKED` and a prior bot approval is stale/dismissed after a push, trigger that bot again (`@coderabbitai full review` for CR, `@greptileai` for Greptile) and keep polling. Human escalation is only for an actual human-authored `CHANGES_REQUESTED`, not stale bot approval.
+
 ## Step 1b — CI Must Pass Before Merge (NON-NEGOTIABLE)
 
 Before running `gh pr merge` on ANY PR, verify ALL CI check-runs are complete and passing. Use `.claude/scripts/ci-status.sh <PR_NUMBER_OR_SHA> --format summary`: exit `0` clean+complete, `1` incomplete (WAIT), `3` blocking failures (FIX). `.claude/scripts/merge-gate.sh` calls it; fallback commands live in `.claude/reference/cr-polling-commands.md`.

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -146,7 +146,7 @@ fi
 OWNER="${OWNER_REPO%/*}"
 REPO="${OWNER_REPO#*/}"
 
-PR_JSON=$(gh pr view "$PR_NUMBER" --json number,state,headRefOid,mergeStateStatus,mergeable,reviewDecision 2>/dev/null || true)
+PR_JSON=$(gh pr view "$PR_NUMBER" --json number,state,headRefOid,baseRefName,mergeStateStatus,mergeable,reviewDecision 2>/dev/null || true)
 if [[ -z "$PR_JSON" ]]; then
   emit_json false unknown cr "[\"PR #$PR_NUMBER not found\"]" "" "$(emit_empty_ci)" "" "" "$(emit_empty_code_owner_bots)"
   exit 3
@@ -154,6 +154,7 @@ fi
 
 PR_STATE=$(echo "$PR_JSON" | jq -r '.state // "UNKNOWN"')
 HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid // ""')
+BASE_REF=$(echo "$PR_JSON" | jq -r '.baseRefName // ""')
 MERGE_STATE=$(echo "$PR_JSON" | jq -r '.mergeStateStatus // ""')
 REVIEW_DECISION=$(echo "$PR_JSON" | jq -r '.reviewDecision // ""')
 
@@ -219,7 +220,12 @@ fi
 # names CR or Greptile as a code owner.
 CODEOWNERS_TEXT=""
 for codeowners_path in CODEOWNERS .github/CODEOWNERS docs/CODEOWNERS; do
-  if CODEOWNERS_JSON=$(gh api "repos/$OWNER/$REPO/contents/$codeowners_path" 2>/dev/null); then
+  if [[ -n "$BASE_REF" ]]; then
+    CODEOWNERS_JSON=$(gh api "repos/$OWNER/$REPO/contents/$codeowners_path" -f ref="$BASE_REF" 2>/dev/null || true)
+  else
+    CODEOWNERS_JSON=$(gh api "repos/$OWNER/$REPO/contents/$codeowners_path" 2>/dev/null || true)
+  fi
+  if [[ -n "$CODEOWNERS_JSON" ]]; then
     CODEOWNERS_TEXT=$(echo "$CODEOWNERS_JSON" | jq -r '.content // ""' | base64 --decode 2>/dev/null || true)
     if [[ -n "$CODEOWNERS_TEXT" ]]; then
       break
@@ -228,7 +234,10 @@ for codeowners_path in CODEOWNERS .github/CODEOWNERS docs/CODEOWNERS; do
 done
 
 CODE_OWNER_BOTS=$(printf '%s\n' "$CODEOWNERS_TEXT" | jq -R -s -c '
-  ascii_downcase as $text
+  split("\n")
+  | map(select(test("^\\s*#") | not))
+  | join("\n")
+  | ascii_downcase as $text
   | [
       if ($text | test("(^|[^a-z0-9_-])@?coderabbitai([^a-z0-9_-]|$)")) then "coderabbitai[bot]" else empty end,
       if ($text | test("(^|[^a-z0-9_-])@?greptile-apps([^a-z0-9_-]|$)")) then "greptile-apps[bot]" else empty end
@@ -332,9 +341,10 @@ CR_IS_CODE_OWNER=$(echo "$CODE_OWNER_BOTS" | jq -e 'index("coderabbitai[bot]") !
 GREPTILE_IS_CODE_OWNER=$(echo "$CODE_OWNER_BOTS" | jq -e 'index("greptile-apps[bot]") != null' >/dev/null 2>&1 && echo true || echo false)
 
 if [[ -n "$REVIEW_DECISION" && "$REVIEW_DECISION" != "APPROVED" ]]; then
-  if [[ "$REVIEWER" == "cr" && "$CR_IS_CODE_OWNER" == true ]]; then
+  if [[ "$CR_IS_CODE_OWNER" == true ]]; then
     MISSING+=("branch protection reviewDecision is $REVIEW_DECISION, not APPROVED, with CodeRabbit in CODEOWNERS — if the prior CR approval was dismissed as stale, trigger @coderabbitai full review")
-  elif [[ "$REVIEWER" == "greptile" && "$GREPTILE_IS_CODE_OWNER" == true ]]; then
+  fi
+  if [[ "$GREPTILE_IS_CODE_OWNER" == true ]]; then
     MISSING+=("branch protection reviewDecision is $REVIEW_DECISION, not APPROVED, with Greptile in CODEOWNERS — if the prior Greptile approval was dismissed as stale, trigger @greptileai")
   fi
 fi

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -9,7 +9,9 @@
 #   - Greptile path : severity-gated — clean OR only P1/P2 (fixed) OR P0 fixed + re-review clean
 # Also enforces the pre-merge CI gate from .claude/rules/cr-merge-gate.md Step 1b
 # (incomplete runs OR blocking conclusions = not merge-ready) and the BEHIND check
-# (mergeStateStatus != BEHIND) per issue #273.
+# (mergeStateStatus != BEHIND) per issue #273. When CR or Greptile is listed
+# in CODEOWNERS, also verifies GitHub branch protection's reviewDecision is
+# APPROVED so stale/dismissed bot approvals cannot accidentally pass the gate.
 #
 # Usage:
 #   merge-gate.sh <pr_number> [--reviewer cr|bugbot|greptile]
@@ -35,7 +37,9 @@
 #       "blocking": [{"name": "...", "conclusion": "..."}],
 #       "incomplete": [{"name": "...", "status": "..."}]
 #     },
-#     "merge_state": "CLEAN"|"BEHIND"|"BLOCKED"|...
+#     "merge_state": "CLEAN"|"BEHIND"|"BLOCKED"|...,
+#     "review_decision": "APPROVED"|"CHANGES_REQUESTED"|"REVIEW_REQUIRED"|...,
+#     "code_owner_bots": ["coderabbitai[bot]", "greptile-apps[bot]"]
 #   }
 #
 # Exit codes:
@@ -108,8 +112,8 @@ fi
 # Helpers
 # --------------------------------------------------------------------------
 emit_json() {
-  # emit_json <met> <reviewer> <path> <missing_json_array> <head_sha> <ci_status_json> <merge_state>
-  local met="$1" reviewer="$2" path="$3" missing="$4" head_sha="$5" ci_status="$6" merge_state="$7"
+  # emit_json <met> <reviewer> <path> <missing_json_array> <head_sha> <ci_status_json> <merge_state> <review_decision> <code_owner_bots_json>
+  local met="$1" reviewer="$2" path="$3" missing="$4" head_sha="$5" ci_status="$6" merge_state="$7" review_decision="$8" code_owner_bots="$9"
   jq -cn \
     --argjson met "$met" \
     --arg reviewer "$reviewer" \
@@ -118,11 +122,17 @@ emit_json() {
     --arg head_sha "$head_sha" \
     --argjson ci_status "$ci_status" \
     --arg merge_state "$merge_state" \
-    '{met: $met, reviewer: $reviewer, path: $path, missing: $missing, head_sha: $head_sha, ci_status: $ci_status, merge_state: $merge_state}'
+    --arg review_decision "$review_decision" \
+    --argjson code_owner_bots "$code_owner_bots" \
+    '{met: $met, reviewer: $reviewer, path: $path, missing: $missing, head_sha: $head_sha, ci_status: $ci_status, merge_state: $merge_state, review_decision: $review_decision, code_owner_bots: $code_owner_bots}'
 }
 
 emit_empty_ci() {
   echo '{"total":0,"passing":0,"failing":0,"in_progress":0,"blocking":[],"incomplete":[]}'
+}
+
+emit_empty_code_owner_bots() {
+  echo '[]'
 }
 
 # --------------------------------------------------------------------------
@@ -130,29 +140,30 @@ emit_empty_ci() {
 # --------------------------------------------------------------------------
 OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || true)
 if [[ -z "$OWNER_REPO" ]]; then
-  emit_json false unknown cr '["gh repo view failed — not in a git repo or no remote"]' "" "$(emit_empty_ci)" ""
+  emit_json false unknown cr '["gh repo view failed — not in a git repo or no remote"]' "" "$(emit_empty_ci)" "" "" "$(emit_empty_code_owner_bots)"
   exit 4
 fi
 OWNER="${OWNER_REPO%/*}"
 REPO="${OWNER_REPO#*/}"
 
-PR_JSON=$(gh pr view "$PR_NUMBER" --json number,state,headRefOid,mergeStateStatus,mergeable 2>/dev/null || true)
+PR_JSON=$(gh pr view "$PR_NUMBER" --json number,state,headRefOid,mergeStateStatus,mergeable,reviewDecision 2>/dev/null || true)
 if [[ -z "$PR_JSON" ]]; then
-  emit_json false unknown cr "[\"PR #$PR_NUMBER not found\"]" "" "$(emit_empty_ci)" ""
+  emit_json false unknown cr "[\"PR #$PR_NUMBER not found\"]" "" "$(emit_empty_ci)" "" "" "$(emit_empty_code_owner_bots)"
   exit 3
 fi
 
 PR_STATE=$(echo "$PR_JSON" | jq -r '.state // "UNKNOWN"')
 HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid // ""')
 MERGE_STATE=$(echo "$PR_JSON" | jq -r '.mergeStateStatus // ""')
+REVIEW_DECISION=$(echo "$PR_JSON" | jq -r '.reviewDecision // ""')
 
 if [[ "$PR_STATE" != "OPEN" ]]; then
-  emit_json false unknown cr "[\"PR #$PR_NUMBER is $PR_STATE — not open\"]" "$HEAD_SHA" "$(emit_empty_ci)" "$MERGE_STATE"
+  emit_json false unknown cr "[\"PR #$PR_NUMBER is $PR_STATE — not open\"]" "$HEAD_SHA" "$(emit_empty_ci)" "$MERGE_STATE" "$REVIEW_DECISION" "$(emit_empty_code_owner_bots)"
   exit 3
 fi
 
 if [[ -z "$HEAD_SHA" ]]; then
-  emit_json false unknown cr '["could not determine HEAD SHA"]' "" "$(emit_empty_ci)" "$MERGE_STATE"
+  emit_json false unknown cr '["could not determine HEAD SHA"]' "" "$(emit_empty_ci)" "$MERGE_STATE" "$REVIEW_DECISION" "$(emit_empty_code_owner_bots)"
   exit 4
 fi
 
@@ -163,7 +174,7 @@ fi
 # inside a helper function called via $(), because exit inside $() only kills
 # the subshell and the main script continues with garbage data.
 die_api() {
-  emit_json false "${REVIEWER_OVERRIDE:-unknown}" "unknown" "[\"gh api failed: $1\"]" "$HEAD_SHA" "$(emit_empty_ci)" "$MERGE_STATE"
+  emit_json false "${REVIEWER_OVERRIDE:-unknown}" "unknown" "[\"gh api failed: $1\"]" "$HEAD_SHA" "$(emit_empty_ci)" "$MERGE_STATE" "$REVIEW_DECISION" "$(emit_empty_code_owner_bots)"
   exit 4
 }
 
@@ -202,6 +213,26 @@ fi
 if ! THREADS_JSON=$(gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR_NUMBER) { reviewThreads(first: 100) { nodes { isResolved comments(first: 100) { nodes { author { login } } } } } } } }" 2>/dev/null); then
   die_api "GraphQL-reviewThreads"
 fi
+
+# Runtime CODEOWNERS detection. Branch protection is repo-specific, so only
+# enforce reviewDecision against bot code-owner approvals when this repo actually
+# names CR or Greptile as a code owner.
+CODEOWNERS_TEXT=""
+for codeowners_path in CODEOWNERS .github/CODEOWNERS docs/CODEOWNERS; do
+  if CODEOWNERS_JSON=$(gh api "repos/$OWNER/$REPO/contents/$codeowners_path" 2>/dev/null); then
+    CODEOWNERS_TEXT=$(echo "$CODEOWNERS_JSON" | jq -r '.content // ""' | base64 --decode 2>/dev/null || true)
+    if [[ -n "$CODEOWNERS_TEXT" ]]; then
+      break
+    fi
+  fi
+done
+
+CODE_OWNER_BOTS=$(printf '%s\n' "$CODEOWNERS_TEXT" | jq -R -s -c '
+  ascii_downcase as $text
+  | [
+      if ($text | test("(^|[^a-z0-9_-])@?coderabbitai([^a-z0-9_-]|$)")) then "coderabbitai[bot]" else empty end,
+      if ($text | test("(^|[^a-z0-9_-])@?greptile-apps([^a-z0-9_-]|$)")) then "greptile-apps[bot]" else empty end
+    ]')
 
 # --------------------------------------------------------------------------
 # CI status — delegated to ci-status.sh; adapt its shape for this script's
@@ -295,6 +326,17 @@ UNRESOLVED_TOTAL=$(echo "$THREADS_JSON" | jq -r '
   | length')
 if [[ "$UNRESOLVED_TOTAL" -gt 0 ]]; then
   MISSING+=("$UNRESOLVED_TOTAL unresolved review thread(s) — resolve via GraphQL before merge")
+fi
+
+CR_IS_CODE_OWNER=$(echo "$CODE_OWNER_BOTS" | jq -e 'index("coderabbitai[bot]") != null' >/dev/null 2>&1 && echo true || echo false)
+GREPTILE_IS_CODE_OWNER=$(echo "$CODE_OWNER_BOTS" | jq -e 'index("greptile-apps[bot]") != null' >/dev/null 2>&1 && echo true || echo false)
+
+if [[ "$REVIEW_DECISION" != "APPROVED" ]]; then
+  if [[ "$REVIEWER" == "cr" && "$CR_IS_CODE_OWNER" == true ]]; then
+    MISSING+=("branch protection reviewDecision is $REVIEW_DECISION, not APPROVED, with CodeRabbit in CODEOWNERS — if the prior CR approval was dismissed as stale, trigger @coderabbitai full review")
+  elif [[ "$REVIEWER" == "greptile" && "$GREPTILE_IS_CODE_OWNER" == true ]]; then
+    MISSING+=("branch protection reviewDecision is $REVIEW_DECISION, not APPROVED, with Greptile in CODEOWNERS — if the prior Greptile approval was dismissed as stale, trigger @greptileai")
+  fi
 fi
 
 # Path-specific checks.
@@ -437,7 +479,7 @@ fi
 
 MISSING_JSON=$(printf '%s\n' "${MISSING[@]:-}" | jq -R . | jq -cs 'map(select(length > 0))')
 
-emit_json "$MET" "$REVIEWER" "$REVIEWER" "$MISSING_JSON" "$HEAD_SHA" "$CI_STATUS" "$MERGE_STATE"
+emit_json "$MET" "$REVIEWER" "$REVIEWER" "$MISSING_JSON" "$HEAD_SHA" "$CI_STATUS" "$MERGE_STATE" "$REVIEW_DECISION" "$CODE_OWNER_BOTS"
 
 if [[ "$MET" == true ]]; then
   exit 0

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -221,9 +221,9 @@ fi
 CODEOWNERS_TEXT=""
 for codeowners_path in CODEOWNERS .github/CODEOWNERS docs/CODEOWNERS; do
   if [[ -n "$BASE_REF" ]]; then
-    CODEOWNERS_JSON=$(gh api "repos/$OWNER/$REPO/contents/$codeowners_path" -f ref="$BASE_REF" 2>/dev/null || true)
+    CODEOWNERS_JSON=$(gh api --method GET "repos/$OWNER/$REPO/contents/$codeowners_path" -f ref="$BASE_REF" 2>/dev/null || true)
   else
-    CODEOWNERS_JSON=$(gh api "repos/$OWNER/$REPO/contents/$codeowners_path" 2>/dev/null || true)
+    CODEOWNERS_JSON=$(gh api --method GET "repos/$OWNER/$REPO/contents/$codeowners_path" 2>/dev/null || true)
   fi
   if [[ -n "$CODEOWNERS_JSON" ]]; then
     CODEOWNERS_TEXT=$(echo "$CODEOWNERS_JSON" | jq -r '.content // ""' | base64 --decode 2>/dev/null || true)

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -331,7 +331,7 @@ fi
 CR_IS_CODE_OWNER=$(echo "$CODE_OWNER_BOTS" | jq -e 'index("coderabbitai[bot]") != null' >/dev/null 2>&1 && echo true || echo false)
 GREPTILE_IS_CODE_OWNER=$(echo "$CODE_OWNER_BOTS" | jq -e 'index("greptile-apps[bot]") != null' >/dev/null 2>&1 && echo true || echo false)
 
-if [[ "$REVIEW_DECISION" != "APPROVED" ]]; then
+if [[ -n "$REVIEW_DECISION" && "$REVIEW_DECISION" != "APPROVED" ]]; then
   if [[ "$REVIEWER" == "cr" && "$CR_IS_CODE_OWNER" == true ]]; then
     MISSING+=("branch protection reviewDecision is $REVIEW_DECISION, not APPROVED, with CodeRabbit in CODEOWNERS — if the prior CR approval was dismissed as stale, trigger @coderabbitai full review")
   elif [[ "$REVIEWER" == "greptile" && "$GREPTILE_IS_CODE_OWNER" == true ]]; then

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -423,9 +423,11 @@ jq -r '.merge_state | "[MERGE] mergeable=\(.mergeable), status=\(.mergeStateStat
 | `mergeable` | `CONFLICTING` | Rebase onto main: `git fetch origin main && git rebase origin/main`. Fix conflicts, continue, force-push. |
 | `mergeable` | `UNKNOWN` | GitHub still computing — note and re-run `/fixpr` later. |
 | `mergeStateStatus` | `BEHIND` | Rebase onto main: `git fetch origin main && git rebase origin/main`. If conflicts arise mid-rebase (replaying commits individually can conflict even when a three-way merge wouldn't), resolve them the same way as `CONFLICTING` above, then `git rebase --continue`. Force-push. Wait for CI to re-run before verifying merge gate. |
-| `mergeStateStatus` | `BLOCKED` | Required checks/reviews missing — already covered by 5c/5d, but report any residual. |
+| `mergeStateStatus` | `BLOCKED` | Required checks/reviews missing — already covered by 5c/5d. If CodeRabbit or Greptile is in CODEOWNERS and the last approval is stale/dismissed after a push, recover by triggering that bot re-review (`@coderabbitai full review` or `@greptileai`) instead of escalating to the author. |
 | `mergeStateStatus` | `UNSTABLE` | A non-required check pending/failing — typically CR/Greptile on the new SHA. If 5d emitted `REVIEW_PENDING`, stop with that status. |
-| `reviewDecision` | `CHANGES_REQUESTED` | A human reviewer requested changes — report; cannot auto-resolve. |
+| `reviewDecision` | `CHANGES_REQUESTED` | Changes were requested. If the requester is a bot, process findings through this skill; if a human requested changes, report it as non-automatable. |
+
+When residual branch protection says review is missing or `reviewDecision != "APPROVED"`, run `.claude/scripts/merge-gate.sh "$PR_NUMBER"` and read `.code_owner_bots`. If it lists `coderabbitai[bot]` or `greptile-apps[bot]`, a current-HEAD approval from that bot is the merge unblocker. A stale/dismissed bot approval is recoverable review debt: trigger the matching bot and re-run the gate after it responds. Do not ask the PR author for an approval GitHub will not accept.
 
 After any rebase + force-push: `[MERGE] rebase complete, force-pushed (SHA: <new-sha>) — CI re-triggered. Re-run /fixpr after CI completes.`
 
@@ -458,4 +460,4 @@ Status:          CLEAN | THREADS_STUCK | REVIEW_PENDING | CI_PENDING | CI_FAILIN
 - `CI_FAILING` — transient CI failures that cannot be fixed locally (report which).
 - `CONFLICTS` — merge conflicts could not be auto-resolved (needs manual intervention).
 - `BEHIND` — branch behind base, auto-rebased and force-pushed; now waiting for CI re-run. Re-run `/fixpr` after CI completes.
-- `NEEDS_HUMAN_REVIEW` — a human reviewer requested changes (cannot auto-resolve).
+- `NEEDS_HUMAN_REVIEW` — a human reviewer requested changes, or no configured code-owner bot can satisfy the missing required approval. If CR/Greptile is in CODEOWNERS and only its approval is stale/dismissed, downgrade to `REVIEW_PENDING` after triggering the bot re-review.

--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -50,6 +50,8 @@ GATE_EXIT=$?
 - Exit `3` → PR not found (already merged/closed). Stop.
 - Exit `2`/`4` → script or gh error; surface the stderr message to the user.
 
+If `missing` says branch protection `reviewDecision` is not `APPROVED` and `.code_owner_bots` lists `coderabbitai[bot]` or `greptile-apps[bot]`, do not ask the PR author to approve. Trigger the matching bot re-review (`@coderabbitai full review` or `@greptileai`) and wait for a fresh current-HEAD approval.
+
 Reviewer assignment is resolved automatically from `~/.claude/session-state.json` and live history. Pass `--reviewer cr|bugbot|greptile` to override.
 
 ### Step 3: Verify acceptance criteria

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -91,7 +91,7 @@ GATE_EXIT=$?
 ```
 
 - Exit `0` → gate met, proceed.
-- Exit `1` → gate NOT met. Stop and report the `missing` array from the JSON output verbatim (e.g., "need 1 explicit CR APPROVED review on HEAD", "branch is BEHIND base", "CI has 2 failing check-run(s): ...").
+- Exit `1` → gate NOT met. Stop and report the `missing` array from the JSON output verbatim (e.g., "need 1 explicit CR APPROVED review on HEAD", "branch is BEHIND base", "CI has 2 failing check-run(s): ..."). If the JSON lists `coderabbitai[bot]` or `greptile-apps[bot]` in `.code_owner_bots` and the blocker is a stale/dismissed bot approval, trigger that bot's re-review instead of asking the PR author to approve.
 - Exit `3` → PR not found; skip to Phase 3 as described above.
 - Exit `2`/`4` → script or gh error; surface the stderr message.
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Document CR/Greptile code-owner bot approvals in the authoritative merge gate rules
- Detect CR/Greptile in CODEOWNERS at runtime and include branch-protection `reviewDecision` in `merge-gate.sh`
- Update `/fixpr`, `/merge`, and `/wrap` guidance so stale bot approvals trigger bot re-review instead of author self-approval escalation
- Guard unavailable/empty `reviewDecision` values and harden CODEOWNERS detection against base-branch, comment-line, and `gh api` method edge cases

Closes #333

## Test plan
- [x] `cr-merge-gate.md` adds a "Code-owner bots" section describing CR/Greptile in CODEOWNERS satisfying `require_code_owner_reviews`
- [x] `fixpr/SKILL.md` updated: `NEEDS_HUMAN_REVIEW` is downgraded to recoverable when CR is a code owner and approval is stale/dismissed
- [x] `merge-gate.sh` verifies `reviewDecision == "APPROVED"` on current HEAD SHA for configured bot code-owners; on stale/dismissed bot approval, hints to trigger bot re-review
- [x] Search rule/skill text for "human approving review", "ask the user to approve", "human reviewer required" — correct as needed
- [x] /wrap, /merge no longer ask author to self-approve when bot code-owners are configured
- [x] `bash -n .claude/scripts/merge-gate.sh`
- [x] CODEOWNERS jq detection returns `coderabbitai[bot]` and `greptile-apps[bot]` for matching CODEOWNERS content
- [x] CODEOWNERS jq detection ignores commented-out bot owner lines
- [x] CODEOWNERS lookup uses the PR base ref with explicit GET query parameters
- [x] Rule corpus word count remains below `.claude/rules/.budget-soft-cap` and the hard cap
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cbf4d3c-f0f3-4d86-a566-1e1de2058a63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cbf4d3c-f0f3-4d86-a566-1e1de2058a63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified merge-gate rules: approvals from configured code-owner bots (coderabbitai, greptile-apps) on the current HEAD satisfy code-owner review requirements.

* **Chores**
  * Merge gate will automatically re-trigger configured bot reviews when bot approvals are stale/dismissed and continue evaluation rather than escalating to PR authors; bot vs human review requests are now handled distinctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Treat stale bot approvals as valid only when they are fresh and current**

### What Changed
- The merge gate now recognizes when CodeRabbit or Greptile is listed in `CODEOWNERS` and accepts that bot’s approval on the current branch head as the required code-owner approval.
- If a bot approval was dismissed or became stale after a push, the gate now asks for a fresh bot re-review instead of telling the PR author to approve it.
- Repos that do not report branch-protection review state are no longer blocked by a missing or empty `reviewDecision`.
- Merge and repair guidance now tells users to trigger the matching bot review when a bot approval is the blocker.

### Impact
`✅ Fewer false merge blocks for bot-owned reviews`
`✅ Less time waiting on stale approvals`
`✅ Clearer merge instructions for CodeRabbit and Greptile reviews`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=jhHN3V_rifAq_jNoUGmaREDIf14NrTLREeu1y1k-t3s&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
