### PR TITLE
feat(recap): add /recap functional-summary skill

### DIFF
--- a/.claude/skills/recap/SKILL.md
+++ b/.claude/skills/recap/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: recap
+description: Produce a concise, conversational functional summary of what a PR or issue actually changed or hopes to accomplish — nested bullets by default, optional Markdown table. Functional / feature lens, not an implementation walkthrough.
+triggers:
+  - recap PR
+  - recap issue
+  - tldr PR
+  - tldr issue
+  - functional summary
+  - summarize PR
+  - summarize issue
+  - what did this PR do
+argument-hint: "[PR#|issue#|URL] [--table] [--full] [--technical]"
+model: sonnet
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+Produce a **functional-improvement summary** of a PR or issue: what the work *did* (a merged/open PR) or *hopes to do* (an open issue), written for a technical collaborator who wants the feature perspective — **not** the implementation walkthrough.
+
+`/recap` is the single-target companion to `/standup`. `/standup` rolls up *all* recent activity across a time window for a daily report; `/recap` zooms in on **one** PR or issue and renders its functional story as nested bullets (or a table). Reach for `/standup` for "what happened lately"; reach for `/recap` for "explain this one PR/issue to my collaborator."
+
+## Output modes
+
+| Mode | Flag | Effect |
+|------|------|--------|
+| Nested bullets | *(default)* | Top-level bullet = functional change; sub-bullets = scope/notes |
+| Table | `--table` | Markdown table with `Change \| Notes` columns |
+| Full | `--full` | Relax the word budget; keep nested-bullet (or table) structure |
+| Technical | `--technical` | Add a second tier of detail per bullet (mechanism, files, key endpoints) **without** removing the conversational top-level bullet |
+
+Flags compose: `--table --technical` adds a third "Technical detail" column; `--full --technical` keeps both expansions.
+
+## Step 1: Parse arguments and flags
+
+Parse `$ARGUMENTS`. **Extract flags first**, then interpret whatever remains as the target identifier.
+
+- **Flags** (any order, anywhere in `$ARGUMENTS`): `--table`, `--full`, `--technical`. Set a boolean for each; strip them from the argument string.
+- **Target identifier** (the non-flag remainder):
+  - **URL** (`https://github.com/<owner>/<repo>/pull/123` or `.../issues/123`) → extract the trailing number; the path segment (`/pull/` vs `/issues/`) fixes the type.
+  - **`#N` or bare number** (`452`, `#457`) → strip any leading `#`; type is not yet known (resolve in Step 2).
+  - **Empty** → auto-detect (see below).
+
+### Auto-detect when no target is given
+
+1. Try the current branch's PR:
+   ```bash
+   AUTO_PR=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
+   ```
+   If non-empty, target is that PR.
+2. If no PR, try to recover an issue number from the branch name (`issue-<N>-*` or a leading `<N>-*`):
+   ```bash
+   BRANCH=$(git branch --show-current 2>/dev/null || true)
+   AUTO_ISSUE=$(printf '%s' "$BRANCH" | grep -oE '(^|issue-)[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+   ```
+   If non-empty, target is that issue.
+3. If neither resolves, **stop and ask**: "What should I recap? Give a PR number, issue number, or URL (e.g. `/recap 452`, `/recap #457`, or a GitHub URL)."
+
+## Step 2: Determine target type and fetch data
+
+**Type resolution:**
+- URL with `/pull/` → PR. URL with `/issues/` → issue.
+- Auto-detected PR (Step 1) → PR. Auto-detected issue → issue.
+- Bare number → try PR first, fall back to issue:
+  ```bash
+  if gh pr view "$N" --json number >/dev/null 2>&1; then
+    TYPE=pr
+  elif gh issue view "$N" --json number >/dev/null 2>&1; then
+    TYPE=issue
+  else
+    echo "Could not find PR or issue #$N in this repo — it may be deleted, private, or in another repo." >&2
+    exit 1
+  fi
+  ```
+  > **Note:** in GitHub a PR *is* an issue under the hood, so `gh pr view <N>` succeeding is the authoritative "this number is a PR" signal. Only fall back to `gh issue view` when the PR lookup fails.
+
+**For a PR**, fetch state plus a diff stat (the stat is for *your* understanding of scope — it does **not** go in the output):
+```bash
+gh pr view "$N" --json number,title,body,state,mergedAt,isDraft,additions,deletions,changedFiles,headRefName
+gh pr diff "$N" --stat 2>/dev/null || true
+```
+Also scan the PR body for a linked issue (`Closes #N`, `Fixes #N`, `Resolves #N`, case-insensitive). If found, fetch that issue's title + body for additional "why" context:
+```bash
+gh issue view "$LINKED_N" --json number,title,body,state 2>/dev/null || true
+```
+
+**For an issue**, fetch state, body, and recent comments (comments often carry plan/scope refinements), plus any linked PRs:
+```bash
+gh issue view "$N" --json number,title,body,state,createdAt --comments
+```
+
+If a JSON fetch fails outright (deleted / private / wrong repo), stop with a one-line graceful error — do not emit a half-summary.
+
+## Step 3: Choose tense
+
+Tense is driven by target state:
+
+| Target state | Tense | Example bullet opener |
+|--------------|-------|-----------------------|
+| Merged PR (`mergedAt` non-null) | **Past** | "Cleaned up review threads automatically…" |
+| Open, non-draft PR | **Present** | "Lets you merge once review is clean…" |
+| Draft PR (`isDraft: true`) | **Conditional** | "Will let you merge once review is clean…" |
+| Open issue | **Future / conditional** | "Aims to let you merge once review is clean…" |
+| Closed-not-merged PR (`state: CLOSED`, `mergedAt` null) | **Past + closure note** | "Attempted to… (closed without merging)" |
+
+Lead the summary with a one-line context header that states what the target is and its state, e.g. `**PR #452 (merged)** — …` or `**Issue #457 (open)** — …`.
+
+## Step 4: Write the summary (the important part)
+
+Synthesize the functional story from title + body + diff stat + linked issue. **Do not** copy the body, the acceptance criteria, or file lists. Decide what the change *does for a person* and say that.
+
+### Default tone & audience (non-negotiable)
+
+The default reader is **your technical collaborator on this repo** who, for this summary, wants the **functional / feature perspective** — not an engineering spec. Write the way you'd explain it to them over coffee.
+
+- **Lead with why it matters.** Each top-level bullet communicates the user-visible or workflow-visible improvement, not the mechanism. ✅ "PRs now merge themselves once review is clean." ❌ "Adds a polling loop to the merge command with a 20-minute cap."
+- **Conversational, active voice.** Use first/second person where it helps ("you can now…", "we now handle…"). Avoid passive engineering voice ("a loop has been added").
+- **No jargon by default.** Strip internal acronyms and tool-speak — `CR`, `AC`, `SHA`, `GraphQL`, `mergeStateStatus`, `check-runs`, endpoint names, function names. Replace each with the plain-language thing it *does*. Only keep a term if it's universally understood by the collaborator and genuinely adds meaning.
+- **No file paths, line numbers, or commit hashes** in default output — those live in `--technical` mode.
+- **No marketing or hype** ("revolutionary", "blazing-fast", "game-changing").
+
+### Structure & length
+
+- **Default = nested Markdown bullets.** Top-level bullet = one functional change (≤15 words). Sub-bullets = scope / important caveats (≤10 words each). Aim for **3–8 top-level bullets**; total output **≤300 words**.
+- Skip low-value detail: formatting-only changes, comment tweaks, pure refactors with no behavior change.
+- `--full` removes the word ceiling but keeps the nested-bullet (or table) shape — never collapse into paragraphs.
+
+Example default-mode shape:
+```
+**PR #452 (merged)** — Tightens how review feedback gets closed out before merge.
+
+- Review comments now get tidied up automatically once the code actually addresses them
+  - Posts a quick "fixed here" note before closing each one
+  - Never closes a comment it hasn't verified is handled
+- Merging is blocked while any review comment is still open
+  - You get the unresolved links surfaced so nothing slips through
+```
+
+### `--table` mode
+
+Emit a Markdown table instead of bullets. Each row = one functional change.
+```
+| Change | Notes |
+|---|---|
+| Review comments close out automatically once addressed | Posts a "fixed here" note first; never closes unverified |
+| Merge is blocked while any comment is open | Surfaces the unresolved links to you |
+```
+With `--technical`, add a third column: `| Change | Notes | Technical detail |`.
+
+### `--technical` mode
+
+Keep the conversational top-level bullet, then add **one** sub-bullet (bullets mode) or the extra column (table mode) with the technical why/how: which files/scripts changed, the concrete mechanism, key endpoints. Still skip low-value detail.
+```
+- Review comments now close out automatically once addressed
+  - Posts a "fixed here" note first; never closes unverified
+  - *Technical:* `/wrap` delegates to `/fixpr`, which replies via `reply-thread.sh` then resolves threads through the GitHub GraphQL `resolveReviewThread` mutation
+```
+
+### Anti-patterns to avoid (read before writing)
+
+- ❌ **Engineering-voice bullet text:** "Implements X", "Adds Y", "Refactors Z" as the *lead* of a default-mode bullet. (These are fine inside `--technical` sub-bullets.)
+- ❌ **File-path enumeration in bullets:** "Updated `.claude/skills/wrap/SKILL.md`, `merge-gate.sh`…".
+- ❌ **Acceptance-criteria verbatim copy:** "- [x] Skill verifies the PR is merge-ready before generating any bypass".
+- ❌ **Technical-detail dumps** where a one-liner would do.
+- ❌ **Jargon tokens in default mode:** `CR`, `AC`, `SHA`, `GraphQL`, `mergeStateStatus`, etc.
+- ❌ **Marketing / hype language.**
+
+### Style anchor — the authoritative source of "good"
+
+The **Examples** section of issue #457 is the authoritative anchor for what "good" output looks like. When examples are present there, treat them as the style target: diff a draft summary against the "Good" examples and confirm the family resemblance (tone, length, level of abstraction); steer away from anything resembling the "Avoid" counter-examples. Fetch them when calibrating:
+```bash
+gh issue view 457 --json body --jq '.body' | sed -n '/## Examples/,/## Acceptance Criteria/p'
+```
+If the issue's Examples section is still a placeholder (not yet filled in), fall back to the tone rules and the worked example above — and mention briefly that no user examples were available to anchor against.
+
+## Step 5: Edge cases
+
+Handle these gracefully — emit a short note plus the best summary the available data supports:
+
+- **PR with no description body** → note "This PR has no description — summarizing from its title and what it touched", then give a minimal summary from the title + diff stat. Do not invent detail.
+- **Closed-but-not-merged PR** → open with the closure (`state: CLOSED`, no `mergedAt`) and summarize what it *attempted* and, if discernible, why it stalled.
+- **Issue with no body** → summarize from the title alone with a one-line note that the issue has no description.
+- **Issue with linked PRs** → mention the linkage only if it materially adds to "what work is hoped for" (e.g. "Partially delivered by PR #N").
+- **Deleted / private / wrong-repo reference** → stop with a single graceful line: "Couldn't find that PR/issue — it may be deleted, private, or in another repo."
+- **Batch request** (multiple numbers/URLs in `$ARGUMENTS`) → not supported in v1; recap the first target and tell the user to run `/recap` once per target.
+
+## Usage examples
+
+- `/recap 452` — recap merged PR #452 in past tense (nested bullets, ≤300 words).
+- `/recap #457` — recap issue #457 in future/conditional tense.
+- `/recap` — auto-detect the current branch's PR (or branch issue number) and recap it.
+- `/recap 452 --table` — same content as a `Change | Notes` table.
+- `/recap 452 --technical` — adds a technical sub-bullet per change without losing the conversational lead.
+- `/recap 452 --full` — relaxes the word budget for a richer summary, still nested bullets.
+- `/recap https://github.com/owner/repo/pull/452 --table --technical` — table with a third technical-detail column.
+
+---
+
+## After merge: symlink this skill (per `skill-symlinks.md`)
+
+Only after this PR merges to `main`:
+```bash
+git -C "$HOME/.claude/skills-worktree" fetch origin main --quiet
+git -C "$HOME/.claude/skills-worktree" reset --hard origin/main --quiet
+ln -s "$HOME/.claude/skills-worktree/.claude/skills/recap" "$HOME/.claude/skills/recap"
+```
+If `~/.claude/skills/` does not exist yet, create it first: `mkdir -p ~/.claude/skills/`.

--- a/.claude/skills/recap/SKILL.md
+++ b/.claude/skills/recap/SKILL.md
@@ -39,10 +39,36 @@ Flags compose: `--table --technical` adds a third "Technical detail" column; `--
 Parse `$ARGUMENTS`. **Extract flags first**, then interpret whatever remains as the target identifier.
 
 - **Flags** (any order, anywhere in `$ARGUMENTS`): `--table`, `--full`, `--technical`. Set a boolean for each; strip them from the argument string.
-- **Target identifier** (the non-flag remainder):
-  - **URL** (`https://github.com/<owner>/<repo>/pull/123` or `.../issues/123`) → extract the trailing number; the path segment (`/pull/` vs `/issues/`) fixes the type.
-  - **`#N` or bare number** (`452`, `#457`) → strip any leading `#`; type is not yet known (resolve in Step 2).
+- **Target identifier** — take the **first** non-flag token only (see batch handling below). It is one of:
+  - **URL** (`https://github.com/<owner>/<repo>/pull/123` or `.../issues/123`) → extract **both** the `<owner>/<repo>` and the trailing number; the path segment (`/pull/` vs `/issues/`) fixes the type. **The owner/repo from the URL must qualify every later `gh` call** (`--repo <owner>/<repo>`) — otherwise a URL for another repo would silently recap whatever item shares that number in the *current* repo.
+  - **`#N` or bare number** (`452`, `#457`) → strip any leading `#`; target the **current** repo; type is not yet known (resolve in Step 2).
   - **Empty** → auto-detect (see below).
+
+Parse the remainder into a target id plus a repo qualifier:
+```bash
+# REST = $ARGUMENTS with the three flags stripped, whitespace-collapsed.
+REPO_FLAG=""                      # empty = current repo; set only for a URL target
+read -r -a TOKENS <<<"$REST"
+TARGET="${TOKENS[0]:-}"           # first non-flag token only — never pass the whole string to gh
+if (( ${#TOKENS[@]} > 1 )); then
+  echo "Note: /recap takes one target at a time — recapping ${TARGET} and ignoring the rest (${TOKENS[*]:1}). Run /recap once per PR/issue." >&2
+fi
+case "$TARGET" in
+  https://github.com/*/pull/*|https://github.com/*/issues/*)
+    REPO_OWNER_NAME=$(printf '%s' "$TARGET" | sed -E 's#https://github.com/([^/]+/[^/]+)/(pull|issues)/.*#\1#')
+    REPO_FLAG="--repo $REPO_OWNER_NAME"
+    case "$TARGET" in *"/pull/"*) TYPE=pr ;; *"/issues/"*) TYPE=issue ;; esac
+    N=$(printf '%s' "$TARGET" | grep -oE '[0-9]+$')
+    ;;
+  \#[0-9]*|[0-9]*)
+    N="${TARGET#\#}"
+    ;;
+  "")
+    : # empty → auto-detect below
+    ;;
+esac
+```
+Carry `REPO_FLAG` through Step 2 — every `gh pr view` / `gh issue view` / `gh pr diff` call appends it so a URL target always resolves against its own repo, and a bare number stays in the current repo.
 
 ### Auto-detect when no target is given
 
@@ -51,12 +77,12 @@ Parse `$ARGUMENTS`. **Extract flags first**, then interpret whatever remains as 
    AUTO_PR=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
    ```
    If non-empty, target is that PR.
-2. If no PR, try to recover an issue number from the branch name (`issue-<N>-*` or a leading `<N>-*`):
+2. If no PR, try to recover an issue number from the branch name — only the deliberate forms `issue-<N>-*` or a leading `<N>-*` (the trailing hyphen is **required**, so a date-prefixed branch like `2026-q1-cleanup` does **not** get misread as issue #2026):
    ```bash
    BRANCH=$(git branch --show-current 2>/dev/null || true)
-   AUTO_ISSUE=$(printf '%s' "$BRANCH" | grep -oE '(^|issue-)[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+   AUTO_ISSUE=$(printf '%s' "$BRANCH" | grep -oE '(^|issue-)[0-9]+-' | grep -oE '[0-9]+' | head -1 || true)
    ```
-   If non-empty, target is that issue.
+   If non-empty, target is that issue. A bare numeric prefix with no following hyphen (e.g. `2026q1`) is intentionally ignored — fall through to step 3.
 3. If neither resolves, **stop and ask**: "What should I recap? Give a PR number, issue number, or URL (e.g. `/recap 452`, `/recap #457`, or a GitHub URL)."
 
 ## Step 2: Determine target type and fetch data
@@ -64,14 +90,14 @@ Parse `$ARGUMENTS`. **Extract flags first**, then interpret whatever remains as 
 **Type resolution:**
 - URL with `/pull/` → PR. URL with `/issues/` → issue.
 - Auto-detected PR (Step 1) → PR. Auto-detected issue → issue.
-- Bare number → try PR first, fall back to issue:
+- Bare number / URL whose type wasn't already fixed → try PR first, fall back to issue (`$REPO_FLAG` keeps the lookup in the right repo — empty for a bare number, the URL's owner/repo for a URL):
   ```bash
-  if gh pr view "$N" --json number >/dev/null 2>&1; then
+  if gh pr view "$N" $REPO_FLAG --json number >/dev/null 2>&1; then
     TYPE=pr
-  elif gh issue view "$N" --json number >/dev/null 2>&1; then
+  elif gh issue view "$N" $REPO_FLAG --json number >/dev/null 2>&1; then
     TYPE=issue
   else
-    echo "Could not find PR or issue #$N in this repo — it may be deleted, private, or in another repo." >&2
+    echo "Could not find PR or issue #$N${REPO_FLAG:+ in ${REPO_FLAG#--repo }} — it may be deleted, private, or in another repo." >&2
     exit 1
   fi
   ```
@@ -79,17 +105,17 @@ Parse `$ARGUMENTS`. **Extract flags first**, then interpret whatever remains as 
 
 **For a PR**, fetch state plus a diff stat (the stat is for *your* understanding of scope — it does **not** go in the output):
 ```bash
-gh pr view "$N" --json number,title,body,state,mergedAt,isDraft,additions,deletions,changedFiles,headRefName
-gh pr diff "$N" --stat 2>/dev/null || true
+gh pr view "$N" $REPO_FLAG --json number,title,body,state,mergedAt,isDraft,additions,deletions,changedFiles,headRefName
+gh pr diff "$N" $REPO_FLAG --stat 2>/dev/null || true
 ```
-Also scan the PR body for a linked issue (`Closes #N`, `Fixes #N`, `Resolves #N`, case-insensitive). If found, fetch that issue's title + body for additional "why" context:
+Also scan the PR body for a linked issue (`Closes #N`, `Fixes #N`, `Resolves #N`, case-insensitive). If found, fetch that issue's title + body for additional "why" context (same `$REPO_FLAG`, since a linked issue lives in the PR's repo):
 ```bash
-gh issue view "$LINKED_N" --json number,title,body,state 2>/dev/null || true
+gh issue view "$LINKED_N" $REPO_FLAG --json number,title,body,state 2>/dev/null || true
 ```
 
 **For an issue**, fetch state, body, and recent comments (comments often carry plan/scope refinements), plus any linked PRs:
 ```bash
-gh issue view "$N" --json number,title,body,state,createdAt --comments
+gh issue view "$N" $REPO_FLAG --json number,title,body,state,createdAt --comments
 ```
 
 If a JSON fetch fails outright (deleted / private / wrong repo), stop with a one-line graceful error — do not emit a half-summary.
@@ -170,9 +196,9 @@ Keep the conversational top-level bullet, then add **one** sub-bullet (bullets m
 
 ### Style anchor — the authoritative source of "good"
 
-The **Examples** section of issue #457 is the authoritative anchor for what "good" output looks like. When examples are present there, treat them as the style target: diff a draft summary against the "Good" examples and confirm the family resemblance (tone, length, level of abstraction); steer away from anything resembling the "Avoid" counter-examples. Fetch them when calibrating:
+The **Examples** section of issue #457 **in the `auerbachb/claude-code-config` repo** is the authoritative anchor for what "good" output looks like. When examples are present there, treat them as the style target: diff a draft summary against the "Good" examples and confirm the family resemblance (tone, length, level of abstraction); steer away from anything resembling the "Avoid" counter-examples. Fetch them when calibrating — always pin the repo, since `/recap` is globally symlinked and would otherwise read issue #457 from whatever repo happens to be current:
 ```bash
-gh issue view 457 --json body --jq '.body' | sed -n '/## Examples/,/## Acceptance Criteria/p'
+gh issue view 457 --repo auerbachb/claude-code-config --json body --jq '.body' | sed -n '/## Examples/,/## Acceptance Criteria/p'
 ```
 If the issue's Examples section is still a placeholder (not yet filled in), fall back to the tone rules and the worked example above — and mention briefly that no user examples were available to anchor against.
 
@@ -185,7 +211,7 @@ Handle these gracefully — emit a short note plus the best summary the availabl
 - **Issue with no body** → summarize from the title alone with a one-line note that the issue has no description.
 - **Issue with linked PRs** → mention the linkage only if it materially adds to "what work is hoped for" (e.g. "Partially delivered by PR #N").
 - **Deleted / private / wrong-repo reference** → stop with a single graceful line: "Couldn't find that PR/issue — it may be deleted, private, or in another repo."
-- **Batch request** (multiple numbers/URLs in `$ARGUMENTS`) → not supported in v1; recap the first target and tell the user to run `/recap` once per target.
+- **Batch request** (multiple numbers/URLs in `$ARGUMENTS`) → not supported in v1. Step 1's parser already takes only the first non-flag token and prints a one-line note listing the ignored ids, so the extra tokens are never passed to `gh`; recap that first target and tell the user to run `/recap` once per target.
 
 ## Usage examples
 

--- a/.claude/skills/recap/SKILL.md
+++ b/.claude/skills/recap/SKILL.md
@@ -45,6 +45,7 @@ Parse `$ARGUMENTS`. **Extract flags first**, then interpret whatever remains as 
   - **Empty** → auto-detect (see below).
 
 Parse the remainder into a target id plus a repo qualifier:
+
 ```bash
 # REST = $ARGUMENTS with the three flags stripped, whitespace-collapsed.
 REPO_FLAG=""                      # empty = current repo; set only for a URL target
@@ -62,12 +63,22 @@ case "$TARGET" in
     ;;
   \#[0-9]*|[0-9]*)
     N="${TARGET#\#}"
+    # Require an all-digit id — `123abc`, `2026-q1`, etc. are typos, not targets.
+    if ! [[ "$N" =~ ^[0-9]+$ ]]; then
+      echo "Not a valid PR/issue target: '$TARGET'. Give a pure number (452), #number (#457), or a GitHub PR/issue URL." >&2
+      exit 1
+    fi
     ;;
   "")
     : # empty → auto-detect below
     ;;
+  *)
+    echo "Unrecognized target: '$TARGET'. Give a pure number (452), #number (#457), or a GitHub PR/issue URL." >&2
+    exit 1
+    ;;
 esac
 ```
+
 Carry `REPO_FLAG` through Step 2 — every `gh pr view` / `gh issue view` / `gh pr diff` call appends it so a URL target always resolves against its own repo, and a bare number stays in the current repo.
 
 ### Auto-detect when no target is given
@@ -77,12 +88,14 @@ Carry `REPO_FLAG` through Step 2 — every `gh pr view` / `gh issue view` / `gh 
    AUTO_PR=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
    ```
    If non-empty, target is that PR.
-2. If no PR, try to recover an issue number from the branch name — only the deliberate forms `issue-<N>-*` or a leading `<N>-*` (the trailing hyphen is **required**, so a date-prefixed branch like `2026-q1-cleanup` does **not** get misread as issue #2026):
+2. If no PR, try to recover an issue number from the branch name. Match **only** the explicit `issue-<N>-*` convention (the repo's standard branch shape) — an `issue-` prefix is required so date-style branches like `2026-q1-cleanup` can never be misread as issue #2026:
+
    ```bash
    BRANCH=$(git branch --show-current 2>/dev/null || true)
-   AUTO_ISSUE=$(printf '%s' "$BRANCH" | grep -oE '(^|issue-)[0-9]+-' | grep -oE '[0-9]+' | head -1 || true)
+   AUTO_ISSUE=$(printf '%s' "$BRANCH" | grep -oE '^issue-[0-9]+-' | grep -oE '[0-9]+' | head -1 || true)
    ```
-   If non-empty, target is that issue. A bare numeric prefix with no following hyphen (e.g. `2026q1`) is intentionally ignored — fall through to step 3.
+
+   If non-empty, target is that issue. Any other branch shape (bare numeric prefixes, date prefixes, feature names) is intentionally ignored — fall through to step 3 and ask the user.
 3. If neither resolves, **stop and ask**: "What should I recap? Give a PR number, issue number, or URL (e.g. `/recap 452`, `/recap #457`, or a GitHub URL)."
 
 ## Step 2: Determine target type and fetch data
@@ -104,19 +117,25 @@ Carry `REPO_FLAG` through Step 2 — every `gh pr view` / `gh issue view` / `gh 
   > **Note:** in GitHub a PR *is* an issue under the hood, so `gh pr view <N>` succeeding is the authoritative "this number is a PR" signal. Only fall back to `gh issue view` when the PR lookup fails.
 
 **For a PR**, fetch state plus a diff stat (the stat is for *your* understanding of scope — it does **not** go in the output):
+
 ```bash
 gh pr view "$N" $REPO_FLAG --json number,title,body,state,mergedAt,isDraft,additions,deletions,changedFiles,headRefName
 gh pr diff "$N" $REPO_FLAG --stat 2>/dev/null || true
 ```
+
 Also scan the PR body for a linked issue (`Closes #N`, `Fixes #N`, `Resolves #N`, case-insensitive). If found, fetch that issue's title + body for additional "why" context (same `$REPO_FLAG`, since a linked issue lives in the PR's repo):
+
 ```bash
 gh issue view "$LINKED_N" $REPO_FLAG --json number,title,body,state 2>/dev/null || true
 ```
 
-**For an issue**, fetch state, body, and recent comments (comments often carry plan/scope refinements), plus any linked PRs:
+**For an issue**, fetch state, body, recent comments (comments often carry plan/scope refinements), and the linked PRs that reference it — `closedByPullRequestsReferences` is what powers the "mention the linkage" edge case below, so it must be requested here:
+
 ```bash
-gh issue view "$N" $REPO_FLAG --json number,title,body,state,createdAt --comments
+gh issue view "$N" $REPO_FLAG --json number,title,body,state,createdAt,closedByPullRequestsReferences --comments
 ```
+
+`closedByPullRequestsReferences` is an array of `{number, title, state}` for each PR that closes/references the issue — use it (and only it) to decide whether to mention linkage. If it is empty, there are no linked PRs to mention.
 
 If a JSON fetch fails outright (deleted / private / wrong repo), stop with a one-line graceful error — do not emit a half-summary.
 
@@ -209,7 +228,7 @@ Handle these gracefully — emit a short note plus the best summary the availabl
 - **PR with no description body** → note "This PR has no description — summarizing from its title and what it touched", then give a minimal summary from the title + diff stat. Do not invent detail.
 - **Closed-but-not-merged PR** → open with the closure (`state: CLOSED`, no `mergedAt`) and summarize what it *attempted* and, if discernible, why it stalled.
 - **Issue with no body** → summarize from the title alone with a one-line note that the issue has no description.
-- **Issue with linked PRs** → mention the linkage only if it materially adds to "what work is hoped for" (e.g. "Partially delivered by PR #N").
+- **Issue with linked PRs** → using the `closedByPullRequestsReferences` array fetched in Step 2 (not guesswork), mention the linkage only if it materially adds to "what work is hoped for" (e.g. "Partially delivered by PR #N"). Empty array → no linkage to mention.
 - **Deleted / private / wrong-repo reference** → stop with a single graceful line: "Couldn't find that PR/issue — it may be deleted, private, or in another repo."
 - **Batch request** (multiple numbers/URLs in `$ARGUMENTS`) → not supported in v1. Step 1's parser already takes only the first non-flag token and prints a one-line note listing the ignored ids, so the extra tokens are never passed to `gh`; recap that first target and tell the user to run `/recap` once per target.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ After setup, Claude Code will automatically:
 - **Review locally, then on GitHub** — Runs CodeRabbit CLI reviews before pushing (instant feedback, no PR noise). After PR creation, the reviewer chain is CodeRabbit primary, BugBot (Cursor) second tier, Greptile last resort, then self-review only if every reviewer is unavailable; CodeAnt and Graphite AI Reviews provide supplemental AI review signals.
 - **Verify and merge** — Checks every acceptance criteria checkbox against the code, confirms CI is green, then squash-merges with branch cleanup.
 - **Orchestrate multi-agent work** — Decomposes large tasks into phases (fix, review, merge) with health monitoring, handoff files, and heartbeat enforcement.
-- **Manage your project** — 22 slash commands for backlog prioritization, sprint planning, team metrics, standups, and cross-thread orchestration.
+- **Manage your project** — 23 slash commands for backlog prioritization, sprint planning, team metrics, standups, and cross-thread orchestration.
 
 Review ownership is sticky once a fallback tier takes over:
 
@@ -124,7 +124,7 @@ ls -la ~/.claude/skills/       # each skill -> ~/.claude/skills-worktree/.claude
 
 ## Slash Commands
 
-All 22 commands are invoked as `/command` in a Claude Code session. They are defined as skill files in `.claude/skills/` and symlinked globally.
+All 23 commands are invoked as `/command` in a Claude Code session. They are defined as skill files in `.claude/skills/` and symlinked globally.
 
 | Command | Category | Description |
 |---------|----------|-------------|
@@ -143,6 +143,7 @@ All 22 commands are invoked as `/command` in a Claude Code session. They are def
 | `/start-issue` | Planning | End-to-end issue-to-coding setup — plan polling, plan merge, worktree, branch |
 | `/fixpr` | Review | Single-pass PR cleanup — fixes review findings and CI failures, replies to findings, resolves threads |
 | `/pr-review-help` | Review | Executive PR review — multi-PR parallel strategic analysis |
+| `/recap` | Workflow | Functional summary of a single PR or issue — nested bullets or table |
 | `/standup` | Workflow | Daily standup summary (single contributor) |
 | `/status` | Workflow | Dashboard of open PRs with review state |
 | `/go-on` | Workflow | Resume an interrupted review workflow |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new `/recap` skill — a single-target companion to `/standup` that produces a concise, conversational **functional summary** of what a PR actually changed (or what an issue hopes to accomplish), as nested Markdown bullets with optional `--table`, `--full`, and `--technical` modes.

Where `/standup` rolls up *all* recent activity over a time window, `/recap` zooms in on **one** PR or issue and renders its functional story for a technical collaborator who wants the feature perspective — not the implementation walkthrough.

### What it does
- **Accepts** a PR number, issue number, or GitHub URL; **auto-detects** the current branch's PR (or an `issue-<N>-*` branch number) when no argument is given.
- **Distinguishes PR vs issue** and picks tense accordingly: past for merged PRs, present for open PRs, conditional for drafts, future for issues, closure note for closed-not-merged PRs.
- **Default output** = nested bullets (top-level = functional change, sub-bullets = scope/notes), aimed at a technical collaborator, leading with *why it matters* rather than the mechanism.
- **`--table`** renders a `Change | Notes` Markdown table; **`--full`** relaxes the ≤300-word budget; **`--technical`** adds a second detail tier (mechanism/files/endpoints) without dropping the conversational top-level bullet.
- **Jargon-free by default** (no `CR`/`AC`/`SHA`/`GraphQL`/file paths/commit hashes), documents anti-patterns, and anchors its style on issue #457's Examples section.
- **Edge cases** handled gracefully: no-description PRs/issues, closed-not-merged PRs, issues with linked PRs, deleted/private references.
- Documents the post-merge global symlink step per `skill-symlinks.md`.

### Files
- `.claude/skills/recap/SKILL.md` (new)
- `README.md` — adds `/recap` to the Slash Commands table; bumps command count to 23.

Closes #457

## Test Plan

- [ ] Run on a merged PR with a rich body (e.g. #452) → nested bullets in **past** tense; total ≤300 words.
- [ ] Run on an open issue (e.g. #457) → nested bullets in **future/conditional** tense; total ≤300 words.
- [ ] Run with `--table` → Markdown table with `Change | Notes` columns.
- [ ] Run with `--full` on a 1000+ word PR body → longer output, still nested bullets (not paragraphs).
- [ ] Run on a PR with no description → graceful "no description — summarizing from title + diff stats" fallback.
- [ ] Run on a closed-not-merged PR → output notes the closure and last meaningful state.
- [ ] Run on an issue with linked PRs → summary mentions linkage when it adds context.
- [ ] Verify tense logic across merged (past), open (present), draft (conditional) PR states.
- [ ] Default-mode output on 3 random merged PRs contains zero jargon tokens (`CR`, `AC`, `SHA`, `GraphQL`, `mergeStateStatus`) and zero file paths.
- [ ] Bullet 1 of each default-mode summary leads with the user-visible improvement, not the mechanism.
- [ ] `--technical` re-run adds a detail sub-tier per bullet without removing the conversational top-level bullet.
- [ ] Sample output is perceptibly closer in tone to issue #457's "Good" examples than the "Avoid" examples.
- [ ] Skill symlinked to `~/.claude/skills/recap` per `skill-symlinks.md` after merge to main.

## Notes
- Command name `/recap` is the recommended default from issue #457; no alternate name was confirmed in the issue thread.
- The skill is fully self-contained in one `SKILL.md` (per the CodeRabbit plan) — no changes to `/wrap` or `merge-gate.sh`, which avoids the noted conflict window with #455/#471/#448.
- Local `coderabbit review --agent` could not run in this cloud VM (CLI installs but has no auth token available); the GitHub-side CodeRabbit review will run on this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b35d5039-c2ca-4780-9acf-2252e574e693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b35d5039-c2ca-4780-9acf-2252e574e693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `/recap` command that generates a concise, conversational summary of a GitHub pull request or issue.
  * Supports optional formatting modes (including table output and an expanded technical view) and can resolve targets from a URL, an issue/PR number, or the current branch when detected.
* **Documentation**
  * Updated the README slash-commands list and the documented total command count to include `/recap`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->