### PR TITLE
docs: verify phase protocols and exit reports (closes #162)

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -11,3 +11,4 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `cr-polling-commands.md` — full multi-line `gh api` commands for CR review polling and CI verification
 - `graphql-thread-resolution.md` — full GraphQL queries/mutations for resolving PR review threads
 - `exit-report-format.md` — full structured exit report block specification
+- `issue-162-phase-protocol-verification.md` — static verification log for exit reports, phase B/C protocols, and monitor loop ordering (issue #162)

--- a/.claude/reference/issue-162-phase-protocol-verification.md
+++ b/.claude/reference/issue-162-phase-protocol-verification.md
@@ -74,11 +74,17 @@ Not exercised in this environment (no live token exhaustion). **Spec check:** Ph
 ## Commands (reproduce)
 
 ```bash
-# Phase A sample (from exit-report-format.md)
+# Phase A sample (from exit-report-format.md) — each KEY: value must be one argument
+# so word-splitting does not break lines (see exit-report-format.md).
 printf '%s\n' \
-  EXIT_REPORT PHASE_COMPLETE: A PR_NUMBER: 618 HEAD_SHA: abc1234 \
-  REVIEWER: cr OUTCOME: pushed_fixes \
-  'FILES_CHANGED: src/foo.ts, src/bar.ts' NEXT_PHASE: B \
+  EXIT_REPORT \
+  'PHASE_COMPLETE: A' \
+  'PR_NUMBER: 618' \
+  'HEAD_SHA: abc1234' \
+  'REVIEWER: cr' \
+  'OUTCOME: pushed_fixes' \
+  'FILES_CHANGED: src/foo.ts, src/bar.ts' \
+  'NEXT_PHASE: B' \
   'HANDOFF_FILE: ~/.claude/handoffs/pr-618-handoff.json' \
   | .claude/scripts/verify-exit-report-block.sh
 ```

--- a/.claude/reference/issue-162-phase-protocol-verification.md
+++ b/.claude/reference/issue-162-phase-protocol-verification.md
@@ -1,0 +1,89 @@
+# Issue #162 — Phase protocols & exit reports verification
+
+**Date:** 2026-04-29  
+**Scope:** Static verification against shipped rules and agent templates (PR #160). No live Cursor parent/subagent runs in this environment.
+
+**Artifacts added in this change:**
+
+- `.claude/scripts/verify-exit-report-block.sh` — machine check for required `EXIT_REPORT` fields (stdin).
+
+## 1. Exit report format (AC: structured `EXIT_REPORT` parses)
+
+**Source of truth:** `.claude/reference/exit-report-format.md`, templates in `.claude/agents/phase-a-fixer.md`, `phase-b-reviewer.md`, `phase-c-merger.md`.
+
+**Method:** Extracted canonical example blocks and ran:
+
+```bash
+.claude/scripts/verify-exit-report-block.sh < sample.txt
+```
+
+| Sample | Origin | Result |
+|--------|--------|--------|
+| Phase A block (8 fields) | `exit-report-format.md` | PASS |
+| Phase B block | `phase-b-reviewer.md` template | PASS |
+| Phase C block (`FILES_CHANGED:` empty) | `phase-c-merger.md` template | PASS |
+| Incomplete block | synthetic | FAIL (missing fields) |
+
+**Note on issue #162 wording:** Test scenarios asked for a “fenced” block; agent instructions use a ```text fence in markdown for readability. The runtime contract is the plain `EXIT_REPORT` header plus colon-separated lines (see `exit-report-format.md`).
+
+## 2. Phase B Completion Protocol (6-step checklist)
+
+**Source:** `.claude/rules/phase-protocols.md` — “Phase B Completion Protocol (MANDATORY)”, numbered steps 1–6:
+
+1. Parse the exit report  
+2. Branch on OUTCOME (`merge_ready` vs replacement path)  
+3. Verify review state via GitHub API before Phase C  
+4. Launch Phase C within 60s only with merge authorization  
+5. Update `session-state.json`  
+6. Report to user (with timestamp)  
+
+**Verification:** Checklist is explicit and ordered; “Phase C launch is top priority after Phase B reports `merge_ready`” is stated immediately after the list. **Behavioral enforcement** in-repo is via parent-agent rules (`phase-protocols.md`, `subagent-orchestration.md`); this pass did not execute a live parent loop.
+
+**Doc drift (GitHub issue vs rules):** Issue #162 “Test Scenarios §3” says to verify behavior “After Phase B reports `clean` or `merge_ready`”. The **authoritative** rule is: only `merge_ready` advances to Phase C; `clean` triggers replacement Phase B (`phase-protocols.md` Phase B step 2). Treat the issue scenario text as outdated relative to `phase-protocols.md`.
+
+## 3. Phase C Completion Protocol
+
+**Source:** `.claude/rules/phase-protocols.md` — “Phase C Completion Protocol (MANDATORY)” lists **five** numbered steps (parse → branch on OUTCOME → update session-state → handoff cleanup after confirmed merge → report). Issue #162 AC called this “4-step”; the committed rule file has five numbered items — align AC with the file or renumber in a follow-up doc edit.
+
+**Merge / handoff:** Phase C agent template (`phase-c-merger.md`) states the parent deletes the handoff only after `OUTCOME: merged` and GitHub confirms merge — consistent with `phase-protocols.md` Phase C step 4.
+
+**Doc drift:** Issue scenario §4 references `ac_verified`; Phase C `OUTCOME` values are `merged` | `blocked` per `exit-report-format.md` and agent template.
+
+## 4. Monitor loop priority (transitions before heartbeats)
+
+**Source:** `.claude/rules/monitor-mode.md` — “Monitor Loop — Per-Cycle Checklist (MANDATORY)”:
+
+1. Process completed subagents and parse exit reports  
+2. Execute phase transitions; launch transitions stalled in `session-state.json`  
+3. Escalate-review for CR reviewer PRs  
+4. Send heartbeat if due  
+5. Investigate stale agents  
+
+**Verification:** Steps 1–2 (parsing + transitions) are ordered **before** step 4 (heartbeat). **PASS** by specification audit.
+
+## 5. Post-compaction recovery (pending phase transitions)
+
+**Source:** `.claude/rules/monitor-mode.md` — “Post-Compaction Recovery (MANDATORY)” step 4: “Verify stale agent outputs, Phase B coverage, and **pending transitions**; launch anything stalled.”
+
+**Verification:** Pending transitions are explicitly in the recovery checklist. **PASS** by specification audit.
+
+## 6. Exhaustion / replacement (issue scenario 6)
+
+Not exercised in this environment (no live token exhaustion). **Spec check:** Phase A template sets `OUTCOME: exhaustion` and `NEXT_PHASE: A`; Phase B template sets `OUTCOME: exhaustion` and `NEXT_PHASE: B`. Phase A protocol (`phase-protocols.md`) requires replacement Phase A within 60s without asking (exhaustion path). **Deferred:** runtime observation.
+
+## Commands (reproduce)
+
+```bash
+# Phase A sample (from exit-report-format.md)
+printf '%s\n' \
+  EXIT_REPORT PHASE_COMPLETE: A PR_NUMBER: 618 HEAD_SHA: abc1234 \
+  REVIEWER: cr OUTCOME: pushed_fixes \
+  'FILES_CHANGED: src/foo.ts, src/bar.ts' NEXT_PHASE: B \
+  'HANDOFF_FILE: ~/.claude/handoffs/pr-618-handoff.json' \
+  | .claude/scripts/verify-exit-report-block.sh
+```
+
+## Follow-ups (optional GitHub issues)
+
+1. Refresh issue #162 test scenarios: Phase B → C only on `merge_ready` (not `clean`); replace `ac_verified` with `merged` / `blocked`.  
+2. Align “4-step” vs five numbered Phase C steps in AC wording.

--- a/.claude/scripts/verify-exit-report-block.sh
+++ b/.claude/scripts/verify-exit-report-block.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Verify stdin contains a parseable EXIT_REPORT per
+# .claude/reference/exit-report-format.md — header line plus KEY: value fields.
+# Exit 0 = valid block with all required fields; 1 = missing/invalid.
+set -euo pipefail
+
+required=(
+  PHASE_COMPLETE
+  PR_NUMBER
+  HEAD_SHA
+  REVIEWER
+  OUTCOME
+  FILES_CHANGED
+  NEXT_PHASE
+  HANDOFF_FILE
+)
+
+content=$(cat || true)
+if ! printf '%s\n' "$content" | grep -qx 'EXIT_REPORT'; then
+  echo "verify-exit-report-block: missing EXIT_REPORT header line" >&2
+  exit 1
+fi
+
+# Contiguous block: EXIT_REPORT then KEY: value (value may be empty; optional single space after colon)
+mapfile -t lines < <(printf '%s\n' "$content" | awk '
+  /^EXIT_REPORT$/ { inblk=1; next }
+  inblk && /^[A-Z_]+:/ { print; next }
+  inblk { exit }
+')
+
+declare -A seen=()
+for line in "${lines[@]}"; do
+  key=${line%%:*}
+  [[ -n "$key" ]] || continue
+  seen["$key"]=1
+done
+
+missing=()
+for k in "${required[@]}"; do
+  [[ -n "${seen[$k]-}" ]] || missing+=("$k")
+done
+
+if ((${#missing[@]})); then
+  echo "verify-exit-report-block: missing required field(s): ${missing[*]}" >&2
+  exit 1
+fi
+
+# Disallow tab-only or multiple spaces after colon (keep single space or none per templates)
+while IFS= read -r line; do
+  if [[ "$line" =~ ^[A-Z_]+:[[:space:]] ]]; then
+    rest=${line#*:}
+    if [[ "$rest" =~ ^[[:space:]]{2,} ]]; then
+      echo "verify-exit-report-block: disallowed multiple spaces after colon: $line" >&2
+      exit 1
+    fi
+    if [[ "$rest" =~ $'\t' ]]; then
+      echo "verify-exit-report-block: tab in value start not allowed: $line" >&2
+      exit 1
+    fi
+  fi
+done < <(printf '%s\n' "${lines[@]}")
+
+echo "OK: EXIT_REPORT block has all required fields ($(printf '%s ' "${required[@]}"))"
+exit 0

--- a/.claude/scripts/verify-exit-report-block.sh
+++ b/.claude/scripts/verify-exit-report-block.sh
@@ -2,6 +2,7 @@
 # Verify stdin contains a parseable EXIT_REPORT per
 # .claude/reference/exit-report-format.md — header line plus KEY: value fields.
 # Exit 0 = valid block with all required fields; 1 = missing/invalid.
+# Uses read loops instead of mapfile/associative arrays — macOS ships bash 3.2.
 set -euo pipefail
 
 required=(
@@ -21,23 +22,27 @@ if ! printf '%s\n' "$content" | grep -qx 'EXIT_REPORT'; then
   exit 1
 fi
 
-# Contiguous block: EXIT_REPORT then KEY: value (value may be empty; optional single space after colon)
-mapfile -t lines < <(printf '%s\n' "$content" | awk '
+# Contiguous block: EXIT_REPORT then KEY: value (value may be empty)
+lines=()
+while IFS= read -r line; do
+  lines+=("$line")
+done < <(printf '%s\n' "$content" | awk '
   /^EXIT_REPORT$/ { inblk=1; next }
   inblk && /^[A-Z_]+:/ { print; next }
   inblk { exit }
 ')
 
-declare -A seen=()
-for line in "${lines[@]}"; do
-  key=${line%%:*}
-  [[ -n "$key" ]] || continue
-  seen["$key"]=1
-done
-
 missing=()
 for k in "${required[@]}"; do
-  [[ -n "${seen[$k]-}" ]] || missing+=("$k")
+  found=0
+  for line in "${lines[@]}"; do
+    case "$line" in
+      "$k:"*) found=1; break ;;
+    esac
+  done
+  if [[ "$found" -eq 0 ]]; then
+    missing+=("$k")
+  fi
 done
 
 if ((${#missing[@]})); then
@@ -45,8 +50,8 @@ if ((${#missing[@]})); then
   exit 1
 fi
 
-# Disallow tab-only or multiple spaces after colon (keep single space or none per templates)
-while IFS= read -r line; do
+# Disallow tab-only or multiple spaces after colon
+for line in "${lines[@]}"; do
   if [[ "$line" =~ ^[A-Z_]+:[[:space:]] ]]; then
     rest=${line#*:}
     if [[ "$rest" =~ ^[[:space:]]{2,} ]]; then
@@ -58,7 +63,7 @@ while IFS= read -r line; do
       exit 1
     fi
   fi
-done < <(printf '%s\n' "${lines[@]}")
+done
 
 echo "OK: EXIT_REPORT block has all required fields ($(printf '%s ' "${required[@]}"))"
 exit 0


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Static verification for issue #162 (PR #160 contracts): documented audit of `phase-protocols.md`, `monitor-mode.md`, and Phase A/B/C agent templates; added `.claude/scripts/verify-exit-report-block.sh` to validate required `EXIT_REPORT` fields from stdin; recorded doc drift between GitHub issue test scenarios and authoritative rules.

Closes #162

## Test plan

- [x] Ran `verify-exit-report-block.sh` on Phase A/B/C canonical template blocks (all exit 0); incomplete sample exits 1
- [x] Cross-checked Phase B 6-step and Phase C numbered protocols in `phase-protocols.md` against issue AC
- [x] Confirmed monitor loop steps 1–2 precede heartbeat (step 4) in `monitor-mode.md`
- [x] Confirmed post-compaction recovery step 4 mentions pending transitions in `monitor-mode.md`
- [x] Test report committed at `.claude/reference/issue-162-phase-protocol-verification.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e9997a5-9a63-49de-8847-063aae2ed6ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e9997a5-9a63-49de-8847-063aae2ed6ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add static checks for exit reports and document phase protocol verification**

### What Changed
- Added a script that checks an `EXIT_REPORT` block for the required fields before it is accepted.
- The checker now works on older macOS Bash and rejects malformed spacing in the report lines.
- Added a verification log covering exit report parsing, Phase B and Phase C protocol order, monitor loop priority, and post-compaction recovery rules.
- Updated the reference README to point to the new verification log.

### Impact
`✅ Fewer invalid exit reports`
`✅ Clearer phase handoff checks`
`✅ Easier review of protocol rules`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=lOpsMbVmljIWJfXudJNa-c2Za2bESBcBVFoUCMRqDVU&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
