### PR TITLE
feat(skills): add /monitor — verify all 4 AI reviewers engaged on every open PR

### DIFF
--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -75,12 +75,16 @@ CR_HOURLY_SH=$(resolve_script cr-review-hourly.sh) || true   # optional; degrade
 
 ```bash
 PRS=$(gh pr list --state open --limit 50 --json number,title,isDraft,headRefOid,url)
+
+# Narrow to a single PR BEFORE counting, so a targeted audit of a closed/missing
+# PR yields COUNT == 0 (an open-list count would mask the empty result).
+if [[ -n "$PR_ARG" ]]; then
+  PRS=$(jq --argjson n "$PR_ARG" 'map(select(.number == $n))' <<<"$PRS")
+fi
 COUNT=$(jq 'length' <<<"$PRS")
 ```
 
-If a bare `<PR>` argument was given, narrow to it: `PRS=$(jq --argjson n "$PR_ARG" 'map(select(.number == $n))' <<<"$PRS")`.
-
-If `COUNT == 0` (or the single PR is not open), say **"No open PRs to audit."** and stop.
+If `COUNT == 0`, say **"No open PRs to audit."** and stop. (A bare `<PR>` that is closed or not found leaves `PRS` empty, so this also covers "the requested PR is not open.")
 
 ---
 
@@ -92,7 +96,9 @@ For each PR, run the shared state helper **once** — it aggregates the 3 commen
 BUNDLE=$("$PR_STATE_SH" --pr "$N") || { echo "skip #$N: pr-state.sh failed"; continue; }
 ```
 
-Build the 4-reviewer matrix from the bundle. A reviewer is **engaged** when it produced, on the current HEAD, any of: a **review object**, a **check-run** whose name matches the reviewer, OR a **finding-bearing comment**. Pure ack comments (e.g. CR's "Actions performed — Full review triggered", "actionable comments posted: 0", rate-limit notices) do **not** count.
+Build the 4-reviewer matrix from the bundle. A reviewer is **engaged** when it produced, **on the current HEAD SHA**, any of: a **review object**, a **check-run** whose name matches the reviewer, OR a **finding-bearing comment**. Pure ack comments (e.g. CR's "Actions performed — Full review triggered", "actionable comments posted: 0", rate-limit notices) do **not** count.
+
+The HEAD scoping matters: a reviewer that only ran on an older commit must show ❌ so its trigger is re-posted after a push. Check-runs and commit statuses in the bundle are already pulled from the HEAD SHA, so they are inherently current; reviews and inline comments are filtered by `commit_id == head_sha` (`.pr.head_sha` from the bundle), and conversation comments (which carry no `commit_id`) only count when their body references the HEAD SHA (full or short) — the same SHA-scoping `fixpr` uses in its "detect reviewer activity on the pushed SHA" step.
 
 ```bash
 MATRIX=$(jq -c '
@@ -112,20 +118,31 @@ MATRIX=$(jq -c '
       or ($b | test("no actionable comments were generated"; "i"))
       or ($b | test("rate limit"; "i"));
   . as $b
+  | (.pr.head_sha // "") as $head
+  | ($head[0:7]) as $short
   | reviewers
   | map(. as $r
       | {
+          # Review object on the current HEAD SHA.
           has_review:
-            ([$b.comments.reviews[]? | select(.user.login == $r.login)] | length > 0),
+            ([$b.comments.reviews[]?
+               | select(.user.login == $r.login and (.commit_id == $head))] | length > 0),
+          # Check-run (or CR legacy commit-status) — both already HEAD-scoped by pr-state.sh.
           has_check:
             (([$b.check_runs.all[]?
                | (.name // "" | ascii_downcase) as $n
                | select(any($r.needles[]; . as $needle | $n | contains($needle)))] | length > 0)
              or ($r.key == "coderabbit" and ($b.bot_statuses.CodeRabbit != null))),
+          # Finding-bearing comment on HEAD: inline scoped by commit_id; conversation by SHA mention.
           has_finding_comment:
-            ([ ($b.comments.inline[]?, $b.comments.conversation[]?)
-               | select(.user.login == $r.login)
-               | select(is_ack(.body) | not) ] | length > 0)
+            (([$b.comments.inline[]?
+               | select(.user.login == $r.login
+                        and ((.commit_id // .original_commit_id // "") == $head)
+                        and (is_ack(.body) | not))] | length > 0)
+             or ($head != "" and ([$b.comments.conversation[]?
+               | select(.user.login == $r.login
+                        and (is_ack(.body) | not)
+                        and (((.body // "") | contains($head)) or ((.body // "") | contains($short))))] | length > 0)))
         }
       | . + {key: $r.key, engaged: (.has_review or .has_check or .has_finding_comment)}
     )
@@ -185,13 +202,16 @@ Using `$CR_HEALTH` from Step 2: if the CR check-run is `completed` **and** a rat
 
 ### 4c. CR explicit-trigger budget (2/hour per PR + account hourly cap)
 
-Before proposing `@coderabbitai full review` for any PR, check the account hourly budget once:
+Before proposing `@coderabbitai full review` for any PR, check the account hourly budget once. Guard the optional script so a **missing** `cr-review-hourly.sh` is never mistaken for an exhausted budget (only an actual exit `1` from the script means exhausted):
 
 ```bash
-[[ -n "$CR_HOURLY_SH" ]] && "$CR_HOURLY_SH" --check >/dev/null 2>&1 || CR_BUDGET_EXHAUSTED=$?
+CR_BUDGET_OK=1
+if [[ -n "$CR_HOURLY_SH" ]]; then
+  "$CR_HOURLY_SH" --check >/dev/null 2>&1 || CR_BUDGET_OK=0
+fi
 ```
 
-Exit `1` ⇒ account budget exhausted — drop CR from the proposed triggers this run and say so. The per-PR **2 explicit `@coderabbitai full review`/hour** cap is enforced atomically at post time by `cr-review-hourly.sh --record-explicit <N>` (Step 5): if it returns `surface_user: true` / exits non-zero, the trigger was **not** recorded — do not post it, and surface the cooldown to the user.
+`CR_BUDGET_OK=0` ⇒ account budget exhausted — drop CR from the proposed triggers this run and say so. When `cr-review-hourly.sh` is absent, `CR_BUDGET_OK` stays `1` (degrade gracefully — do not silently suppress CR). The per-PR **2 explicit `@coderabbitai full review`/hour** cap is enforced atomically at post time by `cr-review-hourly.sh --record-explicit <N>` (Step 5): if it returns `surface_user: true` / exits non-zero, the trigger was **not** recorded — do not post it, and surface the cooldown to the user.
 
 ---
 

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -74,7 +74,10 @@ CR_HOURLY_SH=$(resolve_script cr-review-hourly.sh) || true   # optional; degrade
 ## Step 1 — Inventory open PRs
 
 ```bash
-PRS=$(gh pr list --state open --limit 50 --json number,title,isDraft,headRefOid,url)
+# Cover the WHOLE open backlog, not just the first page. gh pr list paginates
+# internally up to --limit, so set it well above any realistic backlog (raise it
+# further if a repo can exceed this). A low cap would silently skip later PRs.
+PRS=$(gh pr list --state open --limit 1000 --json number,title,isDraft,headRefOid,url)
 
 # Narrow to a single PR BEFORE counting, so a targeted audit of a closed/missing
 # PR yields COUNT == 0 (an open-list count would mask the empty result).
@@ -202,16 +205,21 @@ Using `$CR_HEALTH` from Step 2: if the CR check-run is `completed` **and** a rat
 
 ### 4c. CR explicit-trigger budget (2/hour per PR + account hourly cap)
 
-Before proposing `@coderabbitai full review` for any PR, check the account hourly budget once. Guard the optional script so a **missing** `cr-review-hourly.sh` is never mistaken for an exhausted budget (only an actual exit `1` from the script means exhausted):
+Before proposing `@coderabbitai full review` for any PR, check the account hourly budget once. Map the script's exit code explicitly — `cr-review-hourly.sh --check` exits `0` (budget available), `1` (account budget exhausted), or another code (`2` usage, `5` write failure). Treat **only exit `1`** as exhausted; a missing script or any other nonzero is a helper problem, not an exhausted budget, so surface it and keep CR proposable rather than silently dropping it:
 
 ```bash
-CR_BUDGET_OK=1
+CR_BUDGET_OK=1            # 1 = propose CR; 0 = budget exhausted, drop CR
 if [[ -n "$CR_HOURLY_SH" ]]; then
-  "$CR_HOURLY_SH" --check >/dev/null 2>&1 || CR_BUDGET_OK=0
+  "$CR_HOURLY_SH" --check >/dev/null 2>&1; RC=$?
+  case "$RC" in
+    0) ;;                                  # budget available
+    1) CR_BUDGET_OK=0 ;;                    # account budget exhausted — drop CR
+    *) echo "warn: cr-review-hourly.sh --check failed (exit $RC) — not assuming exhausted; CR stays proposable" >&2 ;;
+  esac
 fi
 ```
 
-`CR_BUDGET_OK=0` ⇒ account budget exhausted — drop CR from the proposed triggers this run and say so. When `cr-review-hourly.sh` is absent, `CR_BUDGET_OK` stays `1` (degrade gracefully — do not silently suppress CR). The per-PR **2 explicit `@coderabbitai full review`/hour** cap is enforced atomically at post time by `cr-review-hourly.sh --record-explicit <N>` (Step 5): if it returns `surface_user: true` / exits non-zero, the trigger was **not** recorded — do not post it, and surface the cooldown to the user.
+`CR_BUDGET_OK=0` ⇒ account budget exhausted — drop CR from the proposed triggers this run and say so. A missing `cr-review-hourly.sh` (or any non-`1` failure) leaves `CR_BUDGET_OK=1` (degrade gracefully — surface the error, don't silently suppress CR). The per-PR **2 explicit `@coderabbitai full review`/hour** cap is enforced atomically at post time by `cr-review-hourly.sh --record-explicit <N>` (Step 5), which uses the same exit-code contract (exit `1` = cooldown/cap reached; other nonzero = helper error).
 
 ---
 
@@ -234,11 +242,13 @@ On confirmation, post each comment. For a CodeRabbit trigger, record it against 
 
 ```bash
 post_trigger() {  # $1=PR  $2=comment  $3=reviewer-key
-  if [[ "$3" == "coderabbit" ]]; then
-    if [[ -n "$CR_HOURLY_SH" ]]; then
-      OUT=$("$CR_HOURLY_SH" --record-explicit "$1") || {
-        echo "skip CR on #$1: $(jq -r '.explicit_triggers_in_window // "budget"' <<<"$OUT" 2>/dev/null) — cap/budget reached"; return 0; }
-    fi
+  if [[ "$3" == "coderabbit" && -n "$CR_HOURLY_SH" ]]; then
+    OUT=$("$CR_HOURLY_SH" --record-explicit "$1"); RC=$?
+    case "$RC" in
+      0) ;;                                  # recorded — clear to post
+      1) echo "skip CR on #$1: cooldown/cap or account budget reached — not posting"; return 0 ;;
+      *) echo "skip CR on #$1: cr-review-hourly.sh --record-explicit failed (exit $RC) — surfacing, not posting" >&2; return 0 ;;
+    esac
   fi
   gh pr comment "$1" --body "$2" && echo "posted on #$1: $2"
 }

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: monitor
+description: Audit every open PR for engagement from all four AI reviewers (CodeRabbit, CodeAnt, BugBot, Graphite). Builds a ✅/❌ gap matrix from pr-state.sh (reviews + comments + check-runs on HEAD), detects blockers (draft PRs, CR rate-limit), and posts the missing trigger comments after confirmation. Read-only audit by default; never auto-flips drafts or auto-merges. Triggers on "/monitor", "check all PRs for reviewer engagement", "make sure all 4 reviewers ran", "did codeant/cursor/graphite review #N".
+triggers:
+  - monitor
+  - check all PRs for reviewer engagement
+  - make sure all 4 reviewers ran
+  - did codeant review
+  - did cursor review
+  - did graphite review
+  - reviewer engagement matrix
+model: sonnet
+argument-hint: "[<PR>] [--apply] [--repo <owner/repo>] (default: audit all open PRs, confirm before posting)"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+Audit the open PR backlog and confirm that **all four AI code reviewers** have actually engaged on each PR, then post the missing trigger comments. The four reviewers and their exact bot logins / trigger strings are:
+
+| Reviewer | Bot login | Trigger string |
+|----------|-----------|----------------|
+| CodeRabbit | `coderabbitai[bot]` | `@coderabbitai full review` |
+| CodeAnt | `codeant-ai[bot]` | `@codeant-ai review` |
+| BugBot (Cursor) | `cursor[bot]` | `@cursor review` |
+| Graphite | `graphite-app[bot]` | `@graphite-app re-review` |
+
+`/monitor` is **audit-and-trigger only**. It is the action-oriented sibling of read-only `/status`: where `/status` reports merge-readiness, `/monitor` reports *reviewer coverage* and closes gaps. It does **not** drive the fix/resolve loop (that stays with `/fixpr` and the per-PR coding threads) and it never auto-flips drafts, auto-merges, or modifies review-bot config.
+
+## Scope boundaries (HARD STOPS)
+
+- **Never auto-flip a draft to ready-for-review.** Surface it and ask; only the user runs `gh pr ready <N>`.
+- **Never post `@coderabbitai full review` when CodeRabbit is rate-limited**, or when the per-PR 2-explicit-triggers/hour cap is reached, or when the account hourly budget is exhausted (`cr-review-hourly.sh`).
+- **Never auto-merge, dismiss reviews, or resolve threads** — that is `/fixpr` / `/wrap` territory.
+- The other three triggers (`@codeant-ai review`, `@cursor review`, `@graphite-app re-review`) are not hourly-capped — BugBot is per-seat, CodeAnt/Graphite are cheap — but do not spam them: only post for a *missing* reviewer.
+
+## Arguments
+
+Parse from `$ARGUMENTS`:
+
+| Argument | Default | Meaning |
+|----------|---------|---------|
+| `<PR>` (bare integer) | — | Audit only this PR instead of the whole backlog. |
+| `--apply` | off | Skip the confirmation prompt and post missing triggers immediately. Blockers (draft, CR rate-limit/cap) are still honored — `--apply` never overrides a HARD STOP. |
+| `--repo <owner/repo>` | current repo | Target a different repo. Implemented by `export GH_REPO=<owner/repo>` so both `gh` and `pr-state.sh` resolve the same repo. |
+
+## Resolve the shared scripts (once)
+
+Use the standard three-candidate lookup (same pattern as `fixpr`/`babysit-pr`). Prefer the global install; fall back to the in-repo copy when developing the skill itself.
+
+```bash
+resolve_script() {
+  local name="$1" candidate
+  for candidate in \
+    "$HOME/.claude/skills-worktree/.claude/scripts/$name" \
+    "$HOME/.claude/scripts/$name" \
+    ".claude/scripts/$name"; do
+    if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
+  done
+  return 1
+}
+
+PR_STATE_SH=$(resolve_script pr-state.sh)        || { echo "ERROR: pr-state.sh not found" >&2; exit 1; }
+CR_HOURLY_SH=$(resolve_script cr-review-hourly.sh) || true   # optional; degrade gracefully if absent
+
+# --repo: point every gh / pr-state.sh call at the target repo.
+[[ -n "$REPO_ARG" ]] && export GH_REPO="$REPO_ARG"
+```
+
+---
+
+## Step 1 — Inventory open PRs
+
+```bash
+PRS=$(gh pr list --state open --limit 50 --json number,title,isDraft,headRefOid,url)
+COUNT=$(jq 'length' <<<"$PRS")
+```
+
+If a bare `<PR>` argument was given, narrow to it: `PRS=$(jq --argjson n "$PR_ARG" 'map(select(.number == $n))' <<<"$PRS")`.
+
+If `COUNT == 0` (or the single PR is not open), say **"No open PRs to audit."** and stop.
+
+---
+
+## Step 2 — Per-PR engagement scan (reuse `pr-state.sh`)
+
+For each PR, run the shared state helper **once** — it aggregates the 3 comment endpoints (`pulls/{N}/reviews`, `pulls/{N}/comments`, `issues/{N}/comments`, `per_page=100`) plus check-runs and commit statuses from a single HEAD-SHA pull. **Do not re-issue per-PR REST loops in this skill** — read everything from the bundle via `jq`.
+
+```bash
+BUNDLE=$("$PR_STATE_SH" --pr "$N") || { echo "skip #$N: pr-state.sh failed"; continue; }
+```
+
+Build the 4-reviewer matrix from the bundle. A reviewer is **engaged** when it produced, on the current HEAD, any of: a **review object**, a **check-run** whose name matches the reviewer, OR a **finding-bearing comment**. Pure ack comments (e.g. CR's "Actions performed — Full review triggered", "actionable comments posted: 0", rate-limit notices) do **not** count.
+
+```bash
+MATRIX=$(jq -c '
+  def reviewers: [
+    {key:"coderabbit", login:"coderabbitai[bot]", needles:["coderabbit"]},
+    {key:"codeant",    login:"codeant-ai[bot]",   needles:["codeant"]},
+    {key:"bugbot",     login:"cursor[bot]",        needles:["cursor","bugbot"]},
+    {key:"graphite",   login:"graphite-app[bot]",  needles:["graphite"]}
+  ];
+  # Pure-acknowledgment comments that must NOT count as engagement.
+  def is_ack($body):
+    ($body // "") as $b
+    | ($b == "")
+      or ($b | test("actions performed"; "i"))
+      or ($b | test("full review triggered"; "i"))
+      or ($b | test("actionable comments posted:\\s*0\\b"; "i"))
+      or ($b | test("no actionable comments were generated"; "i"))
+      or ($b | test("rate limit"; "i"));
+  . as $b
+  | reviewers
+  | map(. as $r
+      | {
+          has_review:
+            ([$b.comments.reviews[]? | select(.user.login == $r.login)] | length > 0),
+          has_check:
+            (([$b.check_runs.all[]?
+               | (.name // "" | ascii_downcase) as $n
+               | select(any($r.needles[]; . as $needle | $n | contains($needle)))] | length > 0)
+             or ($r.key == "coderabbit" and ($b.bot_statuses.CodeRabbit != null))),
+          has_finding_comment:
+            ([ ($b.comments.inline[]?, $b.comments.conversation[]?)
+               | select(.user.login == $r.login)
+               | select(is_ack(.body) | not) ] | length > 0)
+        }
+      | . + {key: $r.key, engaged: (.has_review or .has_check or .has_finding_comment)}
+    )
+  | { coderabbit: (map(select(.key=="coderabbit"))[0].engaged),
+      codeant:    (map(select(.key=="codeant"))[0].engaged),
+      bugbot:     (map(select(.key=="bugbot"))[0].engaged),
+      graphite:   (map(select(.key=="graphite"))[0].engaged) }
+' "$BUNDLE")
+```
+
+`$MATRIX` is `{coderabbit, codeant, bugbot, graphite}` booleans for PR `$N`. Collect one per PR alongside `number`, `title`, `isDraft`, and a short HEAD SHA.
+
+Also capture the CR check-run health for Step 4:
+
+```bash
+CR_HEALTH=$(jq -c '
+  ([.check_runs.all[]? | (.name // "" | ascii_downcase) as $n | select($n | contains("coderabbit"))] | last) as $cr
+  | { status: ($cr.status // null),
+      conclusion: ($cr.conclusion // null),
+      title: ($cr.title // null),
+      legacy: (.bot_statuses.CodeRabbit.description // null) }
+' "$BUNDLE")
+```
+
+---
+
+## Step 3 — Render the gap matrix
+
+Print a markdown table; ✅ = engaged on HEAD, ❌ = missing. Include the draft flag.
+
+```
+PR    | Draft | Title                          | CodeRabbit | CodeAnt | BugBot | Graphite
+------|-------|--------------------------------|------------|---------|--------|---------
+#481  |       | Add /monitor skill             | ✅          | ✅       | ✅      | ✅
+#479  | draft | Refactor pr-state bundle       | ❌          | ❌       | ✅      | ❌
+#476  |       | Fix merge-gate exit codes      | ✅          | ❌       | ✅      | ❌
+```
+
+Below the table, summarize:
+- **Fully covered:** PRs with all four ✅.
+- **Gaps:** one line per PR listing the missing reviewers, e.g. `#476 — missing: CodeAnt, Graphite`.
+- If every PR is fully covered, say so and skip Steps 4–5.
+
+---
+
+## Step 4 — Detect blockers before triggering
+
+Run these checks per PR with gaps; they gate (or annotate) the triggers proposed in Step 5.
+
+### 4a. Draft state
+
+If a PR `isDraft == true` and any reviewer is missing, surface it: drafts cause reviewers (especially CodeRabbit) to skip silently. **Do not auto-flip.** Recommend the user run `gh pr ready <N>` and re-run `/monitor`. Still list the proposed triggers, but flag that CR will not act while the PR is a draft.
+
+### 4b. CodeRabbit rate-limit / cooldown
+
+Using `$CR_HEALTH` from Step 2: if the CR check-run is `completed` **and** a rate-limit signal appears in its `title` or `legacy` description (matches `rate limit`, case-insensitive), do **not** propose `@coderabbitai full review`. Surface the cooldown and recommend escalation to BugBot/Greptile per `cr-github-review.md` ("Reviewer escalation gate"). The other three triggers are unaffected.
+
+### 4c. CR explicit-trigger budget (2/hour per PR + account hourly cap)
+
+Before proposing `@coderabbitai full review` for any PR, check the account hourly budget once:
+
+```bash
+[[ -n "$CR_HOURLY_SH" ]] && "$CR_HOURLY_SH" --check >/dev/null 2>&1 || CR_BUDGET_EXHAUSTED=$?
+```
+
+Exit `1` ⇒ account budget exhausted — drop CR from the proposed triggers this run and say so. The per-PR **2 explicit `@coderabbitai full review`/hour** cap is enforced atomically at post time by `cr-review-hourly.sh --record-explicit <N>` (Step 5): if it returns `surface_user: true` / exits non-zero, the trigger was **not** recorded — do not post it, and surface the cooldown to the user.
+
+---
+
+## Step 5 — Post the missing triggers (confirmation by default)
+
+Build, per PR, the list of trigger comments for each missing reviewer (skipping any CR trigger blocked by Step 4):
+
+| Missing reviewer | Comment to post |
+|------------------|-----------------|
+| CodeRabbit | `@coderabbitai full review` |
+| CodeAnt | `@codeant-ai review` |
+| BugBot | `@cursor review` |
+| Graphite | `@graphite-app re-review` |
+
+**Default (no `--apply`):** print the full proposed plan (PR → comments) and **ask the user to confirm** before posting anything. Do not post on a bare `/monitor` run without confirmation.
+
+**`--apply`:** skip the prompt and post immediately — but Step 4 HARD STOPs still apply (no CR trigger on a rate-limited/cap-hit/budget-exhausted PR; drafts are reported, not flipped).
+
+On confirmation, post each comment. For a CodeRabbit trigger, record it against the cap **before/at** posting and honor the result:
+
+```bash
+post_trigger() {  # $1=PR  $2=comment  $3=reviewer-key
+  if [[ "$3" == "coderabbit" ]]; then
+    if [[ -n "$CR_HOURLY_SH" ]]; then
+      OUT=$("$CR_HOURLY_SH" --record-explicit "$1") || {
+        echo "skip CR on #$1: $(jq -r '.explicit_triggers_in_window // "budget"' <<<"$OUT" 2>/dev/null) — cap/budget reached"; return 0; }
+    fi
+  fi
+  gh pr comment "$1" --body "$2" && echo "posted on #$1: $2"
+}
+```
+
+Post the four reviewers as separate comments (never batch mentions — combined-mention comments do not trigger reliably). After posting, report what landed where, then suggest re-running `/monitor` after a short delay to confirm the bots picked up.
+
+---
+
+## Step 6 — Optional: emit a "fix all findings" prompt for coding threads
+
+When a PR already has bot findings (unresolved review threads: `jq '.threads.unresolved_count' "$BUNDLE"` > 0) and the user is about to hand it to its coding session, output a copy-pasteable prompt block. This encodes the same anti-loop discipline as `cr-github-review.md` ("Processing CR Feedback"):
+
+```
+Fix every bot finding on PR #<N>:
+1. Verify each finding against the actual code (CR labels duplicates — a "duplicate" is NOT resolved).
+2. Fix all valid findings in ONE commit; push once (batch — don't push per finding; CR caps ~8 reviews/hour).
+3. Reply to every thread with what changed ("Fixed in <sha>: …"). Plain text — do NOT include @cursor in replies.
+4. Resolve each thread via GraphQL (resolveReviewThread); replies alone don't resolve.
+5. Manually mark Resolved any thread GitHub didn't auto-resolve when the line changed.
+6. Do NOT request a new review until every touched thread shows isResolved: true.
+```
+
+Keep this wording in the SKILL so it can be iterated without touching other files.
+
+---
+
+## Notes
+
+- **Reuse, don't reimplement:** Step 2 must go through `pr-state.sh`; the matrix is pure `jq` over the bundle. No ad-hoc `gh api pulls/.../comments` loops in this skill.
+- **Relationship to `/status`:** `/status` is the read-only merge-readiness dashboard; `/monitor` audits *reviewer coverage* and posts the missing triggers. Use `/fixpr` to actually process findings.
+- **Post-merge install:** after this skill lands on `main`, symlink it globally via the skills worktree per `skill-symlinks.md`:
+
+  ```bash
+  git -C "$HOME/.claude/skills-worktree" fetch origin main --quiet
+  git -C "$HOME/.claude/skills-worktree" reset --hard origin/main --quiet
+  ln -s "$HOME/.claude/skills-worktree/.claude/skills/monitor" "$HOME/.claude/skills/monitor"
+  ```
+
+  No script changes are needed — `session-start-sync.sh` syncs the worktree to `origin/main` on session start, so the symlink target resolves automatically after merge.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ ls -la ~/.claude/skills/       # each skill -> ~/.claude/skills-worktree/.claude
 
 ## Slash Commands
 
-All 22 commands are invoked as `/command` in a Claude Code session. They are defined as skill files in `.claude/skills/` and symlinked globally.
+All 23 commands are invoked as `/command` in a Claude Code session. They are defined as skill files in `.claude/skills/` and symlinked globally.
 
 | Command | Category | Description |
 |---------|----------|-------------|
@@ -142,6 +142,7 @@ All 22 commands are invoked as `/command` in a Claude Code session. They are def
 | `/prompt` | Planning | Classify issue complexity, recommend a Claude 4.7/4.6 model tier, generate copy-paste prompt without the removed `effort` field |
 | `/start-issue` | Planning | End-to-end issue-to-coding setup — plan polling, plan merge, worktree, branch |
 | `/fixpr` | Review | Single-pass PR cleanup — fixes review findings and CI failures, replies to findings, resolves threads |
+| `/monitor` | Review | Audit all open PRs for engagement from the 4 AI reviewers (CodeRabbit/CodeAnt/BugBot/Graphite); render a gap matrix and post missing triggers after confirmation |
 | `/pr-review-help` | Review | Executive PR review — multi-PR parallel strategic analysis |
 | `/standup` | Workflow | Daily standup summary (single contributor) |
 | `/status` | Workflow | Dashboard of open PRs with review state |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new skill `.claude/skills/monitor/SKILL.md` (`/monitor`) that audits the open PR backlog and confirms all **four** AI code reviewers have actually engaged on each PR, then posts the missing trigger comments.

The four reviewers (exact logins / triggers):

| Reviewer | Bot login | Trigger |
|----------|-----------|---------|
| CodeRabbit | `coderabbitai[bot]` | `@coderabbitai full review` |
| CodeAnt | `codeant-ai[bot]` | `@codeant-ai review` |
| BugBot (Cursor) | `cursor[bot]` | `@cursor review` |
| Graphite | `graphite-app[bot]` | `@graphite-app re-review` |

### How it works (issue #446 steps 1–6)

1. **Inventory** — `gh pr list --state open --json number,title,isDraft,headRefOid,url`; empty → stop.
2. **Per-PR engagement scan** — one `pr-state.sh --pr <N>` call per PR; a pure-`jq` matrix derives engagement from the bundle (no ad-hoc REST loops). A reviewer counts as engaged when it produced, on the current HEAD, a **review object**, a **matching check-run**, OR a **finding-bearing comment**. Pure ack comments (CR "Actions performed — Full review triggered", "actionable comments posted: 0", rate-limit notices) do **not** count.
3. **Gap matrix** — markdown ✅/❌ table with draft flag + per-PR gap summary.
4. **Blocker detection** — draft PRs are surfaced (never auto-flipped); CR rate-limit/cooldown short-circuits `@coderabbitai full review`; the 2-explicit-triggers/hour cap + account hourly budget are enforced via `cr-review-hourly.sh`.
5. **Post triggers** — confirmation-by-default; `--apply` skips the prompt but still honors every HARD STOP. CR triggers go through `--record-explicit` at post time.
6. **Optional** — emits the canonical "fix all findings, push once, reply, resolve" prompt for coding threads (anti-loop language from `cr-github-review.md`).

Also registers `/monitor` in the `README.md` slash-commands table.

## Test Plan

- [x] `.claude/skills/monitor/SKILL.md` exists with frontmatter (`name`, `description`, `triggers`, `model: sonnet`, `allowed-tools`) — validated via `yaml.safe_load`.
- [ ] Skill is symlinked into global `~/.claude/skills/` per `skill-symlinks.md` (post-merge step; documented in the skill's Notes).
- [x] Step 2 reuses `pr-state.sh` — no ad-hoc per-PR REST loops in the skill body.
- [x] All 4 reviewer logins/triggers are exact (`coderabbitai[bot]`, `codeant-ai[bot]`, `cursor[bot]`, `graphite-app[bot]`).
- [x] Draft-PR detection present; skill never auto-flips drafts to ready-for-review.
- [x] CR rate-limit detection short-circuits `@coderabbitai full review` and respects the 2/hour cap via `cr-review-hourly.sh`.
- [x] Default flow asks for confirmation before posting; `--apply` mode documented.
- [x] README skill table updated to include `/monitor`.
- [x] Engagement-matrix `jq` validated against synthetic bundles: all-engaged → all ✅; ack-only CR + BugBot check-run → only BugBot ✅; CR rate-limit signal correctly detected.
- [ ] Manual end-to-end run against a repo with ≥3 open PRs (one draft, one fully covered, one missing 2+) — pending a live backlog.

## Notes

- Local `coderabbit review --agent` could not run in this environment (CLI installed but signed out, no token available). The GitHub CodeRabbit review will cover this PR after push.

Closes #446

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c571aecb-806d-4e62-8fef-bc7cf77efca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c571aecb-806d-4e62-8fef-bc7cf77efca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/monitor` command to review PR coverage across multiple AI reviewers.
  * Shows a gap matrix for missing reviewer activity and can suggest follow-up actions.
  * Supports an optional apply mode to post missing review triggers after confirmation.
  * Can surface unresolved bot findings in a copy-paste prompt for easy follow-up.

* **Documentation**
  * Updated command documentation to include `/monitor` and reflect the expanded command list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->