### PR TITLE
fix(pr-state): classify CR 'No actionable comments were generated' as acknowledgment

### DIFF
--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -257,12 +257,12 @@ CONVO=$(run_gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per
 #    in sync with the regex branches below.
 #
 #    Branch ordering in classify is deliberate — do NOT reorder without reading this:
-#      1. Explicit-resolution overrides (addressed marker, "actionable comments posted: 0")
-#         are checked FIRST. They mean CR has marked the thread resolved regardless of
-#         any quoted earlier finding language still in the body.
-#      2. The specific "actionable comments posted: 0" check MUST precede the general
-#         "actionable comments posted" finding check — otherwise the general pattern
-#         swallows the zero case and a clean CR summary gets misclassified as a finding.
+#      1. Explicit-resolution overrides (addressed marker, "actionable comments posted: 0",
+#         "no actionable comments were generated") are checked FIRST. They mean CR has
+#         marked the thread resolved regardless of any quoted earlier finding language.
+#      2. The specific "actionable comments posted: 0" and "no actionable comments were
+#         generated" checks MUST precede the general "actionable comments posted" finding
+#         check — otherwise the general pattern swallows clean CR summaries as findings.
 #      3. Finding patterns (severity/badges/phrases/suggestions) come next.
 #      4. Weak-ack fallback (lgtm variants) last, so it can't hide a real finding.
 #      5. Default is finding — under-classifying is the failure mode this skill prevents.
@@ -279,6 +279,7 @@ if [[ -n "$SINCE" ]]; then
       if . == null or . == "" then {class: "acknowledgment", reason: "empty body"}
       elif test("<!--\\s*<review_comment_addressed>\\s*-->"; "") then {class: "acknowledgment", reason: "addressed marker"}
       elif test("actionable comments posted:\\s*0\\b"; "i") then {class: "acknowledgment", reason: "CR reports zero actionable"}
+      elif test("no actionable comments were generated"; "i") then {class: "acknowledgment", reason: "CR no actionable comments generated"}
       elif test("\\b(critical|major|minor|nitpick|p[0-2])\\b"; "i") then {class: "finding", reason: "severity keyword"}
       elif test("🔴|🟠|🟡"; "") then {class: "finding", reason: "severity badge"}
       elif test("actionable comments posted"; "i") then {class: "finding", reason: "actionable phrase"}


### PR DESCRIPTION
## **User description**
## Summary

- CR's newer clean-pass format uses `"No actionable comments were generated in the recent review"` instead of `"actionable comments posted: 0"`
- The `classify` function in `pr-state.sh` only matched the old phrase, causing the new format to fall through to `default → finding` (false positive)
- Adds one `elif` branch for the newer phrase, ordered in the same tier as the existing zero-actionable check (before severity keywords)
- Updates the branch-ordering comment to document both phrases

## Test plan

- [x] `"No actionable comments were generated"` classifies as `acknowledgment` (verified via jq smoke test)
- [x] `"actionable comments posted: 0"` still classifies as `acknowledgment`
- [x] `"actionable comments posted: 3"` still classifies as `finding`
- [x] Local CR review: clean pass

Closes #424


___

## **CodeAnt-AI Description**
**Treat “No actionable comments were generated” as a clean review result**

### What Changed
- Review summaries that say “No actionable comments were generated” are now recognized as acknowledgment instead of a finding
- The existing “actionable comments posted: 0” clean-pass wording still counts as acknowledgment
- The rule notes now list both clean-pass phrases so clean reviews are checked before finding matches

### Impact
`✅ Fewer false review alerts`
`✅ Correct status for empty review passes`
`✅ Cleaner CR results for newer review wording`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=MI0kT-Vpbr4cdUNlxn7-3y3HZwkkZQgGT-msDiI8v88&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
