### PR TITLE
feat: merge-conflict skill (#409)

### DIFF
--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -529,9 +529,9 @@ jq -r '.merge_state | "[MERGE] mergeable=\(.mergeable), status=\(.mergeStateStat
 
 | Field | Blocking value | Action |
 |-------|---------------|--------|
-| `mergeable` | `CONFLICTING` | Rebase onto main: `git fetch origin main && git rebase origin/main`. Fix conflicts, continue, force-push. |
+| `mergeable` | `CONFLICTING` | Rebase onto main: `git fetch origin main && git rebase origin/main`. Fix conflicts (optionally run **`/merge-conflict`** — `.claude/skills/merge-conflict/SKILL.md` — to fetch main, auto-resolve *simple* hunks, stage clean files, and list *complex* hunks), continue, force-push. |
 | `mergeable` | `UNKNOWN` | GitHub still computing — note and re-run `/fixpr` later. |
-| `mergeStateStatus` | `BEHIND` | Rebase onto main: `git fetch origin main && git rebase origin/main`. If conflicts arise mid-rebase (replaying commits individually can conflict even when a three-way merge wouldn't), resolve them the same way as `CONFLICTING` above, then `git rebase --continue`. Force-push. Wait for CI to re-run before verifying merge gate. |
+| `mergeStateStatus` | `BEHIND` | Rebase onto main: `git fetch origin main && git rebase origin/main`. If conflicts arise mid-rebase (replaying commits individually can conflict even when a three-way merge wouldn't), resolve them the same way as `CONFLICTING` above (including optional **`/merge-conflict`**), then `git rebase --continue`. Force-push. Wait for CI to re-run before verifying merge gate. |
 | `mergeStateStatus` | `BLOCKED` | Required checks/reviews missing — already covered by 5c/5d. If CodeRabbit, Greptile, or CodeAnt is in CODEOWNERS and the last approval is stale/dismissed after a push, recover by triggering that bot (`@coderabbitai full review`, `@greptileai`, or `@codeant-ai review`) instead of escalating to the author. |
 | `mergeStateStatus` | `UNSTABLE` | A non-required check pending/failing — typically CR/Greptile on the new SHA. If 5d emitted `REVIEW_PENDING`, stop with that status. |
 | `reviewDecision` | `CHANGES_REQUESTED` | Changes were requested. If the requester is a bot, process findings through this skill; if a human requested changes, report it as non-automatable. |

--- a/.claude/skills/merge-conflict/SKILL.md
+++ b/.claude/skills/merge-conflict/SKILL.md
@@ -82,23 +82,11 @@ For **mixed** files (some simple, some complex): simple hunks are written into t
 3. **Do not edit** complex hunks in this pass unless the user explicitly asks for a proposal-only suggestion — the skill’s contract is report-first.
 4. Tell the user the exact **next git commands** based on state:
    - Mid-merge: `git status` → if all conflicts cleared, `git commit` (merge) or continue as their workflow dictates.
-   - Mid-rebase: fix remaining files → `git add` each → `git rebase --continue` (or `git merge --continue`).
+   - Mid-rebase: fix remaining files → `git add` each → `git rebase --continue`.
 
 ## Global symlink (after the skill is on `main`)
 
-Per `.claude/rules/skill-symlinks.md`:
-
-1. Merge the PR so `.claude/skills/merge-conflict/` exists on `main`.
-2. Refresh the skills worktree and symlink:
-
-```bash
-mkdir -p "$HOME/.claude/skills"
-git -C "$HOME/.claude/skills-worktree" fetch origin main --quiet
-git -C "$HOME/.claude/skills-worktree" reset --hard origin/main --quiet
-ln -sfn "$HOME/.claude/skills-worktree/.claude/skills/merge-conflict" "$HOME/.claude/skills/merge-conflict"
-```
-
-Or run `bash "$(git rev-parse --show-toplevel)/setup-skills-worktree.sh"` from the repo root, which symlinks **all** skills including new ones.
+See `.claude/rules/skill-symlinks.md` or run `setup-skills-worktree.sh` from the repo root — it symlinks all skills automatically.
 
 ## Smoke test (for PR / manual verification)
 

--- a/.claude/skills/merge-conflict/SKILL.md
+++ b/.claude/skills/merge-conflict/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: merge-conflict
+description: Classify merge/rebase conflicts against main, auto-resolve safe (simple) hunks and stage clean files, and report complex hunks for human judgment. Does not commit.
+---
+
+Resolve **local** merge conflicts while reconciling with **latest `origin/main`**. Safe to run **mid-merge** (`git merge` in progress) or **mid-rebase** (`git rebase` stopped on a conflict): the script only reads unmerged paths and the working tree.
+
+## When to use
+
+- After `git merge origin/main` or `git rebase origin/main` stops on conflicts.
+- From **`/fixpr`** when `mergeStateStatus` / `mergeable` indicates conflicts — run this skill **before** hand-editing every file (see cross-link in `.claude/skills/fixpr/SKILL.md` Step 6).
+
+## Hard rules
+
+1. **`git fetch origin main` first** — always refresh main before inspecting conflicts (the helper does this unless `--skip-fetch`).
+2. **Do not `git commit`** — only **`git add`** paths that are fully marker-free after simple resolution. The caller continues merge/rebase or commits separately.
+3. **When in doubt, complex** — the resolver is intentionally conservative; anything ambiguous stays in the file with conflict markers and appears in the report.
+
+## Mechanical step (script)
+
+Locate and run the resolver (skills worktree, home copy, or in-repo):
+
+```bash
+SCRIPT=""
+for candidate in \
+  "$HOME/.claude/skills-worktree/.claude/skills/merge-conflict/resolve_merge_conflicts.py" \
+  ".claude/skills/merge-conflict/resolve_merge_conflicts.py"; do
+  if [[ -f "$candidate" ]]; then
+    SCRIPT="$candidate"
+    break
+  fi
+done
+if [[ -z "$SCRIPT" ]]; then
+  echo "ERROR: resolve_merge_conflicts.py not found" >&2
+  exit 1
+fi
+
+python3 "$SCRIPT" --repo "$(git rev-parse --show-toplevel)"
+EXIT=$?
+# Optional: machine-readable summary for automation
+# python3 "$SCRIPT" --repo "$(git rev-parse --show-toplevel)" --json
+```
+
+- Exit **0** — no complex hunks reported **and** every unmerged path became fully resolved and staged (rare on first pass if conflicts were only simple).
+- Exit **1** — complex hunks, parse/binary skips, or partial resolution; read stdout/stderr and the optional `--json` payload.
+- Exit **2** — not a git repository.
+
+## What the script does
+
+1. `git fetch origin main` (unless `--skip-fetch`).
+2. Lists conflicted files: `git diff --name-only --diff-filter=U`.
+3. For each **text** file, parses `<<<<<<<` / `=======` / `>>>>>>>` hunks and classifies each hunk:
+
+### Simple (auto-resolved)
+
+Applied in the working tree and, if **all** hunks in that file are simple, the file is **`git add`**’d:
+
+- Whole hunk identical after trimming trailing whitespace on each line (`_rstrip_lines`).
+- Same number of non-blank lines in order with only **per-line trailing** whitespace differences.
+- Identical non-blank line sequences (`o_nb == t_nb`) after the stricter checks above.
+- **One-sided empty** + other side is **only** import lines matching conservative `import` / `from … import` (Python) or `import … from '…'` (JS/TS) heuristics.
+- Both sides empty.
+
+### Complex (report only — markers preserved)
+
+- Any differing **non-blank** semantics (different line counts or content where rules above do not apply).
+- **Incoming empty, current non-empty** (deletion vs keep — risky).
+- **Nested conflict markers** inside a hunk body.
+- **Binary** files (detected via NUL in early bytes).
+- Non-regular paths (missing file, submodule quirks) — reported, not edited.
+
+For **mixed** files (some simple, some complex): simple hunks are written into the working tree; **complex hunks stay**. Those files are **not** staged (Git still sees conflicts until you finish the rest manually).
+
+## AI layer after the script
+
+1. Print the **human summary** from the script (or pretty-print `--json`).
+2. For each **complex** entry: confirm **file path**, **line range / labels**, and **why** (use the script’s `reason` verbatim; add context only if you open the file and can cite the two sides briefly).
+3. **Do not edit** complex hunks in this pass unless the user explicitly asks for a proposal-only suggestion — the skill’s contract is report-first.
+4. Tell the user the exact **next git commands** based on state:
+   - Mid-merge: `git status` → if all conflicts cleared, `git commit` (merge) or continue as their workflow dictates.
+   - Mid-rebase: fix remaining files → `git add` each → `git rebase --continue` (or `git merge --continue`).
+
+## Global symlink (after the skill is on `main`)
+
+Per `.claude/rules/skill-symlinks.md`:
+
+1. Merge the PR so `.claude/skills/merge-conflict/` exists on `main`.
+2. Refresh the skills worktree and symlink:
+
+```bash
+mkdir -p "$HOME/.claude/skills"
+git -C "$HOME/.claude/skills-worktree" fetch origin main --quiet
+git -C "$HOME/.claude/skills-worktree" reset --hard origin/main --quiet
+ln -sfn "$HOME/.claude/skills-worktree/.claude/skills/merge-conflict" "$HOME/.claude/skills/merge-conflict"
+```
+
+Or run `bash "$(git rev-parse --show-toplevel)/setup-skills-worktree.sh"` from the repo root, which symlinks **all** skills including new ones.
+
+## Smoke test (for PR / manual verification)
+
+In a throwaway branch:
+
+```bash
+git fetch origin main
+git checkout -B mc-smoke-test "origin/main"
+echo base > /tmp/mc-a.txt && cp /tmp/mc-a.txt conflict-demo.txt && git add conflict-demo.txt && git commit -m "base"
+git checkout -B mc-smoke-side HEAD~0 2>/dev/null || true
+# create parallel commits that conflict trivially (whitespace) then merge --no-commit
+# … or paste conflict markers and `git add` then mark unmerged via merge state
+```
+
+Minimal local simulation: create `demo.txt` with a single **simple** conflict (identical text with trailing space on one side), run `git add -N` / merge plumbing is heavy — easier: use two branches and `git merge --no-ff` with edits. **Practical smoke:** run `python3 .claude/skills/merge-conflict/resolve_merge_conflicts.py --skip-fetch --json` in a repo with `git diff --name-only --diff-filter=U` non-empty after a deliberate conflict; confirm `staged` lists files with only simple hunks.

--- a/.claude/skills/merge-conflict/SKILL.md
+++ b/.claude/skills/merge-conflict/SKILL.md
@@ -49,7 +49,11 @@ EXIT=$?
 
 1. `git fetch origin main` (unless `--skip-fetch`).
 2. Lists conflicted files: `git diff --name-only --diff-filter=U`.
-3. For each **text** file, parses `<<<<<<<` / `=======` / `>>>>>>>` hunks and classifies each hunk:
+3. For each **text** file, parses `<<<<<<<` / `=======` / `>>>>>>>` hunks and classifies each hunk (see Simple / Complex below).
+
+**Unmerged but no markers:** Some conflicts (e.g. modify/delete) leave the path unmerged without injecting `<<<<<<<` lines. Those paths are listed in **`complex_report`** with an explicit reason so they are not silent skips.
+
+**Encoding:** Files are read with UTF-8 + `surrogateescape` so non-UTF-8 bytes do not crash parsing; writes use the same so simple resolutions do not raise `UnicodeEncodeError`.
 
 ### Simple (auto-resolved)
 

--- a/.claude/skills/merge-conflict/resolve_merge_conflicts.py
+++ b/.claude/skills/merge-conflict/resolve_merge_conflicts.py
@@ -203,7 +203,7 @@ def resolve_file(path: Path, text: str) -> FileResult:
         new_text = "\n".join(out_parts)
         if text.endswith("\n") and new_text and not new_text.endswith("\n"):
             new_text += "\n"
-        path.write_text(new_text, encoding="utf-8", newline="")
+        write_repo_text(path, new_text)
         fr.wrote = True
 
     return fr
@@ -228,6 +228,16 @@ def unmerged_paths(repo: Path) -> list[str]:
 
 def is_binary_bytes(b: bytes) -> bool:
     return b"\x00" in b[:8192]
+
+
+def read_repo_text(path: Path) -> str:
+    """Decode worktree file bytes the same way as conflict reads (non-UTF8 safe)."""
+    return path.read_bytes().decode("utf-8", errors="surrogateescape")
+
+
+def write_repo_text(path: Path, text: str) -> None:
+    """Write text so bytes round-trip with read_repo_text (avoids UnicodeEncodeError on surrogates)."""
+    path.write_bytes(text.encode("utf-8", errors="surrogateescape"))
 
 
 def main() -> int:
@@ -303,9 +313,19 @@ def main() -> int:
             continue
 
         if not fr.hunks:
+            complex_report.append(
+                {
+                    "file": rel,
+                    "location": "entire file",
+                    "reason": (
+                        "unmerged path has no inline conflict markers (<<<<<<< / ======= / >>>>>>>); "
+                        "resolve with git checkout --ours/--theirs, manual merge, or your merge tool, then git add"
+                    ),
+                }
+            )
             continue
 
-        still_has_markers = "<<<<<<< " in p.read_text(encoding="utf-8", errors="replace")
+        still_has_markers = "<<<<<<< " in read_repo_text(p)
 
         for h, cls, _ in fr.hunks:
             if cls == "complex":
@@ -320,7 +340,7 @@ def main() -> int:
 
         if not still_has_markers:
             fully.append(rel)
-        elif fr.wrote and before != p.read_text(encoding="utf-8", errors="replace"):
+        elif fr.wrote and before != read_repo_text(p):
             partial.append(rel)
 
     staged: list[str] = []

--- a/.claude/skills/merge-conflict/resolve_merge_conflicts.py
+++ b/.claude/skills/merge-conflict/resolve_merge_conflicts.py
@@ -49,7 +49,13 @@ class FileResult:
 def _lines(s: str) -> list[str]:
     if not s:
         return []
-    return s.splitlines()
+    result = s.splitlines()
+    # splitlines() treats a trailing newline as a terminator and omits the
+    # resulting empty element.  Restore it so that a trailing blank line in a
+    # hunk body is not silently dropped during resolution.
+    if s.endswith(("\n", "\r")):
+        result.append("")
+    return result
 
 
 def _non_blank_lines(s: str) -> list[str]:
@@ -58,6 +64,11 @@ def _non_blank_lines(s: str) -> list[str]:
 
 def _rstrip_lines(s: str) -> str:
     return "\n".join(ln.rstrip() for ln in _lines(s))
+
+
+def _detect_newline(text: str) -> str:
+    """Return the line-ending convention used in *text* ('\\r\\n' or '\\n')."""
+    return "\r\n" if "\r\n" in text else "\n"
 
 
 def _has_nested_markers(chunk: str) -> bool:
@@ -166,6 +177,7 @@ def iter_conflicts(lines: list[str]) -> Iterable[ConflictHunk]:
 
 def resolve_file(path: Path, text: str) -> FileResult:
     fr = FileResult(path=str(path))
+    newline = _detect_newline(text)
     lines = text.splitlines()
     try:
         hunks = list(iter_conflicts(lines))
@@ -202,8 +214,10 @@ def resolve_file(path: Path, text: str) -> FileResult:
 
     if any_simple or not had_complex:
         new_text = "\n".join(out_parts)
-        if text.endswith("\n") and new_text and not new_text.endswith("\n"):
-            new_text += "\n"
+        if newline == "\r\n":
+            new_text = new_text.replace("\n", "\r\n")
+        if text.endswith(newline) and new_text and not new_text.endswith(newline):
+            new_text += newline
         write_repo_text(path, new_text)
         fr.wrote = True
 
@@ -220,10 +234,11 @@ def git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
-def unmerged_paths(repo: Path) -> list[str]:
+def unmerged_paths(repo: Path) -> list[str] | None:
     p = git(["diff", "--name-only", "--diff-filter=U"], repo)
     if p.returncode != 0:
-        return []
+        print(f"ERROR: git diff --diff-filter=U failed: {p.stderr.strip()}", file=sys.stderr)
+        return None
     return [ln.strip() for ln in p.stdout.splitlines() if ln.strip()]
 
 
@@ -260,6 +275,8 @@ def main() -> int:
             print(f"WARN: git fetch origin main failed: {f.stderr.strip()}", file=sys.stderr)
 
     paths = unmerged_paths(repo)
+    if paths is None:
+        return 1
     if not paths:
         summary = {
             "unmerged_paths": [],

--- a/.claude/skills/merge-conflict/resolve_merge_conflicts.py
+++ b/.claude/skills/merge-conflict/resolve_merge_conflicts.py
@@ -98,22 +98,23 @@ def classify_and_resolve(ours: str, theirs: str) -> tuple[str, str | None, str]:
     if _rstrip_lines(ours) == _rstrip_lines(theirs):
         return "simple", _rstrip_lines(ours), ""
 
+    if o_nb == t_nb:
+        # Identical non-blank line sequence; preserve blank-line structure from theirs
+        return "simple", _rstrip_lines(theirs), ""
+
     if len(o_nb) == len(t_nb) and all(
         a.rstrip() == b.rstrip() for a, b in zip(o_nb, t_nb)
     ):
         # Per-line trailing whitespace only (non-blank lines align in order)
         return "simple", "\n".join(b.rstrip() for b in t_nb), ""
 
-    if o_nb == t_nb:
-        # Identical non-blank line sequence; whole-block whitespace handled above
-        return "simple", _rstrip_lines(theirs), ""
-
     o_empty = not o_nb
     t_empty = not t_nb
 
     if o_empty and not t_empty:
         if _all_import_lines(t_nb):
-            return "simple", theirs.rstrip("\n") + ("\n" if theirs.endswith("\n") else ""), ""
+            # No trailing newline: resolve_file joins out_parts with "\n" between elements
+            return "simple", theirs.rstrip("\n"), ""
         return "complex", None, "one side empty, other side has non-import content (possible deletion vs addition)"
 
     if t_empty and not o_empty:

--- a/.claude/skills/merge-conflict/resolve_merge_conflicts.py
+++ b/.claude/skills/merge-conflict/resolve_merge_conflicts.py
@@ -106,7 +106,7 @@ def classify_and_resolve(ours: str, theirs: str) -> tuple[str, str | None, str]:
         a.rstrip() == b.rstrip() for a, b in zip(o_nb, t_nb)
     ):
         # Per-line trailing whitespace only (non-blank lines align in order)
-        return "simple", "\n".join(b.rstrip() for b in t_nb), ""
+        return "simple", _rstrip_lines(theirs), ""
 
     o_empty = not o_nb
     t_empty = not t_nb

--- a/.claude/skills/merge-conflict/resolve_merge_conflicts.py
+++ b/.claude/skills/merge-conflict/resolve_merge_conflicts.py
@@ -363,9 +363,18 @@ def main() -> int:
             partial.append(rel)
 
     staged: list[str] = []
+    stage_failed = False
     for rel in fully:
         g = git(["add", "--", rel], repo)
         if g.returncode != 0:
+            stage_failed = True
+            complex_report.append(
+                {
+                    "file": rel,
+                    "location": "git add",
+                    "reason": g.stderr.strip() or "git add failed",
+                }
+            )
             print(f"WARN: git add failed for {rel}: {g.stderr}", file=sys.stderr)
         else:
             staged.append(rel)
@@ -396,7 +405,7 @@ def main() -> int:
                 print(f"  - {item['file']}: {item['location']}")
                 print(f"    why: {item['reason']}")
 
-    exit_ok = not complex_report and len(fully) == len(paths)
+    exit_ok = not complex_report and not stage_failed and len(staged) == len(paths)
     return 0 if exit_ok else 1
 
 

--- a/.claude/skills/merge-conflict/resolve_merge_conflicts.py
+++ b/.claude/skills/merge-conflict/resolve_merge_conflicts.py
@@ -40,8 +40,8 @@ class ConflictHunk:
 @dataclass
 class FileResult:
     path: str
-    hunks: list[tuple[ConflictHunk, str, str | None]] = field(default_factory=list)
-    # (hunk, classification, resolved_body or None if complex)
+    hunks: list[tuple[ConflictHunk, str, str | None, str]] = field(default_factory=list)
+    # (hunk, classification, resolved_body or None if complex, reason)
     error: str | None = None
     wrote: bool = False
 
@@ -195,8 +195,8 @@ def resolve_file(path: Path, text: str) -> FileResult:
         while line_idx < h.start_line - 1:
             out_parts.append(lines[line_idx])
             line_idx += 1
-        cls, resolved, _reason = classify_and_resolve(h.body_ours, h.body_theirs)
-        fr.hunks.append((h, cls, resolved))
+        cls, resolved, reason = classify_and_resolve(h.body_ours, h.body_theirs)
+        fr.hunks.append((h, cls, resolved, reason))
         if cls == "simple" and resolved is not None:
             any_simple = True
             if resolved != "":
@@ -345,9 +345,8 @@ def main() -> int:
 
         still_has_markers = "<<<<<<< " in read_repo_text(p)
 
-        for h, cls, _ in fr.hunks:
+        for h, cls, _, reason in fr.hunks:
             if cls == "complex":
-                _c, _r, reason = classify_and_resolve(h.body_ours, h.body_theirs)
                 complex_report.append(
                     {
                         "file": rel,

--- a/.claude/skills/merge-conflict/resolve_merge_conflicts.py
+++ b/.claude/skills/merge-conflict/resolve_merge_conflicts.py
@@ -49,13 +49,7 @@ class FileResult:
 def _lines(s: str) -> list[str]:
     if not s:
         return []
-    result = s.splitlines()
-    # splitlines() treats a trailing newline as a terminator and omits the
-    # resulting empty element.  Restore it so that a trailing blank line in a
-    # hunk body is not silently dropped during resolution.
-    if s.endswith(("\n", "\r")):
-        result.append("")
-    return result
+    return s.splitlines()
 
 
 def _non_blank_lines(s: str) -> list[str]:
@@ -64,6 +58,14 @@ def _non_blank_lines(s: str) -> list[str]:
 
 def _rstrip_lines(s: str) -> str:
     return "\n".join(ln.rstrip() for ln in _lines(s))
+
+
+def _normalize_hunk(s: str) -> str:
+    """Rstrip each line; preserve a trailing blank line if the input ends with a newline."""
+    result = "\n".join(ln.rstrip() for ln in s.splitlines())
+    if s.endswith(("\n", "\r\n")) and result:
+        result += "\n"
+    return result
 
 
 def _detect_newline(text: str) -> str:
@@ -107,17 +109,17 @@ def classify_and_resolve(ours: str, theirs: str) -> tuple[str, str | None, str]:
     t_nb = _non_blank_lines(theirs)
 
     if _rstrip_lines(ours) == _rstrip_lines(theirs):
-        return "simple", _rstrip_lines(ours), ""
+        return "simple", _normalize_hunk(theirs), ""
 
     if o_nb == t_nb:
         # Identical non-blank line sequence; preserve blank-line structure from theirs
-        return "simple", _rstrip_lines(theirs), ""
+        return "simple", _normalize_hunk(theirs), ""
 
     if len(o_nb) == len(t_nb) and all(
         a.rstrip() == b.rstrip() for a, b in zip(o_nb, t_nb)
     ):
         # Per-line trailing whitespace only (non-blank lines align in order)
-        return "simple", _rstrip_lines(theirs), ""
+        return "simple", _normalize_hunk(theirs), ""
 
     o_empty = not o_nb
     t_empty = not t_nb
@@ -210,7 +212,7 @@ def resolve_file(path: Path, text: str) -> FileResult:
         out_parts.append(lines[line_idx])
         line_idx += 1
 
-    had_complex = any(c == "complex" for _, c, _ in fr.hunks)
+    had_complex = any(c == "complex" for _, c, _, _ in fr.hunks)
 
     if any_simple or not had_complex:
         new_text = "\n".join(out_parts)

--- a/.claude/skills/merge-conflict/resolve_merge_conflicts.py
+++ b/.claude/skills/merge-conflict/resolve_merge_conflicts.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""
+Mechanical merge-conflict scan and conservative auto-resolution.
+
+Used by the /merge-conflict skill. When in doubt, leaves hunks untouched (complex).
+Does not commit — caller may git add resolved paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+CONFLICT_START = re.compile(r"^<<<<<<< (.+)$")
+CONFLICT_MID = re.compile(r"^=======\s*$")
+CONFLICT_END = re.compile(r"^>>>>>>> (.+)$")
+
+# Lines that look like pure imports (conservative: only these patterns are "simple" one-sided adds).
+_PY_IMPORT = re.compile(r"^\s*(from\s+\S+\s+import|import\s+\S+)")
+_JS_TS_IMPORT = re.compile(r"^\s*import\s+[\s\S]*\s+from\s+['\"]|^\s*import\s+['\"]")
+
+
+@dataclass
+class ConflictHunk:
+    label_ours: str
+    body_ours: str
+    body_theirs: str
+    label_theirs: str
+    start_line: int  # 1-based line of <<<<<<<
+    end_line: int  # 1-based line of >>>>>>>
+
+
+@dataclass
+class FileResult:
+    path: str
+    hunks: list[tuple[ConflictHunk, str, str | None]] = field(default_factory=list)
+    # (hunk, classification, resolved_body or None if complex)
+    error: str | None = None
+    wrote: bool = False
+
+
+def _lines(s: str) -> list[str]:
+    if not s:
+        return []
+    return s.splitlines()
+
+
+def _non_blank_lines(s: str) -> list[str]:
+    return [ln for ln in _lines(s) if ln.strip()]
+
+
+def _rstrip_lines(s: str) -> str:
+    return "\n".join(ln.rstrip() for ln in _lines(s))
+
+
+def _has_nested_markers(chunk: str) -> bool:
+    if "<<<<<<< " in chunk or ">>>>>>> " in chunk:
+        return True
+    for ln in _lines(chunk):
+        if ln.startswith("=======") and ln.strip() == "=======":
+            return True
+    return False
+
+
+def _all_import_lines(lines: Iterable[str]) -> bool:
+    for ln in lines:
+        t = ln.strip()
+        if not t:
+            continue
+        if t.startswith("#"):
+            return False
+        if _PY_IMPORT.match(ln) or _JS_TS_IMPORT.match(ln):
+            continue
+        return False
+    return True
+
+
+def classify_and_resolve(ours: str, theirs: str) -> tuple[str, str | None, str]:
+    """
+    Returns (classification, resolved_or_none, reason_if_complex).
+
+    classification is 'simple' or 'complex'.
+    resolved_or_none is merged body without markers when simple.
+    """
+    if _has_nested_markers(ours) or _has_nested_markers(theirs):
+        return "complex", None, "nested or embedded conflict markers inside hunk"
+
+    o_nb = _non_blank_lines(ours)
+    t_nb = _non_blank_lines(theirs)
+
+    if _rstrip_lines(ours) == _rstrip_lines(theirs):
+        return "simple", _rstrip_lines(ours), ""
+
+    if len(o_nb) == len(t_nb) and all(
+        a.rstrip() == b.rstrip() for a, b in zip(o_nb, t_nb)
+    ):
+        # Per-line trailing whitespace only (non-blank lines align in order)
+        return "simple", "\n".join(b.rstrip() for b in t_nb), ""
+
+    if o_nb == t_nb:
+        # Identical non-blank line sequence; whole-block whitespace handled above
+        return "simple", _rstrip_lines(theirs), ""
+
+    o_empty = not o_nb
+    t_empty = not t_nb
+
+    if o_empty and not t_empty:
+        if _all_import_lines(t_nb):
+            return "simple", theirs.rstrip("\n") + ("\n" if theirs.endswith("\n") else ""), ""
+        return "complex", None, "one side empty, other side has non-import content (possible deletion vs addition)"
+
+    if t_empty and not o_empty:
+        return "complex", None, "incoming side empty while current side has content (risky deletion)"
+
+    if o_empty and t_empty:
+        return "simple", "", ""
+
+    return "complex", None, "both sides have differing non-blank content (semantic or formatting beyond trailing space)"
+
+
+def iter_conflicts(lines: list[str]) -> Iterable[ConflictHunk]:
+    i = 0
+    n = len(lines)
+    while i < n:
+        m = CONFLICT_START.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        label_ours = m.group(1).strip()
+        start_line = i + 1
+        i += 1
+        o_buf: list[str] = []
+        while i < n and not CONFLICT_MID.match(lines[i]):
+            o_buf.append(lines[i])
+            i += 1
+        if i >= n:
+            raise ValueError(f"unterminated conflict (missing =======) starting line {start_line}")
+        i += 1  # skip =======
+        t_buf: list[str] = []
+        while i < n and not CONFLICT_END.match(lines[i]):
+            t_buf.append(lines[i])
+            i += 1
+        if i >= n:
+            raise ValueError(f"unterminated conflict (missing >>>>>>>) starting line {start_line}")
+        m_end = CONFLICT_END.match(lines[i])
+        label_theirs = m_end.group(1).strip() if m_end else ""
+        end_line = i + 1
+        i += 1
+        yield ConflictHunk(
+            label_ours=label_ours,
+            body_ours="\n".join(o_buf),
+            body_theirs="\n".join(t_buf),
+            label_theirs=label_theirs,
+            start_line=start_line,
+            end_line=end_line,
+        )
+
+
+def resolve_file(path: Path, text: str) -> FileResult:
+    fr = FileResult(path=str(path))
+    lines = text.splitlines()
+    try:
+        hunks = list(iter_conflicts(lines))
+    except ValueError as e:
+        fr.error = str(e)
+        return fr
+
+    if not hunks:
+        return fr
+
+    out_parts: list[str] = []
+    line_idx = 0
+    any_simple = False
+    for h in hunks:
+        while line_idx < h.start_line - 1:
+            out_parts.append(lines[line_idx])
+            line_idx += 1
+        cls, resolved, _reason = classify_and_resolve(h.body_ours, h.body_theirs)
+        fr.hunks.append((h, cls, resolved))
+        if cls == "simple" and resolved is not None:
+            any_simple = True
+            if resolved != "":
+                out_parts.append(resolved)
+        else:
+            for j in range(h.start_line - 1, h.end_line):
+                out_parts.append(lines[j])
+        line_idx = h.end_line
+
+    while line_idx < len(lines):
+        out_parts.append(lines[line_idx])
+        line_idx += 1
+
+    had_complex = any(c == "complex" for _, c, _ in fr.hunks)
+
+    if any_simple or not had_complex:
+        new_text = "\n".join(out_parts)
+        if text.endswith("\n") and new_text and not new_text.endswith("\n"):
+            new_text += "\n"
+        path.write_text(new_text, encoding="utf-8", newline="")
+        fr.wrote = True
+
+    return fr
+
+
+def git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def unmerged_paths(repo: Path) -> list[str]:
+    p = git(["diff", "--name-only", "--diff-filter=U"], repo)
+    if p.returncode != 0:
+        return []
+    return [ln.strip() for ln in p.stdout.splitlines() if ln.strip()]
+
+
+def is_binary_bytes(b: bytes) -> bool:
+    return b"\x00" in b[:8192]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Classify and partially resolve merge conflicts.")
+    ap.add_argument("--repo", type=Path, default=Path.cwd(), help="Git repository root")
+    ap.add_argument("--skip-fetch", action="store_true", help="Skip git fetch origin main (for tests/offline)")
+    ap.add_argument("--json", action="store_true", help="Print machine-readable JSON summary to stdout")
+    args = ap.parse_args()
+    repo = args.repo.resolve()
+
+    git_dir = repo / ".git"
+    if not git_dir.exists() and not git_dir.is_file():
+        print("ERROR: not a git repository (.git missing)", file=sys.stderr)
+        return 2
+
+    if not args.skip_fetch:
+        f = git(["fetch", "origin", "main"], repo)
+        if f.returncode != 0:
+            print(f"WARN: git fetch origin main failed: {f.stderr.strip()}", file=sys.stderr)
+
+    paths = unmerged_paths(repo)
+    if not paths:
+        summary = {
+            "unmerged_paths": [],
+            "fully_resolved": [],
+            "partially_resolved": [],
+            "complex_report": [],
+            "staged": [],
+        }
+        if args.json:
+            print(json.dumps(summary, indent=2))
+        else:
+            print("No unmerged paths (git diff --name-only --diff-filter=U is empty).")
+        return 0
+
+    fully: list[str] = []
+    partial: list[str] = []
+    complex_report: list[dict[str, object]] = []
+
+    for rel in paths:
+        p = repo / rel
+        if not p.is_file():
+            complex_report.append(
+                {
+                    "file": rel,
+                    "location": "skipped",
+                    "reason": "path is not a regular file (submodule, deleted, or missing)",
+                }
+            )
+            continue
+        raw = p.read_bytes()
+        if is_binary_bytes(raw):
+            complex_report.append(
+                {
+                    "file": rel,
+                    "location": "binary file",
+                    "reason": "binary merge conflict requires human merge tool",
+                }
+            )
+            continue
+        text = raw.decode("utf-8", errors="surrogateescape")
+        before = text
+        fr = resolve_file(p, text)
+
+        if fr.error:
+            complex_report.append(
+                {
+                    "file": rel,
+                    "location": "parse error",
+                    "reason": fr.error,
+                }
+            )
+            continue
+
+        if not fr.hunks:
+            continue
+
+        still_has_markers = "<<<<<<< " in p.read_text(encoding="utf-8", errors="replace")
+
+        for h, cls, _ in fr.hunks:
+            if cls == "complex":
+                _c, _r, reason = classify_and_resolve(h.body_ours, h.body_theirs)
+                complex_report.append(
+                    {
+                        "file": rel,
+                        "location": f"lines {h.start_line}-{h.end_line} (labels: {h.label_ours} / {h.label_theirs})",
+                        "reason": reason or "classified as complex",
+                    }
+                )
+
+        if not still_has_markers:
+            fully.append(rel)
+        elif fr.wrote and before != p.read_text(encoding="utf-8", errors="replace"):
+            partial.append(rel)
+
+    staged: list[str] = []
+    for rel in fully:
+        g = git(["add", "--", rel], repo)
+        if g.returncode != 0:
+            print(f"WARN: git add failed for {rel}: {g.stderr}", file=sys.stderr)
+        else:
+            staged.append(rel)
+
+    summary = {
+        "unmerged_paths": paths,
+        "fully_resolved": fully,
+        "partially_resolved": partial,
+        "complex_report": complex_report,
+        "staged": staged,
+    }
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print("=== merge-conflict ===")
+        print(f"Unmerged: {paths}")
+        if fully:
+            print(f"Fully resolved + staged: {fully}")
+        if partial:
+            print(
+                "Partially resolved (simple hunks applied in working tree; conflict markers remain): "
+                + ", ".join(partial)
+            )
+            print("  Complete the remaining hunks manually, then git add those paths.")
+        if complex_report:
+            print("Complex (human judgment):")
+            for item in complex_report:
+                print(f"  - {item['file']}: {item['location']}")
+                print(f"    why: {item['reason']}")
+
+    exit_ok = not complex_report and len(fully) == len(paths)
+    return 0 if exit_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .DS_Store
 
+# Python
+__pycache__/
+*.py[cod]
+
 # Runtime lock files
 .claude/scheduled_tasks.lock
 .claude/scheduled_tasks.json

--- a/tests/test_merge_conflict_resolve.py
+++ b/tests/test_merge_conflict_resolve.py
@@ -53,7 +53,8 @@ class ClassifyTests(unittest.TestCase):
         cls, resolved, _ = mod.classify_and_resolve(ours, theirs)
         self.assertEqual(cls, "simple")
         assert resolved is not None
-        self.assertIn("from x import y", resolved)
+        self.assertEqual(resolved, "from x import y\nimport z")
+        self.assertFalse(resolved.endswith("\n"))
 
     def test_empty_ours_non_import_complex(self) -> None:
         ours = ""
@@ -70,6 +71,15 @@ class ClassifyTests(unittest.TestCase):
         self.assertEqual(cls, "complex")
         self.assertIsNone(resolved)
         self.assertIn("incoming side empty", reason)
+
+    def test_identical_nonblank_sequence_preserves_blank_lines(self) -> None:
+        """o_nb == t_nb branch must run (not swallowed by per-line rstrip-only path)."""
+        ours = "a\n\nb\n"
+        theirs = "a\n\nb\n"
+        cls, resolved, _ = mod.classify_and_resolve(ours, theirs)
+        self.assertEqual(cls, "simple")
+        assert resolved is not None
+        self.assertEqual(resolved, "a\n\nb")
 
 
 class WriteRepoTextTests(unittest.TestCase):

--- a/tests/test_merge_conflict_resolve.py
+++ b/tests/test_merge_conflict_resolve.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Unit tests for merge-conflict resolve_merge_conflicts.py."""
+
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / ".claude" / "skills" / "merge-conflict" / "resolve_merge_conflicts.py"
+
+spec = importlib.util.spec_from_file_location("merge_conflict_resolve", SCRIPT)
+mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_identical_trailing_whitespace_simple(self) -> None:
+        ours = "foo  \nbar\n"
+        theirs = "foo\nbar\n"
+        cls, resolved, reason = mod.classify_and_resolve(ours, theirs)
+        self.assertEqual(cls, "simple")
+        self.assertIsNotNone(resolved)
+        assert resolved is not None
+        self.assertEqual(resolved, "foo\nbar")
+        self.assertEqual(reason, "")
+
+    def test_per_line_trailing_simple(self) -> None:
+        ours = "a \nb\n"
+        theirs = "a\nb \n"
+        cls, resolved, _ = mod.classify_and_resolve(ours, theirs)
+        self.assertEqual(cls, "simple")
+        assert resolved is not None
+        self.assertEqual(resolved, "a\nb")
+
+    def test_different_content_complex(self) -> None:
+        ours = "return 1\n"
+        theirs = "return 2\n"
+        cls, resolved, reason = mod.classify_and_resolve(ours, theirs)
+        self.assertEqual(cls, "complex")
+        self.assertIsNone(resolved)
+        self.assertIn("differing", reason)
+
+    def test_empty_ours_import_only_simple(self) -> None:
+        ours = ""
+        theirs = "from x import y\nimport z\n"
+        cls, resolved, _ = mod.classify_and_resolve(ours, theirs)
+        self.assertEqual(cls, "simple")
+        assert resolved is not None
+        self.assertIn("from x import y", resolved)
+
+    def test_empty_ours_non_import_complex(self) -> None:
+        ours = ""
+        theirs = "x = 1\n"
+        cls, resolved, reason = mod.classify_and_resolve(ours, theirs)
+        self.assertEqual(cls, "complex")
+        self.assertIsNone(resolved)
+        self.assertIn("non-import", reason)
+
+    def test_empty_theirs_complex(self) -> None:
+        ours = "keep me\n"
+        theirs = ""
+        cls, resolved, reason = mod.classify_and_resolve(ours, theirs)
+        self.assertEqual(cls, "complex")
+        self.assertIsNone(resolved)
+        self.assertIn("incoming side empty", reason)
+
+
+class ResolveFileTests(unittest.TestCase):
+    def test_writes_resolved_file(self) -> None:
+        content = (
+            "before\n"
+            "<<<<<<< HEAD\n"
+            "a  \n"
+            "=======\n"
+            "a\n"
+            ">>>>>>> branch\n"
+            "after\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            p = pathlib.Path(td) / "f.txt"
+            p.write_text(content, encoding="utf-8")
+            fr = mod.resolve_file(p, content)
+            self.assertTrue(fr.wrote)
+            self.assertEqual(len(fr.hunks), 1)
+            self.assertEqual(fr.hunks[0][1], "simple")
+            out = p.read_text(encoding="utf-8")
+            self.assertNotIn("<<<<<<<", out)
+            self.assertEqual(out, "before\na\nafter\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_merge_conflict_resolve.py
+++ b/tests/test_merge_conflict_resolve.py
@@ -2,7 +2,9 @@
 """Unit tests for merge-conflict resolve_merge_conflicts.py."""
 
 import importlib.util
+import json
 import pathlib
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -70,6 +72,18 @@ class ClassifyTests(unittest.TestCase):
         self.assertIn("incoming side empty", reason)
 
 
+class WriteRepoTextTests(unittest.TestCase):
+    def test_surrogateescape_round_trip(self) -> None:
+        """Non-UTF-8 file bytes must survive write after decode(read) with surrogateescape."""
+        with tempfile.TemporaryDirectory() as td:
+            p = pathlib.Path(td) / "latin1.txt"
+            p.write_bytes(b"caf\xe9\n")
+            text = mod.read_repo_text(p)
+            self.assertIn("\udce9", text)
+            mod.write_repo_text(p, text)
+            self.assertEqual(p.read_bytes(), b"caf\xe9\n")
+
+
 class ResolveFileTests(unittest.TestCase):
     def test_writes_resolved_file(self) -> None:
         content = (
@@ -91,6 +105,81 @@ class ResolveFileTests(unittest.TestCase):
             out = p.read_text(encoding="utf-8")
             self.assertNotIn("<<<<<<<", out)
             self.assertEqual(out, "before\na\nafter\n")
+
+    def test_non_utf8_simple_hunk_does_not_crash(self) -> None:
+        """Resolved output must re-encode when file has non-UTF-8 bytes outside the hunk."""
+        with tempfile.TemporaryDirectory() as td:
+            p = pathlib.Path(td) / "f.txt"
+            # Latin-1 é outside conflict; simple whitespace-only hunk inside
+            raw = (
+                b"caf\xe9\n"
+                b"<<<<<<< HEAD\n"
+                b"x  \n"
+                b"=======\n"
+                b"x\n"
+                b">>>>>>> branch\n"
+            )
+            p.write_bytes(raw)
+            text = raw.decode("utf-8", errors="surrogateescape")
+            fr = mod.resolve_file(p, text)
+            self.assertTrue(fr.wrote)
+            out = p.read_bytes()
+            self.assertTrue(out.startswith(b"caf\xe9\n"))
+            self.assertIn(b"x\n", out)
+            self.assertNotIn(b"<<<<<<<", out)
+
+
+class UnmergedNoMarkersIntegrationTests(unittest.TestCase):
+    def test_modify_delete_reported_in_complex(self) -> None:
+        """Unmerged paths without conflict markers appear in complex_report."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = pathlib.Path(td)
+            subprocess.run(["git", "init", "-b", "main", "-q"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "t@t"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+            (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+            subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "base"], cwd=repo, check=True)
+            subprocess.run(["git", "checkout", "-b", "other", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "rm", "-q", "tracked.txt"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "del"], cwd=repo, check=True)
+            subprocess.run(["git", "checkout", "main", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "checkout", "-b", "feature", "-q"], cwd=repo, check=True)
+            (repo / "tracked.txt").write_text("changed\n", encoding="utf-8")
+            subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "mod"], cwd=repo, check=True)
+            r = subprocess.run(
+                ["git", "merge", "other", "--no-commit"],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(r.returncode, 0)
+            self.assertIn("tracked.txt", r.stderr + r.stdout)
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--repo",
+                    str(repo),
+                    "--skip-fetch",
+                    "--json",
+                ],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 1)
+            data = json.loads(proc.stdout)
+            names = [str(x["file"]) for x in data["complex_report"]]
+            self.assertIn("tracked.txt", names)
+            reasons = " ".join(str(x["reason"]) for x in data["complex_report"])
+            self.assertIn("no inline conflict markers", reasons)
 
 
 if __name__ == "__main__":

--- a/tests/test_merge_conflict_resolve.py
+++ b/tests/test_merge_conflict_resolve.py
@@ -22,8 +22,8 @@ spec.loader.exec_module(mod)
 
 class ClassifyTests(unittest.TestCase):
     def test_identical_trailing_whitespace_simple(self) -> None:
-        ours = "foo  \nbar\n"
-        theirs = "foo\nbar\n"
+        ours = "foo  \nbar"
+        theirs = "foo\nbar"
         cls, resolved, reason = mod.classify_and_resolve(ours, theirs)
         self.assertEqual(cls, "simple")
         self.assertIsNotNone(resolved)
@@ -32,8 +32,8 @@ class ClassifyTests(unittest.TestCase):
         self.assertEqual(reason, "")
 
     def test_per_line_trailing_simple(self) -> None:
-        ours = "a \nb\n"
-        theirs = "a\nb \n"
+        ours = "a \nb"
+        theirs = "a\nb "
         cls, resolved, _ = mod.classify_and_resolve(ours, theirs)
         self.assertEqual(cls, "simple")
         assert resolved is not None
@@ -74,8 +74,8 @@ class ClassifyTests(unittest.TestCase):
 
     def test_identical_nonblank_sequence_preserves_blank_lines(self) -> None:
         """o_nb == t_nb branch must run (not swallowed by per-line rstrip-only path)."""
-        ours = "a\n\nb\n"
-        theirs = "a\n\nb\n"
+        ours = "a\nb"
+        theirs = "a\n\nb"
         cls, resolved, _ = mod.classify_and_resolve(ours, theirs)
         self.assertEqual(cls, "simple")
         assert resolved is not None


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the **`/merge-conflict`** skill (`.claude/skills/merge-conflict/SKILL.md`) and a mechanical helper `resolve_merge_conflicts.py` that:

- Runs `git fetch origin main` before inspecting conflicts (overridable with `--skip-fetch` for tests/offline).
- Enumerates unmerged paths via `git diff --name-only --diff-filter=U`.
- Classifies each conflict hunk as **simple** (conservative auto-resolve) vs **complex**.
- Writes simple resolutions with **UTF-8 + surrogateescape** round-trip (`read_repo_text` / `write_repo_text`) so non-UTF-8 text does not crash on write.
- **`git add`** only files with **no** remaining conflict markers.
- **`complex_report`** includes unmerged paths **without** `<<<<<<<` markers (e.g. modify/delete), parse errors, and binary files.
- Prints structured output for complex hunks. **No commit.**

Cross-links **`/fixpr`** Step 6 to this skill.

## Test plan

- [x] `python3 -m unittest discover -s tests -p 'test_*.py' -v` passes (includes `tests/test_merge_conflict_resolve.py`).
- [x] Script compiles (`python3 -m py_compile .claude/skills/merge-conflict/resolve_merge_conflicts.py`).
- [ ] After merge: symlink per `.claude/rules/skill-symlinks.md` (`setup-skills-worktree.sh` or `ln -sfn` to skills worktree).

## Smoke test (manual)

1. Create a branch with a trivial conflict (e.g. identical lines differing only in trailing spaces on one side).
2. Run: `python3 .claude/skills/merge-conflict/resolve_merge_conflicts.py --repo "$(git rev-parse --show-toplevel)"`.
3. Confirm fully resolved files appear in `git diff --cached --name-only` and complex hunks remain marked in the working tree with a clear stdout/json report.

Closes #409
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70d20af8-271d-4a8d-947d-62f6c57dd31b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70d20af8-271d-4a8d-947d-62f6c57dd31b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add a merge-conflict helper that auto-resolves safe hunks and reports the rest**

### What Changed
- Added a `/merge-conflict` workflow that refreshes `origin/main`, scans conflicted files, and auto-resolves only clearly safe conflict hunks.
- Cleanly resolved files are staged automatically; mixed files keep their remaining conflict markers and are reported for manual review.
- Conflicts that have no inline markers, binary files, and other risky cases now show up in the report instead of being skipped.
- Fixed conflict handling so files with non-UTF-8 text can still be processed, and simple resolutions no longer drop blank lines or add extra blank ones.
- `/fixpr` now points users to this conflict-resolution flow when merge conflicts block progress.

### Impact
`✅ Faster conflict resolution`
`✅ Fewer manual edits for simple merges`
`✅ Clearer reporting for tricky conflicts`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=SI6kvdOXHi0tjDRNFOQ1qPN6zsuvIHhVrCEyLvpHgYU&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
