### PR TITLE
docs(CLAUDE): [#issue] prefix for thread title bias (#363)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,10 @@ These apply to EVERY message the parent agent sends to the user. No exceptions, 
 
 After context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `monitor-mode.md`) and report it WITH a timestamp.
 
+### Thread title — `[#issue]` prefix
+
+There is no supported customization for auto-generated thread/tab names. **Bias the first message** with a leading `[#N]` token — e.g. single `[#339]` or multi `[#339, #341]` — so the auto-summarizer (which typically picks up leading tokens) is likelier to put the issue number in the title.
+
 ---
 
 ## AUTONOMOUS WORKFLOW EXECUTION — DO NOT ASK PERMISSION

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@ These apply to EVERY message the parent agent sends to the user. No exceptions, 
 
 After context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `monitor-mode.md`) and report it WITH a timestamp.
 
-### Thread title — `[#issue]` prefix
+## Thread title — `[#issue]` prefix
 
-There is no supported customization for auto-generated thread/tab names. **Bias the first message** with a leading `[#N]` token — e.g. single `[#339]` or multi `[#339, #341]` — so the auto-summarizer (which typically picks up leading tokens) is likelier to put the issue number in the title.
+There is no supported customization for auto-generated thread/tab names. **Best-effort only:** start the first *user message* with a leading `[#N]` token — e.g. single `[#339]` or multi `[#339, #341]` — so the auto-summarizer (which typically picks up leading tokens) is likelier to put the issue number(s) in the title.
 
 ---
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the `[#issue]` leading-token convention so Claude Code’s auto-summarizer is likelier to include issue numbers in generated thread/tab titles (no supported customization otherwise).

## Test plan

- [x] `CLAUDE.md` documents the `[#issue]` prefix convention
- [x] Convention is brief and placed after the first section (non-rule-loading-cost area)
- [x] Examples: single `[#339]`, multi `[#339, #341]`
- [x] Notes that auto-summarizer typically picks up leading tokens

Follow-up: addressed CodeRabbit MD001 + wording in `e633d81`.

Closes #363.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-324e7ef1-a1c1-4050-8d53-e4c85a56770a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-324e7ef1-a1c1-4050-8d53-e4c85a56770a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Document how to bias auto-generated thread titles with issue numbers**

### What Changed
- Adds guidance for starting the first user message with a leading `[#N]` token so Claude Code is more likely to include issue numbers in generated thread and tab titles
- Clarifies that this is a best-effort convention, not a supported customization
- Includes examples for one issue number and multiple issue numbers

### Impact
`✅ Clearer thread titles`
`✅ Easier issue tracking in generated tabs`
`✅ Fewer missing issue numbers in summaries`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=Cbin6wTiWfhBuzitFI-7mA-HkIg8dBegUGWb1902xdM&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
