### PR TITLE
feat(fixpr): auto-infer PR from thread/session context when no arg given (#447)

### DIFF
--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -27,7 +27,7 @@
 #         "needs": <str|null>, "blocker_kind": <str|null>,
 #         "owner_repo": <str|null>, "root_repo": <str|null>,
 #         "last_action_at": <iso-8601|"">, "same_repo": <true|false|null> }
-#   `same_repo` is true/false when both the current repo (via `gh repo view`) and
+#   `same_repo` is true/false when both the current repo (via git remote URL) and
 #   the candidate's stored owner_repo are known, else null ("unknown — don't filter
 #   it out"). Always exits 0 with `[]` when the state file is missing or tracks no
 #   active PRs. Cannot be combined with --pr or --since.
@@ -124,13 +124,22 @@ if [[ "$INFER_CANDIDATES" -eq 1 ]]; then
     exit 0
   fi
   # Best-effort current repo detection so candidates can be flagged same_repo.
-  # A gh/network failure here must NOT fail the inference path — fall back to
-  # an empty owner so same_repo is reported as null ("unknown, don't filter").
-  CUR_OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+  # Derived offline from the git remote URL to avoid any network/auth dependency.
+  # Falls back to "" so same_repo is reported as null ("unknown — don't filter").
+  _remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+  if [[ -n "$_remote_url" ]]; then
+    # Handle both HTTPS (https://github.com/owner/repo.git) and SSH (git@github.com:owner/repo.git)
+    _remote_url="${_remote_url%.git}"
+    CUR_OWNER_REPO="${_remote_url##*github.com[:/]}"
+  else
+    CUR_OWNER_REPO=""
+  fi
   # `(.prs // {})` tolerates a state file with no `prs` key. tonumber? keeps
   # non-numeric keys from aborting the whole pass (defensive — keys are always
   # numeric PR strings in practice).
-  jq -c --arg cur "$CUR_OWNER_REPO" '
+  # Only the missing-file / empty-prs cases return []; parse/runtime errors are
+  # surfaced on stderr so state corruption is visible rather than silently masked.
+  _jq_out=$(jq -c --arg cur "$CUR_OWNER_REPO" '
     [ (.prs // {}) | to_entries[]
       | select(.value.phase != null)
       | {
@@ -149,7 +158,14 @@ if [[ "$INFER_CANDIDATES" -eq 1 ]]; then
         }
     ]
     | sort_by(.last_action_at) | reverse
-  ' "$STATE_FILE" 2>/dev/null || echo "[]"
+  ' "$STATE_FILE" 2>&1)
+  _jq_rc=$?
+  if [[ $_jq_rc -ne 0 ]]; then
+    echo "WARNING: pr-state.sh --infer-candidates: failed to parse $STATE_FILE (jq exit $_jq_rc): $_jq_out" >&2
+    echo "[]"
+  else
+    echo "$_jq_out"
+  fi
   exit 0
 fi
 

--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -11,13 +11,30 @@
 #   pr-state.sh --pr 123                 # Use explicit PR number (skips branch detect)
 #   pr-state.sh --since <iso-8601>       # Pre-classify bot comments posted since baseline
 #   pr-state.sh --pr 123 --since <iso>   # Combined
+#   pr-state.sh --infer-candidates       # List session-tracked PR candidates (no GitHub state)
 #   pr-state.sh --help                   # Print usage
 #
 # Output: writes JSON to /tmp/pr-state-<PR>-<epoch>.json and prints the path on stdout.
+#         (--infer-candidates prints a JSON array to stdout instead — see below.)
+#
+# --infer-candidates (shared by /fixpr issue #447 and /wrap issue #448):
+#   Reads ~/.claude/session-state.json and prints a JSON array of the PRs this
+#   session is actively tracking (those with a non-null .phase), newest activity
+#   first (by .last_cron_action.at). No git branch, gh, or network calls are made
+#   for the candidate set itself — this is the fast no-argument inference path for
+#   /fixpr and /wrap. Each element:
+#       { "number": <int>, "phase": <str|null>, "reviewer": <str|null>,
+#         "needs": <str|null>, "blocker_kind": <str|null>,
+#         "owner_repo": <str|null>, "root_repo": <str|null>,
+#         "last_action_at": <iso-8601|"">, "same_repo": <true|false|null> }
+#   `same_repo` is true/false when both the current repo (via `gh repo view`) and
+#   the candidate's stored owner_repo are known, else null ("unknown — don't filter
+#   it out"). Always exits 0 with `[]` when the state file is missing or tracks no
+#   active PRs. Cannot be combined with --pr or --since.
 #
 # Exit codes:
 #   0  OK
-#   2  usage error (unknown flag, --since missing value)
+#   2  usage error (unknown flag, --since missing value, incompatible flag combo)
 #   3  no git branch AND no --pr given
 #   4  PR closed, merged, or not found
 #   5  gh/network error
@@ -44,8 +61,13 @@ run_gh() {
 
 PR_ARG=""
 SINCE=""
+INFER_CANDIDATES=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --infer-candidates)
+      INFER_CANDIDATES=1
+      shift
+      ;;
     --pr)
       PR_ARG="${2:-}"
       if [[ -z "$PR_ARG" ]]; then
@@ -85,6 +107,51 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# ----------------------------------------------------------------------
+# 0. --infer-candidates: list session-tracked PR candidates and exit.
+#    Shared by /fixpr (#447) and /wrap (#448) for no-argument PR inference.
+#    Pure read of ~/.claude/session-state.json — no GitHub state is gathered.
+# ----------------------------------------------------------------------
+if [[ "$INFER_CANDIDATES" -eq 1 ]]; then
+  if [[ -n "$PR_ARG" || -n "$SINCE" ]]; then
+    echo "ERROR: --infer-candidates cannot be combined with --pr or --since" >&2
+    exit 2
+  fi
+  STATE_FILE="$HOME/.claude/session-state.json"
+  if [[ ! -f "$STATE_FILE" ]]; then
+    echo "[]"
+    exit 0
+  fi
+  # Best-effort current repo detection so candidates can be flagged same_repo.
+  # A gh/network failure here must NOT fail the inference path — fall back to
+  # an empty owner so same_repo is reported as null ("unknown, don't filter").
+  CUR_OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+  # `(.prs // {})` tolerates a state file with no `prs` key. tonumber? keeps
+  # non-numeric keys from aborting the whole pass (defensive — keys are always
+  # numeric PR strings in practice).
+  jq -c --arg cur "$CUR_OWNER_REPO" '
+    [ (.prs // {}) | to_entries[]
+      | select(.value.phase != null)
+      | {
+          number: (.key | tonumber? // .key),
+          phase: (.value.phase // null),
+          reviewer: (.value.reviewer // null),
+          needs: (.value.needs // null),
+          blocker_kind: (.value.blocker_kind // null),
+          owner_repo: (.value.owner_repo // null),
+          root_repo: (.value.root_repo // null),
+          last_action_at: (.value.last_cron_action.at // ""),
+          same_repo: (
+            if $cur == "" or (.value.owner_repo // "") == "" then null
+            else (.value.owner_repo == $cur) end
+          )
+        }
+    ]
+    | sort_by(.last_action_at) | reverse
+  ' "$STATE_FILE" 2>/dev/null || echo "[]"
+  exit 0
+fi
 
 # ----------------------------------------------------------------------
 # 1. PR context

--- a/.claude/scripts/tests/pr-state-infer-candidates.test.sh
+++ b/.claude/scripts/tests/pr-state-infer-candidates.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Unit test for `pr-state.sh --infer-candidates` (issues #447 / #448).
+#
+# Verifies the shared no-argument PR-inference helper:
+#   - missing state file / no `prs` key / no active PRs -> `[]`, exit 0
+#   - only PRs with a non-null `.phase` are emitted (active tracking)
+#   - candidates sorted newest-activity-first by `.last_cron_action.at`
+#   - `same_repo` is true / false / null per owner_repo match vs current repo
+#   - `--infer-candidates` rejects `--pr` / `--since` combos (exit 2)
+#
+# Uses a temporary HOME (never touches ~/.claude) and a stub `gh` on PATH so
+# repo detection is deterministic and offline. Requires jq.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/.claude/scripts/pr-state.sh"
+
+TMP_HOME="$(mktemp -d)"
+FAKE_BIN="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_HOME" "$FAKE_BIN"; }
+trap cleanup EXIT
+
+# Stub gh: only `gh repo view --json nameWithOwner ...` is exercised by the
+# inference path. Return a fixed repo so same_repo is deterministic offline.
+cat > "$FAKE_BIN/gh" <<'GH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
+  echo "auerbachb/skingod"
+  exit 0
+fi
+exit 1
+GH
+chmod +x "$FAKE_BIN/gh"
+
+export HOME="$TMP_HOME"
+export PATH="$FAKE_BIN:$PATH"
+mkdir -p "$HOME/.claude"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- Case 1: missing state file -> [] exit 0 ---
+out=$(bash "$SCRIPT" --infer-candidates) || fail "missing-file: non-zero exit"
+[[ "$out" == "[]" ]] || fail "missing-file: expected [] got: $out"
+
+# --- Case 2: ordering + active filter + same_repo true/false/null ---
+cat > "$HOME/.claude/session-state.json" <<'JSON'
+{ "prs": {
+  "462": {"phase":"B","reviewer":"cr","needs":"cr_confirmation_pass","owner_repo":"auerbachb/skingod","last_cron_action":{"at":"2026-05-04T16:48:00Z"}},
+  "458": {"phase":"B","reviewer":"bugbot","needs":"bugbot_review_poll","owner_repo":"auerbachb/skingod","last_cron_action":{"at":"2026-05-04T16:40:00Z"}},
+  "777": {"phase":"C","owner_repo":"other/repo","last_cron_action":{"at":"2026-05-04T16:59:00Z"}},
+  "888": {"phase":"A","last_cron_action":{"at":"2026-05-04T16:30:00Z"}},
+  "999": {"reviewer":"cr"}
+}}
+JSON
+out=$(bash "$SCRIPT" --infer-candidates)
+# 999 has no phase -> excluded; 4 active candidates remain.
+count=$(jq 'length' <<<"$out")
+[[ "$count" == "4" ]] || fail "expected 4 active candidates, got $count: $out"
+# Newest activity first: 777 (16:59) > 462 (16:48) > 458 (16:40) > 888 (16:30).
+order=$(jq -r '[.[].number] | join(",")' <<<"$out")
+[[ "$order" == "777,462,458,888" ]] || fail "bad recency order: $order"
+# same_repo: matching owner_repo -> true, different -> false, missing -> null.
+[[ "$(jq -r '.[]|select(.number==462)|.same_repo' <<<"$out")" == "true" ]]  || fail "462 same_repo != true"
+[[ "$(jq -r '.[]|select(.number==777)|.same_repo' <<<"$out")" == "false" ]] || fail "777 same_repo != false"
+[[ "$(jq -r '.[]|select(.number==888)|.same_repo' <<<"$out")" == "null" ]]  || fail "888 same_repo != null"
+# number is emitted as an integer, not a string.
+[[ "$(jq -r '.[0].number | type' <<<"$out")" == "number" ]] || fail "number not emitted as integer"
+
+# --- Case 3: incompatible flag combos -> exit 2 ---
+rc=0; bash "$SCRIPT" --infer-candidates --pr 5 >/dev/null 2>&1 || rc=$?
+[[ "$rc" -eq 2 ]] || fail "--infer-candidates --pr expected exit 2, got $rc"
+rc=0; bash "$SCRIPT" --infer-candidates --since 2020-01-01T00:00:00Z >/dev/null 2>&1 || rc=$?
+[[ "$rc" -eq 2 ]] || fail "--infer-candidates --since expected exit 2, got $rc"
+
+# --- Case 4: state file with no `prs` key -> [] ---
+echo '{"root_repo":"/r"}' > "$HOME/.claude/session-state.json"
+out=$(bash "$SCRIPT" --infer-candidates)
+[[ "$out" == "[]" ]] || fail "no-prs-key: expected [] got: $out"
+
+# --- Case 5: prs present but none active (all phase null) -> [] ---
+echo '{"prs":{"1":{"reviewer":"cr"},"2":{"head_sha":"abc"}}}' > "$HOME/.claude/session-state.json"
+out=$(bash "$SCRIPT" --infer-candidates)
+[[ "$out" == "[]" ]] || fail "no-active: expected [] got: $out"
+
+echo "OK: pr-state.sh --infer-candidates (missing file, ordering, active filter, same_repo, flag combos, empty prs)"

--- a/.claude/scripts/tests/pr-state-infer-candidates.test.sh
+++ b/.claude/scripts/tests/pr-state-infer-candidates.test.sh
@@ -8,7 +8,7 @@
 #   - `same_repo` is true / false / null per owner_repo match vs current repo
 #   - `--infer-candidates` rejects `--pr` / `--since` combos (exit 2)
 #
-# Uses a temporary HOME (never touches ~/.claude) and a stub `gh` on PATH so
+# Uses a temporary HOME (never touches ~/.claude) and stubs `gh`/`git` on PATH so
 # repo detection is deterministic and offline. Requires jq.
 set -euo pipefail
 
@@ -20,17 +20,25 @@ FAKE_BIN="$(mktemp -d)"
 cleanup() { rm -rf "$TMP_HOME" "$FAKE_BIN"; }
 trap cleanup EXIT
 
-# Stub gh: only `gh repo view --json nameWithOwner ...` is exercised by the
-# inference path. Return a fixed repo so same_repo is deterministic offline.
+# Stub gh: still needed for non-inference paths that may call gh.
 cat > "$FAKE_BIN/gh" <<'GH'
 #!/usr/bin/env bash
-if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
-  echo "auerbachb/skingod"
-  exit 0
-fi
 exit 1
 GH
 chmod +x "$FAKE_BIN/gh"
+
+# Stub git: intercept `git remote get-url origin` (used by the offline same_repo
+# detection path) and return a fixed repo URL so the result is deterministic.
+# All other git subcommands are forwarded to the real git binary.
+cat > "$FAKE_BIN/git" <<'GIT'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "remote" && "${2:-}" == "get-url" && "${3:-}" == "origin" ]]; then
+  echo "https://github.com/auerbachb/skingod.git"
+  exit 0
+fi
+exec "$(command -v git 2>/dev/null || true)" "$@"
+GIT
+chmod +x "$FAKE_BIN/git"
 
 export HOME="$TMP_HOME"
 export PATH="$FAKE_BIN:$PATH"

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -24,6 +24,7 @@ All mechanical GitHub API work — pagination, GraphQL queries, comment classifi
 
 | Step | Kind | Done by |
 |------|------|---------|
+| 0a. Resolve target PR (arg or infer) | Judgment + Mechanical | AI thread scan + `pr-state.sh --infer-candidates` (no-arg inference, issue #447) |
 | 0. Gather PR state | Mechanical | `pr-state.sh` writes `/tmp/pr-state-<PR>-<epoch>.json` |
 | 1. Classify review findings | Judgment | AI reads JSON + source files |
 | 2. Classify CI failures | Judgment | AI reads `check-runs/<id>.output.summary` |
@@ -84,11 +85,79 @@ if [[ -z "$SCRIPT" ]]; then
   echo "ERROR: pr-state.sh not found (checked ~/.claude/scripts/, ~/.claude/skills-worktree/.claude/scripts/, and in-repo .claude/scripts/)" >&2
   exit 1
 fi
-
-AUDIT=$("$SCRIPT")
 ```
 
-If `pr-state.sh` itself exits non-zero it prints the reason to stderr (no PR, closed PR, detached HEAD, etc.). Stop and report. Exit codes: `0` OK, `2` usage error, `3` no branch and no `--pr`, `4` PR closed/not found, `5` gh/network error.
+### Step 0a: Resolve the target PR (explicit argument → thread/session inference)
+
+`/fixpr` may be invoked **with** a PR (`/fixpr <url>` or `/fixpr <N>`) or **with no argument**. Resolve the target into `$PR_NUMBER_ARG` *before* calling `pr-state.sh`, so a no-argument re-run is a fast convenience instead of a dead end (issue #447). The session-state half of this inference is shared verbatim with `/wrap` (issue #448) via `pr-state.sh --infer-candidates` — do not re-implement it.
+
+**1. Capture and parse the explicit argument.** Put whatever the user typed after `/fixpr` into `$FIXPR_ARG` (empty when none). Accept a full PR URL or a bare PR number:
+
+```bash
+PR_NUMBER_ARG=""
+if [[ -n "${FIXPR_ARG:-}" ]]; then
+  if [[ "$FIXPR_ARG" =~ ^https?://github\.com/[^/]+/[^/]+/pull/([0-9]+) ]]; then
+    PR_NUMBER_ARG="${BASH_REMATCH[1]}"          # extracted from pull/<N>
+  elif [[ "$FIXPR_ARG" =~ ^[0-9]+$ ]]; then
+    PR_NUMBER_ARG="$FIXPR_ARG"                   # bare positive integer
+  else
+    echo "ERROR: /fixpr argument not recognized: '$FIXPR_ARG' (expected a PR URL or number)" >&2
+    exit 2
+  fi
+  echo "[CONTEXT] Using explicitly provided PR #$PR_NUMBER_ARG"
+fi
+```
+
+**2. When no argument was given, infer the target.** Skip this entire step when `$PR_NUMBER_ARG` is already set. Build a candidate set from two sources, then resolve:
+
+- **Thread scan (AI layer).** Read back through *this* conversation for the most recent `/fixpr <url-or-number>` and `/wrap <url-or-number>` invocations and any PR the thread just operated on (pushed to, audited). Extract PR numbers from the `pull/<N>` pattern. Record them **in order, most-recently-mentioned first** — thread recency is the strongest signal (the issue's motivating case: a `/fixpr <url>` ran moments ago, then a bare `/fixpr`).
+- **Session state (script layer).** Pull the PRs this session is actively tracking, newest activity first:
+
+```bash
+CANDIDATES_JSON=$("$SCRIPT" --infer-candidates 2>/dev/null || echo "[]")
+# Prefer same-repo candidates; same_repo==null means "unknown repo, keep it".
+SESSION_CANDIDATES=$(jq -c '[ .[] | select(.same_repo != false) ]' <<<"$CANDIDATES_JSON")
+jq -r '.[] | "  session-candidate: #\(.number) (phase=\(.phase // "?"), needs=\(.needs // "?"), last_action=\(.last_action_at // "?"))"' <<<"$SESSION_CANDIDATES"
+```
+
+(`--infer-candidates` is a pure read of `~/.claude/session-state.json`; a global `pr-state.sh` too old to know the flag exits non-zero and the `|| echo "[]"` fallback degrades gracefully to thread-only inference.)
+
+**3. Resolve candidates → `$PR_NUMBER_ARG` (or prompt).** Merge the thread list and `SESSION_CANDIDATES` into a unique set keyed by PR number, tracking each PR's source(s) (`thread`, `session`) and recency:
+
+| Situation | Action |
+|-----------|--------|
+| **Exactly one unique candidate** (from either source) | Select it. Set `PR_NUMBER_ARG=<N>` and print the `[INFERRED]` line (formats below). Proceed — do **not** ask. |
+| **Multiple candidates, one clearly most recent** | Pick the most-recently-mentioned. **Thread recency outranks session timestamps:** if any PR appeared in the thread scan, the newest thread mention wins; otherwise use the session candidate with the newest `last_action_at` (only when it is strictly newer than the next — not tied). Set `PR_NUMBER_ARG`, print the `[INFERRED]` line **and** the one-line `Also tracking:` note. |
+| **Genuinely ambiguous** (two+ tied on recency, e.g. two thread PRs mentioned equally recently or session candidates tied on `last_action_at`) | Do **not** guess. Print `[CONTEXT] No PR argument and no branch PR; multiple candidates:` followed by the candidate list with sources, and ask the user which PR they meant — same behavior as before #447. Leave `PR_NUMBER_ARG` empty. |
+| **No candidates at all** | Leave `PR_NUMBER_ARG` empty and fall through to branch auto-detection below — `pr-state.sh` with no `--pr` either finds the branch's PR or exits `3`/`4` and you report it (unchanged pre-#447 behavior). |
+
+`[INFERRED]` log formats (print exactly one, before the `[CONTEXT]`/audit output below — it is the user's only catch point for a misfire):
+
+```text
+[INFERRED] PR #462 from thread context (last /fixpr invocation)
+[INFERRED] PR #462 from session state (most recent activity at 2026-05-04T16:48:00Z)
+[INFERRED] PR #462 (most recent of 2 active PRs); override with /fixpr #458 if needed
+```
+
+When inference picked from multiple candidates, append the override hint on its own line (one line; annotate each other PR with its session `needs`/`phase`):
+
+```text
+Also tracking: #458 (bugbot_review_poll), #445 (cr_confirmation_pass)
+```
+
+### Step 0b: Run the audit
+
+Call `pr-state.sh` with the resolved PR when inference or an explicit argument produced one; otherwise fall back to branch auto-detection:
+
+```bash
+if [[ -n "$PR_NUMBER_ARG" ]]; then
+  AUDIT=$("$SCRIPT" --pr "$PR_NUMBER_ARG")
+else
+  AUDIT=$("$SCRIPT")
+fi
+```
+
+If `pr-state.sh` itself exits non-zero it prints the reason to stderr (no PR, closed PR, detached HEAD, etc.). Stop and report. Exit codes: `0` OK, `2` usage error, `3` no branch and no `--pr`, `4` PR closed/not found, `5` gh/network error. With Step 0a in place, exit `3` (no branch and no `--pr`) only reaches you when inference also found **no** candidate — that is the genuine "which PR did you mean?" case.
 
 Pull the values that the later steps need out of the JSON once:
 

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -21,5 +21,8 @@ jobs:
       - name: stale-worktree-warn integration test
         run: bash .claude/hooks/tests/stale-worktree-warn.test.sh
 
+      - name: pr-state --infer-candidates unit test
+        run: bash .claude/scripts/tests/pr-state-infer-candidates.test.sh
+
       - name: env-guard unit tests
         run: python3 -m unittest tests.test_env_guard -v


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `/fixpr` is invoked with **no argument**, it previously relied solely on `git branch --show-current` → `gh pr view` to find the PR. That fails whenever the session is checked out on an unrelated branch (a worktree for another issue, the skills worktree, or an orchestration thread), turning a quick re-run into a dead end — even when the thread just operated on a specific PR moments earlier.

This adds a pre-flight inference layer so a no-argument `/fixpr` is a fast re-run convenience, and documents the previously-undocumented explicit `/fixpr <url>` / `/fixpr <N>` forms.

Closes #447.

## What changed

- **`pr-state.sh` — new `--infer-candidates` mode** (the shared, scriptable half, reused verbatim by `/wrap` #448): a pure read of `~/.claude/session-state.json` that lists the PRs this session is actively tracking (non-null `.phase`), newest activity first by `.last_cron_action.at`. Each candidate carries `phase`/`reviewer`/`needs`/`blocker_kind`/`owner_repo`/`root_repo`/`last_action_at` plus a `same_repo` flag (`true`/`false` vs the current repo via `gh repo view`, or `null` when unknown so it isn't filtered out). Always exits `0` with `[]` when the state file is missing or tracks no active PRs; rejects `--pr`/`--since` combos with exit `2`. No GitHub/network calls for the candidate set itself.
- **`fixpr/SKILL.md` — new Step 0a/0b:** parse an explicit `/fixpr <url|N>` argument; when none is given, combine a thread scan (last `/fixpr|/wrap` invocation — AI layer) with the session-state candidates (script layer) and resolve:
  - exactly one candidate → proceed automatically;
  - multiple with one clearly most recent → default to the most-recently-mentioned (thread recency outranks session timestamps) with a one-line `Also tracking:` note;
  - genuinely ambiguous (tied) → list candidates and prompt, as before.
  - The chosen PR is logged via `[INFERRED] PR #N from <source>` **before** the audit so a misfire is catchable. Falls back to existing branch auto-detection (and the unchanged exit-3 prompt) when there are no candidates.
- **Graceful degradation:** a global `pr-state.sh` too old to know `--infer-candidates` exits non-zero and the `|| echo "[]"` fallback drops to thread-only inference.
- **Test + CI:** `.claude/scripts/tests/pr-state-infer-candidates.test.sh` (temp HOME + stub `gh`) covers missing file / no `prs` key / no active PRs, recency ordering, the active filter, `same_repo` true/false/null, integer numbers, and flag-combo rejection. Wired into `.github/workflows/hook-scripts.yml`.

## Acceptance criteria (issue #447)

- [x] `/fixpr` with no argument and exactly one PR active in the session proceeds automatically on that PR — Step 0a §3 "exactly one unique candidate" row.
- [x] `/fixpr` with no argument and multiple active PRs defaults to the most-recently-mentioned with a visible note — Step 0a §3 "multiple candidates" row + `Also tracking:` line.
- [x] Genuinely ambiguous cases still prompt the user — Step 0a §3 "genuinely ambiguous" row preserves pre-#447 behavior.
- [x] Inferred PR is logged clearly — `[INFERRED] PR #N from <source>` printed before the audit output.

## Test plan

- [x] `bash .claude/scripts/tests/pr-state-infer-candidates.test.sh` passes locally.
- [x] `bash -n` clean on `pr-state.sh` and the test.
- [x] `pr-state.sh --help` and existing `--pr`/`--since`/no-arg paths unchanged (the inference branch short-circuits before PR context and is gated on `--infer-candidates`).
- [ ] CI `Hook scripts` job runs the new unit test on the PR.
- [ ] CodeRabbit review clean (local `coderabbit review --agent` unavailable in the cloud VM; relying on GitHub CR on the PR).

## Notes

- `/wrap` (#448) is the twin; it reuses `pr-state.sh --infer-candidates` rather than re-implementing the session-state lookup.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad46cc21-838f-4f54-9cb1-bb77792b42be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad46cc21-838f-4f54-9cb1-bb77792b42be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Let `/fixpr` pick the right PR when no number is given**

### What Changed
- `/fixpr` can now resolve a target PR from the current thread and session activity when the command is run without a PR number or URL.
- If there is one clear match, it proceeds automatically; if there are several, it picks the most recent one and shows the other tracked PRs; if it is still unclear, it asks which PR to use.
- The shared PR-state helper can now list active session-tracked PRs without calling GitHub, which supports faster no-argument inference and works even when the current branch is unrelated.
- Added test coverage for missing session state, ordering, repo matching, and invalid flag combinations.

### Impact
`✅ Faster /fixpr retries`
`✅ Fewer dead ends from the wrong branch`
`✅ Clearer PR selection when multiple issues are tracked`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
