### PR TITLE
docs(reference): CodeAnt Code Quality integration eval — verdict keep advisory (#444)

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -36,6 +36,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `script-extraction-audit.md` — deterministic script extraction inventory (#271)
 - `graphite-stacked-prs-research-2026-05.md` — stacked PR economics (#418 / #433)
+- `codeant-code-quality-eval-2026-06.md` — deeper CodeAnt Code Quality integration eval; verdict: keep advisory (#444)
 
 ### Diagrams (mermaid stubs and indexes)
 

--- a/.claude/reference/codeant-code-quality-eval-2026-06.md
+++ b/.claude/reference/codeant-code-quality-eval-2026-06.md
@@ -1,0 +1,188 @@
+# CodeAnt Code Quality Integration Evaluation — 2026-06
+
+Issue: [#444](https://github.com/auerbachb/claude-code-config/issues/444)
+
+Date reviewed: 2026-06-25
+
+Builds on: `ai-review-tool-audit-2026-04.md` (#368), the 30-day follow-up (#376),
+and the CodeAnt merge-gate integration shipped in #404 / #408 / #420.
+
+## Verdict
+
+**KEEP ADVISORY (CR-path peer) — do NOT promote to a blocking gate tier, and do
+NOT add the CodeAnt Quality Gates CI action.**
+
+Concretely:
+
+- **Adopt:** nothing new. The current posture (CodeAnt `codeant-ai[bot]` reviewed
+  on the CR path; a fresh `APPROVED` on HEAD can satisfy the primary review;
+  supplemental cleanliness rule applies when CodeAnt participated) is the right
+  level of integration.
+- **Partial:** one **documentation-only** clarification is warranted — the
+  CodeAnt *check-run* branch in `merge-gate.sh` / `cr-merge-gate.md` is
+  forward-compat, not a live signal in this repo (see Question 2). No behavior
+  change.
+- **Defer:** Quality Gates CI action, coverage enforcement, docstrings, and
+  promoting CodeAnt to a standalone or gate-blocking quality tier. Re-evaluate
+  only if the triggers in "Next evaluation" fire.
+
+Rationale in one line: CodeAnt is reliable at *participating* but approves
+essentially every PR (low discrimination), emits **no GitHub check-run** here,
+and its differentiating Code Quality features (SAST/SCA/IaC/coverage/duplication)
+target application code this markdown/shell/yaml repo does not have.
+
+## Decision matrix
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Promote CodeAnt to gate-blocking peer of CodeRabbit (its `APPROVED` required, not just sufficient) | **Reject** | CodeAnt approved 31/31 participating PRs (incl. after COMMENTED). A reviewer that never withholds approval adds no blocking signal — it would only add a failure point when it is silent (e.g. #468). |
+| Make CodeAnt the *primary* reviewer with CR as fallback (to relieve CR quota) | **Reject** | Same low-discrimination concern. CR quota pressure is real but the answer is batching + escalation (already in place), not delegating the gate to a rubber-stamp. |
+| Add `CodeAnt-AI/codeant-quality-gates` CI action as a required check | **Reject (defer)** | Requires a `cdt_…` API-token repo secret + workflow maintenance; its checks (secrets, SAST, SCA, IaC, duplicate code, coverage) are aimed at application source. This repo is config/docs — near-zero unique value, real setup/maintenance cost. |
+| Enable coverage enforcement / docstring generation | **Reject** | No application test suite to cover; docstrings N/A for markdown/shell/yaml. |
+| Keep CodeAnt as CR-path peer (status quo) | **Keep** | High participation, processed like other bots, costs nothing extra (already paying $24/user/mo). Pure upside as a second opinion. |
+| Document that the CodeAnt check-run gate path is forward-compat only | **Adopt (docs-only, follow-up issue)** | Prevents future readers from assuming a live CodeAnt check exists; clarifies that the review-object path is the only active signal today. |
+
+## The four ticket questions, answered
+
+### Q1 — What additional Code Quality features does Premium include beyond what we use?
+
+Premium ($24/user/month, already paying) bundles, beyond the inline AI review +
+PR summaries we already consume:
+
+- **Quality Gates** — pass/fail PR verdicts for security, duplication,
+  dependency (SCA), IaC, and coverage issues. Delivered via the
+  `CodeAnt-AI/codeant-quality-gates` GitHub Action in CI (needs a `cdt_…` token),
+  **not** by the `codeant-ai[bot]` reviewer.
+- **Static Analysis & SAST (on PRs)** — security scanning of changed lines.
+- **Code coverage checks** — total + new-code coverage gates (needs the
+  `codeant-coverage-action` to upload reports).
+- **AI Code Review dashboards, Dev Metrics, Scan Center** — analytics surfaces.
+- **Jira/Azure Boards integration, CI/CD pipeline integration, Slack support,
+  SOC2/HIPAA/VAPT reports.**
+
+Source: <https://www.codeant.ai/pricing>,
+<https://www.codeant.ai/ai-code-review/quality-gates>,
+<https://github.com/CodeAnt-AI/codeant-quality-gates> (reviewed 2026-06-25).
+
+**Relevance to this repo:** low. SAST/SCA/IaC/coverage/duplication all target
+application code and dependency manifests. This repository is Claude Code
+configuration — markdown, shell, and YAML — with no application runtime, no
+package dependency graph to scan, and no test coverage to enforce. The highest-
+value findings here (rule contradictions, stale instructions, unsafe shell,
+missing gates, word-budget overflow) are already covered by CodeRabbit path
+instructions, BugBot, the `rule-lint`/`hook-tests` CI checks, and CodeAnt's own
+inline AI review.
+
+### Q2 — Is the CodeAnt check-run reliable enough to treat as a merge-gate tier?
+
+**There is no CodeAnt check-run to gate on.** Across the 32 PRs merged since the
+#404 integration (2026-04-30 → 2026-06-25), **zero** posted a CodeAnt check-run
+or a CodeAnt commit-status context. Check-runs observed were `rule-lint`,
+`hook-tests`, `post-cursor-review`, `Cursor Bugbot`, and `Graphite / AI Reviews`;
+the only review status context was `CodeRabbit`. CodeAnt's signal in this repo is
+delivered purely as **review objects + inline/conversation comments**.
+
+Consequence: the CodeAnt *check-run* branch in `merge-gate.sh` (the
+`conclusion: success` path) and its mirror in `cr-merge-gate.md` Step 1 are
+**dead code in practice** — they only fire if someone adds the Quality Gates CI
+action. They are harmless forward-compat, but should be labeled as such so future
+maintainers don't treat a missing CodeAnt check as a blocker. (Captured as the
+docs-only follow-up in the decision matrix.)
+
+What *is* reliable is CodeAnt's **review participation**: 31 of 32 PRs received a
+CodeAnt review (~97%); the lone miss was #468. But participation reliability is
+not the same as gate-worthiness — see the discrimination data below.
+
+| Signal | Observed (32 PRs, 2026-04-30 → 2026-06-25) | Gate-worthy? |
+|--------|--------------------------------------------|--------------|
+| Posts a review at all | 31/32 (~97%) | Reliable participation |
+| Posts a GitHub check-run | 0/32 | No check to gate on |
+| Final state reaches `APPROVED` on HEAD | 31/31 participating | **Too permissive to block on** |
+| `CHANGES_REQUESTED` ever issued (final) | 0/32 | Never withholds approval |
+
+CodeAnt cycles through `COMMENTED` → `APPROVED` as fixes land (e.g. #441 had 24
+review events, #453 had 16), and it does post real inline findings on
+substantive PRs (e.g. #422: 14 inline, #441: 11, #453: 8). So it is an *active*
+second opinion, not silent. But because it converges to `APPROVED` on every PR,
+making its approval **required** would add a flaky dependency (silent-bot risk
+like #468) without adding any real blocking power. Keeping it as a *sufficient*
+CR-path approval (current behavior) captures the upside without the risk.
+
+### Q3 — Would deeper integration reduce Greptile spend or CR quota pressure?
+
+- **Greptile spend: no material savings available.** Greptile is already
+  last-resort/sticky and effectively never auto-triggers (auto-review disabled
+  per `greptile-setup.md`; no Greptile check-run appeared in the scanned PRs).
+  There is essentially no recurring Greptile spend for CodeAnt to displace.
+  Greptile's role is an *availability hedge* for when CR **and** BugBot are both
+  down — CodeAnt's rubber-stamp approvals cannot substitute for that
+  failure-mode coverage.
+- **CR quota pressure: real, but not solved by promoting CodeAnt.** The lever
+  for CR quota is already implemented: fix-batching into one push, the hourly
+  tracker (`cr-review-hourly.sh`), and the CR→BugBot→Greptile escalation gate.
+  Designating CodeAnt as primary to skip CR would mean trusting a reviewer that
+  approves everything — trading a quota problem for a quality-of-gate problem.
+  Net: not worth it.
+- **Cost position: cost-neutral.** We already pay $24/user/month for Premium and
+  CodeAnt is already in the flow. Keeping advisory adds $0. Adopting Quality
+  Gates adds no license cost but adds CI minutes, a managed API-token secret, and
+  workflow maintenance — net cost-increasing for ~zero value on this repo.
+
+### Q4 — Are workflow / SKILL.md changes needed to surface CodeAnt findings and resolve threads automatically?
+
+**No — this is already done.** CodeAnt is a first-class citizen in the automation:
+
+- `cr-github-review.md` — polls `codeant-ai[bot]` on all three PR endpoints; has
+  the "CodeAnt & Graphite (supplemental)" subsection; `maybe-trigger-ai-review.sh`
+  posts `@codeant-ai review` on the #362 path.
+- `merge-gate.sh` / `cr-merge-gate.md` — routes CodeAnt-only PRs to the CR path
+  (#408); a fresh CodeAnt `APPROVED` on HEAD satisfies the primary review;
+  supplemental cleanliness + retraction rules encoded; CODEOWNERS handling
+  present.
+- `fixpr/SKILL.md` — Step 3b detects CodeAnt activity on the new SHA and posts
+  `@codeant-ai review` only when missing; the SHA-scoped verify step (5d) treats
+  CodeAnt; stale `codeant-ai[bot]` `CHANGES_REQUESTED` is dismissed via
+  `dismiss-stale-bot-changes.sh`.
+- `resolve-review-threads.sh` — `codeant-ai` is in the default author allowlist,
+  so CodeAnt threads are resolved via GraphQL like every other bot.
+
+A dedicated `/fixcodeant` skill is **not** warranted: CodeAnt's threads follow
+the same inline/conversation shape as the other bots and are already handled by
+the shared resolver and `/fixpr`.
+
+> Note: the issue and the CodeRabbit plan both reference a `.claude/rules/codeant-graphite.md`
+> rule file. **No such file exists.** The CodeAnt content lives in
+> `cr-github-review.md` (supplemental subsection) and `cr-merge-gate.md`. Any
+> future change should target those files, not the non-existent one.
+
+## Method / data provenance
+
+- PR set: `gh pr list --state merged` filtered to `mergedAt >= 2026-04-30` (the
+  #404 CodeAnt-integration cutoff) → 32 PRs.
+- Per PR: `codeant-ai[bot]` review states from `/pulls/{N}/reviews`; CodeAnt
+  check-runs from `/commits/{HEAD}/check-runs` and `/statuses`; inline findings
+  from `/pulls/{N}/comments`; conversation comments from `/issues/{N}/comments`.
+- All counts are point-in-time as of 2026-06-25 and reflect this repository only.
+- Feature/pricing facts from CodeAnt's public pricing + Quality Gates docs and
+  the `codeant-quality-gates` action repo (reviewed 2026-06-25).
+
+Caveat: the agent has read-only `gh` access and no CodeAnt dashboard/billing
+visibility. Dashboard-only settings (custom AI rules, learnings, enabled feature
+toggles) were not directly inspected; conclusions about Quality Gates rest on the
+absence of any CodeAnt check-run/status in the PR history plus public docs.
+
+## Next evaluation
+
+Keep advisory. Re-open this evaluation only if a trigger fires:
+
+1. CodeAnt begins issuing genuine `CHANGES_REQUESTED` that catch material issues
+   CodeRabbit/BugBot miss (i.e. it gains discrimination) → reconsider gate-peer
+   promotion.
+2. The repo grows real application code, a dependency manifest, or a test suite
+   → reconsider the Quality Gates CI action for SAST/SCA/coverage.
+3. CR quota exhaustion becomes a recurring merge blocker that batching +
+   escalation no longer absorbs → reconsider CodeAnt-primary routing.
+
+Otherwise fold into the next periodic AI-review-tool audit (successor to #368 /
+#376). Recommended docs-only follow-up: label the CodeAnt check-run branch in
+`merge-gate.sh` / `cr-merge-gate.md` as forward-compat (Question 2).


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Evaluates whether to deepen CodeAnt **Code Quality** integration into the review chain, per issue #444. This is a research/eval task; the deliverable is a decision document. **Verdict: KEEP ADVISORY** (CR-path peer, status quo) — do **not** promote CodeAnt to a blocking gate tier and do **not** add the Quality Gates CI action. No behavior changes to rules or scripts.

New doc: `.claude/reference/codeant-code-quality-eval-2026-06.md` (indexed in the reference README), following the `ai-review-tool-audit-2026-04.md` pattern.

### Why keep advisory (grounded in this repo's PR history, 32 PRs since the #404 integration)

- **No check-run to gate on.** 0/32 PRs posted a CodeAnt check-run or status context. CodeAnt's only signal here is review objects + comments. The CodeAnt *check-run* branch in `merge-gate.sh` / `cr-merge-gate.md` is forward-compat, not a live signal (docs-only follow-up suggested).
- **Approves everything.** CodeAnt reviewed 31/32 PRs (~97%) and reached `APPROVED` on every participating PR; it never issued a final `CHANGES_REQUESTED`. Reliable participation, but too permissive to make its approval *required*.
- **Premium Code Quality features don't fit this repo.** SAST/SCA/IaC/coverage/duplication target application code + dependency manifests; this is a markdown/shell/yaml config repo.
- **No Greptile spend to save** (already last-resort/disabled); CR quota relief is better served by existing batching + escalation than by trusting a rubber-stamp reviewer as primary.
- **Workflow/SKILL.md integration is already complete** — `cr-github-review.md`, `merge-gate.sh`, `fixpr/SKILL.md`, and `resolve-review-threads.sh` all already handle `codeant-ai[bot]`. A `/fixcodeant` skill is not warranted.

The doc answers all four ticket questions, includes a decision matrix, data provenance, and re-evaluation triggers. It also flags that the `codeant-graphite.md` rule file referenced in the issue/CR-plan does not exist (content lives in `cr-github-review.md` + `cr-merge-gate.md`).

Closes #444.

## Test plan

- [x] Decision document created in `.claude/reference/` following the established audit-doc structure
- [x] All four ticket questions explicitly answered (Premium feature gap, check-run gate-worthiness, Greptile/CR cost impact, workflow/SKILL.md changes)
- [x] Verdict + decision matrix (promote / keep advisory / disable) documented with rationale
- [x] Recommendation grounded in empirical repo data (32 PRs scanned: reviews, check-runs, findings) with provenance noted
- [x] New doc indexed in `.claude/reference/README.md`
- [x] No code changes (verdict is keep-advisory) — rules/scripts untouched; rule-file word budget unaffected (only `.claude/reference/` modified)
- [x] Next-evaluation triggers documented

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33c032eb-be32-4d8c-ab98-1177324e0908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33c032eb-be32-4d8c-ab98-1177324e0908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Document the decision to keep CodeAnt advisory-only**

### What Changed
- Added a new evaluation doc recording the decision not to make CodeAnt a blocking gate or add the Quality Gates CI action
- Summarized why CodeAnt stays as a review-only signal: it participates reliably, but does not provide a separate check that can gate merges
- Clarified that the existing CodeAnt check-run path is only future-facing guidance, not an active signal in this repo
- Linked the new evaluation from the reference README for easier discovery

### Impact
`✅ Clearer CodeAnt review policy`
`✅ Fewer mistaken merge-gate assumptions`
`✅ Easier follow-up on AI review decisions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
