### PR TITLE
Always trigger @cursor review on PR open and every push

### DIFF
--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -170,7 +170,7 @@ Use the shared helper — it tries the inline reply endpoint first, falls back t
 
 ### Re-Reviews
 
-After fixing BugBot findings and pushing, BugBot auto-reviews the new push. If auto-review doesn't fire within 10 min, trigger manually: `gh pr comment {{PR_NUMBER}} --body "@cursor review"`
+After fixing BugBot findings and pushing, expect `@cursor review` from CI on every push (`cursor-review-pr-comment.yml`). If BugBot still hasn't landed after polling, post again: `gh pr comment {{PR_NUMBER}} --body "@cursor review"` — duplicates are OK.
 
 ## Greptile Review Path (when `reviewer` = `greptile`)
 

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,5 @@
+# Memory index (repo-tracked subset)
+
+Cursor auto-memory normally lives under `~/.claude/projects/*/memory/`. This repo tracks durable notes that belong in git.
+
+- [feedback_bugbot_auto_trigger_unreliable.md](feedback_bugbot_auto_trigger_unreliable.md) — Always post `@cursor review` on every PR push (CI + `/fixpr`); BugBot auto-trigger is unreliable; per-seat cost.

--- a/.claude/memory/feedback_bugbot_auto_trigger_unreliable.md
+++ b/.claude/memory/feedback_bugbot_auto_trigger_unreliable.md
@@ -6,10 +6,6 @@ type: feedback
 
 # BugBot auto-trigger unreliable
 
-BugBot’s GitHub “auto-trigger on push” is unreliable on later pushes even when settings suggest it should run every time. Agents used to post `@cursor review` only when no BugBot activity appeared on the new SHA after a wait; that detection frequently missed real gaps.
+BugBot's GitHub "auto-trigger on push" is unreliable on later pushes even when settings suggest it should run every time. Agents used to post `@cursor review` only when no BugBot activity appeared on the new SHA after a wait; that detection frequently missed real gaps.
 
-**Current behavior (issue #361):** The workflow `.github/workflows/cursor-review-pr-comment.yml` posts `@cursor review` on every PR open, reopen, and synchronize (every push). `/fixpr` also always appends `@cursor review` after its conditional triggers for the other bots. Duplicates are acceptable.
-
-**Cost:** BugBot (Cursor) is included per seat — there are no per-review or per-comment charges for spamming the trigger. Prefer reliability over skipping.
-
-**Why:** Per-seat billing → safe to always-trigger; conditional detection cost more agent confusion than it saved.
+**Durable lesson:** BugBot's GitHub auto-trigger is unreliable on later pushes, and Cursor is billed per seat rather than per trigger. Keep the exact operational procedure in the rule/skill files; this memory exists to preserve the rationale for always favoring reliability.

--- a/.claude/memory/feedback_bugbot_auto_trigger_unreliable.md
+++ b/.claude/memory/feedback_bugbot_auto_trigger_unreliable.md
@@ -4,6 +4,8 @@ description: Why we always post @cursor review on every PR push via CI and /fixp
 type: feedback
 ---
 
+# BugBot auto-trigger unreliable
+
 BugBot’s GitHub “auto-trigger on push” is unreliable on later pushes even when settings suggest it should run every time. Agents used to post `@cursor review` only when no BugBot activity appeared on the new SHA after a wait; that detection frequently missed real gaps.
 
 **Current behavior (issue #361):** The workflow `.github/workflows/cursor-review-pr-comment.yml` posts `@cursor review` on every PR open, reopen, and synchronize (every push). `/fixpr` also always appends `@cursor review` after its conditional triggers for the other bots. Duplicates are acceptable.

--- a/.claude/memory/feedback_bugbot_auto_trigger_unreliable.md
+++ b/.claude/memory/feedback_bugbot_auto_trigger_unreliable.md
@@ -1,0 +1,13 @@
+---
+name: BugBot auto-trigger unreliable
+description: Why we always post @cursor review on every PR push via CI and /fixpr
+type: feedback
+---
+
+BugBot’s GitHub “auto-trigger on push” is unreliable on later pushes even when settings suggest it should run every time. Agents used to post `@cursor review` only when no BugBot activity appeared on the new SHA after a wait; that detection frequently missed real gaps.
+
+**Current behavior (issue #361):** The workflow `.github/workflows/cursor-review-pr-comment.yml` posts `@cursor review` on every PR open, reopen, and synchronize (every push). `/fixpr` also always appends `@cursor review` after its conditional triggers for the other bots. Duplicates are acceptable.
+
+**Cost:** BugBot (Cursor) is included per seat — there are no per-review or per-comment charges for spamming the trigger. Prefer reliability over skipping.
+
+**Why:** Per-seat billing → safe to always-trigger; conditional detection cost more agent confusion than it saved.

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -4,21 +4,18 @@
 > **Ask first:** Never — fix findings autonomously.
 > **Never:** Trigger Greptile before checking if BugBot already posted a review. Include `@cursor` in reply comments (may trigger a re-review). Ignore BugBot findings.
 
-BugBot is the **second-tier** AI code reviewer — included with Cursor (per-seat), sits between CR (primary) and Greptile (last resort). The full review chain: **CR → BugBot → Greptile → self-review.** CodeAnt/Graphite parallel on CR path: `codeant-graphite.md`.
+BugBot is the **second-tier** reviewer (Cursor, per-seat) between CR and Greptile: **CR → BugBot → Greptile → self-review.** Parallel CodeAnt/Graphite: `codeant-graphite.md`.
 
-**Always-trigger:** This repo posts `@cursor review` on every PR open and every push via `.github/workflows/cursor-review-pr-comment.yml` because BugBot’s GitHub auto-trigger is unreliable on later pushes. Do **not** rely on “wait for auto-trigger” alone — see memory `feedback_bugbot_auto_trigger_unreliable.md`.
+**Always-trigger:** CI posts `@cursor review` on every PR open/push (`cursor-review-pr-comment.yml`); GitHub auto-trigger is unreliable — see `feedback_bugbot_auto_trigger_unreliable.md`.
 
 **Escalation authority:** The numbered gate + STOP conditions live in `cr-github-review.md` ("Reviewer escalation gate"). Use `.claude/scripts/escalate-review.sh <PR_NUMBER>` for the per-cycle `STATUS=` verdict; this file only defines BugBot behavior after `STATUS=switch_bugbot`.
 
 ## BugBot Basics
 
 - **Bot username:** `cursor[bot]`
-- **Auto-trigger (GitHub):** May be ON in product settings, but do **not** assume it fires every time — treat it as best-effort only.
-- **Unconditional trigger (this repo):** CI always posts `@cursor review` on PR open and every push (`cursor-review-pr-comment.yml`). Agents (`/fixpr`, phase workflows) also post `@cursor review` after pushes where applicable — duplicate triggers are OK.
-- **Manual trigger:** Same comment — `@cursor review` — anytime you need an extra run outside CI (rare).
-- **Cost:** Per-seat product — no per-comment or per-review charges for BugBot; always-triggering is safe from a billing standpoint.
-- **Review time:** Typically fast (~1-3 minutes)
-- **No CLI** — local review loop uses CR CLI only; BugBot is GitHub-only
+- **Triggers:** GitHub auto-trigger is best-effort only. This repo: CI + agents always post `@cursor review` on open/push (`cursor-review-pr-comment.yml`, `/fixpr`); duplicates OK. Manual: same comment if needed.
+- **Cost:** Per-seat — safe to always-trigger.
+- **Review time:** ~1–3 min. **No CLI** (GitHub-only).
 
 ## Polling for BugBot Reviews
 
@@ -46,9 +43,7 @@ Verify all findings against actual code. Fix all valid findings in one commit, p
 
 ## Merge Gate
 
-**A clean BugBot review independently satisfies the merge gate.** BugBot requires 1 clean pass on the current HEAD, while CR requires an explicit review with `state: "APPROVED"` whose `commit_id` matches the current HEAD SHA (SHA freshness enforced; a later `CHANGES_REQUESTED` on the same SHA retracts the approval). See `cr-merge-gate.md` Step 1 for the canonical CR-path definition.
-
-**Canonical definition:** See `cr-merge-gate.md` (Step 1) for the authoritative merge gate including the BugBot path.
+**A clean BugBot review satisfies the merge gate alone.** CR path needs an explicit `APPROVED` on current HEAD (see `cr-merge-gate.md` Step 1).
 
 ## Re-Reviews
 

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -4,16 +4,19 @@
 > **Ask first:** Never — fix findings autonomously.
 > **Never:** Trigger Greptile before checking if BugBot already posted a review. Include `@cursor` in reply comments (may trigger a re-review). Ignore BugBot findings.
 
-BugBot is the **second-tier** AI code reviewer — free, auto-triggers on every push/PR open, and sits between CR (primary) and Greptile (last resort). The full review chain: **CR → BugBot → Greptile → self-review.** CodeAnt/Graphite parallel on CR path: `codeant-graphite.md`.
+BugBot is the **second-tier** AI code reviewer — included with Cursor (per-seat), sits between CR (primary) and Greptile (last resort). The full review chain: **CR → BugBot → Greptile → self-review.** CodeAnt/Graphite parallel on CR path: `codeant-graphite.md`.
+
+**Always-trigger:** This repo posts `@cursor review` on every PR open and every push via `.github/workflows/cursor-review-pr-comment.yml` because BugBot’s GitHub auto-trigger is unreliable on later pushes. Do **not** rely on “wait for auto-trigger” alone — see memory `feedback_bugbot_auto_trigger_unreliable.md`.
 
 **Escalation authority:** The numbered gate + STOP conditions live in `cr-github-review.md` ("Reviewer escalation gate"). Use `.claude/scripts/escalate-review.sh <PR_NUMBER>` for the per-cycle `STATUS=` verdict; this file only defines BugBot behavior after `STATUS=switch_bugbot`.
 
 ## BugBot Basics
 
 - **Bot username:** `cursor[bot]`
-- **Auto-trigger:** ON — runs on every push and every PR open (both "Only Run When Mentioned" and "Only Run Once Automatically" are OFF)
-- **Manual trigger:** Comment `@cursor review` on any PR (for re-reviews or when auto-trigger didn't fire)
-- **Cost:** Free (included with Cursor)
+- **Auto-trigger (GitHub):** May be ON in product settings, but do **not** assume it fires every time — treat it as best-effort only.
+- **Unconditional trigger (this repo):** CI always posts `@cursor review` on PR open and every push (`cursor-review-pr-comment.yml`). Agents (`/fixpr`, phase workflows) also post `@cursor review` after pushes where applicable — duplicate triggers are OK.
+- **Manual trigger:** Same comment — `@cursor review` — anytime you need an extra run outside CI (rare).
+- **Cost:** Per-seat product — no per-comment or per-review charges for BugBot; always-triggering is safe from a billing standpoint.
 - **Review time:** Typically fast (~1-3 minutes)
 - **No CLI** — local review loop uses CR CLI only; BugBot is GitHub-only
 
@@ -49,4 +52,4 @@ Verify all findings against actual code. Fix all valid findings in one commit, p
 
 ## Re-Reviews
 
-After fixing BugBot findings, BugBot auto-reviews the new push (since auto-trigger is ON). No need to manually trigger `@cursor review` unless the auto-review didn't fire within 10 minutes — then post `@cursor review` as a manual trigger.
+After fixing BugBot findings and pushing, expect a new BugBot pass on the new HEAD: CI already posted `@cursor review` on that push. If anything still looks stale after polling, post `@cursor review` again — duplicates are acceptable.

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -40,7 +40,7 @@ The merge gate depends on which reviewer owns the PR:
 **BugBot path** (CR failed, BugBot responded, Greptile never triggered — sticky; see `bugbot.md`):
 
 - 1 clean BugBot review on the current HEAD SHA satisfies the gate (BugBot's completion signals are reliable).
-- After fixing BugBot findings, BugBot auto-reviews the new push. If auto-review doesn't fire within 10 min, trigger manually via `@cursor review`.
+- After fixing BugBot findings, CI already posted `@cursor review` on that push; `/fixpr` also posts it after agent pushes. If BugBot still hasn't completed after polling, post `@cursor review` again — duplicates are acceptable (see `bugbot.md`).
 - Stay on BugBot — do not switch back to CR. Ignore late CR reviews.
 
 **Greptile path** (Greptile was triggered at any point — both CR and BugBot failed — sticky assignment, see `greptile.md`):

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -517,8 +517,10 @@ case "$REVIEWER" in
         BB_STATE=$(echo "$LATEST_BB" | jq -r '.state // ""')
         # Always check for inline findings — BugBot can post inline diff comments
         # without a review body, so gating on body length would miss them.
+        # Filter by original_commit_id == sha to exclude stale comments GitHub
+        # "moves" to the new HEAD when commit_id advances but the diff line persists.
         INLINE_BB=$(echo "$PR_COMMENTS_JSON" | jq --arg sha "$HEAD_SHA" '
-          [.[]? | select(.user.login == "cursor[bot]" and .commit_id == $sha)] | length')
+          [.[]? | select(.user.login == "cursor[bot]" and .commit_id == $sha and (.original_commit_id // .commit_id) == $sha)] | length')
         if [[ "$BB_STATE" == "CHANGES_REQUESTED" ]] || [[ "$INLINE_BB" -gt 0 ]]; then
           MISSING+=("latest BugBot review on HEAD has findings ($INLINE_BB inline)")
         fi

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -2,11 +2,13 @@
 # merge-gate.sh — Verify the merge gate for a PR (CR / BugBot / Greptile / CodeAnt).
 #
 # Implements the authoritative gate defined in .claude/rules/cr-merge-gate.md:
-#   - CR path       : 1 explicit CR APPROVED review whose commit_id == current HEAD SHA
-#                     + zero unresolved CR threads (SHA freshness enforced; acks /
-#                     check-run completion alone do NOT satisfy the gate)
-#                     + when CodeAnt has artifacts on that SHA, CodeAnt clean signal
-#                     (explicit APPROVED on HEAD or CodeAnt check-run success) — issue #367
+#   - CR path       : 1 explicit CodeRabbit OR CodeAnt APPROVED review on current
+#                     HEAD SHA + zero unresolved threads (SHA freshness enforced).
+#                     CodeRabbit check-run must be green when CodeRabbit supplies
+#                     the approval; CodeAnt-only approval skips that check-run.
+#                     When CodeAnt has artifacts on that SHA, CodeAnt clean signal
+#                     must also hold (explicit APPROVED or successful CodeAnt
+#                     check-run vs CHANGES_REQUESTED) — issue #367
 #   - BugBot path   : 1 clean BugBot review on current HEAD + zero unresolved BugBot threads
 #   - Greptile path : severity-gated — clean OR only P1/P2 (fixed) OR P0 fixed + re-review clean
 # Also enforces the pre-merge CI gate from .claude/rules/cr-merge-gate.md Step 1b
@@ -374,7 +376,8 @@ fi
 case "$REVIEWER" in
   cr)
 
-    # CodeRabbit check-run status on current HEAD.
+    # CodeRabbit check-run status on current HEAD (required only when CodeRabbit
+    # supplies the APPROVED review on this SHA — CodeAnt-only approval skips it).
     CR_CHECK=$(echo "$CHECK_RUNS_JSON" | jq -c '[.check_runs[]? | select(.name == "CodeRabbit")] | first // empty')
     CR_CHECK_OK=false
     if [[ -n "$CR_CHECK" ]]; then
@@ -391,21 +394,13 @@ case "$REVIEWER" in
       fi
     fi
 
-    if [[ "$CR_CHECK_OK" != true ]]; then
-      MISSING+=("CodeRabbit check-run not green on HEAD ${HEAD_SHA:0:7}")
-    fi
-
-    # Require 1 explicit CR APPROVED review on the current HEAD SHA (per issue #337).
+    # Require 1 explicit CodeRabbit OR CodeAnt APPROVED review on the current HEAD SHA.
     # SHA freshness is intrinsic to the filter: commit_id must equal $HEAD_SHA, so a
     # prior APPROVED on a stale SHA does NOT satisfy the gate.
     #
-    # Also check for approval retraction on the current SHA — if CR posts an
-    # APPROVED review and later posts a CHANGES_REQUESTED on the same SHA, the
-    # approval is retracted and the gate is NOT met (even if a still-later
-    # COMMENTED review is the literal last review). Compare the newest
-    # APPROVED timestamp to the newest CHANGES_REQUESTED timestamp directly,
-    # not just the overall latest-review state — a COMMENTED follow-up must
-    # not paper over a retraction.
+    # Retraction: if a bot posts APPROVED and later CHANGES_REQUESTED on the same
+    # SHA, the approval is retracted. Compare newest APPROVED vs newest
+    # CHANGES_REQUESTED per bot (COMMENTED follow-ups must not paper over retraction).
     LATEST_CR_APPROVED_AT=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" '
       [.[]?
         | select(.user.login == "coderabbitai[bot]" and .commit_id == $sha and .state == "APPROVED")
@@ -423,76 +418,60 @@ case "$REVIEWER" in
       [.[]? | select(.user.login == "coderabbitai[bot]" and .commit_id == $sha)]
       | length')
 
-    if [[ "$APPROVED_CR_ON_HEAD" -lt 1 ]]; then
-      MISSING+=("need 1 explicit CR APPROVED review on HEAD ${HEAD_SHA:0:7} (have 0 approved of $TOTAL_CR_ON_HEAD CR review(s) on this SHA)")
-    elif [[ -n "$LATEST_CR_CHANGES_REQUESTED_AT" && "$LATEST_CR_CHANGES_REQUESTED_AT" > "$LATEST_CR_APPROVED_AT" ]]; then
-      MISSING+=("CR approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger")
+    LATEST_CA_APPROVED_AT=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" '
+      [.[]?
+        | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha and .state == "APPROVED")
+        | .submitted_at]
+      | sort | last // ""')
+    LATEST_CA_CHANGES_REQUESTED_AT=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" '
+      [.[]?
+        | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha and .state == "CHANGES_REQUESTED")
+        | .submitted_at]
+      | sort | last // ""')
+    APPROVED_CA_ON_HEAD=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
+      [.[]? | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha and .state == "APPROVED")]
+      | length')
+    TOTAL_CA_ON_HEAD=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
+      [.[]? | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha)]
+      | length')
+
+    # Retraction: later CHANGES_REQUESTED on same SHA invalidates APPROVED (ISO timestamps).
+    CR_RETRACTED=false
+    if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && -n "$LATEST_CR_CHANGES_REQUESTED_AT" && -n "$LATEST_CR_APPROVED_AT" ]]; then
+      if [[ "$LATEST_CR_CHANGES_REQUESTED_AT" > "$LATEST_CR_APPROVED_AT" ]]; then
+        CR_RETRACTED=true
+      fi
+    fi
+    CA_RETRACTED=false
+    if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && -n "$LATEST_CA_CHANGES_REQUESTED_AT" && -n "$LATEST_CA_APPROVED_AT" ]]; then
+      if [[ "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_APPROVED_AT" ]]; then
+        CA_RETRACTED=true
+      fi
     fi
 
-    # CodeAnt (codeant-ai[bot]) — only when it has already participated on this SHA (#367).
-    # Resolver gap: treat explicit APPROVED on HEAD like CR, and accept a green CodeAnt
-    # check-run when the bot does not emit a GitHub review object.
-    CODEANT_REVIEWS_ON_HEAD=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
-      [.[]? | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha)] | length')
-    CODEANT_INLINE_ON_HEAD=$(echo "$PR_COMMENTS_JSON" | jq --arg sha "$HEAD_SHA" '
-      [.[]? | select(.user.login == "codeant-ai[bot]" and ((.commit_id // .original_commit_id // "") == $sha))] | length')
-    CODEANT_CONVO_ON_HEAD=$(echo "$ISSUE_COMMENTS_JSON" | jq -r --arg sha "$HEAD_SHA" '
-      def short: $sha[0:7];
-      [.[]?
-        | select(.user.login == "codeant-ai[bot]")
-        | .body // ""
-        | select((contains($sha)) or (contains(short)))]
-      | length')
-    CODEANT_CHECK_ON_HEAD=false
-    if echo "$CHECK_RUNS_JSON" | jq -e '
-      .check_runs[]?
-      | select(
-          ((.name // "") | test("codeant"; "i"))
-          or ((.app.slug // "") | test("codeant"; "i"))
-          or ((.app.name // "") | test("codeant"; "i"))
-        )
-      ' >/dev/null 2>&1; then
-      CODEANT_CHECK_ON_HEAD=true
+    CR_APPROVAL_VALID=false
+    if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false ]]; then
+      CR_APPROVAL_VALID=true
     fi
-    if [[ "$CODEANT_REVIEWS_ON_HEAD" -gt 0 || "$CODEANT_INLINE_ON_HEAD" -gt 0 || "$CODEANT_CONVO_ON_HEAD" -gt 0 || "$CODEANT_CHECK_ON_HEAD" == true ]]; then
-      LATEST_CA_APPROVED_AT=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" '
-        [.[]?
-          | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha and .state == "APPROVED")
-          | .submitted_at]
-        | sort | last // ""')
-      LATEST_CA_CHANGES_AT=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" '
-        [.[]?
-          | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha and .state == "CHANGES_REQUESTED")
-          | .submitted_at]
-        | sort | last // ""')
-      LATEST_CA_CHECK_OK_AT=$(echo "$CHECK_RUNS_JSON" | jq -r '
-        [.check_runs[]?
-          | select((.status // "") == "completed" and (.conclusion // "") == "success")
-          | select(
-              ((.name // "") | test("codeant"; "i"))
-              or ((.app.slug // "") | test("codeant"; "i"))
-              or ((.app.name // "") | test("codeant"; "i"))
-            )
-          | (.completed_at // .started_at // "")]
-        | sort | last // ""')
-      LATEST_CA_CLEAN_AT="$LATEST_CA_APPROVED_AT"
-      if [[ -n "$LATEST_CA_CHECK_OK_AT" && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHECK_OK_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
-        LATEST_CA_CLEAN_AT="$LATEST_CA_CHECK_OK_AT"
-      fi
-      if [[ -n "$LATEST_CA_CHANGES_AT" && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHANGES_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
-        MISSING+=("CodeAnt CHANGES_REQUESTED on HEAD ${HEAD_SHA:0:7} — address findings or wait for APPROVED / successful CodeAnt check-run after fix")
-      else
-        CODEANT_APPROVED_COUNT=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
-          [.[]? | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha and .state == "APPROVED")] | length')
-        CODEANT_CHECK_OK=false
-        if [[ -n "$LATEST_CA_CHECK_OK_AT" ]]; then
-          CODEANT_CHECK_OK=true
-        fi
-        if [[ "$CODEANT_APPROVED_COUNT" -lt 1 && "$CODEANT_CHECK_OK" != true ]]; then
-          MISSING+=("CodeAnt participated on HEAD ${HEAD_SHA:0:7} but no explicit APPROVED review and no successful CodeAnt check-run — wait or comment @codeant-ai review")
-        fi
-      fi
+    CA_APPROVAL_VALID=false
+    if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false ]]; then
+      CA_APPROVAL_VALID=true
     fi
+
+    if [[ "$CR_APPROVAL_VALID" == true ]]; then
+      if [[ "$CR_CHECK_OK" != true ]]; then
+        MISSING+=("CodeRabbit check-run not green on HEAD ${HEAD_SHA:0:7}")
+      fi
+    elif [[ "$CA_APPROVAL_VALID" == true ]]; then
+      : # CodeAnt APPROVED on HEAD — no CodeRabbit check-run required
+    elif [[ "$CR_RETRACTED" == true ]]; then
+      MISSING+=("CR approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger")
+    elif [[ "$CA_RETRACTED" == true ]]; then
+      MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger")
+    else
+      MISSING+=("need 1 explicit CodeRabbit or CodeAnt APPROVED review on HEAD ${HEAD_SHA:0:7} (CR: $TOTAL_CR_ON_HEAD review(s), CodeAnt: $TOTAL_CA_ON_HEAD review(s) on this SHA)")
+    fi
+
     ;;
 
   bugbot)

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -516,7 +516,7 @@ case "$REVIEWER" in
       if [[ -n "$LATEST_CA_CHANGES_REQUESTED_AT" && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
         MISSING+=("CodeAnt CHANGES_REQUESTED on HEAD ${HEAD_SHA:0:7} is newer than the latest CodeAnt clean signal — address findings or wait for APPROVED / successful CodeAnt check-run")
       elif [[ "$CA_APPROVAL_VALID" != true && "$CODEANT_CHECK_OK" != true ]]; then
-        MISSING+=("CodeAnt participated on HEAD ${HEAD_SHA:0:7} but no explicit APPROVED review and no successful CodeAnt check-run — wait or comment @codeant-ai review")
+        MISSING+=("CodeAnt participated on HEAD ${HEAD_SHA:0:7} but no explicit APPROVED review and no successful CodeAnt check-run (have $TOTAL_CA_ON_HEAD CodeAnt review(s) on this SHA) — wait or comment @codeant-ai review")
       fi
     fi
 

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -435,6 +435,17 @@ case "$REVIEWER" in
         CR_RETRACTED=true
       fi
     fi
+    CA_RETRACTED=false
+    if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && -n "$LATEST_CA_CHANGES_REQUESTED_AT" && -n "$LATEST_CA_APPROVED_AT" ]]; then
+      if [[ "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_APPROVED_AT" ]]; then
+        CA_RETRACTED=true
+      fi
+    fi
+
+    CR_APPROVAL_VALID=false
+    if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false ]]; then
+      CR_APPROVAL_VALID=true
+    fi
     CA_APPROVAL_VALID=false
     if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false ]]; then
       CA_APPROVAL_VALID=true

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -2,10 +2,12 @@
 # merge-gate.sh — Verify the merge gate for a PR (CR / BugBot / Greptile / CodeAnt).
 #
 # Implements the authoritative gate defined in .claude/rules/cr-merge-gate.md:
-#   - CR path       : 1 explicit CodeRabbit OR CodeAnt APPROVED review on current
-#                     HEAD SHA + zero unresolved threads (SHA freshness enforced).
-#                     CodeRabbit check-run must be green when CodeRabbit supplies
-#                     the approval; CodeAnt-only approval skips that check-run.
+#   - CR path       : 1 explicit CodeRabbit APPROVED on current HEAD SHA + green
+#                     CodeRabbit check-run (SHA freshness + retraction enforced).
+#                     CodeAnt is supplemental: when CodeAnt participated on that SHA,
+#                     require CodeAnt APPROVED or a successful CodeAnt check-run;
+#                     CodeAnt CHANGES_REQUESTED blocks only if newer than the latest
+#                     clean signal (APPROVED or successful check completion).
 #   - BugBot path   : 1 clean BugBot review on current HEAD + zero unresolved BugBot threads
 #   - Greptile path : severity-gated — clean OR only P1/P2 (fixed) OR P0 fixed + re-review clean
 # Also enforces the pre-merge CI gate from .claude/rules/cr-merge-gate.md Step 1b
@@ -373,8 +375,7 @@ fi
 case "$REVIEWER" in
   cr)
 
-    # CodeRabbit check-run status on current HEAD (required only when CodeRabbit
-    # supplies the APPROVED review on this SHA — CodeAnt-only approval skips it).
+    # CodeRabbit check-run must be green on HEAD whenever we are on the CR path.
     CR_CHECK=$(echo "$CHECK_RUNS_JSON" | jq -c '[.check_runs[]? | select(.name == "CodeRabbit")] | first // empty')
     CR_CHECK_OK=false
     if [[ -n "$CR_CHECK" ]]; then
@@ -391,13 +392,8 @@ case "$REVIEWER" in
       fi
     fi
 
-    # Require 1 explicit CodeRabbit OR CodeAnt APPROVED review on the current HEAD SHA.
-    # SHA freshness is intrinsic to the filter: commit_id must equal $HEAD_SHA, so a
-    # prior APPROVED on a stale SHA does NOT satisfy the gate.
-    #
-    # Retraction: if a bot posts APPROVED and later CHANGES_REQUESTED on the same
-    # SHA, the approval is retracted. Compare newest APPROVED vs newest
-    # CHANGES_REQUESTED per bot (COMMENTED follow-ups must not paper over retraction).
+    # Require 1 explicit CodeRabbit APPROVED on HEAD (SHA freshness in the jq filter).
+    # Retraction: CHANGES_REQUESTED newer than APPROVED on same SHA invalidates approval.
     LATEST_CR_APPROVED_AT=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" '
       [.[]?
         | select(.user.login == "coderabbitai[bot]" and .commit_id == $sha and .state == "APPROVED")
@@ -439,34 +435,78 @@ case "$REVIEWER" in
         CR_RETRACTED=true
       fi
     fi
-    CA_RETRACTED=false
-    if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && -n "$LATEST_CA_CHANGES_REQUESTED_AT" && -n "$LATEST_CA_APPROVED_AT" ]]; then
-      if [[ "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_APPROVED_AT" ]]; then
-        CA_RETRACTED=true
-      fi
-    fi
-
-    CR_APPROVAL_VALID=false
-    if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false ]]; then
-      CR_APPROVAL_VALID=true
-    fi
     CA_APPROVAL_VALID=false
     if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false ]]; then
       CA_APPROVAL_VALID=true
     fi
 
-    if [[ "$CR_APPROVAL_VALID" == true ]]; then
-      if [[ "$CR_CHECK_OK" != true ]]; then
-        MISSING+=("CodeRabbit check-run not green on HEAD ${HEAD_SHA:0:7}")
+    if [[ "$CR_APPROVAL_VALID" != true ]]; then
+      if [[ "$CR_RETRACTED" == true ]]; then
+        MISSING+=("CR approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger")
+      else
+        MISSING+=("need 1 explicit CodeRabbit APPROVED review on HEAD ${HEAD_SHA:0:7} (have $TOTAL_CR_ON_HEAD CR review(s) on this SHA)")
       fi
-    elif [[ "$CA_APPROVAL_VALID" == true ]]; then
-      : # CodeAnt APPROVED on HEAD — no CodeRabbit check-run required
-    elif [[ "$CR_RETRACTED" == true ]]; then
-      MISSING+=("CR approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger")
-    elif [[ "$CA_RETRACTED" == true ]]; then
-      MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger")
-    else
-      MISSING+=("need 1 explicit CodeRabbit or CodeAnt APPROVED review on HEAD ${HEAD_SHA:0:7} (CR: $TOTAL_CR_ON_HEAD review(s), CodeAnt: $TOTAL_CA_ON_HEAD review(s) on this SHA)")
+    elif [[ "$CR_CHECK_OK" != true ]]; then
+      MISSING+=("CodeRabbit check-run not green on HEAD ${HEAD_SHA:0:7}")
+    fi
+
+    # CodeAnt supplemental gate (#367 / CodeRabbit review): only when CodeAnt left
+    # artifacts on this SHA — require APPROVED or successful CodeAnt check-run, and
+    # treat CHANGES_REQUESTED as blocking only if it is newer than the latest clean signal.
+    CODEANT_REVIEWS_ON_HEAD=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
+      [.[]? | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha)] | length')
+    CODEANT_INLINE_ON_HEAD=$(echo "$PR_COMMENTS_JSON" | jq --arg sha "$HEAD_SHA" '
+      [.[]? | select(.user.login == "codeant-ai[bot]" and ((.commit_id // .original_commit_id // "") == $sha))] | length')
+    CODEANT_CONVO_ON_HEAD=$(echo "$ISSUE_COMMENTS_JSON" | jq -r --arg sha "$HEAD_SHA" '
+      def short: $sha[0:7];
+      [.[]?
+        | select(.user.login == "codeant-ai[bot]")
+        | .body // ""
+        | select((contains($sha)) or (contains(short)))]
+      | length')
+    CODEANT_CHECK_PRESENT=false
+    if echo "$CHECK_RUNS_JSON" | jq -e '
+      .check_runs[]?
+      | select(
+          ((.name // "") | test("codeant"; "i"))
+          or ((.app.slug // "") | test("codeant"; "i"))
+          or ((.app.name // "") | test("codeant"; "i"))
+        )
+      ' >/dev/null 2>&1; then
+      CODEANT_CHECK_PRESENT=true
+    fi
+
+    CODEANT_PARTICIPATED=false
+    if [[ "$CODEANT_REVIEWS_ON_HEAD" -gt 0 || "$CODEANT_INLINE_ON_HEAD" -gt 0 || "$CODEANT_CONVO_ON_HEAD" -gt 0 || "$CODEANT_CHECK_PRESENT" == true ]]; then
+      CODEANT_PARTICIPATED=true
+    fi
+
+    if [[ "$CODEANT_PARTICIPATED" == true ]]; then
+      LATEST_CA_CHECK_OK_AT=$(echo "$CHECK_RUNS_JSON" | jq -r '
+        [.check_runs[]?
+          | select((.status // "") == "completed" and (.conclusion // "") == "success")
+          | select(
+              ((.name // "") | test("codeant"; "i"))
+              or ((.app.slug // "") | test("codeant"; "i"))
+              or ((.app.name // "") | test("codeant"; "i"))
+            )
+          | (.completed_at // .started_at // "")]
+        | sort | last // ""')
+      CODEANT_CHECK_OK=false
+      if [[ -n "$LATEST_CA_CHECK_OK_AT" ]]; then
+        CODEANT_CHECK_OK=true
+      fi
+
+      LATEST_CA_CLEAN_AT="$LATEST_CA_APPROVED_AT"
+      if [[ -n "$LATEST_CA_CHECK_OK_AT" && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHECK_OK_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
+        LATEST_CA_CLEAN_AT="$LATEST_CA_CHECK_OK_AT"
+      fi
+
+      if [[ -n "$LATEST_CA_CHANGES_REQUESTED_AT" && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
+        MISSING+=("CodeAnt CHANGES_REQUESTED on HEAD ${HEAD_SHA:0:7} is newer than the latest CodeAnt clean signal — address findings or wait for APPROVED / successful CodeAnt check-run")
+      elif [[ "$CA_APPROVAL_VALID" != true && "$CODEANT_CHECK_OK" != true ]]; then
+        MISSING+=("CodeAnt participated on HEAD ${HEAD_SHA:0:7} but no explicit APPROVED review and no successful CodeAnt check-run — wait or comment @codeant-ai review")
+      fi
     fi
 
     ;;

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -445,8 +445,6 @@ case "$REVIEWER" in
     # CodeAnt supplemental gate (#367 / CodeRabbit review): only when CodeAnt left
     # artifacts on this SHA — require APPROVED or successful CodeAnt check-run, and
     # treat CHANGES_REQUESTED as blocking only if it is newer than the latest clean signal.
-    CODEANT_REVIEWS_ON_HEAD=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
-      [.[]? | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha)] | length')
     CODEANT_INLINE_ON_HEAD=$(echo "$PR_COMMENTS_JSON" | jq --arg sha "$HEAD_SHA" '
       [.[]? | select(.user.login == "codeant-ai[bot]" and ((.commit_id // .original_commit_id // "") == $sha))] | length')
     CODEANT_CONVO_ON_HEAD=$(echo "$ISSUE_COMMENTS_JSON" | jq -r --arg sha "$HEAD_SHA" '
@@ -469,7 +467,7 @@ case "$REVIEWER" in
     fi
 
     CODEANT_PARTICIPATED=false
-    if [[ "$CODEANT_REVIEWS_ON_HEAD" -gt 0 || "$CODEANT_INLINE_ON_HEAD" -gt 0 || "$CODEANT_CONVO_ON_HEAD" -gt 0 || "$CODEANT_CHECK_PRESENT" == true ]]; then
+    if [[ "$TOTAL_CA_ON_HEAD" -gt 0 || "$CODEANT_INLINE_ON_HEAD" -gt 0 || "$CODEANT_CONVO_ON_HEAD" -gt 0 || "$CODEANT_CHECK_PRESENT" == true ]]; then
       CODEANT_PARTICIPATED=true
     fi
 

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -6,9 +6,6 @@
 #                     HEAD SHA + zero unresolved threads (SHA freshness enforced).
 #                     CodeRabbit check-run must be green when CodeRabbit supplies
 #                     the approval; CodeAnt-only approval skips that check-run.
-#                     When CodeAnt has artifacts on that SHA, CodeAnt clean signal
-#                     must also hold (explicit APPROVED or successful CodeAnt
-#                     check-run vs CHANGES_REQUESTED) — issue #367
 #   - BugBot path   : 1 clean BugBot review on current HEAD + zero unresolved BugBot threads
 #   - Greptile path : severity-gated — clean OR only P1/P2 (fixed) OR P0 fixed + re-review clean
 # Also enforces the pre-merge CI gate from .claude/rules/cr-merge-gate.md Step 1b

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -375,23 +375,6 @@ fi
 case "$REVIEWER" in
   cr)
 
-    # CodeRabbit check-run must be green on HEAD whenever we are on the CR path.
-    CR_CHECK=$(echo "$CHECK_RUNS_JSON" | jq -c '[.check_runs[]? | select(.name == "CodeRabbit")] | first // empty')
-    CR_CHECK_OK=false
-    if [[ -n "$CR_CHECK" ]]; then
-      CR_STATUS=$(echo "$CR_CHECK" | jq -r '.status // ""')
-      CR_CONCLUSION=$(echo "$CR_CHECK" | jq -r '.conclusion // ""')
-      if [[ "$CR_STATUS" == "completed" && "$CR_CONCLUSION" == "success" ]]; then
-        CR_CHECK_OK=true
-      fi
-    else
-      # Fallback: legacy commit-status API.
-      STATUSES_JSON=$(gh api "repos/$OWNER/$REPO/commits/$HEAD_SHA/statuses" 2>/dev/null || echo '[]')
-      if echo "$STATUSES_JSON" | jq -e '.[] | select(.context | test("CodeRabbit"; "i")) | select(.state == "success")' >/dev/null 2>&1; then
-        CR_CHECK_OK=true
-      fi
-    fi
-
     # Require 1 explicit CodeRabbit APPROVED on HEAD (SHA freshness in the jq filter).
     # Retraction: CHANGES_REQUESTED newer than APPROVED on same SHA invalidates approval.
     LATEST_CR_APPROVED_AT=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" '
@@ -457,8 +440,6 @@ case "$REVIEWER" in
       else
         MISSING+=("need 1 explicit CodeRabbit APPROVED review on HEAD ${HEAD_SHA:0:7} (have $TOTAL_CR_ON_HEAD CR review(s) on this SHA)")
       fi
-    elif [[ "$CR_CHECK_OK" != true ]]; then
-      MISSING+=("CodeRabbit check-run not green on HEAD ${HEAD_SHA:0:7}")
     fi
 
     # CodeAnt supplemental gate (#367 / CodeRabbit review): only when CodeAnt left

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -19,7 +19,7 @@ All mechanical GitHub API work — pagination, GraphQL queries, comment classifi
 | 1. Classify review findings | Judgment | AI reads JSON + source files |
 | 2. Classify CI failures | Judgment | AI reads `check-runs/<id>.output.summary` |
 | 3. Fix & push | Judgment | AI edits files, commits, pushes |
-| 3b. Trigger missing AI reviewers | Mechanical | wait 2 minutes, detect 4-bot activity on the new SHA, post one trigger comment per missing bot |
+| 3b. Trigger missing AI reviewers | Mechanical | wait 2 minutes, detect CR/Graphite/CodeAnt activity on the new SHA, post triggers for missing bots, always post `@cursor review` |
 | 4. Reply & resolve | Mechanical | `gh api` calls against IDs from the JSON |
 | 4c. Post-push thread verify (if Step 3 pushed) | Mechanical | Re-fetch threads on new HEAD; explicitly resolve any touched thread still `isResolved: false` (fixes unchanged-line orphans), then `--verify-only` |
 | 5. Verify | Mechanical | Re-run `pr-state.sh --since $RUN_STARTED_AT` |
@@ -174,7 +174,7 @@ If nothing needed fixing (all already-fixed/outdated, CI all green), skip the co
 
 Only run this step when Step 3 made a push. If Step 3 skipped the commit/push, skip this step too.
 
-Use the `$PUSHED_AT` captured immediately before `git push` in Step 3. Capturing it before the push avoids a race where a fast bot starts between push completion and the timestamp capture. After the push completes, wait exactly 2 minutes before checking reviewer status so auto-triggers have time to post activity:
+Use the `$PUSHED_AT` captured immediately before `git push` in Step 3. Capturing it before the push avoids a race where a fast bot starts between push completion and the timestamp capture. After the push completes, wait exactly 2 minutes before checking reviewer status so CodeRabbit / Graphite / CodeAnt auto-triggers have time to post activity (BugBot is covered separately — always trigger `@cursor review` unconditionally; see `bugbot.md` and memory `feedback_bugbot_auto_trigger_unreliable.md`):
 
 ```bash
 PUSHED_SHA=$(git rev-parse HEAD)
@@ -182,7 +182,7 @@ echo "[REVIEWERS] waiting 120s for auto-triggered reviewers on ${PUSHED_SHA:0:7}
 sleep 120
 ```
 
-Detect activity from all 4 proactive reviewers on the pushed SHA. Check all three PR comment endpoints plus check-runs for activity after `$PUSHED_AT`. Conversation-level comments do not expose a `commit_id`, so they only count as activity on the pushed SHA when the body mentions the full SHA or short SHA; otherwise, use SHA-scoped reviews, inline comments, or check-runs to avoid treating a late summary from the previous SHA as coverage for the new one:
+Detect activity from the 3 conditionally triggered reviewers (CodeRabbit, Graphite, CodeAnt) on the pushed SHA. Check all three PR comment endpoints plus check-runs for activity after `$PUSHED_AT`. Conversation-level comments do not expose a `commit_id`, so they only count as activity on the pushed SHA when the body mentions the full SHA or short SHA; otherwise, use SHA-scoped reviews, inline comments, or check-runs to avoid treating a late summary from the previous SHA as coverage for the new one:
 
 ```bash
 REVIEWS=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" | jq -s 'add // []')
@@ -230,15 +230,10 @@ REVIEWER_ACTIVITY=$(jq -n \
        or any($inline[]?; .user.login == "codeant-ai[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
        or convo_by("codeant-ai[bot]")
        or check_by(["CodeAnt", "codeant-ai"])),
-    cursor:
-      (any($reviews[]?; .user.login == "cursor[bot]" and .commit_id == $sha and recent(.submitted_at))
-       or any($inline[]?; .user.login == "cursor[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
-       or convo_by("cursor[bot]")
-       or check_by(["Cursor Bugbot", "cursor"])),
   }')
 ```
 
-For each reviewer whose value is `false`, post exactly one dedicated PR-level trigger comment. Do not batch mentions; combined-mention comments fail to trigger reliably. Post these comments sequentially in this order, skipping reviewers that already auto-triggered. CodeRabbit is additionally capped at 2 manual `@coderabbitai full review` triggers per PR in the trailing hour:
+For each of **coderabbit**, **graphite**, **codeant** whose value is `false`, post exactly one dedicated PR-level trigger comment. Do not batch mentions; combined-mention comments fail to trigger reliably. Post these comments sequentially in this order, skipping reviewers that already auto-triggered. CodeRabbit is additionally capped at 2 manual `@coderabbitai full review` triggers per PR in the trailing hour:
 
 ```bash
 jq -r 'to_entries[] | "[REVIEWERS] \(.key): \(if .value then "auto-triggered" else "missing" end)"' <<<"$REVIEWER_ACTIVITY"
@@ -265,12 +260,10 @@ fi
 if [[ "$(jq -r '.codeant' <<<"$REVIEWER_ACTIVITY")" != "true" ]]; then
   gh pr comment "$PR_NUMBER" --body "@codeant-ai review"
 fi
-if [[ "$(jq -r '.cursor' <<<"$REVIEWER_ACTIVITY")" != "true" ]]; then
-  gh pr comment "$PR_NUMBER" --body "@cursor review"
-fi
+gh pr comment "$PR_NUMBER" --body "@cursor review"
 ```
 
-Cost/rate-limit note: `@codeant-ai review` and `@cursor review` may consume their respective review budgets, so skip them whenever auto-trigger activity is already present on the new SHA. Greptile is intentionally NOT part of this proactive trigger set; it remains last-resort only per `greptile.md`.
+Cost/rate-limit note: `@codeant-ai review` may consume CodeAnt’s review budget, so skip it when auto-trigger activity is already present on the new SHA. **`@cursor review` is always posted** after a `/fixpr` push (composes with CI and issue #370’s four-reviewer triggers); BugBot is per-seat with no per-call charges — duplicates are acceptable. Greptile is intentionally NOT part of this proactive trigger set; it remains last-resort only per `greptile.md`.
 
 ---
 
@@ -514,7 +507,7 @@ Status:          CLEAN | THREADS_STUCK | REVIEW_PENDING | CI_PENDING | CI_FAILIN
 
 - `CLEAN` — **all four conditions simultaneously:** zero unresolved threads (5a), `new_since_baseline.finding_count == 0` (5b), every present review-bot status/check-run for the current HEAD is complete/successful (5d), no merge blockers (6). Missing any one disqualifies `CLEAN` — pick the more specific status below.
 - `THREADS_STUCK` — some threads could not be resolved via GraphQL (report which).
-- `REVIEW_PENDING` — 5d found a review-bot status/check-run still pending on the current HEAD, or a reviewer has not responded yet after Step 3b triggered it. Re-run `/fixpr` after it flips to a completed state. Do NOT declare CLEAN.
+- `REVIEW_PENDING` — 5d found a review-bot status/check-run still pending on the current HEAD, or a reviewer has not responded yet after Step 3b (including the unconditional `@cursor review`). Re-run `/fixpr` after it flips to a completed state. Do NOT declare CLEAN.
 - `NEW_FINDINGS` — 5b's `finding_count > 0`. Stop the run. A fresh `/fixpr` captures a new `$RUN_STARTED_AT` and re-audits from Step 0.
 - `CI_PENDING` — push was made, and non-review-bot CI is not yet complete. Re-run `/fixpr` after CI.
 - `CI_FAILING` — transient CI failures that cannot be fixed locally (report which).

--- a/.github/workflows/cursor-review-pr-comment.yml
+++ b/.github/workflows/cursor-review-pr-comment.yml
@@ -7,6 +7,8 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  # issues.createComment on a PR needs issues:write; GITHUB_TOKEN on pull_request
+  # may still 403 without pull-requests:write — keep both (see PR #399).
   contents: read
   issues: write
   pull-requests: write

--- a/.github/workflows/cursor-review-pr-comment.yml
+++ b/.github/workflows/cursor-review-pr-comment.yml
@@ -1,14 +1,17 @@
 # Issue #361: Always post @cursor review on PR open and every push so BugBot runs
 # reliably (auto-trigger alone misses often). BugBot is per-seat — no per-comment cost.
+#
+# pull_request_target: fork PRs get read-only GITHUB_TOKEN on pull_request; we only
+# call issues.createComment (no checkout / untrusted code). See GitHub hardening docs.
 name: Cursor BugBot review trigger
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
-  # issues.createComment on a PR needs issues:write; GITHUB_TOKEN on pull_request
-  # may still 403 without pull-requests:write — keep both (see PR #399).
+  # pull_request_target runs in base context; token can comment on PRs from forks.
+  # issues.createComment needs issues:write; keep pull-requests:write for parity with prior runs.
   contents: read
   issues: write
   pull-requests: write

--- a/.github/workflows/cursor-review-pr-comment.yml
+++ b/.github/workflows/cursor-review-pr-comment.yml
@@ -7,7 +7,9 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   post-cursor-review:

--- a/.github/workflows/cursor-review-pr-comment.yml
+++ b/.github/workflows/cursor-review-pr-comment.yml
@@ -1,0 +1,25 @@
+# Issue #361: Always post @cursor review on PR open and every push so BugBot runs
+# reliably (auto-trigger alone misses often). BugBot is per-seat — no per-comment cost.
+name: Cursor BugBot review trigger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  post-cursor-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment @cursor review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '@cursor review'
+            });

--- a/.github/workflows/cursor-review-pr-comment.yml
+++ b/.github/workflows/cursor-review-pr-comment.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  pull-requests: write
+  issues: write
 
 jobs:
   post-cursor-review:


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a GitHub Actions workflow that posts `@cursor review` on every PR **opened**, **reopened**, and **synchronized** (every push). Updates `bugbot.md`, `/fixpr` post-push triggers, and related docs so agents no longer rely on unreliable BugBot auto-trigger detection.

Tracked memory `.claude/memory/feedback_bugbot_auto_trigger_unreliable.md` explains why we always-trigger and that BugBot is per-seat (no per-call charges).

**Follow-up from review:** Workflow `GITHUB_TOKEN` needs `issues: write` **and** `pull-requests: write` (and `contents: read`) for `issues.createComment` on PRs from `pull_request` events — `issues: write` alone returned 403 in CI (see job logs on PR #399).

## Test plan

- [x] Merge this PR and confirm the workflow runs on the PR itself (opened + each push) and leaves `@cursor review` comments
- [x] Confirm `/fixpr` Step 3b always posts `@cursor review` after a push while still conditionally triggering CR / Graphite / CodeAnt when missing
- [x] `bash .github/scripts/rule-lint.sh` passes (rules corpus under hard cap)

Closes #361
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19db362-016f-42c8-b9cc-af2262cad63e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19db362-016f-42c8-b9cc-af2262cad63e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now posts an automated "@cursor review" on PR open/reopen/sync and after agent pushes; merge gate updated to accept explicit bot approvals on the current HEAD with refined supplemental acceptance/retraction rules for secondary bots.

* **Chores / Documentation**
  * Re-review guidance now expects CI-triggered reviews (no fixed manual timeout), permits duplicate "@cursor review" posts when polling shows stale results, and adds repo-tracked memory/docs noting unreliable auto-trigger behavior and per-seat cost.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Always post @cursor review and tighten review-gate checks**

### What Changed
- A PR now gets an automatic `@cursor review` comment when it is opened, reopened, or updated with a push, so BugBot is prompted reliably.
- `/fixpr` now always posts `@cursor review` after a push, even if other reviewer triggers already fired.
- Documentation was updated to say BugBot is triggered by CI on every push, duplicates are acceptable, and BugBot is a per-seat tool.
- The merge gate now treats CodeRabbit approval as the primary CR signal and allows CodeAnt to satisfy the gate only when it has a clean signal on the same commit.

### Impact
`✅ Fewer missed BugBot reviews`
`✅ Faster re-review after pushes`
`✅ Clearer merge checks for CR and CodeAnt`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=TjcqjqYQAUJcfPLuP5VlMBv-5znwdPNVSUVsc8_bp7I&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
