### PR TITLE
docs(adherence): require pr-state.sh before inline PR polling across skills

### DIFF
--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -47,9 +47,11 @@ Using a **unique per-launch local name** (timestamp suffix) sidesteps git's work
 
 ## Before Requesting Any New Review (MANDATORY)
 
+> **pr-state.sh first (NON-NEGOTIABLE):** Before calling `gh api .../pulls/{N}/reviews`, `pulls/{N}/comments`, or `issues/{N}/comments` directly, call `pr-state.sh --pr N` first and read the cached JSON bundle. All polling in this agent reads from the shared `$STATE` bundle — do not re-issue inline `gh api` calls for these three endpoints.
+
 Run the session-start / pre-review comment audit per `cr-github-review.md` ("Session-start / pre-review comment audit"):
 
-1. Fetch all 3 comment endpoints with `per_page=100`.
+1. Call `pr-state.sh --pr {{PR_NUMBER}}` and read all 3 comment endpoints from the returned JSON bundle (`per_page=100` is handled by the script).
 2. Identify any unresolved findings from `coderabbitai[bot]`, `cursor[bot]`, or `greptile-apps[bot]`.
 3. **If ANY unresolved findings exist: invoke `/fixpr`.** `/fixpr` fixes, commits once, pushes, replies to every thread, resolves via GraphQL. Do NOT fix manually and do NOT request a new review on top of unaddressed feedback.
 4. **STOP condition:** do not proceed to the polling loop (or request a new review) until step 3 completes.

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -44,6 +44,8 @@ gh pr view {{PR_NUMBER}} --json state,title,mergeStateStatus,commits
 
 ## Step 1: Verify Merge Gate (and CI)
 
+> **pr-state.sh first (NON-NEGOTIABLE):** Before calling `gh api .../pulls/{N}/reviews`, `pulls/{N}/comments`, or `issues/{N}/comments` directly, call `pr-state.sh --pr N` first and read the cached JSON bundle. This agent delegates to `merge-gate.sh`, which calls `pr-state.sh` internally — do not add inline `gh api` calls to these three endpoints.
+
 Run the shared merge-gate verifier. It implements the three-path gate from `.claude/rules/cr-merge-gate.md` (CR 1-clean-approval on current HEAD, BugBot 1-clean, Greptile severity-gated), plus these explicit pre-merge gates — each is a hard STOP if not satisfied:
 
 - **Gate 1a — CI terminal state.** All check-runs `status: "completed"` with no blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`). In-progress checks BLOCK — do NOT present the merge prompt; wait and re-poll.

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -20,6 +20,8 @@ CodeRabbit caps **~8 GitHub PR reviews per hour** per account; **each push** con
 
 ## How this skill is structured
 
+> **pr-state.sh first (NON-NEGOTIABLE):** Before calling `gh api .../pulls/{N}/reviews`, `pulls/{N}/comments`, or `issues/{N}/comments` directly, call `pr-state.sh --pr N` first and read the cached JSON bundle. Inline `gh api` calls for these three endpoints are only permitted inside Step 3b's reviewer-activity detection block, which requires a custom post-push timestamp filter that `pr-state.sh` does not expose. Every other polling or review-state lookup MUST go through `pr-state.sh`.
+
 All mechanical GitHub API work — pagination, GraphQL queries, comment classification — lives in the shared script `.claude/scripts/pr-state.sh`. This file tells the AI layer how to invoke the script and what to do with its output (the JSON bundle).
 
 | Step | Kind | Done by |

--- a/.claude/skills/go-on/SKILL.md
+++ b/.claude/skills/go-on/SKILL.md
@@ -144,6 +144,8 @@ Output: `Reviewer: CR` / `Reviewer: BugBot` / `Reviewer: Greptile`.
 
 ## Step 6: Check for review response
 
+> **pr-state.sh first (NON-NEGOTIABLE):** Before calling `gh api .../pulls/{N}/reviews`, `pulls/{N}/comments`, or `issues/{N}/comments` directly, call `pr-state.sh --pr N` first and read the cached JSON bundle. The inline `gh api` calls below are legacy check-run and rate-limit spot-checks retained because they target commit-level endpoints (`/commits/{SHA}/check-runs`, `/commits/{SHA}/statuses`) not covered by `pr-state.sh`. For review, inline comment, and conversation endpoint lookups, use `pr-state.sh` exclusively.
+
 ### If PR is on CR:
 
 Check the commit status for CodeRabbit:

--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -37,6 +37,8 @@ If running in a worktree, stop here and use the message from the Worktree check 
 
 ### Step 2: Verify the merge gate
 
+> **pr-state.sh first (NON-NEGOTIABLE):** Before calling `gh api .../pulls/{N}/reviews`, `pulls/{N}/comments`, or `issues/{N}/comments` directly, call `pr-state.sh --pr N` first and read the cached JSON bundle. This skill delegates to `merge-gate.sh`, which calls `pr-state.sh` internally — do not add inline `gh api` calls to these three endpoints.
+
 Run the shared merge-gate verifier, which implements the authoritative gate from `.claude/rules/cr-merge-gate.md` (CR 1 explicit APPROVED review on current HEAD / BugBot 1-clean / Greptile severity, plus CI and BEHIND checks):
 
 ```bash

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -30,6 +30,8 @@ If no open PRs, say "No open PRs." and stop.
 
 ### Step 2: For each PR, gather review state
 
+> **pr-state.sh first (NON-NEGOTIABLE):** Before calling `gh api .../pulls/{N}/reviews`, `pulls/{N}/comments`, or `issues/{N}/comments` directly, call `pr-state.sh --pr N` first and read the cached JSON bundle. All review-state queries in this skill read from the `$STATE` bundle — do not add inline `gh api` calls to these three endpoints.
+
 For each open PR, run the shared PR-state helper once per PR. One invocation returns reviews, inline comments, issue comments, unresolved threads, check-runs, and bot status rollups — all derived from the same HEAD SHA:
 
 ```bash

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -159,6 +159,8 @@ If the PR is already merged or closed, skip to Phase 3 (follow-up detection).
 
 ### Step 1.2: Scan for unresolved review findings
 
+> **pr-state.sh first (NON-NEGOTIABLE):** Before calling `gh api .../pulls/{N}/reviews`, `pulls/{N}/comments`, or `issues/{N}/comments` directly, call `pr-state.sh --pr N` first and read the cached JSON bundle. All review-state queries in this skill read from the `$BUNDLE` returned by `pr-state.sh` — do not add inline `gh api` calls to these three endpoints.
+
 Use the shared `pr-state.sh` helper to fetch and pre-classify review activity from all three endpoints in one call. It filters to `coderabbitai[bot]`, `greptile-apps[bot]`, and `cursor[bot]` (BugBot) and tags each comment with `classification.class` (`finding` vs `acknowledgment`). The classifier only runs when `--since <iso>` is passed — pass the PR's `createdAt` to include every bot comment on the PR. The helper writes the JSON bundle to a tempfile and prints its **path** on stdout — capture the path, then read with `jq < "$BUNDLE"`:
 
 `$PR_NUM` is already fixed by Step 1.1's cascade — reuse it; do **not** re-derive it from `gh pr view` (a bare call would target the current branch's PR, not the inferred one):


### PR DESCRIPTION
## **User description**
## Summary

- Adds a `pr-state.sh first (NON-NEGOTIABLE)` blockquote rule to `/fixpr`, `/go-on`, `/merge`, `/status`, `/wrap` SKILL.md files and `phase-b-reviewer`/`phase-c-merger` agent definitions
- Rule directs agents to call `pr-state.sh --pr N` before any inline `gh api .../pulls/{N}/reviews`, `pulls/{N}/comments`, or `issues/{N}/comments` call
- Documents legitimate exemptions: commit-level check-run endpoints (go-on), post-push timestamp filtering (fixpr), merge-gate.sh internal delegation (merge/phase-b/phase-c)

Closes #488

## Test plan

- [x] `/fixpr/SKILL.md` has `pr-state.sh first (NON-NEGOTIABLE)` blockquote before Step 3b exemption
- [x] `/go-on/SKILL.md` has `pr-state.sh first (NON-NEGOTIABLE)` blockquote before Step 6 with commit-level endpoint exemption
- [x] `/merge/SKILL.md` has `pr-state.sh first (NON-NEGOTIABLE)` blockquote in Step 2
- [x] `/status/SKILL.md` has `pr-state.sh first (NON-NEGOTIABLE)` blockquote in Step 2
- [x] `/wrap/SKILL.md` has `pr-state.sh first (NON-NEGOTIABLE)` blockquote in Step 1.2
- [x] `phase-b-reviewer.md` has `pr-state.sh first (NON-NEGOTIABLE)` blockquote in "Before Requesting Any New Review"
- [x] `phase-c-merger.md` has `pr-state.sh first (NON-NEGOTIABLE)` blockquote in "Step 1: Verify Merge Gate"
- [x] Wording is consistent across all 7 files
- [x] Exemptions are documented per-file and accurate
- [x] No CLAUDE.md or `.claude/rules/` changes (no word-budget impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Require `pr-state.sh` before inline PR polling**

### What Changed
- Added a clear rule in review, merge, status, wrap, and follow-up flows to use `pr-state.sh --pr N` before checking PR reviews, comments, or unresolved discussion state
- Updated the review and merge agents to read from the shared cached PR-state bundle instead of calling those GitHub endpoints directly
- Kept a narrow exception where some existing checks still use direct GitHub calls only when they need commit-level status data or a special post-push filter

### Impact
`✅ Fewer duplicate PR checks`
`✅ More consistent review polling`
`✅ Clearer PR-state handling across skills`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
