### PR TITLE
fix(pr-state): classify CR rate-limit and full-review ack as acknowledgment

### DIFF
--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -257,9 +257,10 @@ CONVO=$(run_gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per
 #    in sync with the regex branches below.
 #
 #    Branch ordering in classify is deliberate — do NOT reorder without reading this:
-#      1. Explicit-resolution overrides (addressed marker, "actionable comments posted: 0",
-#         "no actionable comments were generated") are checked FIRST. They mean CR has
-#         marked the thread resolved regardless of any quoted earlier finding language.
+#      1. Explicit-resolution / clean-pass overrides (addressed marker, "actionable comments posted: 0",
+#         "no actionable comments were generated", "rate limit exceeded", "full review triggered")
+#         are checked FIRST. They mean CR has marked the thread resolved, hit a rate-limit notice,
+#         or posted a review-started ack — regardless of any quoted earlier finding language.
 #      2. The specific "actionable comments posted: 0" and "no actionable comments were
 #         generated" checks MUST precede the general "actionable comments posted" finding
 #         check — otherwise the general pattern swallows clean CR summaries as findings.
@@ -280,6 +281,8 @@ if [[ -n "$SINCE" ]]; then
       elif test("<!--\\s*<review_comment_addressed>\\s*-->"; "") then {class: "acknowledgment", reason: "addressed marker"}
       elif test("actionable comments posted:\\s*0\\b"; "i") then {class: "acknowledgment", reason: "CR reports zero actionable"}
       elif test("no actionable comments were generated"; "i") then {class: "acknowledgment", reason: "CR no actionable comments generated"}
+      elif test("rate limit exceeded"; "i") then {class: "acknowledgment", reason: "rate limit notice"}
+      elif test("full review triggered"; "i") then {class: "acknowledgment", reason: "review-started ack"}
       elif test("\\b(critical|major|minor|nitpick|p[0-2])\\b"; "i") then {class: "finding", reason: "severity keyword"}
       elif test("🔴|🟠|🟡"; "") then {class: "finding", reason: "severity badge"}
       elif test("actionable comments posted"; "i") then {class: "finding", reason: "actionable phrase"}

--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -258,7 +258,8 @@ CONVO=$(run_gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per
 #
 #    Branch ordering in classify is deliberate — do NOT reorder without reading this:
 #      1. Explicit-resolution / clean-pass overrides (addressed marker, "actionable comments posted: 0",
-#         "no actionable comments were generated", "rate limit exceeded", "full review triggered")
+#         "no actionable comments were generated", "rate limit exceeded" / "rate-limited by coderabbit",
+#         "full review triggered")
 #         are checked FIRST. They mean CR has marked the thread resolved, hit a rate-limit notice,
 #         or posted a review-started ack — regardless of any quoted earlier finding language.
 #      2. The specific "actionable comments posted: 0" and "no actionable comments were
@@ -281,7 +282,7 @@ if [[ -n "$SINCE" ]]; then
       elif test("<!--\\s*<review_comment_addressed>\\s*-->"; "") then {class: "acknowledgment", reason: "addressed marker"}
       elif test("actionable comments posted:\\s*0\\b"; "i") then {class: "acknowledgment", reason: "CR reports zero actionable"}
       elif test("no actionable comments were generated"; "i") then {class: "acknowledgment", reason: "CR no actionable comments generated"}
-      elif test("rate limit exceeded"; "i") then {class: "acknowledgment", reason: "rate limit notice"}
+      elif test("rate limit exceeded|rate-limited by coderabbit"; "i") then {class: "acknowledgment", reason: "rate limit notice"}
       elif test("full review triggered"; "i") then {class: "acknowledgment", reason: "review-started ack"}
       elif test("\\b(critical|major|minor|nitpick|p[0-2])\\b"; "i") then {class: "finding", reason: "severity keyword"}
       elif test("🔴|🟠|🟡"; "") then {class: "finding", reason: "severity badge"}

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -445,7 +445,7 @@ jq -r '
    - HTML marker `<!-- <review_comment_addressed> -->` → `acknowledgment`
    - `actionable comments posted: 0` → `acknowledgment`. This specific zero-count pattern MUST be checked before the general `actionable comments posted` pattern below — otherwise the general finding pattern would swallow the zero case.
    - `no actionable comments were generated` → `acknowledgment`
-   - `rate limit exceeded` → `acknowledgment`
+   - `rate limit exceeded` or `rate-limited by coderabbit` → `acknowledgment`
    - `full review triggered` → `acknowledgment`
 2. **Finding patterns**:
    - Severity keywords `\b(critical|major|minor|nitpick|p[0-2])\b` or badges `🔴|🟠|🟡`

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -441,9 +441,12 @@ jq -r '
 
 **Classification rules** (these live in `pr-state.sh`; the list below is the contract — keep the two in sync if either changes). Patterns are checked in this order; first match wins:
 
-1. **Explicit-resolution overrides** (checked first — these signals mean CR has already marked the thread addressed, so they win even if the body still contains finding language from a quoted earlier review):
+1. **Explicit-resolution / clean-pass overrides** (checked first — these signals mean CR has already marked the thread addressed, posted a rate-limit notice, or posted a review-started ack, so they win even if the body still contains finding language from a quoted earlier review):
    - HTML marker `<!-- <review_comment_addressed> -->` → `acknowledgment`
    - `actionable comments posted: 0` → `acknowledgment`. This specific zero-count pattern MUST be checked before the general `actionable comments posted` pattern below — otherwise the general finding pattern would swallow the zero case.
+   - `no actionable comments were generated` → `acknowledgment`
+   - `rate limit exceeded` → `acknowledgment`
+   - `full review triggered` → `acknowledgment`
 2. **Finding patterns**:
    - Severity keywords `\b(critical|major|minor|nitpick|p[0-2])\b` or badges `🔴|🟠|🟡`
    - Actionable phrases: `actionable comments posted` (non-zero), `issues? found`, `findings?:`, `potential[_ ]issue`


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the `classify` jq function in `.claude/scripts/pr-state.sh` so PR bot comments whose bodies include CodeRabbit rate-limit text or a full-review trigger acknowledgment are counted as **acknowledgments** (same tier as other clean-pass overrides), ordered **before** severity and finding patterns so they short-circuit correctly.

Updates the classification contract in `.claude/skills/fixpr/SKILL.md` Step 5b to stay in sync with the script.

## Test plan

- [x] Comment body containing `Rate limit exceeded` classifies as `acknowledgment`
- [x] Comment body containing `Full review triggered` classifies as `acknowledgment`
- [x] Existing ack and finding patterns unaffected (smoke-tested: zero actionable, actionable count, severity keyword)

Closes #427.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa2c3a31-0d1c-400c-afc8-c913ba9ad2ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa2c3a31-0d1c-400c-afc8-c913ba9ad2ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
Treat CodeRabbit rate-limit and review-start messages as acknowledgments

### What Changed
- CodeRabbit comments that mention a rate limit or a full review being triggered are now treated as acknowledgments instead of findings
- Comments saying no actionable items were generated still count as acknowledgments, and the matching rules are kept in sync with the review-state guide
- The new matching order prevents quoted finding text from overriding these clean-pass messages

### Impact
`✅ Fewer false review findings`
`✅ Clearer PR bot status`
`✅ More reliable review-state checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=fjYxTme3S6LkDDbgCSJEVDkwQWAR3M7RhT6-dxUHXAM&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
