### PR TITLE
feat(hooks): session-start nudge when first message lacks [#N] prefix

### DIFF
--- a/.claude/hooks/issue-prefix-nudge.sh
+++ b/.claude/hooks/issue-prefix-nudge.sh
@@ -3,7 +3,7 @@
 # When the first prompt does not start with a leading [#N] style token, injects
 # additionalContext pointing at CLAUDE.md. Non-blocking; always exits 0.
 #
-# Sentinel (per session, not in skills-worktree): ~/.claude/issue-prefix-nudge-first-<session_id>
+# Sentinel (per session): /tmp/issue-prefix-nudge-first-<session_id> — OS-managed cleanup.
 
 INPUT=$(cat 2>/dev/null || true)
 
@@ -13,10 +13,16 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 session_id=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
-session_id="${session_id:-${CLAUDE_SESSION_ID:-default}}"
+session_id="${session_id:-${CLAUDE_SESSION_ID:-}}"
 session_id="${session_id//[^[:alnum:]_.-]/_}"
 
-state_dir="${HOME}/.claude"
+# Without a session_id we cannot track "first message of this session" — skip nudge.
+if [[ -z "$session_id" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+state_dir="/tmp"
 sentinel="${state_dir}/issue-prefix-nudge-first-${session_id}"
 
 if [[ -f "$sentinel" ]]; then

--- a/.claude/hooks/issue-prefix-nudge.sh
+++ b/.claude/hooks/issue-prefix-nudge.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Issue prefix nudge — UserPromptSubmit hook (first user message per session only).
+# When the first prompt does not start with a leading [#N] style token, injects
+# additionalContext pointing at CLAUDE.md. Non-blocking; always exits 0.
+#
+# Sentinel (per session, not in skills-worktree): ~/.claude/issue-prefix-nudge-first-<session_id>
+
+INPUT=$(cat 2>/dev/null || true)
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo '{}'
+  exit 0
+fi
+
+session_id=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+session_id="${session_id:-${CLAUDE_SESSION_ID:-default}}"
+session_id="${session_id//[^[:alnum:]_.-]/_}"
+
+state_dir="${HOME}/.claude"
+sentinel="${state_dir}/issue-prefix-nudge-first-${session_id}"
+
+if [[ -f "$sentinel" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+mkdir -p "$state_dir" 2>/dev/null || true
+if ! touch "$sentinel" 2>/dev/null; then
+  echo '{}'
+  exit 0
+fi
+
+prompt=$(printf '%s' "$INPUT" | jq -r '(.prompt // .message // "") | tostring' 2>/dev/null) || prompt=""
+
+# Trim leading ASCII whitespace
+while [[ "$prompt" == [[:space:]]* ]]; do
+  prompt="${prompt#?}"
+done
+
+# Match CLAUDE.md: [#339] or [#339, #341] — leading [# then a digit
+if [[ "$prompt" =~ ^\[[#][0-9] ]]; then
+  echo '{}'
+  exit 0
+fi
+
+nudge='Optional thread title hint: start the first user message with a leading [#N] token (e.g. [#339] or [#339, #341]) so auto-summarized tab titles are likelier to include the issue. See CLAUDE.md "Thread title".'
+
+jq -n --arg msg "$nudge" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $msg
+  }
+}'
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Rule files in `.claude/rules/` auto-load alongside `CLAUDE.md` and define the de
 
 ## Hook Scripts
 
-Twelve hook scripts and hook utilities support Claude Code sessions:
+Thirteen hook scripts and hook utilities support Claude Code sessions:
 
 | Script | Event | Purpose |
 |--------|-------|---------|
@@ -190,6 +190,7 @@ Twelve hook scripts and hook utilities support Claude Code sessions:
 | `worktree-guard.sh` | PreToolUse (Write/Edit/NotebookEdit) | Blocks file edits in `claude-code-config` repo when root is on `main` |
 | `env-guard.py` | PreToolUse (Write/Edit/MultiEdit/NotebookEdit/Bash) | Blocks edits and shell writes to `.env` files that may contain secrets |
 | `timestamp-injector.sh` | UserPromptSubmit | Injects real system-clock Eastern timestamp context to prevent hallucinated dates |
+| `issue-prefix-nudge.sh` | UserPromptSubmit | On the first user message of a session only, nudges when the prompt lacks a leading `[#N]` issue prefix (see CLAUDE.md) |
 | `silence-detector.sh` | PostToolUse (all) | Warns if agent has been silent >5 minutes |
 | `silence-detector-ack.sh` | Stop | Resets the silence timer after each response |
 | `trust-flag-repair.sh` | Stop | Repairs trust flags in `~/.claude.json` for all projects |

--- a/global-settings.json
+++ b/global-settings.json
@@ -95,6 +95,11 @@
             "type": "command",
             "command": "/path/to/claude-code-config/.claude/hooks/stale-worktree-warn.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/issue-prefix-nudge.sh",
+            "timeout": 5
           }
         ]
       }

--- a/setup-skills-worktree.sh
+++ b/setup-skills-worktree.sh
@@ -213,6 +213,7 @@ HOOKS_MANIFEST=(
   $'PostToolUse\t\tsilence-detector.sh\t5'
   $'UserPromptSubmit\t\ttimestamp-injector.sh\t5'
   $'UserPromptSubmit\t\tstale-worktree-warn.sh\t30'
+  $'UserPromptSubmit\t\tissue-prefix-nudge.sh\t5'
 )
 
 SETTINGS_FILE="$HOME/.claude/settings.json"


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `UserPromptSubmit` hook `issue-prefix-nudge.sh` that runs **once per Claude session** (sentinel under `~/.claude/issue-prefix-nudge-first-<session_id>`). On the first user prompt, if the trimmed text does not start with `[#` followed by a digit (per CLAUDE.md thread-title convention), the hook emits **non-blocking** `additionalContext` suggesting the `[#N]` / `[#N, #M]` prefix.

## Test plan

- [x] **Without prefix:** First message in a new session is plain text → hook output includes `additionalContext` with the nudge.
- [x] **With prefix:** First message starts with `[#407]` (or similar) → hook returns `{}` (no nudge).
- [x] **Second message:** Same session, second message without prefix → still `{}` (sentinel prevents repeat).
- [x] `setup.sh` / drift check: `global-settings.json` entry matches `HOOKS_MANIFEST` in `setup-skills-worktree.sh`.

## Smoke test (local)

With isolated `HOME` and `CLAUDE_SESSION_ID`, stdin JSON `{"prompt":"hello","session_id":"..."}` produced nudge JSON once; second invocation returned `{}`. Session starting with `[#407] ...` returned `{}` on first and second message.

Closes #407
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c780e834-bf8f-42b7-be63-c37ad739b3fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c780e834-bf8f-42b7-be63-c37ad739b3fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
Nudge the first prompt in a session to include an issue number prefix

### What Changed
- The first user message in a session now shows a gentle hint when it does not start with a `[#N]` issue prefix
- The nudge appears only once per session and does not block sending the message
- If no session ID is available, the nudge is skipped instead of creating a permanent reminder file
- The reminder state is stored in a temporary location so it is cleaned up automatically

### Impact
`✅ Clearer thread titles`
`✅ Fewer missing issue references`
`✅ Less leftover session state`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=nwxwEG-3jJvJl39K2qzlAYzvqZoOhG6jTF8S-Tvaui0&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
