### PR TITLE
docs(prompt): per-block model label inside each tilde-fenced prompt

### DIFF
--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -231,7 +231,7 @@ Rationale: {1-line explanation of why this tier was selected, citing the dominan
 
 **OUTPUT MUST USE `~~~` FENCES, NOT BACKTICKS.** The opening and closing lines of every per-issue prompt block must be exactly `~~~`.
 
-**Map `issue_tier` to `{MODEL}` (per issue, for the block header line only):**
+**Map tier to `{MODEL}` string** (same Heavy / Standard / Light → model mapping for both the batch **Tier Recommendation** line and each per-issue `**Model:**` line — use **batch tier** for Tier Recommendation and **per-issue `issue_tier`** for each block):
 - **Heavy** → `Opus 4.7 (1M context)`
 - **Standard** → `Opus 4.7`
 - **Light** → `Sonnet 4.6`

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -164,7 +164,7 @@ When `PM_AUTO_DETECT=true`, partition the classified issues into two groups usin
 | `file_count` | 0–1 |
 | `ac_count` | ≤ 3 |
 
-| `dependency_count` | 0 (count only dependencies referencing or referenced by this specific issue, not the batch total) |
+| `dependency_count_per_issue` | 0 (count only dependencies referencing or referenced by this specific issue, not the batch total) |
 
 | `touches_rules` | `false` |
 | `touches_claude_md` | `false` |

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -12,6 +12,8 @@ Analyze one or more GitHub issues, classify complexity, and produce a copy-paste
 
 **MANDATORY OUTPUT FORMAT:** Every per-issue prompt block MUST open and close with `~~~` tilde fences. NEVER use backtick fences as the outer prompt-block delimiter.
 
+**Per-block model label (mandatory):** The first content inside each tilde-fenced block (immediately after the opening `~~~`) MUST be a single line: `**Model:** {MODEL} — {REASON}` where `{MODEL}` is the model string for **that issue's** `issue_tier` (from Step 5 — not the batch tier), and `{REASON}` is a concise task-type phrase of **at most 10 words** derived from that issue's signals (dominant drivers such as rules/CLAUDE.md, orchestration, file count, AC count, skills, dependencies, or scope keywords). The label must be **inside** the tilde fence so a pasted block is self-explanatory without surrounding prose.
+
 ## Step 0: Parse Arguments and Detect Context
 
 Parse `$ARGUMENTS` as space-separated issue references. Strip `#` prefixes to get bare issue numbers.
@@ -195,7 +197,7 @@ When `PM_AUTO_DETECT=true` and Step 5.5 produced a non-empty subagent-eligible g
 
 If all issues are subagent-eligible, skip the Tier Recommendation and prompt blocks entirely — only output the Subagent Candidates section. If no issues are subagent-eligible (or `PM_AUTO_DETECT` is not `true`), skip the Subagent Candidates section entirely.
 
-For single-issue input, there is one prompt block. For batch input, there are multiple prompt blocks, each independently copyable (i.e., self-contained with all context; this does not imply each block has its own tier). All blocks in a batch share the batch-level tier, so an individually Light issue's block may include Heavy-tier checkpoints when the batch tier is Heavy. **Batch tier is computed from thread-prompt issues only** — subagent candidates do not influence the batch tier.
+For single-issue input, there is one prompt block. For batch input, there are multiple prompt blocks, each independently copyable (i.e., self-contained with all context). **Per-issue `issue_tier`** drives the **Model** line at the top of that issue's block (each block can differ in a batch). **Batch tier** (from thread-prompt issues only) still drives the global **Tier Recommendation** prose and whether **Protocol Checkpoints** appear inside each block — when the batch tier is Heavy, include Heavy checkpoints in every thread-prompt block even if that issue's `issue_tier` is Light. **Batch tier is computed from thread-prompt issues only** — subagent candidates do not influence the batch tier.
 
 **Fence nesting rule:** MUST use tilde fences (`~~~`) for all outer prompt blocks. Do NOT use backtick fences as outer delimiters. Inner code examples (bash commands, SQL, file paths, etc.) may use the standard three backtick characters because a `~~~`-delimited outer block is not closed by inner backticks; this keeps each full prompt block copyable as one unit in renderers that mishandle nested backtick fences.
 
@@ -229,9 +231,17 @@ Rationale: {1-line explanation of why this tier was selected, citing the dominan
 
 **OUTPUT MUST USE `~~~` FENCES, NOT BACKTICKS.** The opening and closing lines of every per-issue prompt block must be exactly `~~~`.
 
+**Map `issue_tier` to `{MODEL}` (per issue, for the block header line only):**
+- **Heavy** → `Opus 4.7 (1M context)`
+- **Standard** → `Opus 4.7`
+- **Light** → `Sonnet 4.6`
+
+**`{REASON}` construction:** Choose a short phrase (≤10 words) that names the main complexity driver for **this issue alone** — e.g. touches `.claude/rules`, touches `CLAUDE.md`, orchestration keywords, dependency web, many files from the CR plan, high `ac_count`, skill paths, multi-file feature work, or Light-scope keywords. Do not copy the batch Tier Recommendation rationale into every block when reasons differ per issue.
+
 Then, for each issue, output a self-contained prompt block. Use tilde fences (`~~~`, shown here as the outer boundary):
 
 ~~~
+**Model:** Opus 4.7 — skill change with many acceptance checks
 ### Issue #{NUMBER}: {TITLE}
 
 **Acceptance Criteria:**
@@ -348,6 +358,7 @@ For an issue with `touches_skill=true` and `ac_count=4`, the skill emits the Tie
 The prompt block that follows:
 
 ~~~
+**Model:** Opus 4.7 — skill file with multiple acceptance criteria
 ### Issue #110: {Title}
 
 **Acceptance Criteria:**


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `/prompt` skill (`.claude/skills/prompt/SKILL.md`) so every copy-paste tilde-fenced block starts with **`**Model:** {model} — {reason}`** on the first line inside the fence. The model string comes from **per-issue `issue_tier`** (Heavy / Standard / Light → Opus 4.7 (1M) / Opus 4.7 / Sonnet 4.6). The reason is **≤10 words** and must reflect that issue’s dominant signals, not the batch-level tier. Batch tier still drives the standalone **Tier Recommendation** section and **Protocol Checkpoints** inclusion when the batch is Heavy.

Closes #412

## Test plan

- [x] Skill text requires the model line as the first line inside each `~~~` block
- [x] Per-issue vs batch tier behavior documented (model from `issue_tier`; checkpoints from batch tier when Heavy)
- [x] Sample multi-issue `/prompt` output below shows **different** model lines per block

## Sample `/prompt #412 #1` (illustrative)

After this change, an agent following the skill would emit blocks along these lines (issue #1 = Heavy-class split work; #412 = Standard-class skill output change):

~~~
**Model:** Opus 4.7 (1M context) — CLAUDE.md and rules restructuring
### Issue #1: Split CLAUDE.md into .claude/rules/ for better adherence
…
~~~

~~~
**Model:** Opus 4.7 — skill output format with three acceptance checks
### Issue #412: prompt: label model + reason at the top of each copy-paste prompt block
…
~~~

(CodeRabbit CLI was not available in this environment; `coderabbit review --prompt-only` was not run locally.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8d43979-e7bb-4e21-bb7b-2abf100566cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8d43979-e7bb-4e21-bb7b-2abf100566cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add per-block model labels to prompt output and clarify tier handling**

### What Changed
- Each copy-paste prompt block now starts with a `**Model:** {MODEL} — {REASON}` line inside the tilde fence, so the block is self-explanatory when pasted on its own
- The model shown in each block now comes from that issue’s tier, while the overall batch tier still controls the top-level Tier Recommendation and whether heavy checkpoints are included
- The prompt guide now uses a clearer per-issue dependency label to avoid mixing up single-issue and batch-wide dependency counts

### Impact
`✅ Clearer copy-paste prompt blocks`
`✅ Correct model labels for mixed-issue batches`
`✅ Fewer tier and dependency mix-ups`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=P-B8LZ9xwpRi9iqqNkTfkmEtcHZoF2LPUzivMHQ6SNE&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
