### PR TITLE
merge-gate: CodeAnt APPROVED on HEAD satisfies CR path (#408)

### DIFF
--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -22,6 +22,7 @@ The merge gate depends on which reviewer owns the PR:
 **CR path** (neither BugBot nor Greptile was triggered — `merge-gate.sh` reviewer `cr`):
 
 - **Gate:** at least one of: **CodeRabbit** (`coderabbitai[bot]`) or **CodeAnt** (`codeant-ai[bot]`) with `state: "APPROVED"` and `commit_id == current HEAD SHA`. Either bot satisfies the primary review; you do not need both when only one reviewed.
+- **Routing (live scan):** CodeAnt or CodeRabbit in PR history → CR path; cursor-only → BugBot (`merge-gate.sh`, `reviewer-of.sh`).
 - **SHA freshness:** stale approvals do not count (wrong `commit_id`); re-trigger `@coderabbitai full review` or `@codeant-ai review` for the bot that must refresh, subject to the rate cap, and keep polling.
 - **Retraction:** a newer same-SHA `CHANGES_REQUESTED` from the **same** bot retracts that bot's earlier `APPROVED` until findings are fixed, pushed, and re-approved (same rule as legacy CR-only, evaluated per bot).
 - **Not approvals:**

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -9,7 +9,7 @@
 
 Stop polling ONLY when one current-HEAD review path below is satisfied:
 
-1. **CR:** explicit clean `APPROVED` on current HEAD **and** CodeAnt clean when CodeAnt has participated on that SHA (`codeant-graphite.md`, `merge-gate.sh`).
+1. **CR path:** explicit clean `APPROVED` from **CodeRabbit** (`coderabbitai[bot]`) **or** **CodeAnt** (`codeant-ai[bot]`) on current HEAD, same SHA-freshness and same-SHA retraction rules as legacy CR-only; **and** when CodeAnt has participated on that SHA, CodeAnt clean per supplemental rule (`codeant-graphite.md`, `merge-gate.sh`).
 2. **BugBot:** clean BugBot pass on current HEAD.
 3. **Greptile:** severity gate passed.
 
@@ -19,11 +19,11 @@ Stop polling ONLY when one current-HEAD review path below is satisfied:
 
 The merge gate depends on which reviewer owns the PR:
 
-**CR-only path** (neither BugBot nor Greptile was triggered):
+**CR path** (neither BugBot nor Greptile was triggered — `merge-gate.sh` reviewer `cr`):
 
-- **Gate:** 1 CR review with `state: "APPROVED"` and `commit_id == current HEAD SHA`.
-- **SHA freshness:** stale approvals do not count; re-trigger `@coderabbitai full review` subject to the rate cap and keep polling.
-- **Retraction:** a newer same-SHA `CHANGES_REQUESTED` retracts an earlier `APPROVED` until findings are fixed, pushed, and re-approved.
+- **Gate:** at least one of: **CodeRabbit** (`coderabbitai[bot]`) or **CodeAnt** (`codeant-ai[bot]`) with `state: "APPROVED"` and `commit_id == current HEAD SHA`. Either bot satisfies the primary review; you do not need both when only one reviewed.
+- **SHA freshness:** stale approvals do not count (wrong `commit_id`); re-trigger `@coderabbitai full review` or `@codeant-ai review` for the bot that must refresh, subject to the rate cap, and keep polling.
+- **Retraction:** a newer same-SHA `CHANGES_REQUESTED` from the **same** bot retracts that bot's earlier `APPROVED` until findings are fixed, pushed, and re-approved (same rule as legacy CR-only, evaluated per bot).
 - **Not approvals:**
   - The "Actions performed — Full review triggered" ack comment (review started, not finished).
   - "0 unresolved threads right now" without an APPROVED review on the current SHA.

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -2,8 +2,8 @@
 # merge-gate.sh — Verify the merge gate for a PR (CR / BugBot / Greptile / CodeAnt).
 #
 # Implements the authoritative gate defined in .claude/rules/cr-merge-gate.md:
-#   - CR path       : 1 explicit CodeRabbit APPROVED on current HEAD SHA + green
-#                     CodeRabbit check-run (SHA freshness + retraction enforced).
+#   - CR path       : 1 explicit CodeRabbit OR CodeAnt APPROVED on current HEAD SHA
+#                     (SHA freshness + same-SHA retraction per bot, same rules as legacy CR-only).
 #                     CodeAnt is supplemental: when CodeAnt participated on that SHA,
 #                     require CodeAnt APPROVED or a successful CodeAnt check-run;
 #                     CodeAnt CHANGES_REQUESTED blocks only if newer than the latest
@@ -13,7 +13,7 @@
 # Also enforces the pre-merge CI gate from .claude/rules/cr-merge-gate.md Step 1b
 # (incomplete runs OR blocking conclusions = not merge-ready), merge metadata
 # (mergeStateStatus including BEHIND, mergeable including CONFLICTING) per
-# cr-merge-gate.md Step 1d / issue #273. When CR or Greptile is listed
+# cr-merge-gate.md Step 1d / issue #273. When CR, Greptile, or CodeAnt is listed
 # in CODEOWNERS, also verifies GitHub branch protection's reviewDecision is
 # APPROVED so stale/dismissed bot approvals cannot accidentally pass the gate.
 #
@@ -434,11 +434,20 @@ case "$REVIEWER" in
       CA_APPROVAL_VALID=true
     fi
 
-    if [[ "$CR_APPROVAL_VALID" != true ]]; then
-      if [[ "$CR_RETRACTED" == true ]]; then
-        MISSING+=("CR approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger")
-      else
-        MISSING+=("need 1 explicit CodeRabbit APPROVED review on HEAD ${HEAD_SHA:0:7} (have $TOTAL_CR_ON_HEAD CR review(s) on this SHA)")
+    PRIMARY_REVIEW_MET=false
+    if [[ "$CR_APPROVAL_VALID" == true || "$CA_APPROVAL_VALID" == true ]]; then
+      PRIMARY_REVIEW_MET=true
+    fi
+
+    if [[ "$PRIMARY_REVIEW_MET" != true ]]; then
+      if [[ "$CR_RETRACTED" == true && "$CA_APPROVAL_VALID" != true ]]; then
+        MISSING+=("CodeRabbit approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger @coderabbitai full review")
+      fi
+      if [[ "$CA_RETRACTED" == true && "$CR_APPROVAL_VALID" != true ]]; then
+        MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger @codeant-ai review")
+      fi
+      if [[ "$CR_RETRACTED" != true && "$CA_RETRACTED" != true ]]; then
+        MISSING+=("need 1 explicit CodeRabbit or CodeAnt APPROVED review on HEAD ${HEAD_SHA:0:7} (have $TOTAL_CR_ON_HEAD CodeRabbit, $TOTAL_CA_ON_HEAD CodeAnt review(s) on this SHA)")
       fi
     fi
 

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -24,7 +24,8 @@
 # Reviewer resolution order (unless --reviewer is passed):
 #   1. ~/.claude/session-state.json  .prs["<N>"].reviewer  ("cr"/"bugbot"/"greptile"/"g")
 #   2. Live history scan — greptile-apps[bot] present → greptile;
-#      cursor[bot] present AND coderabbitai[bot] absent → bugbot; else cr.
+#      cursor[bot] present AND coderabbitai[bot] absent AND codeant-ai[bot] absent
+#      → bugbot; else cr (CodeAnt-only reviews use the CR path per #408).
 #      (BugBot auto-triggers on every push, so both bots are present on normal
 #      CR-owned PRs. The absence check ensures the live scan defaults to cr;
 #      CR→BugBot escalation is tracked via session-state, not the live scan.)
@@ -302,10 +303,12 @@ resolve_reviewer() {
   if echo "$authors" | grep -q '^greptile-apps\[bot\]$'; then
     echo "greptile"; return
   fi
-  # Only return bugbot when cursor[bot] is the sole reviewer — if coderabbitai[bot]
-  # is also present, CR is the primary reviewer (BugBot auto-triggers on every push).
+  # Only return bugbot when cursor[bot] is the sole AI reviewer — if coderabbitai[bot]
+  # or codeant-ai[bot] is present, use the CR path (BugBot auto-triggers on every push).
   # CR→BugBot escalation is tracked via session-state, not the live scan.
-  if echo "$authors" | grep -q '^cursor\[bot\]$' && ! echo "$authors" | grep -q '^coderabbitai\[bot\]$'; then
+  if echo "$authors" | grep -q '^cursor\[bot\]$' \
+    && ! echo "$authors" | grep -q '^coderabbitai\[bot\]$' \
+    && ! echo "$authors" | grep -q '^codeant-ai\[bot\]$'; then
     echo "bugbot"; return
   fi
   echo "cr"

--- a/.claude/scripts/reviewer-of.sh
+++ b/.claude/scripts/reviewer-of.sh
@@ -34,8 +34,8 @@
 #   2. Live history — collect distinct `user.login` values across the three
 #      endpoints (pulls/reviews, pulls/comments, issues/comments, paginated):
 #        • greptile-apps[bot] present → greptile
-#        • cursor[bot] present AND coderabbitai[bot] absent → bugbot
-#        • coderabbitai[bot] present → cr
+#        • cursor[bot] present AND coderabbitai[bot] absent AND codeant-ai[bot] absent → bugbot
+#        • coderabbitai[bot] or codeant-ai[bot] present → cr
 #        • else → unknown (exit 1)
 #      Matches the resolve_reviewer() logic in merge-gate.sh.
 #
@@ -353,19 +353,21 @@ done
 AUTHORS="$(sort -u "$AUTHORS_TMP")"
 
 # Detection priority matches merge-gate.sh resolve_reviewer(): greptile wins
-# over anything else (sticky); bugbot only when cursor is the sole reviewer
-# (CR+cursor means CR is primary — BugBot auto-triggers on every push);
-# otherwise cr if CR has any activity.
+# over anything else (sticky); bugbot only when cursor is the sole AI reviewer
+# among CR-path bots (CodeAnt without CodeRabbit still uses the cr path — #408);
+# otherwise cr if CodeRabbit or CodeAnt has activity.
 if printf '%s\n' "$AUTHORS" | grep -q '^greptile-apps\[bot\]$'; then
   printf '%s\n' "greptile"
   exit 0
 fi
 if printf '%s\n' "$AUTHORS" | grep -q '^cursor\[bot\]$' \
-   && ! printf '%s\n' "$AUTHORS" | grep -q '^coderabbitai\[bot\]$'; then
+   && ! printf '%s\n' "$AUTHORS" | grep -q '^coderabbitai\[bot\]$' \
+   && ! printf '%s\n' "$AUTHORS" | grep -q '^codeant-ai\[bot\]$'; then
   printf '%s\n' "bugbot"
   exit 0
 fi
-if printf '%s\n' "$AUTHORS" | grep -q '^coderabbitai\[bot\]$'; then
+if printf '%s\n' "$AUTHORS" | grep -q '^coderabbitai\[bot\]$' \
+   || printf '%s\n' "$AUTHORS" | grep -q '^codeant-ai\[bot\]$'; then
   printf '%s\n' "cr"
   exit 0
 fi


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`merge-gate.sh` now treats an explicit `codeant-ai[bot]` `APPROVED` review on the current PR head SHA as satisfying the primary review requirement on the CR path (OR with CodeRabbit), using the same `commit_id == HEAD` freshness and per-bot same-SHA retraction logic as CodeRabbit. Missing-review messages name **CodeRabbit** vs **CodeAnt** when reporting retraction or “need approval” gaps.

**Reviewer routing (#408 follow-up):** The live scan now picks the CR path when **either** `coderabbitai[bot]` **or** `codeant-ai[bot]` appears in PR activity (mirrored in `reviewer-of.sh`). Previously, `cursor[bot]` + absence of CodeRabbit incorrectly selected BugBot, making CodeAnt-only approvals unreachable. Same one-line routing note added under Step 1 in `cr-merge-gate.md`.

Closes #408

## Test plan

- [x] `merge-gate.sh` accepts CodeAnt (`codeant-ai[bot]`) `APPROVED` on current HEAD SHA as satisfying the primary review path (same SHA rule as CR; OR with CodeRabbit)
- [x] CodeAnt approval on a stale SHA does not count; same-SHA CodeAnt `CHANGES_REQUESTED` after `APPROVED` is treated as retraction with a CodeAnt-named message
- [x] Script output names CodeAnt (not “CR”) when the gap/retraction is CodeAnt-specific
- [x] CodeRabbit-only path unchanged when `CA_APPROVAL_VALID` is false (still requires `CR_APPROVAL_VALID`)
- [x] Live reviewer scan routes CodeAnt-only PRs to `cr` path (not BugBot)
- [x] `cr-merge-gate.md` documents CodeAnt as an accepted reviewer on the CR path + routing

## Verification

- `bash -n .claude/scripts/merge-gate.sh` `reviewer-of.sh`
- `.github/scripts/rule-lint.sh` (OK)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a519389e-906c-45f3-86a0-d9fa123c4cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a519389e-906c-45f3-86a0-d9fa123c4cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Count CodeAnt approvals toward the CR merge path**

### What Changed
- PRs with CodeAnt activity now stay on the CR path instead of being misrouted to BugBot
- A current-head approval from either CodeRabbit or CodeAnt can now satisfy the main CR review requirement
- If the same bot later requests changes on that same SHA, its earlier approval is treated as retracted
- Merge-gate messages and docs now name CodeRabbit or CodeAnt directly when approval is missing or retracted

### Impact
`✅ Fewer PRs stuck on the wrong review path`
`✅ Fewer merge blocks for CodeAnt-approved changes`
`✅ Clearer approval and retraction messages`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=SMcgbvzN_Br9a8rHOXD4wR-0onI_CI5AOxmjwR8aVNI&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
