### PR TITLE
docs(models): update model references to new lineup (Opus 4.8, Sonnet 4.6, Haiku 4.5) (#459)

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -40,6 +40,8 @@ Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the par
 
 Each agent definition declares a default `model` in frontmatter. The parent must also set `model` explicitly at every Agent tool call site per `.claude/rules/subagent-orchestration.md` "Model Selection" — the call-site parameter overrides the frontmatter default and keeps cost decisions visible at every spawn point.
 
+**Current alias resolution (verified 2026-06):** `opus` → Opus 4.8, `sonnet` → Sonnet 4.6, `haiku` → Haiku 4.5. Frontmatter intentionally uses bare aliases — Claude Code resolves them to the latest non-legacy model of each family, so agent definitions don't need editing when Anthropic ships a new version. If the runtime ever stops resolving bare aliases, switch frontmatter to explicit versioned IDs (e.g., `claude-opus-4-8`, `claude-sonnet-4-6`) and update this note.
+
 **Per-phase rationale:**
 
 | Agent | Model | Why |

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -35,6 +35,8 @@ If agent definitions are unavailable (e.g., repo without `.claude/agents/`):
 | `pm-worker` | `sonnet` |
 | Read-only review agents (e.g., `/pr-review-help`) | `sonnet` |
 
+Aliases currently resolve to: `opus` = Opus 4.8, `sonnet` = Sonnet 4.6, `haiku` = Haiku 4.5 (resolution notes: `.claude/agents/README.md`).
+
 Rules: set `model` explicitly on every spawn; call-site value overrides frontmatter. `CLAUDE_CODE_SUBAGENT_MODEL=opus` is only a legacy safety net. If a Sonnet-tier agent underperforms, escalate to `opus` and document why.
 
 ## Phase Transition Autonomy (Quick Reference)

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -491,7 +491,7 @@ The **user** decides when and where to paste the prompts. The user starts the co
 
 **Model selection for spawned subagents:**
 
-- **Coding subagents** (Phase A/B executing a selected issue): prefer the `/subagent` skill, which already enforces per-phase model selection (`opus` for Phase A/B, `sonnet` for Phase C). See `.claude/rules/subagent-orchestration.md` "Model Selection".
+- **Coding subagents** (Phase A/B executing a selected issue): prefer the `/subagent` skill, which already enforces per-phase model selection (`opus` for Phase A/B, `sonnet` for Phase C; these aliases currently resolve to Opus 4.8 and Sonnet 4.6). See `.claude/rules/subagent-orchestration.md` "Model Selection".
 - **Read-only PM data-gathering subagents** (e.g., scanning GitHub for backlog context, summarizing recent PR activity, reviewing progress on in-flight threads): spawn with `subagent_type: "pm-worker"`, `mode: "bypassPermissions"`, and `model: "sonnet"`. These tasks are template-driven data collection — Sonnet is the right cost tier and the frontmatter default on `pm-worker` matches.
 - **Never omit `model`** at the call site. Explicit model selection keeps cost decisions visible at every spawn point and prevents silent Opus usage for lightweight work.
 

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -84,7 +84,7 @@ If a PR doesn't exist, note it in the output and skip. If ALL PR numbers are inv
 
 Spawn one subagent per valid PR using the Agent tool. All subagents run in parallel.
 
-**Each subagent invocation MUST use `mode: "bypassPermissions"` and `model: "sonnet"`.** This is a read-only strategic review — analysis from a well-defined template, no code modification. Sonnet keeps per-review cost low so parallel portfolio reviews stay economical. See `.claude/rules/subagent-orchestration.md` "Model Selection" for the rationale.
+**Each subagent invocation MUST use `mode: "bypassPermissions"` and `model: "sonnet"`** (the `sonnet` alias currently resolves to Sonnet 4.6). This is a read-only strategic review — analysis from a well-defined template, no code modification. Sonnet keeps per-review cost low so parallel portfolio reviews stay economical. See `.claude/rules/subagent-orchestration.md` "Model Selection" for the rationale.
 
 **Each subagent prompt must include:**
 - The PR number to analyze (substitute `{NUMBER}` in the template below)

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -8,7 +8,15 @@ triggers:
 argument-hint: "[#123 #124 ...] (issue numbers, or omit for PM auto-detect)"
 ---
 
-Analyze one or more GitHub issues, classify complexity, and produce a copy-paste-ready prompt with a model recommendation. The goal is quality-conservative right-sizing — never under-resource a task, but don't waste Opus 4.7 1M tokens on a typo fix.
+Analyze one or more GitHub issues, classify complexity, and produce a copy-paste-ready prompt with a model recommendation. The goal is quality-conservative right-sizing — never under-resource a task, but don't waste Opus 4.8 (1M context) tokens on a typo fix.
+
+## Model Lineup & Effort Levels (current as of 2026-06)
+
+The Claude Code picker offers: **Sonnet 4.6** (default), **Opus 4.8**, **Opus 4.8 (1M context)**, and **Haiku 4.5**. Opus 4.7 / 4.7 (1M) / 4.6 are Legacy — never recommend them. Bare aliases used elsewhere (agent frontmatter, spawn sites) currently resolve as: `opus` → Opus 4.8, `sonnet` → Sonnet 4.6, `haiku` → Haiku 4.5 (see `.claude/rules/subagent-orchestration.md` "Model Selection" and `.claude/agents/README.md`).
+
+The picker also exposes **effort levels** (`low`, `medium`, `high`, `extra`, `max`, `ultracode`). This skill keeps its internal Heavy/Standard/Light tier vocabulary and decision tree unchanged, and maps each tier to a recommended effort level in the output: **Heavy → `max`**, **Standard → `high`**, **Light → `low`**. Users may adjust within a tier's range — e.g., a Heavy task that needs multi-agent orchestration can step up to `ultracode`; a borderline Standard task can step down to `medium`.
+
+**Fast mode:** the picker has a Fast mode toggle that trades depth for speed. `/prompt` does NOT accept a `--fast` flag and does not factor Fast mode into recommendations — it is a user-toggled picker option. For Light-tier work, **Haiku 4.5** (with or without Fast mode) is a valid cheaper alternative to Sonnet 4.6; the output notes this on Light-tier recommendations. A `--fast` flag is a possible follow-up, not part of this skill.
 
 **MANDATORY OUTPUT FORMAT:** Every per-issue prompt block MUST open and close with `~~~` tilde fences. NEVER use backtick fences as the outer prompt-block delimiter.
 
@@ -123,7 +131,7 @@ Apply this decision tree. When signals conflict, choose the **higher** tier (con
 
 **Batch handling rule:** First classify each issue independently to produce a per-issue tier (`issue_tier`). Then compute a batch tier from the most complex `issue_tier` in the set. A batch of 3 issues where one is Heavy makes the batch tier Heavy. The batch tier is used for thread-prompt output formatting and checkpoint inheritance, while per-issue decisions (like Step 5.5 subagent partitioning) must use `issue_tier`.
 
-### Heavy — Opus 4.7 1M
+### Heavy — Opus 4.8 (1M context), effort `max`
 
 Assign Heavy if ANY of these are true:
 - `touches_rules` is true (rule files are highest-stakes)
@@ -133,7 +141,7 @@ Assign Heavy if ANY of these are true:
 - `file_count > 5`
 - `dependency_count > 2`
 
-### Standard — Opus 4.7
+### Standard — Opus 4.8, effort `high`
 
 Assign Standard if ANY of these are true (and Heavy was not triggered):
 - `file_count` is 2–5
@@ -142,7 +150,7 @@ Assign Standard if ANY of these are true (and Heavy was not triggered):
 - Issue body is >200 words with structural patterns (includes a user story, describes a new feature via keywords like "implement", "add", "support")
 - `is_multi_issue` with mixed complexity (at least one non-trivial issue that didn't trigger Heavy)
 
-### Light — Sonnet 4.6
+### Light — Sonnet 4.6 (or Haiku 4.5), effort `low`
 
 Assign Light if ANY of these are true (and Heavy/Standard were not triggered):
 - `file_count` is 0–1
@@ -224,24 +232,24 @@ Output the Tier Recommendation as plain text first (skip if all issues are subag
 ```
 ## Tier Recommendation
 
-**{TIER_NAME}** — {MODEL}
+**{TIER_NAME}** — {MODEL} — effort: {EFFORT}
 
 Rationale: {1-line explanation of why this tier was selected, citing the dominant signal}
 ```
 
 **OUTPUT MUST USE `~~~` FENCES, NOT BACKTICKS.** The opening and closing lines of every per-issue prompt block must be exactly `~~~`.
 
-**Map tier to `{MODEL}` string** (same Heavy / Standard / Light → model mapping for both the batch **Tier Recommendation** line and each per-issue `**Model:**` line — use **batch tier** for Tier Recommendation and **per-issue `issue_tier`** for each block):
-- **Heavy** → `Opus 4.7 (1M context)`
-- **Standard** → `Opus 4.7`
-- **Light** → `Sonnet 4.6`
+**Map tier to `{MODEL}` and `{EFFORT}` strings** (same Heavy / Standard / Light mapping for both the batch **Tier Recommendation** line and each per-issue `**Model:**` line — use **batch tier** for Tier Recommendation and **per-issue `issue_tier`** for each block):
+- **Heavy** → `Opus 4.8 (1M context)`, effort `max` (step up to `ultracode` for multi-agent orchestration work)
+- **Standard** → `Opus 4.8`, effort `high`
+- **Light** → `Sonnet 4.6`, effort `low` (Haiku 4.5 is a valid cheaper alternative — append "(or Haiku 4.5)" to Light-tier recommendations)
 
 **`{REASON}` construction:** Choose a short phrase (≤10 words) that names the main complexity driver for **this issue alone** — e.g. touches `.claude/rules`, touches `CLAUDE.md`, orchestration keywords, dependency web, many files from the CR plan, high `ac_count`, skill paths, multi-file feature work, or Light-scope keywords. Do not copy the batch Tier Recommendation rationale into every block when reasons differ per issue.
 
 Then, for each issue, output a self-contained prompt block. Use tilde fences (`~~~`, shown here as the outer boundary):
 
 ~~~
-**Model:** Opus 4.7 — skill change with many acceptance checks
+**Model:** Opus 4.8 — skill change with many acceptance checks
 ### Issue #{NUMBER}: {TITLE}
 
 **Acceptance Criteria:**
@@ -351,14 +359,14 @@ Falls back to asking: "Which issue(s) should I analyze?"
 
 For an issue with `touches_skill=true` and `ac_count=4`, the skill emits the Tier Recommendation as plain text first, then a self-contained prompt block in a tilde fence. The recommendation rendered to the chat looks like:
 
-> **Standard** — Opus 4.7
+> **Standard** — Opus 4.8 — effort: high
 >
 > Rationale: touches_skill=true (modifies a file under .claude/skills/) drives Standard.
 
 The prompt block that follows:
 
 ~~~
-**Model:** Opus 4.7 — skill file with multiple acceptance criteria
+**Model:** Opus 4.8 — skill file with multiple acceptance criteria
 ### Issue #110: {Title}
 
 **Acceptance Criteria:**

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -280,7 +280,7 @@ worktree directory at all times.
 
 **Agent tool call parameters:**
 - `mode: "bypassPermissions"`
-- `model: "opus"` (heavy reasoning — initial implementation, multi-file edits, PR creation — see `subagent-orchestration.md` "Model Selection")
+- `model: "opus"` (currently resolves to Opus 4.8; heavy reasoning — initial implementation, multi-file edits, PR creation — see `subagent-orchestration.md` "Model Selection")
 - `isolation: "worktree"`
 - `run_in_background: true` (so you can monitor multiple agents)
 
@@ -386,7 +386,7 @@ If missing, reconstruct state from GitHub API.
 **Phase B Agent tool call parameters:**
 - `subagent_type: "phase-b-reviewer"`
 - `mode: "bypassPermissions"`
-- `model: "opus"` (Phase B evaluates review findings and fixes code — see `subagent-orchestration.md` "Model Selection")
+- `model: "opus"` (currently resolves to Opus 4.8; Phase B evaluates review findings and fixes code — see `subagent-orchestration.md` "Model Selection")
 - `isolation: "worktree"` (same as Phase A — Phase B fetches and checks out the PR branch inside its own fresh worktree)
 - `run_in_background: true`
 
@@ -474,7 +474,7 @@ worktree directory at all times.
 **Phase C Agent tool call parameters:**
 - `subagent_type: "phase-c-merger"`
 - `mode: "bypassPermissions"`
-- `model: "sonnet"` (Phase C is lightweight verification plus the mechanical `/wrap` flow — see `subagent-orchestration.md` "Model Selection")
+- `model: "sonnet"` (currently resolves to Sonnet 4.6; Phase C is lightweight verification plus the mechanical `/wrap` flow — see `subagent-orchestration.md` "Model Selection")
 - `isolation: "worktree"` (same as Phase A — Phase C fetches and checks out the PR branch inside its own fresh worktree)
 - `run_in_background: true`
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #459

## Summary

Model-reference sweep across rules, agents, and skills, implementing CodeRabbit's plan from the issue (design choices 1–4 adopted as proposed in the issue thread):

1. **Tier vocabulary preserved** — Heavy/Standard/Light stays as the internal taxonomy; outputs now map Heavy→`max`, Standard→`high`, Light→`low` effort levels.
2. **Effort mapping is single-level per tier** with adjust-within-range guidance (`ultracode` for multi-agent Heavy work, `medium` for borderline Standard).
3. **Fast mode documented only** — no `--fast` flag; explicitly called out as a follow-up candidate in `/prompt` SKILL.md.
4. **Bare aliases kept** in agent frontmatter (`model: opus` / `model: sonnet`); resolution notes added in docs instead.

Additional decision: `/prompt` stays picker-aligned — Fable 5 (API-only) is not surfaced in recommendations.

## Changes

- `.claude/skills/prompt/SKILL.md` — all `Opus 4.7` → `Opus 4.8` (with `(1M context)` for Heavy); new "Model Lineup & Effort Levels" section (picker lineup, legacy callout, alias resolution, effort taxonomy, Fast mode + Haiku 4.5); tier headings, mapping table, Tier Recommendation template (`— effort: {EFFORT}`), and sample outputs updated. **Decision-tree signal thresholds untouched.**
- `.claude/rules/subagent-orchestration.md` — one-line alias-resolution annotation under the Model Selection table (rule file: kept tight for word budget).
- `.claude/agents/README.md` — "Current alias resolution" note in Model Selection; documents why frontmatter intentionally stays bare-alias and the escape hatch if the runtime stops resolving aliases.
- `.claude/skills/pm/SKILL.md`, `.claude/skills/pr-review-help/SKILL.md`, `.claude/skills/subagent/SKILL.md` — version notes at each alias mention.
- Branch synced with `main` after #465 landed (clean auto-merge; `--prompt-only` → `--agent` rename flowed into the prompt skill's checkpoint sample with no conflict).

## Word budget (rule corpus)

`{ cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } | wc -w` → **10,964** post-merge-from-main (was 10,942; +19 from this PR, +3 from #465). Under ratchet cap 11,692, soft 12,000, hard 13,000. `rule-lint` CI check: green.

## Test plan

- [x] `/prompt` on a Heavy-tier issue → recommends `Opus 4.8 (1M context)`, not Opus 4.7 (Heavy mapping + heading updated; no 4.7 string remains in the skill outside the legacy callout)
- [x] `/prompt` on a Standard-tier issue → recommends `Opus 4.8` (Standard mapping + sample outputs updated)
- [x] `/prompt` on a Light-tier issue → recommends `Sonnet 4.6 (or Haiku 4.5)` (Light mapping documents the Haiku alternative per Fast-mode decision)
- [x] Phase A spawn via `.claude/agents/phase-a-fixer.md` resolves to Opus 4.8 — frontmatter stays `model: opus` (documented alias per design choice 4); resolution documented in README and orchestration rule
- [x] `**Model:**` line in `/prompt` output uses the new string verbatim (template + both sample blocks updated)
- [x] Effort taxonomy wired: `max` recommendation reachable — Heavy tier emits `effort: max`, with `ultracode` step-up guidance
- [x] Post-merge grep for `Opus 4.7` outside legacy-context callouts → clean. Remaining hits: the legacy callout in `/prompt` SKILL.md ("Opus 4.7 … are Legacy — never recommend them") and two dated snapshot docs in `.claude/reference/` (May 2026 research/audit artifacts)

## Acceptance criteria

- [x] `prompt/SKILL.md`: all Opus 4.7 → Opus 4.8, tier table reflects effort taxonomy, samples match
- [x] Effort levels supported in output (parallel `effort:` field; internal tiers kept — decided upfront per CR design choice 1/2)
- [x] `subagent-orchestration.md` tier table annotated with resolved versions
- [x] `agents/README.md` current-resolution note
- [x] `pm`/`pr-review-help`/`subagent` skill cross-references annotated
- [x] Haiku 4.5 surfaced for Light/`low` tier
- [x] Fast mode decision documented (explicit non-coverage + follow-up note)
- [x] Frontmatter bare aliases confirmed/kept; versioned-ID escape hatch documented
- [x] No decision-tree regressions — only model/output strings changed, signal thresholds identical

## Review status (as of Fri Jun 12 01:25 PM ET)

- CI: all 3 check-runs green (`hook-tests`, `rule-lint`, `post-cursor-review`) on HEAD `83f669a`.
- **CodeRabbit skipped the review — "Draft detected."** BugBot did not respond to the workflow's `@cursor review` triggers within ~30 min.
- This agent's GitHub access is comment-write-restricted, so it cannot post `@coderabbitai review` or mark the PR ready. **To start the review: mark the PR ready for review, or comment `@coderabbitai review`.**

## Notes for reviewers

- The local CodeRabbit CLI checkpoint could not run in this environment (CLI unavailable); a manual self-review of the full diff was done instead.
- The issue body has no `## Implementation Plan` section; this agent could not edit the issue body (read-only issue access), so the plan-merge gate from `issue-planning.md` was skipped. The CR plan lives in the issue comments (2026-06-08) and was followed as written.
- Interplay with #442: if #442 merges first, re-measure the rule-corpus word count after rebase (known failure mode: `feedback_rebase_word_count_drift`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-856c973e-bb9c-4e43-af22-9853c62b2bd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-856c973e-bb9c-4e43-af22-9853c62b2bd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Update model references and recommendations to the current Claude lineup**

### What Changed
- Replaced outdated model names with the current aliases and version references across agent, skill, and orchestration docs
- Documented how `opus`, `sonnet`, and `haiku` aliases currently resolve, so agent definitions can stay unchanged when versions move forward
- Updated `/prompt` guidance to use the new model lineup, add effort-level recommendations, and note that `Haiku 4.5` is a valid cheaper option for light work
- Added clear notes that `/prompt` does not support a `--fast` flag and that legacy models should not be recommended

### Impact
`✅ Fewer outdated model references`
`✅ Clearer model selection guidance`
`✅ Lower chance of picking legacy models`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
