### PR TITLE
docs: replace removed `coderabbit review --prompt-only` with `--agent` (CLI 0.6.0)

### DIFF
--- a/.claude/reference/ai-review-tool-audit-2026-04.md
+++ b/.claude/reference/ai-review-tool-audit-2026-04.md
@@ -74,7 +74,7 @@ Repo-local config: `.coderabbit.yaml`.
 - GitHub workflow: `.github/workflows/cr-plan-on-issue.yml` auto-comments
   `@coderabbitai plan` on newly opened non-bot issues.
 - Local workflow: `.claude/rules/cr-local-review.md` requires
-  `coderabbit review --prompt-only` before push when the CLI is available.
+  `coderabbit review --agent` before push when the CLI is available.
 - GitHub workflow: `.claude/rules/cr-github-review.md` polls CodeRabbit after
   push and requires current-HEAD approval for the CR merge path.
 

--- a/.claude/reference/repo-audit-2026-05.md
+++ b/.claude/reference/repo-audit-2026-05.md
@@ -277,4 +277,4 @@ Bundle aggressively to limit CR review cycles.
 ## Verification notes (this PR)
 
 - **Corpus word count** ( `CLAUDE.md` + `.claude/rules/*.md` ): **10970** words — under `.claude/rules/.budget-soft-cap` (**11166**). This PR adds reference-only markdown and does not raise the corpus.  
-- **CodeRabbit CLI** was not present in the audit CI environment; human/agent with CLI should run `coderabbit review --prompt-only` before merge per workflow rules.
+- **CodeRabbit CLI** was not present in the audit CI environment; human/agent with CLI should run `coderabbit review --agent` before merge per workflow rules.

--- a/.claude/rules/cr-local-review.md
+++ b/.claude/rules/cr-local-review.md
@@ -8,7 +8,7 @@ Primary review workflow — catches issues before PR noise/quota; does not repla
 
 ### Anti–rate-limit pre-flight (local-first)
 
-**~8 reviews/hour** (hidden cap, tier-dependent). **Batch locally:** `coderabbit review --prompt-only` → fix all → re-run until clean → **one commit, one push**. `/fixpr` matches: all threads + CI, **one** commit/push; cap + session tracking: `cr-github-review.md` and `cr-review-hourly.sh`.
+**~8 reviews/hour** (hidden cap, tier-dependent). **Batch locally:** `coderabbit review --agent` → fix all → re-run until clean → **one commit, one push**. `/fixpr` matches: all threads + CI, **one** commit/push; cap + session tracking: `cr-github-review.md` and `cr-review-hourly.sh`.
 
 ### Prerequisites
 
@@ -19,14 +19,14 @@ Primary review workflow — catches issues before PR noise/quota; does not repla
 
 After implementation, before push. Optional mid-development. Run from repo root:
 
-- `coderabbit review --prompt-only` — all changes (prompt-only is optimized for agent parsing)
+- `coderabbit review --agent` — all changes (`--agent` emits structured NDJSON findings, optimized for agent parsing)
 - `--type uncommitted` / `--type committed` — scope to working dir or last commit
 
 ### Fix loop
-1. Run `coderabbit review --prompt-only` to review changes
+1. Run `coderabbit review --agent` to review changes
 2. Parse the findings — verify each against the actual code before fixing
 3. Fix **all valid findings**
-4. Run `coderabbit review --prompt-only` again
+4. Run `coderabbit review --agent` again
 5. Repeat until CR returns no findings
 
 ### Never Suppress Linter Errors (NON-NEGOTIABLE)

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -13,7 +13,7 @@ Single-pass cleanup of the current branch's PR. After this completes:
 
 CodeRabbit caps **~8 GitHub PR reviews per hour** per account; **each push** consumes one. **Multi-round PRs** exhaust that budget fast if you fix-and-push repeatedly.
 
-**Coalesce locally first:** Before opening `/fixpr` on minor iterations, run **`coderabbit review --prompt-only`** per `cr-local-review.md` on uncommitted changes when feasible — catch issues **before** they cost a GitHub review.
+**Coalesce locally first:** Before opening `/fixpr` on minor iterations, run **`coderabbit review --agent`** per `cr-local-review.md` on uncommitted changes when feasible — catch issues **before** they cost a GitHub review.
 
 **Coalesce inside `/fixpr`:** Steps 1–3 intentionally gather **every** unresolved finding + every failing CI check, then fix **all** actionable items and **`git push` once**. Never push once per finding. One `/fixpr` cycle should produce **at most one** consume-side CR review per completed push (tracked below).
 

--- a/.claude/skills/go-on/SKILL.md
+++ b/.claude/skills/go-on/SKILL.md
@@ -57,10 +57,10 @@ test -x "$CR_BIN" && echo "Found: $CR_BIN" || echo "Not found"
 
 If available, run the local review loop:
 ```bash
-$CR_BIN review --prompt-only
+$CR_BIN review --agent
 ```
 
-- If findings are returned: `[ACTION]` — Fix all valid findings. Run `$CR_BIN review --prompt-only` again after fixing.
+- If findings are returned: `[ACTION]` — Fix all valid findings. Run `$CR_BIN review --agent` again after fixing.
 - **Exit on 1 clean pass** (no findings returned) — `[DONE]` Local CR review passed.
 - **Max 5 total iterations.** If you hit 5 runs without a clean pass, stop and report: `[BLOCKED]` — CR review not converging after 5 iterations.
 - If CR CLI is not available or errors out: `[SKIP]` — CR CLI unavailable, performing self-review instead:

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -402,7 +402,7 @@ Fix/implement issue #{N}: {title}
 2. Read the issue body — this is the canonical implementation plan (includes merged CodeRabbit recommendations when available)
 3. Check issue comments only to detect any plan content not yet merged into the body — if found, merge it first
 4. Implement the changes
-5. Run local CodeRabbit review (`coderabbit review --prompt-only`) — fix all findings
+5. Run local CodeRabbit review (`coderabbit review --agent`) — fix all findings
 6. One clean pass, then commit and push
 7. Create a PR with `Closes #{N}` in the body
 8. Include a Test Plan section with checkboxes for acceptance criteria

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -284,7 +284,7 @@ These are mandatory verification points. The executing agent MUST follow these:
 {Include relevant checkpoints based on the task type:}
 
 **If the task involves pushing code and creating a PR:**
-- [ ] After coding: Run `coderabbit review --prompt-only` — one clean pass required before pushing
+- [ ] After coding: Run `coderabbit review --agent` — one clean pass required before pushing
 - [ ] After pushing: Enter GitHub review polling loop immediately — do NOT ask permission
 - [ ] After CR/Greptile posts findings: Fix all valid findings in ONE commit, push once, reply to every thread
 

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -203,7 +203,7 @@ Print a compact summary to the user:
 {unchecked checkbox items from the issue body}
 
 ---
-Ready to code. Start with step 1 of the plan above. Run local CR review (`coderabbit review --prompt-only`) before pushing.
+Ready to code. Start with step 1 of the plan above. Run local CR review (`coderabbit review --agent`) before pushing.
 ```
 
 Stop after printing the summary. Do NOT start coding automatically — the user may want to review the plan first.

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -232,7 +232,7 @@ worktree directory at all times.
 1. You are already in a worktree — verify with `git branch --show-current`.
 2. Read the issue body above — this is your implementation plan.
 3. Implement the changes.
-4. Run local CodeRabbit review: `coderabbit review --prompt-only`
+4. Run local CodeRabbit review: `coderabbit review --agent`
    - Fix all valid findings.
    - Run again. Repeat until one clean pass with no findings.
    - If coderabbit CLI hangs >2 minutes or errors twice, do a self-review instead.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,7 +94,7 @@ Each Claude Code session follows this sequence:
 1. **Session start** — Pull remote `main`, create a worktree, verify skills worktree exists, check for required GitHub Actions workflows
 2. **Issue creation** — Draft issue, post via `gh issue create`, wait for CodeRabbit plan, merge plans into issue body
 3. **Implementation** — Code on the worktree's feature branch
-4. **Local review** — Run `coderabbit review --prompt-only` until one clean pass
+4. **Local review** — Run `coderabbit review --agent` until one clean pass
 5. **Push and PR** — Commit, push, create PR with `Closes #N` and Test Plan checkboxes
 6. **GitHub review** — Poll CR (7-min timeout), fall back to Greptile if needed, fix findings, reply to threads
 7. **Merge** — Verify merge gate (1 explicit CR APPROVED review on current HEAD, 1 clean BugBot pass on current HEAD, or Greptile severity gate), verify acceptance criteria, squash merge
@@ -133,7 +133,7 @@ The parent agent stays in **monitor mode** while subagents are active — pollin
 Finish coding on feature branch
        |
        v
-Run coderabbit review --prompt-only
+Run coderabbit review --agent
        |
        v
 CR returns findings? --No--> Local review loop done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ For deep-dive architecture (symlink topology, hook lifecycle, multi-agent orches
 - **Every PR links to a GitHub issue.** Create one first via `gh issue create` if none exists. Reference it with `Closes #N` in the PR body.
 - **Branch naming:** `issue-N-short-description`. Never work on `main`.
 - **Always use a worktree** for isolated work — see the "Always use a worktree" section of [CLAUDE.md](CLAUDE.md).
-- **Local review before push:** run `coderabbit review --prompt-only` until one clean pass, then commit and push. See [`.claude/rules/cr-local-review.md`](.claude/rules/cr-local-review.md).
+- **Local review before push:** run `coderabbit review --agent` until one clean pass, then commit and push. See [`.claude/rules/cr-local-review.md`](.claude/rules/cr-local-review.md).
 - **Merge gate:** 1 explicit CodeRabbit APPROVED on current HEAD (plus CodeAnt clean signal when CodeAnt has run on that SHA), or 1 clean BugBot pass, or a clean Greptile severity gate. See [`.claude/rules/cr-merge-gate.md`](.claude/rules/cr-merge-gate.md).
 - **CI must pass before merge** (including the `rule-lint` check that verifies rule-file sizes and index alignment).
 - **Squash merge only:** `gh pr merge --squash --delete-branch`.
@@ -82,7 +82,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) "Hook Lifecycle" and "Hook Auto-Registrat
 
 ## Modifying CLAUDE.md
 
-- CLAUDE.md is the **executive summary** — high-level non-negotiables and pointers to rule files. Target: **≤ 1,000 words**.
+- CLAUDE.md is the **executive summary** — high-level non-negotiables and pointers to rule files. Target: **≤ 1,300 words** (relaxed from 1,000 after #443; keep it lean — detail belongs in rule files).
 - **Detailed protocols, step-by-step procedures, and edge cases belong in `.claude/rules/*.md`**, not in CLAUDE.md.
 - **Do not duplicate** content between CLAUDE.md and rule files. When the same topic appears in both, CLAUDE.md should link to the rule file as the authoritative source.
 - Any change that touches CLAUDE.md must re-run the word-count verification command above.

--- a/SETUP.md
+++ b/SETUP.md
@@ -39,7 +39,7 @@ The script handles everything: directory creation, symlinks, settings merge, hoo
 
 Optional tools (for the full review workflow):
 - [CodeRabbit](https://coderabbit.ai) — AI code review on PRs
-- [CodeRabbit CLI](https://docs.coderabbit.ai/cli) — local pre-push reviews (`coderabbit review --prompt-only`)
+- [CodeRabbit CLI](https://docs.coderabbit.ai/cli) — local pre-push reviews (`coderabbit review --agent`)
 - [Graphite CLI](https://graphite.dev/docs/command-line) — stacked PRs; pair with the Graphite Claude Code plugins enabled via `setup.sh` (see [README.md](README.md#getting-started))
 - [Greptile](https://greptile.com) — fallback reviewer when CodeRabbit is rate-limited
 


### PR DESCRIPTION
## **User description**
## Summary

CodeRabbit CLI **0.6.0** removed the `--prompt-only` flag; running it now errors with a pointer to use `--agent`. This swaps every config/doc reference to the new flag.

Verified against `coderabbit review --help` on 0.6.0:
> `--agent  Emit structured findings for agent workflows`

`--agent` emits NDJSON structured findings; the final line is `{"type":"complete","status":"review_completed","findings":N}` (confirmed live — the CLI even emits its rate-limit envelope as NDJSON, so the renamed flag is validated end-to-end).

## Changes

- **17 references** across **12 files** swapped `coderabbit review --prompt-only` → `coderabbit review --agent`:
  - Rules: `.claude/rules/cr-local-review.md` (×4)
  - Skills: `go-on` (×2), `pm`, `start-issue`, `fixpr`, `prompt`, `subagent`
  - Reference: `repo-audit-2026-05.md`, `ai-review-tool-audit-2026-04.md`
  - Top-level: `CONTRIBUTING.md`, `SETUP.md`, `ARCHITECTURE.md` (×2, incl. ASCII flow diagram)
- Reworded the one prose explanation in `cr-local-review.md` ("prompt-only is optimized for agent parsing" → "`--agent` emits structured NDJSON findings, optimized for agent parsing").
- **Author-requested fold-in** (per issue comment): fixed stale doc-drift at `CONTRIBUTING.md:85` — CLAUDE.md word target `≤ 1,000` → `≤ 1,300` (CLAUDE.md is 1,156 words post-#443).

> `.claude/rules/cr-github-review.md` was a listed candidate but contains **no** `prompt-only` reference (confirmed via grep) — no change needed.

Docs/config only — no behavioral/logic change.

Closes #464

## Test plan

- [x] All `coderabbit review --prompt-only` references replaced with `coderabbit review --agent` (17 occurrences)
- [x] `grep -rn 'prompt-only' .` (excluding `.claude/worktrees/` + `.git/`) returns **zero** matches
- [x] Prose mentioning "prompt-only" updated to describe `--agent` / structured NDJSON output accurately
- [x] New flag validated against CLI 0.6.0 `coderabbit review --help` (`--agent  Emit structured findings for agent workflows`)
- [x] No worktree copies under `.claude/worktrees/**` modified (only 12 tracked files changed)
- [x] `.github/scripts/rule-lint.sh` passes; corpus 10945 words under ratchet cap 11692
- [x] Author-requested `CONTRIBUTING.md:85` CLAUDE.md word target updated (≤1,000 → ≤1,300)
- [x] CI (`rule-lint`) green on the pushed SHA — rule-lint + hook-tests + post-cursor-review + Cursor Bugbot all success on d290075


___

## **CodeAnt-AI Description**
**Update local CodeRabbit review instructions to use `--agent` and align docs with the current CLAUDE.md size target**

### What Changed
- Replaced the removed `coderabbit review --prompt-only` command with `coderabbit review --agent` across local review guidance, setup notes, and workflow docs.
- Clarified that `--agent` returns structured NDJSON findings, so the review loop now reflects the current output users should expect.
- Updated the CLAUDE.md guidance in CONTRIBUTING to the new 1,300-word target.

### Impact
`✅ Fewer broken review-command instructions`
`✅ Clearer local review setup`
`✅ Up-to-date CLAUDE.md size guidance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

