### PR TITLE
feat(fixpr): post-push review-wait loop with 20-min cap and early exit (#454)

### DIFF
--- a/.claude/reference/exit-report-format.md
+++ b/.claude/reference/exit-report-format.md
@@ -28,6 +28,11 @@ HANDOFF_FILE: ~/.claude/handoffs/pr-618-handoff.json
 | `FILES_CHANGED` | comma-separated paths | Files modified (empty string if none) |
 | `NEXT_PHASE` | `B`, `C`, `none` | What parent should launch next |
 | `HANDOFF_FILE` | path | Handoff file path |
+| `FIXPR_WAIT_ITERATIONS` | integer | (when the phase ran `/fixpr`) wait-loop iterations executed — issue #454 |
+| `FIXPR_TOTAL_WAIT_SECS` | integer | (when the phase ran `/fixpr`) cumulative post-push review-wait time |
+| `FIXPR_WAIT_FINAL` | `clean`, `cap-exhausted`, `new-findings-pending` | (when the phase ran `/fixpr`) final wait-loop state from `FIXPR_WAIT_SUMMARY` |
+
+The three `FIXPR_*` fields are required whenever the phase executed the `/fixpr` workflow (copy them from its `FIXPR_WAIT_SUMMARY` footer line); omit them otherwise.
 
 ## Valid OUTCOME Values
 

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: fixpr
-description: Single-pass PR cleanup — audit every review thread + every CI check-run, fix all issues, push once, dismiss stale bot CHANGES_REQUESTED on old commits, resolve all threads via GraphQL, verify CI green. Zero uncollapsed threads and zero failing checks when done.
+description: Bounded-convergence PR cleanup — audit every review thread + every CI check-run, fix all issues, push once per sweep, dismiss stale bot CHANGES_REQUESTED on old commits, resolve all threads via GraphQL, then wait (capped) for bot verdicts + CI on the new SHA, re-sweeping on new findings up to 5 iterations. Zero uncollapsed threads and zero failing checks when done.
 ---
 
-Single-pass cleanup of the current branch's PR. After this completes:
+Bounded-convergence cleanup of the current branch's PR (issue #454 added the post-push review-wait loop to the original single-pass design). After this completes:
 
 1. **Zero uncollapsed review threads** in the browser (all resolved via GraphQL)
 2. **Zero failing CI checks** (all fixed and passing)
 3. **Every finding replied to** with what was done
+4. **A definitive bot verdict on the final SHA** — or an explicit cap-hit report naming what is still pending (never a silent "we pushed, bye" exit)
 
 ### Batching before burning CR quota (Issue #28)
 
@@ -31,15 +32,38 @@ All mechanical GitHub API work — pagination, GraphQL queries, comment classifi
 | 3b. Trigger missing AI reviewers | Mechanical | wait 2 minutes, detect CR/Graphite/CodeAnt activity on the new SHA, post triggers for missing bots, always post `@cursor review` |
 | 4. Reply & resolve | Mechanical | `gh api` calls against IDs from the JSON |
 | 4c. Post-push thread verify (if Step 3 pushed) | Mechanical | Re-fetch threads on new HEAD; explicitly resolve any touched thread still `isResolved: false` (fixes unchanged-line orphans), then `--verify-only` |
+| 4d. Review-wait loop (issue #454) | Mechanical | Poll `pr-state.sh` on the pushed SHA every 30–60s, capped at 20 min; early-exit on full bot+CI verdict; new findings → next sweep |
 | 5. Verify | Mechanical | Re-run `pr-state.sh --since $RUN_STARTED_AT` |
 | 6. Merge blockers | Judgment | AI reads `.merge_state` from the JSON |
 | 7. Final summary | Judgment | AI emits the status |
 
-Execute the steps sequentially. Do NOT poll in a loop — this is a single-pass tool. When a verify pass finds unfinished work, exit with a status code and instruct the user to re-run `/fixpr`.
+Execute the steps sequentially. Steps 0–4c form one **fix sweep**. After a sweep that pushed, Step 4d waits — bounded — for bot verdicts and CI on the **new HEAD SHA**; when new findings or blocking CI arrive mid-wait, start the next sweep at Step 0 (outer cap: `FIXPR_MAX_ITERATIONS`, default 5). `/fixpr` exits when the wait predicate is clean, a cap fires, or a non-loopable status arises (conflicts, human changes requested, stuck threads). This in-turn loop runs within a single agent turn — no `/loop`, `CronCreate`, or `ScheduleWakeup`.
+
+**Environment knobs (issue #454):**
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `FIXPR_WAIT_CAP_SECS` | `1200` | Hard cap per wait iteration (20 min = P93 of bot-response times from a 30-PR sample) |
+| `FIXPR_WAIT_POLL_SECS` | `60` | Poll cadence inside the wait loop (valid range 30–60) |
+| `FIXPR_MAX_ITERATIONS` | `5` | Outer cap on fix-sweep + wait iterations (matches `/wrap` recovery cap, issue #452) |
 
 ---
 
 ## Step 0: Run the initial audit
+
+Initialize the wait-loop counters **once per `/fixpr` invocation** (NOT per sweep — re-entering Step 0 for sweep 2+ must preserve them):
+
+```bash
+FIXPR_WAIT_CAP_SECS="${FIXPR_WAIT_CAP_SECS:-1200}"
+FIXPR_WAIT_POLL_SECS="${FIXPR_WAIT_POLL_SECS:-60}"
+FIXPR_MAX_ITERATIONS="${FIXPR_MAX_ITERATIONS:-5}"
+# Clamp cadence to the 30–60s contract
+(( FIXPR_WAIT_POLL_SECS < 30 )) && FIXPR_WAIT_POLL_SECS=30
+(( FIXPR_WAIT_POLL_SECS > 60 )) && FIXPR_WAIT_POLL_SECS=60
+FIXPR_WAIT_ITER=0          # wait iterations entered so far
+FIXPR_TOTAL_WAIT_SECS=0    # cumulative wall-clock wait across iterations
+FIXPR_WAIT_FINAL=""        # clean | cap-exhausted | new-findings-pending (set by 4d / outer-cap logic)
+```
 
 Locate `pr-state.sh`. Prefer the global install; fall back to the in-repo copy when developing the skill itself. The legacy `audit.sh` wrapper is kept for back-compat — call it only if `pr-state.sh` cannot be found.
 
@@ -455,6 +479,117 @@ When `DID_PUSH=0`, omit Step 4c; Step 4b’s resolver output alone is authoritat
 
 ---
 
+## Step 4d: Post-push review-wait loop (issue #454)
+
+Wait — bounded — for the bots and CI to deliver a verdict on the **current HEAD SHA only** (never the pre-push SHA), so `/fixpr` returns with a definitive answer instead of "we pushed, bye". This is the single owner of post-push polling: `/wrap` trusts this loop's verdict and never adds its own polling cadence on top.
+
+**Entry conditions:**
+
+- `DID_PUSH=1` → always enter. Watch the pushed SHA: `WATCH_SHA=$PUSHED_SHA`, baseline `WAIT_BASELINE=$PUSHED_AT`. Step 3b's fixed 120s reviewer-trigger wait already ran; it does **not** count against this loop's cap (the cap clock starts at loop entry).
+- `DID_PUSH=0` (idempotent path) → run **one** snapshot tick first (same `pr-state.sh` call + jq as below) on the current HEAD (`WATCH_SHA=$HEAD_SHA`, `WAIT_BASELINE=$RUN_STARTED_AT`) **without incrementing `FIXPR_WAIT_ITER`**. If `bots_pending`, `ci_pending`, and `ci_failing` are all empty and `new_findings == 0`, set `FIXPR_WAIT_FINAL=clean` and **exit Step 4d immediately — zero wait, zero iterations, no push** — proceed to Step 5. If bots or CI are still pending on the current SHA (e.g. `/wrap` delegated here mid-review), enter the loop and wait.
+
+**Per-tick snapshot — reuse `pr-state.sh`, do not re-invent endpoint polling.** Each tick fetches one fresh bundle (all 3 comment endpoints + check-runs + commit statuses, `per_page=100`, classification since baseline — the same primitives as `cr-github-review.md`):
+
+```bash
+FIXPR_WAIT_ITER=$((FIXPR_WAIT_ITER + 1))
+WAIT_STARTED=$(date +%s)
+WAIT_OUTCOME=""          # clean | cap-exhausted | new-findings | ci-failing | head-moved
+RETRIGGERED_THIS_WAIT=0
+while :; do
+  TICK=$("$SCRIPT" --pr "$PR_NUMBER" --since "$WAIT_BASELINE")
+  WAIT_STATE=$(jq -c --arg sha "$WATCH_SHA" '
+    . as $root
+    | ["coderabbitai[bot]","cursor[bot]","codeant-ai[bot]","greptile-apps[bot]","graphite-app[bot]"] as $botlist
+    | {"coderabbitai[bot]":"coderabbit","cursor[bot]":"bugbot","codeant-ai[bot]":"codeant",
+       "greptile-apps[bot]":"greptile","graphite-app[bot]":"graphite"} as $needles
+    | def is_review_check($n):
+        ($n // "" | ascii_downcase) as $name
+        | any("coderabbit","graphite","codeant","cursor","bugbot","greptile";
+              . as $x | $name | contains($x));
+    ([$root.comments.reviews[]?.user.login,
+      $root.comments.inline[]?.user.login,
+      $root.comments.conversation[]?.user.login]
+     | map(select(. as $l | $botlist | index($l) != null)) | unique) as $participants
+    | ($root.check_runs.all // []) as $checks
+    | ($root.bot_statuses // {}) as $bstat
+    | ($participants | map(. as $bot
+        | $needles[$bot] as $needle
+        | {bot: $bot,
+           done: (
+             # Review object pinned to the watched SHA. EXCLUDED for BugBot:
+             # cursor[bot] commit_id is stale/unreliable — gate BugBot by its
+             # check-run only (memory feedback_bugbot_commit_id_stale).
+             ( $bot != "cursor[bot]"
+               and any($root.comments.reviews[]?;
+                       .user.login == $bot and (.commit_id // "") == $sha) )
+             # Completed check-run on the watched SHA (check_runs are fetched per
+             # HEAD SHA, so SHA scoping is implicit). conclusion neutral still
+             # counts as complete — BugBot uses neutral for "findings posted".
+             or any($checks[]?;
+                    ((.name // "") | ascii_downcase | contains($needle))
+                    and .status == "completed")
+             # CR/Greptile also report via commit statuses on the watched SHA.
+             or ( $bot == "coderabbitai[bot]" and (($bstat.CodeRabbit.state // "pending") != "pending") )
+             or ( $bot == "greptile-apps[bot]" and (($bstat.Greptile.state // "pending") != "pending") )
+           )})) as $bots
+    | {head_moved: ($root.pr.head_sha != $sha),
+       bots_pending: ($bots | map(select(.done | not) | .bot)),
+       ci_pending: [ $checks[] | select((is_review_check(.name) | not) and .status != "completed") | .name ],
+       ci_failing: [ $checks[] | select((is_review_check(.name) | not)
+                     and (.conclusion == "failure" or .conclusion == "timed_out"
+                          or .conclusion == "action_required" or .conclusion == "startup_failure"
+                          or .conclusion == "stale")) | .name ],
+       new_findings: ($root.new_since_baseline.finding_count // 0)}
+  ' "$TICK")
+
+  ELAPSED=$(( $(date +%s) - WAIT_STARTED ))
+  BOTS_PENDING=$(jq -r '.bots_pending | join(", ") | if . == "" then "none" else . end' <<<"$WAIT_STATE")
+  CI_PENDING=$(jq -r '.ci_pending | join(", ") | if . == "" then "none" else . end' <<<"$WAIT_STATE")
+
+  # Heartbeat — every tick, user-visible, ET-timestamped
+  TS=$(TZ='America/New_York' date +'%a %b %-d %I:%M %p ET')
+  echo "[$TS] [WAIT] iter $FIXPR_WAIT_ITER/$FIXPR_MAX_ITERATIONS — ${ELAPSED}s/${FIXPR_WAIT_CAP_SECS}s on ${WATCH_SHA:0:7} — bots pending: $BOTS_PENDING — CI pending: $CI_PENDING"
+
+  if [[ "$(jq -r '.head_moved' <<<"$WAIT_STATE")" == "true" ]]; then
+    WAIT_OUTCOME="head-moved"; break          # external push — re-audit from Step 0
+  fi
+  if [[ "$(jq -r '.new_findings' <<<"$WAIT_STATE")" -gt 0 ]]; then
+    WAIT_OUTCOME="new-findings"; break        # bots posted findings — next sweep
+  fi
+  if [[ "$(jq -r '.ci_failing | length' <<<"$WAIT_STATE")" -gt 0 ]]; then
+    WAIT_OUTCOME="ci-failing"; break          # blocking CI on the new SHA — next sweep
+  fi
+  if [[ "$BOTS_PENDING" == "none" && "$CI_PENDING" == "none" ]]; then
+    WAIT_OUTCOME="clean"; break               # full verdict in — early exit
+  fi
+  if (( ELAPSED >= FIXPR_WAIT_CAP_SECS )); then
+    WAIT_OUTCOME="cap-exhausted"
+    echo "[WAIT] CAP HIT at ${FIXPR_WAIT_CAP_SECS}s on ${WATCH_SHA:0:7} — NOT falling through silently:"
+    echo "[WAIT]   bots still pending: $BOTS_PENDING"
+    echo "[WAIT]   CI still incomplete: $CI_PENDING"
+    break
+  fi
+  sleep "$FIXPR_WAIT_POLL_SECS"
+done
+FIXPR_TOTAL_WAIT_SECS=$((FIXPR_TOTAL_WAIT_SECS + ELAPSED))
+```
+
+**Participating-bot set is DYNAMIC** — computed fresh each tick from the bot logins seen in any review or comment on this PR, intersected with the allowlist. A CR-only PR never waits on Greptile/BugBot signals. Never use a static list.
+
+**Optional CR re-trigger inside the wait** (per `cr-merge-gate.md` re-trigger policy): if `coderabbitai[bot]` is participating and still pending after **12 min** (`ELAPSED >= 720`) and `RETRIGGERED_THIS_WAIT=0`, you may post one `@coderabbitai full review` — but ONLY when `cr-review-hourly.sh --check` exits 0 AND `cr-review-hourly.sh --record-explicit "$PR_NUMBER"` succeeds (it enforces the ≤2 explicit triggers/PR/hour cap atomically and exits 1 at the cap — at the cap, skip the trigger and keep waiting). Set `RETRIGGERED_THIS_WAIT=1` — at most one re-trigger per wait iteration. The wait loop never triggers any other reviewer; Step 3b owns those.
+
+**Routing on `WAIT_OUTCOME`:**
+
+| Outcome | Action |
+|---------|--------|
+| `clean` | Set `FIXPR_WAIT_FINAL=clean`. Proceed to Step 5 — the verify pass gives the authoritative classification of what the bots posted. |
+| `new-findings`, `ci-failing`, or `head-moved` | If `FIXPR_WAIT_ITER < FIXPR_MAX_ITERATIONS` → start the **next sweep at Step 0** (fresh `$RUN_STARTED_AT` picks up the new findings; the sweep fixes, pushes once, and re-enters this wait on the new SHA). Else → set `FIXPR_WAIT_FINAL=new-findings-pending` and proceed to Step 5/7 with status `NEW_FINDINGS` and the full audit — the outer cap is exhausted. |
+| `cap-exhausted` | Set `FIXPR_WAIT_FINAL=cap-exhausted`. Proceed to Step 5/7 — the cap-hit lines above (pending bots + incomplete CI) MUST appear in the final summary; the status will be `REVIEW_PENDING` or `CI_PENDING` per what is outstanding. |
+
+**Safety (non-negotiable, issues #450/#452/#454):** this loop is read-only plus the single rate-capped CR re-trigger above. It never calls branch-protection APIs, never dismisses human reviews, and never resolves threads — thread resolution happens only in Steps 1–4 after code-verification.
+
+---
+
 ## Step 5: Verify
 
 Run the audit script again with `--since $RUN_STARTED_AT`. This picks up the new HEAD SHA (post-push) **and** pre-classifies any bot comment that landed between Step 0 and now:
@@ -504,7 +639,7 @@ jq -r '
    - LGTM variants: `lgtm`, `looks good`, `approved`, `confirmed`, `resolved`
 4. **Default** (no pattern matched) → `finding`. The safer default — under-classifying here is the failure mode this whole skill exists to prevent.
 
-**If `finding_count > 0`:** do NOT loop. Emit `NEW_FINDINGS` in Step 7 and stop. Re-running `/fixpr` captures a new `$RUN_STARTED_AT` and re-audits from Step 0, picking up the new findings.
+**If `finding_count > 0`:** findings landed between the Step 4d wait exit and this verify. If `FIXPR_WAIT_ITER < FIXPR_MAX_ITERATIONS`, start the next sweep at Step 0 (a fresh `$RUN_STARTED_AT` re-audits and picks them up). At the outer cap: set `FIXPR_WAIT_FINAL=new-findings-pending`, emit `NEW_FINDINGS` in Step 7, and stop — re-running `/fixpr` resets the iteration budget.
 
 ### 5c. CI (if a push was made; exclude review-bot check-runs from CI pending)
 
@@ -552,7 +687,7 @@ Decide from the non-review CI counts before review-bot pending counts:
   - **transient** (runner timeout, startup failure, flaky external dep) → emit `CI_FAILING` in Step 7, note the specific checks, and continue to Step 6 — local fixes aren't possible and the user decides whether to retry.
 - `IN_PROGRESS == 0 && FAILING == 0` → non-review-bot CI is clean on this SHA.
 
-Do NOT poll.
+Do NOT poll here — Step 4d is the single owner of post-push polling. CI still pending at this point means the 4d cap fired (or 4d was skipped on the no-push path); report it, don't wait.
 
 ### 5d. Review-bot commit statuses on the current HEAD
 
@@ -583,7 +718,7 @@ jq -r '.merge_state | "[MERGE] mergeable=\(.mergeable), status=\(.mergeStateStat
 |-------|---------------|--------|
 | `mergeable` | `CONFLICTING` | Rebase onto main: `git fetch origin main && git rebase origin/main`. Fix conflicts (optionally run **`/merge-conflict`** — `.claude/skills/merge-conflict/SKILL.md` — to fetch main, auto-resolve *simple* hunks, stage clean files, and list *complex* hunks), continue, force-push. |
 | `mergeable` | `UNKNOWN` | GitHub still computing — note and re-run `/fixpr` later. |
-| `mergeStateStatus` | `BEHIND` | Rebase onto main: `git fetch origin main && git rebase origin/main`. If conflicts arise mid-rebase (replaying commits individually can conflict even when a three-way merge wouldn't), resolve them the same way as `CONFLICTING` above (including optional **`/merge-conflict`**), then `git rebase --continue`. Force-push. Wait for CI to re-run before verifying merge gate. |
+| `mergeStateStatus` | `BEHIND` | Rebase onto main: `git fetch origin main && git rebase origin/main`. If conflicts arise mid-rebase (replaying commits individually can conflict even when a three-way merge wouldn't), resolve them the same way as `CONFLICTING` above (including optional **`/merge-conflict`**), then `git rebase --continue`. Force-push, then — if `FIXPR_WAIT_ITER < FIXPR_MAX_ITERATIONS` — enter the Step 4d wait loop on the new SHA (counts as a wait iteration) instead of exiting blind. |
 | `mergeStateStatus` | `BLOCKED` | Required checks/reviews missing — already covered by 5c/5d. If CodeRabbit, Greptile, or CodeAnt is in CODEOWNERS and the last approval is stale/dismissed after a push, recover by triggering that bot (`@coderabbitai full review`, `@greptileai`, or `@codeant-ai review`) instead of escalating to the author. |
 | `mergeStateStatus` | `UNSTABLE` | A non-required check pending/failing — typically CR/Greptile on the new SHA. If 5d emitted `REVIEW_PENDING`, stop with that status. |
 | `reviewDecision` | `CHANGES_REQUESTED` | Changes were requested. **Stale** bot `CHANGES_REQUESTED` (wrong `commit_id` vs HEAD) are cleared by Step 3a after each push — not escalation. If a **human** left `CHANGES_REQUESTED` on the current HEAD, report as non-automatable. |
@@ -610,20 +745,23 @@ CI checks:       P total, Q were failing
   - Transient:   S (cannot fix locally)
 Merge state:     mergeable=..., status=..., review=...
 Push:            <sha> or "no push needed"
+Wait loop:       $FIXPR_WAIT_ITER iteration(s), total wait ${FIXPR_TOTAL_WAIT_SECS}s, final state: clean | cap-exhausted | new-findings-pending
+  - Pending at cap: <bots-pending list + CI-pending list when final state is cap-exhausted; omit otherwise>
 Status:          CLEAN | THREADS_STUCK | REVIEW_PENDING | CI_PENDING | CI_FAILING | CONFLICTS | BEHIND | NEEDS_HUMAN_REVIEW | NEW_FINDINGS
 FIXPR_WRAP_STATUS: <exact same token as Status — single-line machine-parseable copy for /wrap issue #452>
+FIXPR_WAIT_SUMMARY: iterations=<N> total_wait_secs=<S> final=<clean|cap-exhausted|new-findings-pending>
 ```
 
-`/wrap` recovery may delegate here; parents grep **`FIXPR_WRAP_STATUS:`** (and echo **`Status:`**) into heartbeats without re-parsing prose.
+`/wrap` recovery may delegate here; parents grep **`FIXPR_WRAP_STATUS:`** and **`FIXPR_WAIT_SUMMARY:`** (and echo **`Status:`**) into heartbeats without re-parsing prose. `FIXPR_WAIT_SUMMARY` is the issue #454 contract: `/wrap` trusts this verdict — the bots and CI were already waited on here, so `/wrap` re-runs `merge-gate.sh` immediately with no polling of its own. `final=clean` when the last wait exited on a full bot+CI verdict (or the idempotent no-push path was already clean — `iterations=0`); `final=cap-exhausted` when the last wait hit `FIXPR_WAIT_CAP_SECS`; `final=new-findings-pending` when the outer iteration cap exhausted with findings still arriving.
 
 **Status definitions:**
 
 - `CLEAN` — **all four conditions simultaneously:** zero unresolved threads (5a), `new_since_baseline.finding_count == 0` (5b), every present review-bot status/check-run for the current HEAD is complete/successful (5d), no merge blockers (6). Missing any one disqualifies `CLEAN` — pick the more specific status below.
 - `THREADS_STUCK` — some threads could not be resolved via GraphQL (report which).
-- `REVIEW_PENDING` — 5d found a review-bot status/check-run still pending on the current HEAD, or a reviewer has not responded yet after Step 3b (including the unconditional `@cursor review`). Re-run `/fixpr` after it flips to a completed state. Do NOT declare CLEAN.
-- `NEW_FINDINGS` — 5b's `finding_count > 0`. Stop the run. A fresh `/fixpr` captures a new `$RUN_STARTED_AT` and re-audits from Step 0.
-- `CI_PENDING` — push was made, and non-review-bot CI is not yet complete. Re-run `/fixpr` after CI.
+- `REVIEW_PENDING` — a review-bot status/check-run is still pending on the current HEAD after the Step 4d wait (i.e., the 20-min cap fired with bots outstanding — `FIXPR_WAIT_FINAL=cap-exhausted`). The footer's "Pending at cap" line names them. Re-run `/fixpr` for a fresh iteration budget. Do NOT declare CLEAN.
+- `NEW_FINDINGS` — findings still arriving at the outer iteration cap (`FIXPR_WAIT_FINAL=new-findings-pending`). Stop the run. A fresh `/fixpr` resets the budget and re-audits from Step 0.
+- `CI_PENDING` — push was made, and non-review-bot CI was still incomplete when the Step 4d cap fired. Re-run `/fixpr` after CI.
 - `CI_FAILING` — transient CI failures that cannot be fixed locally (report which).
 - `CONFLICTS` — merge conflicts could not be auto-resolved (needs manual intervention).
-- `BEHIND` — branch behind base, auto-rebased and force-pushed; now waiting for CI re-run. Re-run `/fixpr` after CI completes.
+- `BEHIND` — branch behind base, auto-rebased and force-pushed, and the wait budget was already exhausted (Step 6 enters the Step 4d wait on the new SHA when iterations remain). Re-run `/fixpr` after CI completes.
 - `NEEDS_HUMAN_REVIEW` — a human reviewer requested changes, or no configured code-owner bot can satisfy the missing required approval. If CR/Greptile is in CODEOWNERS and only its approval is stale/dismissed, downgrade to `REVIEW_PENDING` after triggering the bot re-review.

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -60,9 +60,9 @@ FIXPR_MAX_ITERATIONS="${FIXPR_MAX_ITERATIONS:-5}"
 # Clamp cadence to the 30–60s contract
 (( FIXPR_WAIT_POLL_SECS < 30 )) && FIXPR_WAIT_POLL_SECS=30
 (( FIXPR_WAIT_POLL_SECS > 60 )) && FIXPR_WAIT_POLL_SECS=60
-FIXPR_WAIT_ITER=0          # wait iterations entered so far
-FIXPR_TOTAL_WAIT_SECS=0    # cumulative wall-clock wait across iterations
-FIXPR_WAIT_FINAL=""        # clean | cap-exhausted | new-findings-pending (set by 4d / outer-cap logic)
+FIXPR_WAIT_ITER="${FIXPR_WAIT_ITER:-0}"          # wait iterations entered so far
+FIXPR_TOTAL_WAIT_SECS="${FIXPR_TOTAL_WAIT_SECS:-0}"    # cumulative wall-clock wait across iterations
+FIXPR_WAIT_FINAL="${FIXPR_WAIT_FINAL:-}"        # clean | cap-exhausted | new-findings-pending (set by 4d / outer-cap logic)
 ```
 
 Locate `pr-state.sh`. Prefer the global install; fall back to the in-repo copy when developing the skill itself. The legacy `audit.sh` wrapper is kept for back-compat — call it only if `pr-state.sh` cannot be found.
@@ -486,16 +486,79 @@ Wait — bounded — for the bots and CI to deliver a verdict on the **current H
 **Entry conditions:**
 
 - `DID_PUSH=1` → always enter. Watch the pushed SHA: `WATCH_SHA=$PUSHED_SHA`, baseline `WAIT_BASELINE=$PUSHED_AT`. Step 3b's fixed 120s reviewer-trigger wait already ran; it does **not** count against this loop's cap (the cap clock starts at loop entry).
-- `DID_PUSH=0` (idempotent path) → run **one** snapshot tick first (same `pr-state.sh` call + jq as below) on the current HEAD (`WATCH_SHA=$HEAD_SHA`, `WAIT_BASELINE=$RUN_STARTED_AT`) **without incrementing `FIXPR_WAIT_ITER`**. If `bots_pending`, `ci_pending`, and `ci_failing` are all empty and `new_findings == 0`, set `FIXPR_WAIT_FINAL=clean` and **exit Step 4d immediately — zero wait, zero iterations, no push** — proceed to Step 5. If bots or CI are still pending on the current SHA (e.g. `/wrap` delegated here mid-review), enter the loop and wait.
+- `DID_PUSH=0` (idempotent path) → run **one** snapshot tick first on the current HEAD (`WATCH_SHA=$HEAD_SHA`, `WAIT_BASELINE=$RUN_STARTED_AT`) using the same `pr-state.sh` + jq predicate as the loop below, **without incrementing `FIXPR_WAIT_ITER`**. If `bots_pending`, `ci_pending`, and `ci_failing` are all empty and `new_findings == 0`, set `FIXPR_WAIT_FINAL=clean` and **skip the wait loop entirely — zero wait, zero iterations, no push** — proceed to Step 5. If bots or CI are still pending on the current SHA (e.g. `/wrap` delegated here mid-review), fall through to the wait loop (which increments `FIXPR_WAIT_ITER` once at entry).
 
-**Per-tick snapshot — reuse `pr-state.sh`, do not re-invent endpoint polling.** Each tick fetches one fresh bundle (all 3 comment endpoints + check-runs + commit statuses, `per_page=100`, classification since baseline — the same primitives as `cr-github-review.md`):
+**Per-tick snapshot — reuse `pr-state.sh`, do not re-invent endpoint polling.** Set `WATCH_SHA` / `WAIT_BASELINE` from the entry path above (`PUSHED_SHA`/`PUSHED_AT` when `DID_PUSH=1`, else `HEAD_SHA`/`RUN_STARTED_AT`). Each tick fetches one fresh bundle (all 3 comment endpoints + check-runs + commit statuses, `per_page=100`, classification since baseline — the same primitives as `cr-github-review.md`):
 
 ```bash
-FIXPR_WAIT_ITER=$((FIXPR_WAIT_ITER + 1))
-WAIT_STARTED=$(date +%s)
-WAIT_OUTCOME=""          # clean | cap-exhausted | new-findings | ci-failing | head-moved
-RETRIGGERED_THIS_WAIT=0
-while :; do
+# Idempotent pre-check (DID_PUSH=0 only) — one tick, no iter increment
+SKIP_WAIT_LOOP=0
+if [[ "${DID_PUSH:-0}" -eq 0 ]]; then
+  WATCH_SHA=$HEAD_SHA
+  WAIT_BASELINE=$RUN_STARTED_AT
+  TICK=$("$SCRIPT" --pr "$PR_NUMBER" --since "$WAIT_BASELINE")
+  WAIT_STATE=$(jq -c --arg sha "$WATCH_SHA" '
+    . as $root
+    | ["coderabbitai[bot]","cursor[bot]","codeant-ai[bot]","greptile-apps[bot]","graphite-app[bot]"] as $botlist
+    | {"coderabbitai[bot]":"coderabbit","cursor[bot]":"bugbot","codeant-ai[bot]":"codeant",
+       "greptile-apps[bot]":"greptile","graphite-app[bot]":"graphite"} as $needles
+    | def is_review_check($n):
+        ($n // "" | ascii_downcase) as $name
+        | any("coderabbit","graphite","codeant","cursor","bugbot","greptile";
+              . as $x | $name | contains($x));
+    ([$root.comments.reviews[]?.user.login,
+      $root.comments.inline[]?.user.login,
+      $root.comments.conversation[]?.user.login]
+     | map(select(. as $l | $botlist | index($l) != null)) | unique) as $participants
+    | ($root.check_runs.all // []) as $checks
+    | ($root.bot_statuses // {}) as $bstat
+    | ($participants | map(. as $bot
+        | $needles[$bot] as $needle
+        | {bot: $bot,
+           done: (
+             ( $bot != "cursor[bot]"
+               and any($root.comments.reviews[]?;
+                       .user.login == $bot and (.commit_id // "") == $sha) )
+             or any($checks[]?;
+                    ((.name // "") | ascii_downcase | contains($needle))
+                    and .status == "completed")
+             or ( $bot == "coderabbitai[bot]" and (($bstat.CodeRabbit.state // "pending") != "pending") )
+             or ( $bot == "greptile-apps[bot]" and (($bstat.Greptile.state // "pending") != "pending") )
+           )})) as $bots
+    | {head_moved: ($root.pr.head_sha != $sha),
+       bots_pending: ($bots | map(select(.done | not) | .bot)),
+       ci_pending: [ $checks[] | select((is_review_check(.name) | not) and .status != "completed") | .name ],
+       ci_failing: [ $checks[] | select((is_review_check(.name) | not)
+                     and (.conclusion == "failure" or .conclusion == "timed_out"
+                          or .conclusion == "action_required" or .conclusion == "startup_failure"
+                          or .conclusion == "stale")) | .name ],
+       new_findings: ($root.new_since_baseline.finding_count // 0)}
+  ' "$TICK")
+  BOTS_PENDING=$(jq -r '.bots_pending | join(", ") | if . == "" then "none" else . end' <<<"$WAIT_STATE")
+  CI_PENDING=$(jq -r '.ci_pending | join(", ") | if . == "" then "none" else . end' <<<"$WAIT_STATE")
+  if [[ "$BOTS_PENDING" == "none" && "$CI_PENDING" == "none"
+        && "$(jq -r '.ci_failing | length' <<<"$WAIT_STATE")" -eq 0
+        && "$(jq -r '.new_findings' <<<"$WAIT_STATE")" -eq 0
+        && "$(jq -r '.head_moved' <<<"$WAIT_STATE")" != "true" ]]; then
+    FIXPR_WAIT_FINAL=clean
+    SKIP_WAIT_LOOP=1
+    echo "[WAIT] idempotent pre-check: clean on ${WATCH_SHA:0:7} — zero wait, zero iterations"
+  fi
+fi
+
+if [[ "$SKIP_WAIT_LOOP" -eq 0 ]]; then
+  if [[ "${DID_PUSH:-0}" -eq 1 ]]; then
+    WATCH_SHA=$PUSHED_SHA
+    WAIT_BASELINE=$PUSHED_AT
+  else
+    WATCH_SHA=$HEAD_SHA
+    WAIT_BASELINE=$RUN_STARTED_AT
+  fi
+  FIXPR_WAIT_ITER=$((FIXPR_WAIT_ITER + 1))
+  WAIT_STARTED=$(date +%s)
+  WAIT_OUTCOME=""          # clean | cap-exhausted | new-findings | ci-failing | head-moved
+  RETRIGGERED_THIS_WAIT=0
+  while :; do
   TICK=$("$SCRIPT" --pr "$PR_NUMBER" --since "$WAIT_BASELINE")
   WAIT_STATE=$(jq -c --arg sha "$WATCH_SHA" '
     . as $root
@@ -572,6 +635,7 @@ while :; do
   sleep "$FIXPR_WAIT_POLL_SECS"
 done
 FIXPR_TOTAL_WAIT_SECS=$((FIXPR_TOTAL_WAIT_SECS + ELAPSED))
+fi   # end SKIP_WAIT_LOOP
 ```
 
 **Participating-bot set is DYNAMIC** — computed fresh each tick from the bot logins seen in any review or comment on this PR, intersected with the allowlist. A CR-only PR never waits on Greptile/BugBot signals. Never use a static list.
@@ -583,7 +647,7 @@ FIXPR_TOTAL_WAIT_SECS=$((FIXPR_TOTAL_WAIT_SECS + ELAPSED))
 | Outcome | Action |
 |---------|--------|
 | `clean` | Set `FIXPR_WAIT_FINAL=clean`. Proceed to Step 5 — the verify pass gives the authoritative classification of what the bots posted. |
-| `new-findings`, `ci-failing`, or `head-moved` | If `FIXPR_WAIT_ITER < FIXPR_MAX_ITERATIONS` → start the **next sweep at Step 0** (fresh `$RUN_STARTED_AT` picks up the new findings; the sweep fixes, pushes once, and re-enters this wait on the new SHA). Else → set `FIXPR_WAIT_FINAL=new-findings-pending` and proceed to Step 5/7 with status `NEW_FINDINGS` and the full audit — the outer cap is exhausted. |
+| `new-findings`, `ci-failing`, or `head-moved` | If `FIXPR_WAIT_ITER < FIXPR_MAX_ITERATIONS` → start the **next sweep at Step 0** (fresh `$RUN_STARTED_AT` picks up the new findings; the sweep fixes, pushes once, and re-enters this wait on the new SHA). Else at outer cap, set `FIXPR_WAIT_FINAL` and Status **per outcome** — do not blanket-label everything `new-findings-pending`: `new-findings` → `FIXPR_WAIT_FINAL=new-findings-pending`, Status `NEW_FINDINGS`; `ci-failing` → `FIXPR_WAIT_FINAL=cap-exhausted`, Status `CI_FAILING`; `head-moved` → `FIXPR_WAIT_FINAL=cap-exhausted`, Status note external push in summary (re-run `/fixpr`). |
 | `cap-exhausted` | Set `FIXPR_WAIT_FINAL=cap-exhausted`. Proceed to Step 5/7 — the cap-hit lines above (pending bots + incomplete CI) MUST appear in the final summary; the status will be `REVIEW_PENDING` or `CI_PENDING` per what is outstanding. |
 
 **Safety (non-negotiable, issues #450/#452/#454):** this loop is read-only plus the single rate-capped CR re-trigger above. It never calls branch-protection APIs, never dismisses human reviews, and never resolves threads — thread resolution happens only in Steps 1–4 after code-verification.
@@ -718,7 +782,7 @@ jq -r '.merge_state | "[MERGE] mergeable=\(.mergeable), status=\(.mergeStateStat
 |-------|---------------|--------|
 | `mergeable` | `CONFLICTING` | Rebase onto main: `git fetch origin main && git rebase origin/main`. Fix conflicts (optionally run **`/merge-conflict`** — `.claude/skills/merge-conflict/SKILL.md` — to fetch main, auto-resolve *simple* hunks, stage clean files, and list *complex* hunks), continue, force-push. |
 | `mergeable` | `UNKNOWN` | GitHub still computing — note and re-run `/fixpr` later. |
-| `mergeStateStatus` | `BEHIND` | Rebase onto main: `git fetch origin main && git rebase origin/main`. If conflicts arise mid-rebase (replaying commits individually can conflict even when a three-way merge wouldn't), resolve them the same way as `CONFLICTING` above (including optional **`/merge-conflict`**), then `git rebase --continue`. Force-push, then — if `FIXPR_WAIT_ITER < FIXPR_MAX_ITERATIONS` — enter the Step 4d wait loop on the new SHA (counts as a wait iteration) instead of exiting blind. |
+| `mergeStateStatus` | `BEHIND` | Rebase onto main: `git fetch origin main && git rebase origin/main`. If conflicts arise mid-rebase (replaying commits individually can conflict even when a three-way merge wouldn't), resolve them the same way as `CONFLICTING` above (including optional **`/merge-conflict`**), then `git rebase --continue`. Force-push. When `FIXPR_WAIT_ITER < FIXPR_MAX_ITERATIONS`, treat the force-push as push-equivalent: set `PUSHED_SHA=$(git rev-parse HEAD)`, `PUSHED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")`, `DID_PUSH=1`, run **Step 3a** (dismiss stale bot reviews), **Step 3b** (reviewer triggers + 120s wait), then **Step 4d** on the new SHA. Do **not** jump straight to Step 4d without 3a/3b — bots are never kicked on the rebased SHA otherwise. |
 | `mergeStateStatus` | `BLOCKED` | Required checks/reviews missing — already covered by 5c/5d. If CodeRabbit, Greptile, or CodeAnt is in CODEOWNERS and the last approval is stale/dismissed after a push, recover by triggering that bot (`@coderabbitai full review`, `@greptileai`, or `@codeant-ai review`) instead of escalating to the author. |
 | `mergeStateStatus` | `UNSTABLE` | A non-required check pending/failing — typically CR/Greptile on the new SHA. If 5d emitted `REVIEW_PENDING`, stop with that status. |
 | `reviewDecision` | `CHANGES_REQUESTED` | Changes were requested. **Stale** bot `CHANGES_REQUESTED` (wrong `commit_id` vs HEAD) are cleared by Step 3a after each push — not escalation. If a **human** left `CHANGES_REQUESTED` on the current HEAD, report as non-automatable. |

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -86,15 +86,13 @@ Proceed immediately to Phase 2 — do not ask.
 
 ```bash
 WRAP_RECOVERY_MAX_ITERATIONS="${WRAP_RECOVERY_MAX_ITERATIONS:-5}"
-WRAP_RECOVERY_POLL_SECS="${WRAP_RECOVERY_POLL_SECS:-120}"
-WRAP_RECOVERY_MICRO_POLLS="${WRAP_RECOVERY_MICRO_POLLS:-3}"
 ```
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `WRAP_RECOVERY_MAX_ITERATIONS` | `5` | Hard cap on recovery cycles |
-| `WRAP_RECOVERY_POLL_SECS` | `120` | Sleep between reviewer trigger and re-check |
-| `WRAP_RECOVERY_MICRO_POLLS` | `3` | Within one iteration, brief re-polls after trigger |
+
+**Polling ownership (issue #454):** `/wrap` has NO polling cadence of its own — no sleeps, no micro-polls between gate checks. All waiting for bot verdicts and CI happens inside `/fixpr`'s Step 4d review-wait loop (30–60s cadence, 20-min cap per iteration, outer cap 5). `/wrap` delegates, trusts the returned verdict, and re-runs `merge-gate.sh` immediately.
 
 **Per-iteration heartbeat (mandatory):** Before acting, emit one user-visible line:
 
@@ -156,16 +154,16 @@ After each action, append to **`WRAP_RECOVERY_AUDIT`** (free-form lines or bulle
    - `merge_state == "DIRTY"`; **or**
    - Phase 1 left **`WRAP_PHASE1_FINDINGS`** (classified bot findings still pending remediation).
 
-   **Execution contract:** Do **not** shell out to an opaque “run fixpr” wrapper. Execute the **full** `.claude/skills/fixpr/SKILL.md` workflow (Steps 0–7): `pr-state.sh`, classify findings, fix + single push when needed, `dismiss-stale-bot-changes.sh` after push when applicable, `reply-thread.sh`, `resolve-review-threads.sh`, verify passes, etc. If spawning a Phase A subagent to carry the skill, use **`mode: "bypassPermissions"`**, explicit **`model`**, SAFETY block from `.claude/rules/safety.md`, and handoff path per `.claude/rules/subagent-orchestration.md` — parent stays in **monitor mode** (orchestration only).
+   **Execution contract:** Do **not** shell out to an opaque “run fixpr” wrapper. Execute the **full** `.claude/skills/fixpr/SKILL.md` workflow (Steps 0–7, including the Step 4d review-wait loop): `pr-state.sh`, classify findings, fix + single push when needed, `dismiss-stale-bot-changes.sh` after push when applicable, `reply-thread.sh`, `resolve-review-threads.sh`, the bounded wait for bot verdicts + CI on the new SHA, verify passes, etc. If spawning a Phase A subagent to carry the skill, use **`mode: "bypassPermissions"`**, explicit **`model`**, SAFETY block from `.claude/rules/safety.md`, and handoff path per `.claude/rules/subagent-orchestration.md` — parent stays in **monitor mode** (orchestration only).
 
-   Parse the **`=== fixpr complete ===`** footer for **`Status:`** and **`FIXPR_WRAP_STATUS`** (see fixpr skill). Echo that status into the heartbeat for this cycle.
+   Parse the **`=== fixpr complete ===`** footer for **`Status:`**, **`FIXPR_WRAP_STATUS`**, and **`FIXPR_WAIT_SUMMARY`** (iterations, total wait secs, final state — see fixpr skill). Echo status + wait summary into the heartbeat for this cycle and append them to `WRAP_RECOVERY_AUDIT`. **Trust the verdict (issue #454):** `/fixpr` already waited for the bots and CI on the new SHA — re-fetch HEAD and re-run `merge-gate.sh` **immediately**; never sleep or re-poll on top.
 
    **Stop conditions after `/fixpr`:**
 
    - **`CI_FAILING`** with deterministic code/test failures you cannot fix in-session → stop; surface `missing` / CI summary + audit (matches “unfixable CI” scenario).
-   - **`THREADS_STUCK`**, **`NEEDS_HUMAN_REVIEW`**, or **`NEW_FINDINGS`** where unresolved → stop with audit; instruct re-run `/wrap` or `/fixpr`.
-   - **`REVIEW_PENDING`** → re-enter recovery loop; next gate re-check routes to Branch C (trigger bot + micro-poll) or Branch D. Outer iteration cap still applies.
-   - **`CI_PENDING`** → re-enter recovery loop; next gate re-check routes to Branch D (wait for CI). Outer iteration cap still applies.
+   - **`THREADS_STUCK`**, **`NEEDS_HUMAN_REVIEW`**, or **`NEW_FINDINGS`** where unresolved → stop with audit; instruct re-run `/wrap` or `/fixpr`. (`NEW_FINDINGS` now means `/fixpr` exhausted its own 5-iteration budget — `FIXPR_WAIT_SUMMARY: … final=new-findings-pending`.)
+   - **`REVIEW_PENDING`** (`final=cap-exhausted` — `/fixpr`'s 20-min wait cap fired with the named bots still pending) → re-enter recovery loop; next gate re-check routes to Branch C (trigger bot, then re-delegate the wait to `/fixpr`) or Branch D. Outer iteration cap still applies.
+   - **`CI_PENDING`** (`final=cap-exhausted` with CI incomplete) → re-enter recovery loop; next gate re-check routes to Branch D. Outer iteration cap still applies.
    - **`BEHIND`** → `/fixpr` rebased/force-pushed; re-run the gate. If CI is now pending on the new HEAD, treat as `CI_PENDING`.
    - **`CONFLICTS`** → stop immediately; recommend **`/merge-conflict`** or manual resolution.
    - **`CLEAN`** → **continue** to next recovery iteration (re-run gate).
@@ -179,11 +177,11 @@ After each action, append to **`WRAP_RECOVERY_AUDIT`** (free-form lines or bulle
    - CodeAnt: `@codeant-ai review` when CodeAnt owns the gap.
    - BugBot: when the PR is on the BugBot path (`reviewer == "bugbot"` per `reviewer-of.sh` or `session-state.json`), post `@cursor review` — duplicates are acceptable per `bugbot.md`.
 
-   Then **poll:** sleep `$WRAP_RECOVERY_POLL_SECS`, re-run `merge-gate.sh`, and repeat up to **`WRAP_RECOVERY_MICRO_POLLS`** times **within the same outer iteration**. After micro-polls are exhausted, advance to the next outer iteration and record the chosen checks/results in the audit.
+   Then **delegate the wait to `/fixpr`** (issue #454 — no wrap-side sleep/micro-polls): run the `/fixpr` workflow; its idempotent path makes no push when nothing needs fixing, and its Step 4d loop waits on the current SHA until the triggered bot completes or the 20-min cap fires. Parse `FIXPR_WAIT_SUMMARY`, append to audit, re-run `merge-gate.sh` immediately, advance to the next outer iteration.
 
-   **D. CI incomplete only** (no failing yet) — Do not call `/fixpr` for fix work. Sleep `$WRAP_RECOVERY_POLL_SECS`, append “waiting for CI”, continue to next iteration if under cap.
+   **D. CI incomplete only** (no failing yet) — Do not fix anything. Delegate the wait to `/fixpr` (idempotent — no push; its Step 4d loop polls until non-review-bot CI completes or the cap fires), append “waited for CI via /fixpr: <FIXPR_WAIT_SUMMARY>” to audit, re-run the gate immediately, continue to next iteration if under cap.
 
-   **`merge_state == UNKNOWN`** — Sleep and retry within cap; if still unknown at cap, stop with audit.
+   **`merge_state == UNKNOWN`** — GitHub is still computing mergeability; re-run `merge-gate.sh` on the next iteration (the gate call itself provides the spacing — no sleep). If still unknown at cap, stop with audit.
 
 4. **End of iteration:** If no branch matched and gate still fails, append “unclassified blocker” + full `missing` to audit and proceed to next `i`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #454

## Summary

`/fixpr` gains **Step 4d: post-push review-wait loop** — after every push it now waits (bounded) for bot verdicts and CI on the **new HEAD SHA only**, instead of exiting "we pushed, bye". `/wrap` loses its own polling cadence and trusts `/fixpr`'s verdict: single owner of polling = `/fixpr`.

### `/fixpr` (`.claude/skills/fixpr/SKILL.md`)
- New **Step 4d** polls `pr-state.sh --pr N --since $PUSHED_AT` every `FIXPR_WAIT_POLL_SECS` (default 60, clamped to the 30–60s contract) — reuses the existing bundle (3 comment endpoints + check-runs + commit statuses, `per_page=100`), no duplicated endpoint logic.
- **Early exit** when ALL participating bots (dynamic set: bot logins seen in any review/comment on this PR ∩ allowlist — never static) have a review pinned to the watched SHA or a `status: completed` check-run on it, AND all non-review-bot CI check-runs are completed with non-blocking conclusions.
- **BugBot** completion is gated by its check-run only (`neutral` = findings posted, still complete) — `cursor[bot]` review `commit_id` is excluded as unreliable (memory `feedback_bugbot_commit_id_stale`).
- **Per-iteration hard cap** `FIXPR_WAIT_CAP_SECS` (default 1200s = P93 of the 30-PR bot-response sample from the issue). Cap hits log pending bots + incomplete CI explicitly — never a silent fall-through.
- **New findings / blocking CI mid-wait** → exit wait, restart the fix sweep at Step 0 (fresh baseline), push once, new wait iteration on the new SHA. **Outer cap** `FIXPR_MAX_ITERATIONS` (default 5, matches #452).
- **Heartbeat every tick**: ET timestamp, iteration i/5, elapsed/cap, bots-pending and CI-pending lists.
- **Idempotent**: `DID_PUSH=0` runs one snapshot tick without incrementing the counter; clean SHA → exit immediately, zero wait, no push.
- **Rate cap**: optional CR re-trigger inside the wait only after 12 min, once per wait iteration, and only when `cr-review-hourly.sh --check` passes and `--record-explicit` succeeds (atomic ≤2 explicit triggers/PR/hour).
- **Footer enriched**: `Wait loop:` line + machine-parseable `FIXPR_WAIT_SUMMARY: iterations=<N> total_wait_secs=<S> final=<clean|cap-exhausted|new-findings-pending>`.
- Step 5b/5c/6/7 text reconciled with the loop (the old "do NOT loop / single-pass" contract is replaced by bounded convergence; Step 4d is the only place that polls).

### `/wrap` (`.claude/skills/wrap/SKILL.md`)
- `WRAP_RECOVERY_POLL_SECS` and `WRAP_RECOVERY_MICRO_POLLS` **removed**; new "Polling ownership" rule: no wrap-side sleeps or micro-polls, ever.
- Branch B parses `FIXPR_WAIT_SUMMARY`, echoes it into heartbeat + audit, and re-runs `merge-gate.sh` **immediately** after `/fixpr` returns.
- Branches C (missing bot signal) and D (CI incomplete) delegate the wait to `/fixpr`'s idempotent path instead of sleeping; `UNKNOWN` retries via the next gate call with no sleep.

### `exit-report-format.md`
- Optional `FIXPR_WAIT_ITERATIONS` / `FIXPR_TOTAL_WAIT_SECS` / `FIXPR_WAIT_FINAL` fields, required when the phase executed `/fixpr` (per `phase-protocols.md`).

## Implementation notes
- **CR plan**: unavailable — the auto-planner posted only its ack/enrichment template on #454 and the org is rate-limited; plan built from the issue body's settled design facts (empirical 20-min knee, poll-don't-sleep, dynamic bot set, in-turn loop). The issue-body merge step could not be performed from this environment (read-only issue token); the plan is recorded here instead.
- **#455 sequencing**: #455 is open with no PR in flight; the `/wrap`→`/fixpr` call path it formalizes already exists on main from #452 Branch B, which is the contract this PR enriches. Will rebase if #455 lands mid-flight.
- **Validation**: extracted the Step 4d bash (`bash -n` clean) and exercised the jq predicate against synthetic bundles (clean exit, BugBot check-run-only gating, head-moved, mixed bots + failing CI + new findings) plus a full loop simulation with a stubbed `pr-state.sh` (pending→pending→clean early exit; cap-fire with named pending bots/CI). `rule-lint.sh` passes (10,962 words, cap 11,692).

## Test plan

- [x] Clean-in-5-min early exit (70% bucket): wait loop exits as soon as all participating bots + CI report on the new SHA — verified via loop simulation (pending ×2 ticks → clean → `WAIT_OUTCOME=clean`, no cap wait)
- [x] New-findings-at-8-min refix cycle: `new_findings > 0` mid-wait exits the loop (verified via jq predicate test: `new_findings: 2` detected), routes to a new sweep at Step 0, push, new wait on the new SHA (routing table + Step 5b path)
- [x] Slow-bot 20-min cap fire: cap-hit block names pending bots and incomplete CI — verified via simulation (`CAP HIT … bots still pending: coderabbitai[bot], cursor[bot] — CI still incomplete: test`)
- [x] Pre-clean PR exits first cycle, no push: `DID_PUSH=0` snapshot tick exits with zero wait, zero iterations, no push — predicate verified clean on synthetic bundle (all bots done + CI green → empty pending lists)
- [x] Outer cap at iteration 5 with full audit: `FIXPR_WAIT_ITER == FIXPR_MAX_ITERATIONS` → `final=new-findings-pending`, status `NEW_FINDINGS`, full audit in footer (routing table + Step 5b + status definitions)
- [x] Per-iteration heartbeat: every tick prints ET timestamp, iter i/5, elapsed/cap, bots-pending, CI-pending — verified via simulation output
- [x] `/wrap` trusts the exit report: parses `FIXPR_WAIT_SUMMARY`, re-runs `merge-gate.sh` immediately; `WRAP_RECOVERY_POLL_SECS`/`MICRO_POLLS` removed; zero remaining sleep/micro-poll references in wrap (grep-verified)
- [x] ≤2 CR triggers/hour across iterations: re-trigger requires 12-min elapsed + `RETRIGGERED_THIS_WAIT=0` (once per wait iteration) + `cr-review-hourly.sh --check` exit 0 + `--record-explicit` success (script enforces the per-PR 2/hour cap atomically, exit 1 at cap)
- [x] Safety: wait loop is read-only except the rate-capped CR re-trigger; no branch-protection calls, no human-review dismissals, no thread resolution outside Steps 1–4 code-verification (explicit Safety block in Step 4d)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c78f980a-2ccb-4a5a-bbb3-a0e39722aeb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c78f980a-2ccb-4a5a-bbb3-a0e39722aeb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Extended exit-report format with optional wait-loop metrics and a final wait state when the fixing workflow ran.
  * Updated the fixing and wrapping workflow documentation to reflect bounded bot/CI waiting and new stop/re-entry semantics.

* **Improvements**
  * Enhanced the fixing workflow with a capped, retryable wait loop for bot/CI results on the current HEAD, including clearer “new findings” handling.
  * Updated the wrapping/recovery workflow to delegate bot/CI waiting to the fixing workflow, then immediately re-run the merge gate based on its verdicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->