### PR TITLE
docs: /wrap and /merge merge authorization explicit override (#435)

### DIFF
--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -1,8 +1,8 @@
 # Merge Gate & Pre-Merge Verification
 
 > **This is the single authoritative definition of the merge gate.** All other rule files reference this file instead of duplicating it.
-> **Always:** Verify merge gate before any merge. Verify CI. Verify AC checkboxes against code. Ask user before merging **(except `/wrap` / `/merge`, which skip the extra merge prompt after gate+AC)**.
-> **Ask first:** Merging — always ask the user (except `/wrap`/`/merge`; Step 3).
+> **Always:** Verify merge gate before any merge. Verify CI. Verify AC checkboxes against code. Ask user before merging (except `/wrap`/`/merge`; Step 3).
+> **Ask first:** Merging; `/wrap`/`/merge` skip this step (Step 3).
 > **Never:** Merge without meeting the gate. Merge with failing CI. Merge with unchecked AC boxes. Stop polling because "nothing is unresolved right now" — see "Polling exit criterion" below.
 
 ## Polling exit criterion

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -107,7 +107,8 @@ Every thread must be `isResolved: true` via GraphQL `reviewThreads` (REST misses
 >
 > Skipping this step is a **blocking failure** — the user should never see unchecked AC boxes when asked about merge.
 
-## Step 3 — Ask the user about merging
+## Step 3 — Confirm merge intent with the user
 
-- Ask the user: "Reviews are clean, all AC verified and checked off. Want me to squash and merge, or do you want to review the diff yourself first?"
+**Default:** ask squash-merge vs review. **`/wrap` / `/merge`:** after Steps 1–2, `gh pr merge --squash` with no extra prompt; overrides this step and `CLAUDE.md` for that scope (see skills).
+
 - Always use **squash and merge** (never regular merge or rebase)

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -1,8 +1,8 @@
 # Merge Gate & Pre-Merge Verification
 
 > **This is the single authoritative definition of the merge gate.** All other rule files reference this file instead of duplicating it.
-> **Always:** Verify merge gate before any merge. Verify CI. Verify AC checkboxes against code. Ask user before merging.
-> **Ask first:** Merging — always ask the user.
+> **Always:** Verify merge gate before any merge. Verify CI. Verify AC checkboxes against code. Ask user before merging **(except `/wrap` / `/merge`, which skip the extra merge prompt after gate+AC)**.
+> **Ask first:** Merging — always ask the user (except `/wrap`/`/merge`; Step 3).
 > **Never:** Merge without meeting the gate. Merge with failing CI. Merge with unchecked AC boxes. Stop polling because "nothing is unresolved right now" — see "Polling exit criterion" below.
 
 ## Polling exit criterion

--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -100,6 +100,8 @@ If Step 2 reported `missing` entries about CI ("CI has N failing check-run(s): .
 
 ### Step 5: Squash merge
 
+**Merge authorization:** `/merge` invocation authorizes merge. After Steps 2–3 pass, run `gh pr merge --squash` with no merge prompt — overrides `CLAUDE.md` "PR MERGE AUTHORIZATION" and `cr-merge-gate.md` Step 3 **for `/merge` only**; gate/CI/AC/worktree failures still stop as above.
+
 ```bash
 gh pr merge --squash
 ```

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -151,6 +151,8 @@ gh api "repos/{owner}/{repo}/check-runs/{CHECK_RUN_ID}" --jq '.output.summary'
 
 ### Step 2.4: Squash merge
 
+**Merge authorization:** `/wrap` invocation authorizes merge. After blockers clear (Phase 1 + Steps 2.1–2.2), run `gh pr merge --squash` with no merge prompt — overrides `CLAUDE.md` "PR MERGE AUTHORIZATION" and `cr-merge-gate.md` Step 3 **for `/wrap` only**; real blockers above still stop the flow.
+
 ```bash
 gh pr merge --squash
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Do not merge a PR or commit to `main` unless the issue author approved on the PR/issue **or** the user confirmed that approval in chat. If unclear, ask.
 
+**Exception:** `/wrap` / `/merge` = merge auth for that run; no extra merge prompt after gate+AC (see those skills).
+
 ---
 
 # EVERY MESSAGE — NON-NEGOTIABLE BEHAVIORS
@@ -27,7 +29,7 @@ Best-effort: lead the first user message with `[#N]` (or `[#339, #341]`) so tab 
 The workflow is fully autonomous. At every phase transition — local review, push, PR creation, polling, feedback processing, subagent spawning — **proceed immediately without asking the user.** See `subagent-orchestration.md` "Phase Transition Autonomy" for the complete table.
 
 **The ONLY actions that require user permission:**
-- Merging the PR
+- Merging (except `/wrap` / `/merge` — see above)
 - Respawning a failed subagent
 
 If you catch yourself composing a "should I...?" question about any workflow step, stop — the answer is always yes. Just do it.


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #435

## Summary

- Document that **`/wrap`** and **`/merge`** invocation is merge authorization: after gate + AC pass, run `gh pr merge --squash` with **no** extra merge-confirmation prompt.
- Keep real blockers unchanged (no PR, gate, CI, AC, findings, rebase/BEHIND per existing skills).
- Wire the exception in `CLAUDE.md`, `cr-merge-gate.md` Step 3, and the wrap/merge skills. **Do not** add `--delete-branch` to the merge command (unchanged; branch cleanup stays as documented).
- `rule-lint` passes (auto-loaded corpus under hard limit).

## Test plan

- [x] `bash .github/scripts/rule-lint.sh` passes
- [x] `CLAUDE.md` states `/wrap`/`/merge` exception and autonomous-workflow list stays consistent
- [x] `cr-merge-gate.md` Step 3 distinguishes default ask vs skill override
- [x] `wrap/SKILL.md` and `merge/SKILL.md` state merge authorization + override + no `--delete-branch`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd7bcc98-21e0-46f1-a50e-512acfb474b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd7bcc98-21e0-46f1-a50e-512acfb474b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Process Updates**
  * Streamlined PR merge workflow: `/merge` and `/wrap` now automatically squash-merge PRs without an extra confirmation prompt once review gates and acceptance criteria pass.
  * Clarified scope and precedence: this no-prompt behavior applies only to `/merge` and `/wrap`, while existing gate, acceptance, and CI/worktree failure checks still block merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Clarify that `/wrap` and `/merge` authorize an immediate squash merge**

### What Changed
- `/wrap` and `/merge` now explicitly skip the extra merge confirmation step after gate and approval checks pass
- The merge guidance and central workflow rules now agree on when the user is asked before merging
- The documented behavior still blocks merges when there are failing checks, unresolved findings, or unmet approval requirements

### Impact
`✅ Fewer merge confirmation prompts`
`✅ Clearer /wrap and /merge workflow`
`✅ Less confusion about when a merge can proceed`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=vvkdeUx84Uxb4iDlhyTEXN1QUyNuot4PMmYFDo-Qt_8&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
