### PR TITLE
fix(hooks): reduce stale-worktree false positives for claude/* branches

### DIFF
--- a/.claude/hooks/stale-worktree-warn.sh
+++ b/.claude/hooks/stale-worktree-warn.sh
@@ -76,6 +76,12 @@ branch_issue = branch_match.group(1) if branch_match else ""
 if branch_issue and branch_issue in issue_matches:
     empty()
 
+# Desktop / SDK session worktrees often use `claude/<adjective>-<name>-<hash>` with no
+# issue token in the branch name. That is not evidence of a stale harness worktree —
+# only warn when the branch actually encodes a different issue than the prompt.
+if not branch_issue and re.match(r"^claude/", branch):
+    empty()
+
 prompt_issue = issue_matches[0]
 
 if branch_issue:
@@ -84,9 +90,10 @@ else:
     mismatch = f"current branch '{branch}' does not include issue #{prompt_issue}"
 
 message = (
-    "STALE WORKTREE CHECK: STOP before making edits: "
-    f"{mismatch}. Return to the root repo, sync main, and create a fresh "
-    "issue-matching worktree. See CLAUDE.md 'ALWAYS USE A WORKTREE'."
+    "Worktree / issue mismatch (review before editing): "
+    f"{mismatch}. If you meant this issue, sync main and use a branch named "
+    "`issue-<N>-...` in a linked worktree, or continue here only if this branch "
+    "is intentional. See CLAUDE.md 'ALWAYS USE A WORKTREE'."
 )
 
 print(json.dumps({

--- a/.claude/hooks/tests/stale-worktree-warn.test.sh
+++ b/.claude/hooks/tests/stale-worktree-warn.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Integration tests for stale-worktree-warn.sh (issue #411).
+# Builds a temp repo with two linked worktrees; does not modify the real repo.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK="$REPO_ROOT/.claude/hooks/stale-worktree-warn.sh"
+
+hook_payload() {
+  local cwd="$1"
+  local prompt="$2"
+  python3 -c "import json,sys; print(json.dumps({'cwd': sys.argv[1], 'prompt': sys.argv[2]}))" "$cwd" "$prompt" | "$HOOK"
+}
+
+additional_context() {
+  python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('hookSpecificOutput',{}).get('additionalContext',''))"
+}
+
+TMP_BASE="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_BASE"; }
+trap cleanup EXIT
+
+BARE="$TMP_BASE/bare.git"
+MAIN_WT="$TMP_BASE/main-wt"
+LINKED="$TMP_BASE/linked-wt"
+CLAUDE_WT="$TMP_BASE/claude-wt"
+
+git init --bare "$BARE" >/dev/null
+git clone "$BARE" "$MAIN_WT" >/dev/null
+git -C "$MAIN_WT" config user.email "test@example.com"
+git -C "$MAIN_WT" config user.name "Test"
+echo test >"$MAIN_WT/README.md"
+git -C "$MAIN_WT" add README.md
+git -C "$MAIN_WT" commit -m init >/dev/null
+git -C "$MAIN_WT" push origin HEAD:main >/dev/null
+
+git -C "$MAIN_WT" worktree add -b issue-424-demo "$LINKED" >/dev/null
+git -C "$MAIN_WT" worktree add -b claude/xenodochial-brahmagupta-fce5a4 "$CLAUDE_WT" >/dev/null
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Linked worktree + issue branch + prompt same issue -> no warning
+out="$(hook_payload "$LINKED" 'Fix for #424')"
+ctx="$(echo "$out" | additional_context)"
+[[ -z "$ctx" ]] || fail "expected no warning on issue-424 branch with #424 prompt, got: $out"
+
+# Linked worktree + issue branch + prompt different issue -> warning
+out="$(hook_payload "$LINKED" 'Work on issue #411')"
+ctx="$(echo "$out" | additional_context)"
+[[ -n "$ctx" ]] || fail "expected warning on issue-424 branch with #411 prompt"
+echo "$ctx" | grep -q "issue #424" || fail "message should mention branch issue: $ctx"
+echo "$ctx" | grep -q "issue #411" || fail "message should mention prompt issue: $ctx"
+
+# SDK-style claude/* branch + prompt with issue -> no false positive (no issue token in branch)
+out="$(hook_payload "$CLAUDE_WT" 'Implement #424 acceptance criteria')"
+ctx="$(echo "$out" | additional_context)"
+[[ -z "$ctx" ]] || fail "expected no warning on claude/* branch without issue token, got: $ctx"
+
+# Non-issue branch (not claude/*) + prompt issue -> still warn
+git -C "$MAIN_WT" worktree add -b feature/misc "$TMP_BASE/misc-wt" >/dev/null
+out="$(hook_payload "$TMP_BASE/misc-wt" 'See #424')"
+ctx="$(echo "$out" | additional_context)"
+[[ -n "$ctx" ]] || fail "expected warning on feature/misc with #424 prompt"
+
+echo "OK: stale-worktree-warn integration tests passed"

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -1,0 +1,25 @@
+name: Hook scripts
+
+on:
+  pull_request: {}
+
+permissions:
+  contents: read
+
+jobs:
+  hook-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure git (worktree tests)
+        run: |
+          git config --global user.email "ci@example.com"
+          git config --global user.name "CI"
+
+      - name: stale-worktree-warn integration test
+        run: bash .claude/hooks/tests/stale-worktree-warn.test.sh
+
+      - name: env-guard unit tests
+        run: python3 -m unittest tests.test_env_guard -v

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -39,6 +39,7 @@ RUN git clone --bare /workspace /opt/origin-bare.git \
 
 # Make scripts executable
 RUN chmod +x setup.sh setup-skills-worktree.sh tests/test-setup.sh \
+    .claude/hooks/tests/stale-worktree-warn.test.sh \
     && if [ -d .claude/hooks ]; then find .claude/hooks -name '*.sh' -exec chmod +x {} +; fi
 
 ENTRYPOINT ["bash", "tests/test-setup.sh"]


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #411.

**Root cause:** `stale-worktree-warn.sh` extracts issue numbers from the user prompt and compares them to an issue id parsed from the current branch (`issue-<N>` segment only). Branches like `claude/xenodochial-brahmagupta-fce5a4` carry no `issue-*` token, so `branch_issue` is empty and the hook always treated that as “branch does not include issue #424” — a **false positive** when the session is legitimately on a Desktop/SDK auto worktree while the prompt references a GitHub issue.

**Fix:** If the branch has no embedded issue number and matches `claude/*`, exit with no warning (SDK/Desktop session worktrees are not evidence of a stale harness-linked `issue-N-*` worktree). Real mismatches still warn when the branch **does** encode a different issue (e.g. `issue-424-*` vs prompt `#411`).

**Copy:** Replaced “STOP” / “STALE WORKTREE CHECK” with softer “review before editing” language so models are less likely to treat `additionalContext` as a hard halt.

## Claude Code / worktree naming (investigation)

Upstream Claude Code continues to evolve worktree branch naming (e.g. GitHub discussions around `worktree-*` vs `claude/` prefixes and configurable prefixes). Desktop commonly uses `claude/<descriptor>-<hash>` style branches. Waiting only on Anthropic would leave users blocked on false positives; the hook-side guard is low risk and reversible if naming changes again.

**Tradeoffs**

| Option | Pros | Cons |
|--------|------|------|
| **Hook fix (this PR)** | Stops FP for documented `claude/*` pattern; preserves mismatch detection when `issue-*` is present | If someone works on issue #424 on `claude/foo` and should have been on `issue-424-*`, the hook no longer nags (intentional: we cannot infer issue from `claude/*`) |
| **Wait for app** | No repo change | FPs continue; app may never encode issue numbers in branch names |

## Test plan

- [x] Linked worktree on `issue-424-*` + prompt `#424` → no warning
- [x] Linked worktree on `issue-424-*` + prompt `#411` → warning (mismatch)
- [x] Linked worktree on `claude/xenodochial-brahmagupta-fce5a4` + prompt `#424` → no warning (FP case from #411)
- [x] Linked worktree on `feature/misc` + prompt `#424` → warning (unchanged for non-`claude/*` without issue token)
- [x] `bash .claude/hooks/tests/stale-worktree-warn.test.sh` passes locally
- [x] `python3 -m unittest tests.test_env_guard -v` passes (CI workflow includes this for regression signal)

## Reproduction (before fix)

On a secondary linked worktree whose branch is `claude/xenodochial-brahmagupta-fce5a4`, submit a prompt containing `#424`. The hook previously emitted `additionalContext` claiming the branch did not include issue 424.

## After fix

Same scenario produces `{}` (no `additionalContext`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97a6712b-9dbf-47de-9d5a-2ea76b8b5614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97a6712b-9dbf-47de-9d5a-2ea76b8b5614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Reduce false worktree warnings for Claude session branches**

### What Changed
- Stops showing a stale-worktree warning for `claude/*` branches when the branch does not contain an issue number, so Desktop/SDK sessions are no longer flagged by mistake
- Keeps warning for real mismatches when a branch does include a different issue number, and softens the message so it reads as a review hint instead of a hard stop
- Adds integration coverage for matching, mismatched, and `claude/*` branch cases, and runs the hook test in CI

### Impact
`✅ Fewer false stale-worktree warnings`
`✅ Clearer guidance when a branch and prompt point to different issues`
`✅ Safer hook changes with CI coverage`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=FrDu8Sld096WSmjPuTRZaTMqkHTIHAaJ84YsRZzPKrI&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
