### PR TITLE
docs(harvest): first-pass skill-repo diff + authoring-patterns import (#417)

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -31,13 +31,16 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `skill-sync-hooks.md` — skills worktree sync and hook registration narrative
 - `skill-authoring-patterns.md` — authoring *judgment* for skills/rules (description-as-trigger, match-form-to-failure, bulletproofing); complements CONTRIBUTING.md mechanics
 
+### Living trackers (updated each cycle — not point-in-time)
+
+- `skill-repo-diff.md` — cross-repo pattern-harvest tracker (#417): gap analysis vs superpowers / everything-claude-code, prioritized import backlog, and import log; re-surveyed and appended each cycle
+
 ### Audits and research (point-in-time)
 
 - `ai-review-tool-audit-2026-04.md` — AI review tool chain audit (#368 / #377)
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `script-extraction-audit.md` — deterministic script extraction inventory (#271)
 - `graphite-stacked-prs-research-2026-05.md` — stacked PR economics (#418 / #433)
-- `skill-repo-diff.md` — **living** cross-repo pattern-harvest tracker (#417): gap analysis vs superpowers / everything-claude-code, prioritized import backlog, and import log
 
 ### Diagrams (mermaid stubs and indexes)
 

--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -29,6 +29,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `pm-monitoring-decision.md` — `/loop` vs `CronCreate` hybrid decision
 - `scheduling-failure-modes.md` — recurring poll failure analysis
 - `skill-sync-hooks.md` — skills worktree sync and hook registration narrative
+- `skill-authoring-patterns.md` — authoring *judgment* for skills/rules (description-as-trigger, match-form-to-failure, bulletproofing); complements CONTRIBUTING.md mechanics
 
 ### Audits and research (point-in-time)
 
@@ -36,6 +37,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `script-extraction-audit.md` — deterministic script extraction inventory (#271)
 - `graphite-stacked-prs-research-2026-05.md` — stacked PR economics (#418 / #433)
+- `skill-repo-diff.md` — **living** cross-repo pattern-harvest tracker (#417): gap analysis vs superpowers / everything-claude-code, prioritized import backlog, and import log
 
 ### Diagrams (mermaid stubs and indexes)
 

--- a/.claude/reference/skill-authoring-patterns.md
+++ b/.claude/reference/skill-authoring-patterns.md
@@ -1,0 +1,128 @@
+# Skill & Rule Authoring Patterns
+
+On-demand authoring guidance for **writing effective skills and rules** in this
+repo. CONTRIBUTING.md covers the *mechanics* (file paths, frontmatter fields,
+symlink steps); this document covers the *judgment* — how to make a skill
+discoverable and a discipline rule that actually holds under pressure.
+
+Adapted for our conventions from [obra/superpowers `skills/writing-skills`](https://github.com/obra/superpowers/tree/main/skills/writing-skills)
+(harvested via issue #417). That skill frames authoring as TDD-for-documentation
+(pressure-test → write → close loopholes) and is available at runtime via the
+superpowers plugin; read it for the full testing methodology. The patterns below
+are the parts our own docs were missing.
+
+Not auto-loaded. Read this when creating or revising a skill or rule.
+
+## 1. Description = *when to use*, NOT *what it does*
+
+The `description` field is how the model decides whether to load a skill. The
+single highest-leverage authoring rule:
+
+> **Describe the triggering conditions. Do not summarize the workflow.**
+
+**Why it matters:** when a description summarizes the procedure, agents may follow
+the *summary* and skip reading the skill body. Superpowers documented a case where
+a description saying "code review between tasks" caused an agent to do **one**
+review even though the skill body specified **two**; removing the workflow summary
+fixed it. A description is a router, not an abstract.
+
+```yaml
+# BAD — summarizes the workflow; agent may act on this and never open the skill
+description: Audit every review thread and CI check, fix all issues, push once
+  per sweep, resolve threads, then re-sweep up to 5 times.
+
+# GOOD — triggering conditions only; agent must read the body for the procedure
+description: Use when a PR has unresolved review threads or failing CI checks and
+  needs to be driven to a clean, merge-ready state.
+```
+
+**Caveat for our slash-command skills:** our descriptions double as `/command`
+autocomplete help, so a little "what it does" is acceptable for operator
+discoverability. The rule still applies to the *behavioral* part: lead with
+**when to invoke**, and never let the description become a substitute for the
+step-by-step body. When auditing an existing skill, check: *could an agent skip
+the body and still "comply" with the description?* If yes, the description is
+leaking workflow — trim it.
+
+**Also:** third person, start with "Use when…", pack in real trigger
+keywords (error strings, symptoms, tool names) an agent would search for.
+
+## 2. Match the Form to the Failure
+
+Before writing guidance, classify the *baseline failure* you are correcting. The
+form that fixes one failure type measurably backfires on another.
+
+| Baseline failure | Right form | Wrong form (backfires) |
+|---|---|---|
+| Knows the rule, skips it under pressure | Prohibition + rationalization table + red-flags list | Soft guidance ("prefer…", "consider…") |
+| Complies, but output has the wrong shape (bloated, buried verdict, restates spec) | **Positive recipe / contract**: state what the output *is* — its parts, in order | Prohibition list ("don't restate", "never narrate") |
+| Omits a required element from something it already produces | **Structural slot**: a REQUIRED field in the template they fill in | Prose reminder near the template |
+| Behavior should depend on a condition | **Conditional** keyed to an observable predicate ("if the brief exists, reference it") | Unconditional rule + exemption clauses |
+
+**Why prohibitions backfire on shaping problems:** under a competing incentive,
+agents negotiate with "don't X". In superpowers' head-to-head wording tests, the
+prohibition arm produced *more* of the unwanted content than a positive recipe —
+worse than even no guidance. A recipe leaves nothing to negotiate: the output
+matches the stated shape or it doesn't.
+
+**Rules for whichever form you pick:**
+- **No nuance clauses.** "Don't X unless it matters" reopens the negotiation.
+  Express a real exception as its own conditional on an observable predicate.
+- **Exemption clauses don't scope.** "This limit doesn't apply to code blocks"
+  still suppresses code blocks. Restructure so the rule can't reach the exempt part.
+
+## 3. Bulletproofing Discipline Rules
+
+For rules an agent might rationalize around under pressure (our `safety.md`,
+`main-hygiene.md`, merge-gate rules are exactly this kind):
+
+- **Close loopholes explicitly.** Don't just state the rule — forbid the specific
+  workarounds. "Delete it." → "Delete it. Start over. Not as 'reference', not
+  'adapt it while rewriting', not 'look at it once'. Delete means delete."
+- **Letter vs spirit.** State early: *violating the letter of the rule is
+  violating the spirit of the rule.* This cuts off a whole class of "I'm following
+  the intent" rationalizations.
+- **Rationalization table.** Capture every excuse seen in testing as a row:
+  `| Excuse | Reality |`. Our `Always / Ask first / Never` rule headers already
+  do the front-matter version of this; the table handles the edge cases.
+- **Red-flags list.** A short "STOP if you catch yourself thinking…" list lets an
+  agent self-check mid-rationalization.
+
+These belong in the relevant **rule file** (for auto-loaded discipline) or skill,
+not here.
+
+## 4. Token / Word Efficiency
+
+Skills load on invocation; rules load **every turn** and share a hard
+`rule-lint` budget (see CLAUDE.md "Rule File Size Guidelines"). Be ruthless:
+
+- **Move detail out of the auto-loaded path.** Heavy reference, long commands, and
+  schemas go in `.claude/reference/` and are linked, not inlined — that is what
+  this directory is for.
+- **Cross-reference instead of repeating.** Name the other rule/skill; don't
+  restate its content. Avoid `@`-style force-loading links that burn context.
+- **One excellent example beats five mediocre ones.** Don't write the same
+  pattern in multiple languages or as a fill-in-the-blank template.
+- **Verify:** `wc -w` the file; for rules, run `.github/scripts/rule-lint.sh`.
+
+## 5. When NOT to Write a Skill or Rule
+
+- **One-off solution** — it's a task, not a reusable technique.
+- **Mechanically enforceable** — if a hook, regex, or CI check can enforce it,
+  automate it; reserve docs for judgment calls. (See our `config-protection`
+  backlog item in `skill-repo-diff.md` for an example of converting an advisory
+  rule into mechanical enforcement.)
+- **Already covered** — a runtime plugin skill or an existing rule already does
+  it. Duplicating splits the source of truth.
+- **Project-specific trivia** — put it in CLAUDE.md/rules, not a portable skill.
+
+## Authoring Checklist
+
+- [ ] Description leads with *when to use*; an agent could not "comply" by reading
+      the description alone (see §1).
+- [ ] Guidance form matches the baseline failure type (see §2).
+- [ ] Discipline rules close loopholes + include a rationalization table /
+      red-flags list where pressure is likely (see §3).
+- [ ] Auto-loaded footprint minimized; heavy material lives in `reference/` (§4).
+- [ ] Confirmed this isn't a duplicate or a mechanically-enforceable check (§5).
+- [ ] Mechanics done per CONTRIBUTING.md (frontmatter, rule index, symlink).

--- a/.claude/reference/skill-authoring-patterns.md
+++ b/.claude/reference/skill-authoring-patterns.md
@@ -44,8 +44,10 @@ step-by-step body. When auditing an existing skill, check: *could an agent skip
 the body and still "comply" with the description?* If yes, the description is
 leaking workflow — trim it.
 
-**Also:** third person, start with "Use when…", pack in real trigger
-keywords (error strings, symptoms, tool names) an agent would search for.
+**Also:** lead with the trigger condition ("Use when…") and pack in real
+keywords (error strings, symptoms, tool names) an agent would search for. Avoid
+first-person framing ("I can help you…") — the description is injected into the
+system prompt, not spoken to the user.
 
 ## 2. Match the Form to the Failure
 

--- a/.claude/reference/skill-repo-diff.md
+++ b/.claude/reference/skill-repo-diff.md
@@ -11,12 +11,14 @@ cycles.
 
 ## Reference Repos Surveyed
 
-| Repo | Shape | Relevance to us |
-|------|-------|-----------------|
-| [obra/superpowers](https://github.com/obra/superpowers) | 14 focused, workflow-agnostic discipline skills (TDD, debugging, planning, code review, worktrees) | **High** — overlaps our worktree + plan + review workflow; already installed as a Cursor plugin, so its skills are available at runtime but are **not** in our repo |
-| [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) | ~270 skills (mostly polyglot/domain: per-language TDD, framework patterns, video/design), a large Node hook graph, MCP configs, multi-runtime scaffolds | **Selective** — most skills are language/domain-specific and out of scope; the hook graph and a few meta-skills have transferable ideas |
+| Repo | Surveyed ref | Shape | Relevance to us |
+|------|--------------|-------|-----------------|
+| [obra/superpowers](https://github.com/obra/superpowers) | `main` @ `896224c` (2026-06-18) | 14 focused, workflow-agnostic discipline skills (TDD, debugging, planning, code review, worktrees) | **High** — overlaps our worktree + plan + review workflow; already installed as a Cursor plugin, so its skills are available at runtime but are **not** in our repo |
+| [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) | `main` @ `71d22d0` (2026-06-20) | ~270 skills (mostly polyglot/domain: per-language TDD, framework patterns, video/design), a large Node hook graph, MCP configs, multi-runtime scaffolds | **Selective** — most skills are language/domain-specific and out of scope; the hook graph and a few meta-skills have transferable ideas |
 
-Survey date: 2026-06 (Opus 4.8 run). Re-survey each cycle; both repos move fast.
+**Survey run:** 2026-06-25 (Opus 4.8), against the pinned commits above. Re-survey
+each cycle and record the new run date + commit SHAs — a delta is only real
+relative to a pinned ref; both repos move fast, so coarse dates hide repo churn.
 
 ## How We Differ (adaptation constraints)
 
@@ -37,59 +39,61 @@ with phase A/B/C subagent orchestration. That shapes what fits:
 
 ## Gap Analysis by Dimension
 
-Fit labels: **direct fit** · **needs adaptation** · **doesn't fit our workflow**.
+**Fit legend** (compact codes used in the tables below): `DF` = direct fit ·
+`NA` = needs adaptation · `NF` = doesn't fit our workflow · `—` = parity / n/a.
+Priority tags (`P0`/`P1`/`P2`) and short rationale follow the code where useful.
 
 ### 1. Skill library coverage
 
 | Pattern (source) | We have? | Delta | Fit |
 |---|---|---|---|
-| `writing-skills` meta-skill — authoring discipline: description-as-trigger, match-form-to-failure, bulletproofing (superpowers) | Partial — CONTRIBUTING.md "Adding a New Skill" is purely mechanical (file paths, frontmatter fields) | We lack authoring *judgment* guidance | **needs adaptation** → harvested this cycle (see Import Log) |
-| `systematic-debugging` / `root-cause-tracing` (superpowers) | No dedicated skill; available via plugin | Root-cause-before-fix discipline | doesn't fit (plugin covers it; not a workflow command) |
-| `brainstorming` HARD-GATE before creative work (superpowers) | Partial — `issue-planning.md` + CR plan flow | Overlaps our planning flow; gate framing is novel | needs adaptation (P2 — evaluate vs issue-planning) |
-| `verification-before-completion` (superpowers) | Partial — phase protocols + exit reports enforce evidence | Mostly covered by phase A/B/C | doesn't fit (duplicate) |
-| Per-language TDD/verification skills, framework patterns, video/design (ECC) | No | Out of scope — we're a meta-config repo, not an app | doesn't fit our workflow |
-| `skill-scout` / `skill-stocktake` / `skill-comply` — skill-library hygiene (ECC) | Partial — `audit-skill-usage.sh`, `skill-usage-report.sh` | We track usage but have no "does this skill still comply with our conventions" audit | needs adaptation (P2) |
+| `writing-skills` meta-skill — authoring discipline: description-as-trigger, match-form-to-failure, bulletproofing (superpowers) | Partial — CONTRIBUTING.md "Adding a New Skill" is purely mechanical (file paths, frontmatter fields) | We lack authoring *judgment* guidance | `NA` → harvested this cycle (see Import Log) |
+| `systematic-debugging` / `root-cause-tracing` (superpowers) | No dedicated skill; available via plugin | Root-cause-before-fix discipline | `NF` — plugin covers it; not a workflow command |
+| `brainstorming` HARD-GATE before creative work (superpowers) | Partial — `issue-planning.md` + CR plan flow | Overlaps our planning flow; gate framing is novel | `NA` `P2` — evaluate vs issue-planning |
+| `verification-before-completion` (superpowers) | Partial — phase protocols + exit reports enforce evidence | Mostly covered by phase A/B/C | `NF` — duplicate |
+| Per-language TDD/verification skills, framework patterns, video/design (ECC) | No | Out of scope — we're a meta-config repo, not an app | `NF` |
+| `skill-scout` / `skill-stocktake` / `skill-comply` — skill-library hygiene (ECC) | Partial — `audit-skill-usage.sh`, `skill-usage-report.sh` | We track usage but have no "does this skill still comply with our conventions" audit | `NA` `P2` |
 
 ### 2. Hook patterns
 
 | Hook (source) | We have? | Delta | Fit |
 |---|---|---|---|
-| `pre:config-protection` — block edits to linter/formatter/CR config, steering agent to fix code not weaken config (ECC) | We have the **rule** "Never suppress linter errors" (`cr-local-review.md`) but **no enforcing hook** | Rule is advisory; a PreToolUse hook makes it mechanical | **needs adaptation** (P1 — strong candidate, next cycle) |
-| `post:quality-gate` — run checks after edits (ECC) | No structured post-edit gate | Could lint shell/markdown after edits | needs adaptation (P2 — our CI + `coderabbit review` already cover much of this) |
-| `session:start` bootstrap — load prior context + detect package manager (ECC) | `session-start-sync.sh` (worktree sync + hook registration) | Different scope; ECC also loads bounded prior context | doesn't fit (our scope is config sync, not context restore) |
-| `pre:edit-write:gateguard-fact-force` — block first edit per file until investigation done (ECC) | No | Forces "read importers/schema before editing" | doesn't fit (heavy; friction-prohibitive for our doc-heavy edits) |
-| `PreCompact` state save / `Stop` session metrics / cost tracker (ECC) | We have silence-detector + handoff files | ECC's are JS/metrics-oriented | doesn't fit (stack mismatch) |
-| `stop:format-typecheck`, `console.log` warn, Biome (ECC) | No | JS/TS-specific | doesn't fit our workflow |
+| `pre:config-protection` — block edits to linter/formatter/CR config, steering agent to fix code not weaken config (ECC) | We have the **rule** "Never suppress linter errors" (`cr-local-review.md`) but **no enforcing hook** | Rule is advisory; a PreToolUse hook makes it mechanical | `NA` `P1` — strong candidate, next cycle |
+| `post:quality-gate` — run checks after edits (ECC) | No structured post-edit gate | Could lint shell/markdown after edits | `NA` `P2` — our CI + `coderabbit review` already cover much of this |
+| `session:start` bootstrap — load prior context + detect package manager (ECC) | `session-start-sync.sh` (worktree sync + hook registration) | Different scope; ECC also loads bounded prior context | `NF` — our scope is config sync, not context restore |
+| `pre:edit-write:gateguard-fact-force` — block first edit per file until investigation done (ECC) | No | Forces "read importers/schema before editing" | `NF` — heavy; friction-prohibitive for our doc-heavy edits |
+| `PreCompact` state save / `Stop` session metrics / cost tracker (ECC) | We have silence-detector + handoff files | ECC's are JS/metrics-oriented | `NF` — stack mismatch |
+| `stop:format-typecheck`, `console.log` warn, Biome (ECC) | No | JS/TS-specific | `NF` |
 
 ### 3. CLAUDE.md conventions
 
 | Pattern (source) | We have? | Delta | Fit |
 |---|---|---|---|
-| Executive-summary CLAUDE.md + detail in rule files | **Yes** — already our model (CLAUDE.md ≤1,300 words, rules split out) | Parity | n/a (we lead here) |
-| `using-superpowers` "1% chance a skill applies → you MUST invoke it" gate (superpowers) | Partial — skills auto-trigger by description | Aggressive skill-invocation framing | doesn't fit (our slash-command model differs) |
-| Multi-runtime config mirrors (`.codex`, `.gemini`, `.cursor`, `.opencode`…) (both) | No — we target Claude Code + Cursor | Broad runtime portability | doesn't fit (scope/maintenance cost) |
+| Executive-summary CLAUDE.md + detail in rule files | **Yes** — already our model (CLAUDE.md ≤1,300 words, rules split out) | Parity | `—` — we lead here |
+| `using-superpowers` "1% chance a skill applies → you MUST invoke it" gate (superpowers) | Partial — skills auto-trigger by description | Aggressive skill-invocation framing | `NF` — our slash-command model differs |
+| Multi-runtime config mirrors (`.codex`, `.gemini`, `.cursor`, `.opencode`…) (both) | No — we target Claude Code + Cursor | Broad runtime portability | `NF` — scope/maintenance cost |
 
 ### 4. Prompt-engineering patterns
 
 | Pattern (source) | We have? | Delta | Fit |
 |---|---|---|---|
-| Description = *when to use*, NOT *what it does* (SDO research, superpowers) | **No** — most of our skill descriptions summarize the full workflow (e.g. `fixpr`, `start-issue`) | Workflow-summary descriptions can make agents follow the summary instead of reading the skill | **needs adaptation** → captured this cycle (see authoring patterns doc) |
-| "Match the form to the failure" — prohibition+rationalization-table vs positive recipe vs structural slot vs conditional (superpowers) | No | Sophisticated guidance-design model we lacked | **needs adaptation** → harvested this cycle |
-| Rationalization tables + red-flags lists for discipline rules (superpowers) | Partial — some rules use "Always/Ask first/Never" headers | We have prohibition headers but no rationalization-table convention | needs adaptation → captured this cycle |
+| Description = *when to use*, NOT *what it does* (SDO research, superpowers) | **No** — most of our skill descriptions summarize the full workflow (e.g. `fixpr`, `start-issue`) | Workflow-summary descriptions can make agents follow the summary instead of reading the skill | `NA` → captured this cycle (see authoring patterns doc) |
+| "Match the form to the failure" — prohibition+rationalization-table vs positive recipe vs structural slot vs conditional (superpowers) | No | Sophisticated guidance-design model we lacked | `NA` → harvested this cycle |
+| Rationalization tables + red-flags lists for discipline rules (superpowers) | Partial — some rules use "Always/Ask first/Never" headers | We have prohibition headers but no rationalization-table convention | `NA` → captured this cycle |
 
 ### 5. MCP integrations
 
 | Pattern (source) | We have? | Delta | Fit |
 |---|---|---|---|
-| `.mcp.json` with playwright / sequential-thinking / memory / github (ECC) | We have `mcp__*` permission wildcards but no documented server set | Our workflow is `gh`-CLI-driven, not MCP-driven | doesn't fit (low value for our PR workflow; revisit if we add E2E or browser testing) |
+| `.mcp.json` with playwright / sequential-thinking / memory / GitHub (ECC) | We have `mcp__*` permission wildcards but no documented server set | Our workflow is `gh`-CLI-driven, not MCP-driven | `NF` — low value for our PR workflow; revisit if we add E2E or browser testing |
 
 ### 6. Utility scripts / tooling
 
 | Pattern (source) | We have? | Delta | Fit |
 |---|---|---|---|
-| Consolidated pre/post Bash dispatcher (one hook fans out to many checks) (ECC) | We register hooks individually in `global-settings.json` | A dispatcher reduces per-tool hook overhead | needs adaptation (P2 — only worth it if our hook count grows) |
-| Continuous-learning / pattern-extraction at Stop (ECC `stop:evaluate-session`) | Partial — `/lessons` skill + memory system | Ours is manual/on-demand; theirs is automatic | needs adaptation (P2) |
-| Plugin-root resolver inlined in every hook command (ECC) | Our hooks resolve via `repo-root.sh` + worktree | Parity (different mechanism) | n/a |
+| Consolidated pre/post Bash dispatcher (one hook fans out to many checks) (ECC) | We register hooks individually in `global-settings.json` | A dispatcher reduces per-tool hook overhead | `NA` `P2` — only worth it if our hook count grows |
+| Continuous-learning / pattern-extraction at Stop (ECC `stop:evaluate-session`) | Partial — `/lessons` skill + memory system | Ours is manual/on-demand; theirs is automatic | `NA` `P2` |
+| Plugin-root resolver inlined in every hook command (ECC) | Our hooks resolve via `repo-root.sh` + worktree | Parity (different mechanism) | `—` |
 
 ## Prioritized Import Backlog
 
@@ -128,7 +132,7 @@ conventions; (3) low adaptation/maintenance cost; (4) high daily-use value.
 
 | Date | Source repo | Pattern | PR | Adaptation notes |
 |------|-------------|---------|-----|------------------|
-| 2026-06 | obra/superpowers (`skills/writing-skills`) | Skill/rule authoring-judgment patterns (SDO, match-form-to-failure, bulletproofing) | #417 first pass | Distilled into `skill-authoring-patterns.md` (reference, on-demand) + CONTRIBUTING pointers. Did **not** copy the TDD-for-skills methodology (heavyweight + plugin already provides it); referenced it instead. |
+| 2026-06-25 | obra/superpowers `skills/writing-skills` @ `896224c` | Skill/rule authoring-judgment patterns (SDO, match-form-to-failure, bulletproofing) | [#485](https://github.com/auerbachb/claude-code-config/pull/485) (first pass) | Distilled into `skill-authoring-patterns.md` (reference, on-demand) + CONTRIBUTING pointers. Did **not** copy the TDD-for-skills methodology (heavyweight + plugin already provides it); referenced it instead. |
 
 ## Re-Survey Checklist (each cycle)
 

--- a/.claude/reference/skill-repo-diff.md
+++ b/.claude/reference/skill-repo-diff.md
@@ -1,0 +1,139 @@
+# Skill-Repo Diff — Cross-Repo Pattern Harvest (living document)
+
+Tracking artifact for issue [#417](https://github.com/auerbachb/claude-code-config/issues/417):
+periodically diff this repo against popular Claude Code skill/config repos and
+progressively pull in patterns that fit our way of working.
+
+**This is an ongoing process, not a one-time import.** Each adopted pattern ships
+as its own PR with a clear rationale, gets logged in the Import Log below, and is
+recorded in a comment on #417. Deferred patterns stay in the backlog for future
+cycles.
+
+## Reference Repos Surveyed
+
+| Repo | Shape | Relevance to us |
+|------|-------|-----------------|
+| [obra/superpowers](https://github.com/obra/superpowers) | 14 focused, workflow-agnostic discipline skills (TDD, debugging, planning, code review, worktrees) | **High** — overlaps our worktree + plan + review workflow; already installed as a Cursor plugin, so its skills are available at runtime but are **not** in our repo |
+| [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) | ~270 skills (mostly polyglot/domain: per-language TDD, framework patterns, video/design), a large Node hook graph, MCP configs, multi-runtime scaffolds | **Selective** — most skills are language/domain-specific and out of scope; the hook graph and a few meta-skills have transferable ideas |
+
+Survey date: 2026-06 (Opus 4.8 run). Re-survey each cycle; both repos move fast.
+
+## How We Differ (adaptation constraints)
+
+Our repo is **not** a general skill marketplace. It is a workflow-specific config
+for a GitHub issue → CR plan → worktree → PR → review → squash-merge pipeline,
+with phase A/B/C subagent orchestration. That shapes what fits:
+
+- **Skills are mostly slash-commands** (`/fixpr`, `/wrap`, `/pm`) — operational
+  procedures, not generic techniques. Descriptions double as command help.
+- **Rules auto-load every turn** and live under a hard word budget (`rule-lint`).
+  Generic discipline content competes for that budget, so it usually belongs in
+  `.claude/reference/` (on-demand) or in CONTRIBUTING.md, not in a rule file.
+- **Bash + Markdown**, not JS/TS. ECC's `stop:format-typecheck` /
+  `console.log` / Biome hooks don't map onto our stack.
+- **Superpowers is already a plugin.** Re-importing its skills verbatim would
+  duplicate runtime-available content. We harvest the *judgment patterns* inside
+  them and adapt, rather than copy the skills.
+
+## Gap Analysis by Dimension
+
+Fit labels: **direct fit** · **needs adaptation** · **doesn't fit our workflow**.
+
+### 1. Skill library coverage
+
+| Pattern (source) | We have? | Delta | Fit |
+|---|---|---|---|
+| `writing-skills` meta-skill — authoring discipline: description-as-trigger, match-form-to-failure, bulletproofing (superpowers) | Partial — CONTRIBUTING.md "Adding a New Skill" is purely mechanical (file paths, frontmatter fields) | We lack authoring *judgment* guidance | **needs adaptation** → harvested this cycle (see Import Log) |
+| `systematic-debugging` / `root-cause-tracing` (superpowers) | No dedicated skill; available via plugin | Root-cause-before-fix discipline | doesn't fit (plugin covers it; not a workflow command) |
+| `brainstorming` HARD-GATE before creative work (superpowers) | Partial — `issue-planning.md` + CR plan flow | Overlaps our planning flow; gate framing is novel | needs adaptation (P2 — evaluate vs issue-planning) |
+| `verification-before-completion` (superpowers) | Partial — phase protocols + exit reports enforce evidence | Mostly covered by phase A/B/C | doesn't fit (duplicate) |
+| Per-language TDD/verification skills, framework patterns, video/design (ECC) | No | Out of scope — we're a meta-config repo, not an app | doesn't fit our workflow |
+| `skill-scout` / `skill-stocktake` / `skill-comply` — skill-library hygiene (ECC) | Partial — `audit-skill-usage.sh`, `skill-usage-report.sh` | We track usage but have no "does this skill still comply with our conventions" audit | needs adaptation (P2) |
+
+### 2. Hook patterns
+
+| Hook (source) | We have? | Delta | Fit |
+|---|---|---|---|
+| `pre:config-protection` — block edits to linter/formatter/CR config, steering agent to fix code not weaken config (ECC) | We have the **rule** "Never suppress linter errors" (`cr-local-review.md`) but **no enforcing hook** | Rule is advisory; a PreToolUse hook makes it mechanical | **needs adaptation** (P1 — strong candidate, next cycle) |
+| `post:quality-gate` — run checks after edits (ECC) | No structured post-edit gate | Could lint shell/markdown after edits | needs adaptation (P2 — our CI + `coderabbit review` already cover much of this) |
+| `session:start` bootstrap — load prior context + detect package manager (ECC) | `session-start-sync.sh` (worktree sync + hook registration) | Different scope; ECC also loads bounded prior context | doesn't fit (our scope is config sync, not context restore) |
+| `pre:edit-write:gateguard-fact-force` — block first edit per file until investigation done (ECC) | No | Forces "read importers/schema before editing" | doesn't fit (heavy; friction-prohibitive for our doc-heavy edits) |
+| `PreCompact` state save / `Stop` session metrics / cost tracker (ECC) | We have silence-detector + handoff files | ECC's are JS/metrics-oriented | doesn't fit (stack mismatch) |
+| `stop:format-typecheck`, `console.log` warn, Biome (ECC) | No | JS/TS-specific | doesn't fit our workflow |
+
+### 3. CLAUDE.md conventions
+
+| Pattern (source) | We have? | Delta | Fit |
+|---|---|---|---|
+| Executive-summary CLAUDE.md + detail in rule files | **Yes** — already our model (CLAUDE.md ≤1,300 words, rules split out) | Parity | n/a (we lead here) |
+| `using-superpowers` "1% chance a skill applies → you MUST invoke it" gate (superpowers) | Partial — skills auto-trigger by description | Aggressive skill-invocation framing | doesn't fit (our slash-command model differs) |
+| Multi-runtime config mirrors (`.codex`, `.gemini`, `.cursor`, `.opencode`…) (both) | No — we target Claude Code + Cursor | Broad runtime portability | doesn't fit (scope/maintenance cost) |
+
+### 4. Prompt-engineering patterns
+
+| Pattern (source) | We have? | Delta | Fit |
+|---|---|---|---|
+| Description = *when to use*, NOT *what it does* (SDO research, superpowers) | **No** — most of our skill descriptions summarize the full workflow (e.g. `fixpr`, `start-issue`) | Workflow-summary descriptions can make agents follow the summary instead of reading the skill | **needs adaptation** → captured this cycle (see authoring patterns doc) |
+| "Match the form to the failure" — prohibition+rationalization-table vs positive recipe vs structural slot vs conditional (superpowers) | No | Sophisticated guidance-design model we lacked | **needs adaptation** → harvested this cycle |
+| Rationalization tables + red-flags lists for discipline rules (superpowers) | Partial — some rules use "Always/Ask first/Never" headers | We have prohibition headers but no rationalization-table convention | needs adaptation → captured this cycle |
+
+### 5. MCP integrations
+
+| Pattern (source) | We have? | Delta | Fit |
+|---|---|---|---|
+| `.mcp.json` with playwright / sequential-thinking / memory / github (ECC) | We have `mcp__*` permission wildcards but no documented server set | Our workflow is `gh`-CLI-driven, not MCP-driven | doesn't fit (low value for our PR workflow; revisit if we add E2E or browser testing) |
+
+### 6. Utility scripts / tooling
+
+| Pattern (source) | We have? | Delta | Fit |
+|---|---|---|---|
+| Consolidated pre/post Bash dispatcher (one hook fans out to many checks) (ECC) | We register hooks individually in `global-settings.json` | A dispatcher reduces per-tool hook overhead | needs adaptation (P2 — only worth it if our hook count grows) |
+| Continuous-learning / pattern-extraction at Stop (ECC `stop:evaluate-session`) | Partial — `/lessons` skill + memory system | Ours is manual/on-demand; theirs is automatic | needs adaptation (P2) |
+| Plugin-root resolver inlined in every hook command (ECC) | Our hooks resolve via `repo-root.sh` + worktree | Parity (different mechanism) | n/a |
+
+## Prioritized Import Backlog
+
+Criteria: (1) fills a genuine workflow gap, not a duplicate; (2) aligns with our
+conventions; (3) low adaptation/maintenance cost; (4) high daily-use value.
+
+- **P0 — done this cycle:** Skill/rule **authoring-judgment patterns** (SDO
+  description rule, match-form-to-failure, bulletproofing) → distilled into
+  `.claude/reference/skill-authoring-patterns.md`, linked from CONTRIBUTING.md.
+  Doc-only, zero code risk, directly improves a repo whose whole job is authoring
+  skills/rules. Source: superpowers `skills/writing-skills`.
+- **P1 — next cycle (separate PR):** `config-protection` PreToolUse hook —
+  mechanically warn/block edits to linter/formatter/`.coderabbit.yaml` severity
+  config, reinforcing our existing "never suppress linter errors" rule. Source:
+  ECC `pre:config-protection`. Needs a hook script + `global-settings.json`
+  registration + a local payload test (per CONTRIBUTING "Adding a New Hook").
+- **P2 — deferred (revisit, see below).**
+
+## Deferred Patterns (P2 — revisit in future cycles)
+
+- `post:quality-gate` post-edit lint hook for shell/markdown (overlaps CI + CR).
+- Consolidated Bash hook dispatcher (only worth it if hook count grows).
+- Automatic Stop-time lesson extraction (vs our manual `/lessons`).
+- `skill-comply` / `skill-stocktake` — audit skills against our own conventions.
+- `brainstorming` HARD-GATE framing — evaluate against `issue-planning.md`.
+- MCP catalog (playwright/sequential-thinking) — revisit if we add browser/E2E.
+
+## Explicitly Rejected (does not fit our workflow)
+
+- Per-language TDD/verification/framework skills (ECC) — we're a meta-config repo.
+- JS/TS-specific hooks: `stop:format-typecheck`, Biome, `console.log` warn (ECC).
+- Multi-runtime config mirrors (`.codex`, `.gemini`, `.opencode`) — scope/cost.
+- Re-importing superpowers skills verbatim — already runtime-available as a plugin.
+
+## Import Log
+
+| Date | Source repo | Pattern | PR | Adaptation notes |
+|------|-------------|---------|-----|------------------|
+| 2026-06 | obra/superpowers (`skills/writing-skills`) | Skill/rule authoring-judgment patterns (SDO, match-form-to-failure, bulletproofing) | #417 first pass | Distilled into `skill-authoring-patterns.md` (reference, on-demand) + CONTRIBUTING pointers. Did **not** copy the TDD-for-skills methodology (heavyweight + plugin already provides it); referenced it instead. |
+
+## Re-Survey Checklist (each cycle)
+
+1. Re-clone both reference repos; note new skills/hooks since last survey date.
+2. Update the dimension tables with anything new; re-label fit.
+3. Move any newly-viable backlog item up; ship it as its own PR.
+4. Append to the Import Log and comment on #417 with what was pulled and why.
+5. Keep this document current — it is the canonical state of the harvest.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ Skills live in `.claude/skills/<name>/SKILL.md`.
    - `allowed-tools` (optional: restrict the skill to specific tools)
    - `disable-model-invocation` (optional: prevents auto-trigger AND hides from slash-command autocomplete — avoid unless you really mean both)
 2. **Skill body:** step-by-step instructions, exact bash commands with absolute paths, and clear exit criteria. Subagents skip prose rules — prefer numbered checklists with explicit STOP conditions.
+
+> **Authoring judgment (not just mechanics):** for *how* to write a discoverable description and a discipline rule that holds under pressure — description-as-trigger, matching guidance form to failure type, and bulletproofing — see [`.claude/reference/skill-authoring-patterns.md`](.claude/reference/skill-authoring-patterns.md). It also applies to rules below.
 3. **Symlink checklist after merge** (via the skills worktree — never symlink directly to the root repo):
 
    ```bash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First bounded pass of the ongoing cross-repo pattern harvest (#417). I surveyed both reference repos in their **current** state (the year-old CodeRabbit plan on the issue was never implemented — no harvest artifacts existed) and diffed them against our skills/rules/hooks/scripts.

- **[obra/superpowers](https://github.com/obra/superpowers)** — 14 focused, workflow-agnostic discipline skills. High overlap with our worktree + plan + review flow; already installed as a Cursor plugin (so its skills are runtime-available, not something to re-import verbatim).
- **[affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code)** — ~270 mostly polyglot/domain skills + a large Node hook graph + MCP configs. Selective relevance (hook graph + a few meta-skills).

### What this PR adds (doc-only)

1. **`.claude/reference/skill-repo-diff.md`** — the canonical **living** gap-analysis tracker: comparison across all six dimensions from the issue (skills, hooks, CLAUDE.md, prompts, MCP, scripts), each gap fit-labeled (`direct fit` / `needs adaptation` / `doesn't fit our workflow`), a prioritized import backlog (P0/P1/P2), explicit deferred + rejected lists, an import log, and a per-cycle re-survey checklist. This is the ongoing-process infrastructure the issue asks for.
2. **`.claude/reference/skill-authoring-patterns.md`** — the **first concrete import**: superpowers' `writing-skills` *judgment* patterns, adapted (not copied) to our conventions — description-as-trigger (SDO), match-the-form-to-the-failure, bulletproofing discipline rules, and token/word-budget discipline. Our `CONTRIBUTING.md` only covered authoring *mechanics*; this fills the judgment gap for a repo whose whole job is authoring skills/rules.
3. **`CONTRIBUTING.md`** + **`.claude/reference/README.md`** — link/index the new docs.

### Why this scope (bounded, per the run instructions)

"Don't boil the ocean / propose before bulk-importing." The strongest, lowest-risk, most-aligned first import is doc-only authoring judgment (zero code risk, no untrusted code imported per `safety.md`, doesn't duplicate the runtime plugin). Remaining viable candidates are proposed in the backlog for **future separate PRs** — notably **P1: a `config-protection` PreToolUse hook** (ECC pattern) to mechanically enforce our existing "never suppress linter errors" rule.

### Adaptation rationale (adapt, don't copy)

Superpowers is already a plugin, so re-importing its skills verbatim would split the source of truth. Instead I extracted the authoring *patterns* our docs lacked and referenced the plugin skill for the full TDD-for-skills methodology. ECC's JS/TS hooks and per-language skills are explicitly rejected (stack/scope mismatch).

## Test plan

Acceptance criteria from #417 (first pass):

- [x] Both repos fully read and compared against ours — survey across all six dimensions in `skill-repo-diff.md`, grounded in actual file inspection (e.g. ECC `hooks/hooks.json`, superpowers `skills/writing-skills/SKILL.md`).
- [x] Gap list created and prioritized — fit-labeled tables + P0/P1/P2 backlog + deferred/rejected lists.
- [x] At least 3 high-value patterns identified for adoption — P0 authoring patterns (done here), P1 `config-protection` hook, plus P2 backlog (quality-gate hook, hook dispatcher, auto-lesson extraction, skill-comply).
- [x] First batch of imports completed — authoring-patterns import landed in this PR; the issue stays open and subsequent imports ship as their own PRs per the documented ongoing process.

Verification performed:

- [x] `.github/scripts/rule-lint.sh` → `rule-lint: OK` (no CLAUDE.md/rules changes; word budget unaffected).
- [x] Factual claims spot-checked against the repo (`mcp__*` wildcard in `global-settings.json`, "Never Suppress Linter Errors" in `cr-local-review.md`, CLAUDE.md size-guideline heading) and against the reference repos (hook ids, skill frontmatter, skill counts).
- [x] Internal doc links resolve.

> Note: `coderabbit review --agent` could not authenticate in this cloud env (no `CODERABBIT_API_KEY`; CLI requires `--api-key`). Per `cr-local-review.md`'s fallback, a manual self-review was done instead. GitHub-side CodeRabbit will run on this PR for the merge gate.

## Issue linkage

Refs #417 — **intentionally not `Closes`.** The issue is explicitly an ongoing tracker ("This issue should stay open"), so this PR references it without auto-closing. I'll comment on #417 with what was pulled and why.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74fad9a9-6d6f-4ff8-b576-998a3377f1c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74fad9a9-6d6f-4ff8-b576-998a3377f1c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new authoring reference detailing how skill descriptions should act as reliable trigger conditions, with guidance for discoverability, form matching, and writing resilient discipline rules.
  * Added a living cross-repo pattern-harvest tracker with surveyed coverage, gap analysis, prioritized import backlog, and an update log.
  * Updated contributor instructions for adding a new skill to point to the new authoring reference and emphasize creating durable, review-ready descriptions and discipline rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->