### PR TITLE
feat(rules): CLI-first defaults for vercel/neonctl/railway/cloudinary (#442)

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -13,6 +13,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 
 ### Runbooks and long command forms
 
+- `cli-tool-defaults.md` — installed service CLIs (vercel, neonctl, railway, cloudinary) and common commands; CLI-first over web dashboards
 - `cr-polling-commands.md` — full multi-line `gh api` commands for CR review polling and CI verification
 - `cr-rate-limits.md` — full CR rate-limit caps, hourly-state mechanics, and `cr-review-hourly.sh` flags
 - `codeowner-bot-approvals.md` — CODEOWNERS handling for review bots and stale-approval re-trigger commands

--- a/.claude/reference/cli-tool-defaults.md
+++ b/.claude/reference/cli-tool-defaults.md
@@ -1,0 +1,107 @@
+# CLI Tool Defaults — Vercel, Neon, Railway, Cloudinary
+
+Four service CLIs are installed on this machine (`vercel` v53.0.1, `neonctl` v2.22.0, `railway` v4.30.5, `cloudinary` v1.14.1). **Default to these CLIs for every operation they support — never direct the user to a web dashboard for something a CLI can do.** Referenced from `.claude/rules/repo-bootstrap.md`.
+
+**Secrets:** several commands below print or write credentials (connection strings, pulled env files). Treat that output as secret — never paste it into issues, PRs, commits, or logs (`.claude/rules/safety.md`). Reference env vars by name only (e.g. `CLOUDINARY_URL`), never inline values.
+
+## Vercel
+
+```bash
+vercel --version
+```
+
+**Deployments:**
+
+```bash
+vercel ls                      # recent deployments for the linked project
+vercel deploy                  # preview deployment of cwd
+vercel deploy --prod           # production deployment
+vercel inspect {deployment-url}
+vercel logs {deployment-url}
+```
+
+**Env vars** (never commit pulled files; `.env*` files are untouchable per `safety.md`):
+
+```bash
+vercel env ls
+vercel env add {NAME} {environment}   # value read from stdin — never inline it
+vercel env rm {NAME} {environment}
+vercel env pull {path}                # writes to gitignored path, e.g. .env.local
+```
+
+**Projects & domains:**
+
+```bash
+vercel project ls
+vercel link                    # link cwd to a project
+vercel domains ls
+vercel domains add {domain} {project}
+vercel whoami
+```
+
+## Neon
+
+```bash
+neonctl --version
+```
+
+**Projects & branches:**
+
+```bash
+neonctl projects list
+neonctl branches list --project-id {project-id}
+neonctl branches create --project-id {project-id} --name {branch}
+neonctl branches delete {branch} --project-id {project-id}
+```
+
+**Connection strings** (output contains the DB password — treat as secret):
+
+```bash
+neonctl connection-string {branch} --project-id {project-id}
+neonctl databases list --project-id {project-id} --branch {branch}
+```
+
+## Railway
+
+```bash
+railway --version
+```
+
+**Status, deploys, logs:**
+
+```bash
+railway status                 # linked project / environment / service
+railway up                     # deploy cwd (--detach to skip log streaming)
+railway redeploy
+railway logs
+```
+
+**Env vars & linking:**
+
+```bash
+railway variables              # list for linked service
+railway variables --set "{KEY}={value}"   # use shell vars, not literal secrets
+railway link                   # link cwd to project/environment/service
+railway run {command}          # run a local command with service env injected
+```
+
+## Cloudinary
+
+Auth comes from `CLOUDINARY_URL` in `~/.zshrc` — already configured; reference it by name only, never echo or print it.
+
+```bash
+cloudinary --version
+```
+
+**Uploads, listing, transformations:**
+
+```bash
+cloudinary uploader upload {file} public_id={id}
+cloudinary admin resources max_results=25      # list resources
+cloudinary search "folder:{folder}"
+cloudinary url {public_id} {transformation}    # e.g. w_200,h_200,c_fill
+```
+
+## When a CLI is unavailable
+
+Fall back to the web UI **only** when the CLI fails (auth error, outage, missing subcommand) or genuinely lacks the capability. State which CLI command failed and why before suggesting the dashboard. If a CLI is missing entirely, verify with `which {tool}` and report that, rather than assuming the dashboard is the default.

--- a/.claude/rules/repo-bootstrap.md
+++ b/.claude/rules/repo-bootstrap.md
@@ -41,3 +41,4 @@ The script reports state as `[OK]` / `[MISSING]` / `[SKIP]` (token lacks read pe
 - **Idempotent.** Safe to re-run; only acts when files are missing.
 - **Branch protection requires user confirmation** — never modify autonomously.
 - **Do not downgrade existing protection.** Preserve required reviews, admin enforcement, etc. when adding status checks.
+- **Prefer installed CLI tools** (`vercel`, `neonctl`, `railway`, `cloudinary`) over web dashboards — see `.claude/reference/cli-tool-defaults.md` for commands.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #442

## Summary

Agents were directing users to web dashboards for operations the locally installed CLIs can perform. This PR makes CLI-first the documented default:

- **NEW `.claude/reference/cli-tool-defaults.md`** — per-tool sections (`## Vercel`, `## Neon`, `## Railway`, `## Cloudinary`), each opening with a version-check command, then common operations in fenced bash blocks with `{placeholder}` syntax, following the `cr-polling-commands.md` / `greptile-setup.md` format. Ends with a "When a CLI is unavailable" fallback note (web UI only when the CLI fails or lacks the capability). Secrets handling per `safety.md`: `CLOUDINARY_URL` and connection-string output are referenced by name / flagged as secret — no values anywhere.
- **`.claude/rules/repo-bootstrap.md`** — one mandate bullet appended to the existing `### Rules` section (placement sanity-checked against the post-#463 layout): "Prefer installed CLI tools (`vercel`, `neonctl`, `railway`, `cloudinary`) over web dashboards — see `.claude/reference/cli-tool-defaults.md` for commands."
- **`.claude/reference/README.md`** — index entry for the new reference file.

## Word budget (post-#463 numbers)

Reference files don't count toward the auto-loaded budget; only the one bullet does. Corpus after this change: **10,962 words** (+17), vs ratchet cap **11,692** / soft 12,000 / hard 13,000. `rule-lint.sh` passes (`Rule index alignment: OK (16 files)`, `rule-lint: OK`).

## Review state

- **BugBot (gate owner):** CodeRabbit hit its org rate limit (~3h, out of credits) → fast-path escalation to BugBot per `cr-github-review.md`. `Cursor Bugbot` check-run completed **success** on HEAD `8c129c8` with zero findings and zero review threads — a clean BugBot pass per `bugbot.md`'s completion signal (BugBot posts no review object on clean passes).
- **CI:** all 4 check-runs green (`rule-lint`, `hook-tests`, `post-cursor-review`, `Cursor Bugbot`). `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`.
- **CodeAnt:** no subscription for this account — not applicable.

## Notes

- Implementation plan (CR plan from 2026-05-01 + corrected budget numbers) could not be merged into the issue body: the cloud agent token cannot edit issues or post comments (`GraphQL: Resource not accessible by integration`). The plan is carried here instead.
- Local `coderabbit` CLI is unavailable in this environment — self-review fallback performed per `cr-local-review.md`; GitHub review (BugBot) is the gate.
- #459 (model-reference updates) is open with no PR yet; branch is current with `main` (`4abeb31`) — corpus re-measured on that base.

## Test plan

- [x] A reference file or rule addition documents the available CLIs and their common commands (`.claude/reference/cli-tool-defaults.md` covers all four tools; mandate bullet in `repo-bootstrap.md` auto-loads every turn)
- [x] Agents never say 'go to the dashboard' for operations that a CLI can perform (mandate bullet + "When a CLI is unavailable" note constrain dashboard suggestions to CLI-failure cases)
- [x] The guidance is lightweight enough not to blow the rule word budget (corpus 10,962 < ratchet cap 11,692; `rule-lint.sh` green, CI `rule-lint` check green)
- [x] No secret values in any command example — env vars referenced by name only (`CLOUDINARY_URL`); secret-output commands flagged (verified via grep for secret patterns)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e623aefd-b887-4b28-8560-b7d867c27eb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e623aefd-b887-4b28-8560-b7d867c27eb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

