### PR TITLE
feat(telemetry): add script-usage.log instrumentation to escalate-review.sh

### DIFF
--- a/.claude/scripts/escalate-review.sh
+++ b/.claude/scripts/escalate-review.sh
@@ -25,6 +25,7 @@
 #   4  GitHub/API/state read error
 
 set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 PR_NUMBER=""
 


### PR DESCRIPTION
## **User description**
## Summary

- Adds the standard `script-usage.log` telemetry line to `escalate-review.sh`, matching the identical idiom used by `pr-state.sh`, `cr-review-hourly.sh`, `session-state.sh`, and `greptile-budget.sh`
- The line is placed immediately after `set -euo pipefail`, consistent with all sibling scripts
- No behavior change — only observability is added

Closes #491

## Deferred work (out of scope per task instructions — no concurrent SKILL.md/rule-file edits)

Two items from the issue AC are deferred to separate PRs to avoid conflicts with concurrent agents editing SKILL.md and rule files:
- **Bypass sentinel** (`script-bypass-detector.sh`): detect agents hand-rolling the CR→BugBot→Greptile escalation logic instead of calling `escalate-review.sh` — this requires creating a new script and is a self-contained follow-up
- **Phase agent definitions / monitor-mode skill calls**: tighten SKILL.md and monitor-mode references to explicitly invoke `escalate-review.sh` by path — requires editing shared rule/skill files being touched by concurrent agents

## Test plan

- [x] `escalate-review.sh` appends to `~/.claude/script-usage.log` on every invocation (telemetry line present at line 28, after `set -euo pipefail`)
- [x] Script behavior unchanged — same STATUS verdicts, same exit codes, same logic
- [x] `bash -n escalate-review.sh` passes (syntax check clean)
- [x] Telemetry idiom exactly matches sibling scripts (`pr-state.sh`, `cr-review-hourly.sh`, etc.)
- [x] Local CR review passed (1 finding dismissed as false positive: CR flagged `${*//$'\n'/ }` as PII risk, but this is the established repo idiom and escalate-review.sh only ever receives a PR number integer)
- [ ] Usage appears in `script-usage-report.sh` output within 7 days of merge


___

## **CodeAnt-AI Description**
**Track escalations in usage logs**

### What Changed
- Every run of `escalate-review.sh` is now recorded in the shared usage log
- Logging happens automatically and does not change the script’s verdicts, exit codes, or review flow

### Impact
`✅ Better visibility into escalation script usage`
`✅ Easier monitoring of review automation`
`✅ No change to review decisions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
