### PR TITLE
fix(quota): switch to monthly $1000 cap, demote daily to $100 warn

### DIFF
--- a/.claude/hooks/quota-stop-notify.sh
+++ b/.claude/hooks/quota-stop-notify.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-# quota-stop-notify.sh — Stop hook: surface a one-line daily-spend warning.
+# quota-stop-notify.sh — Stop hook: surface a one-line monthly+daily spend warning.
 #
 # Fires when Claude finishes a response. Reads today's spend snapshot from
-# quota-budget.sh and, when today's spend has reached the configured
-# stop_hook_threshold (default 60% of the daily cap), injects a single
-# additionalContext line so the user sees their run-rate. Below the threshold it
-# stays silent to keep noise low (issue #458, AC: Stop-hook line emits when daily
-# spend >= 60% of cap; suppressed below threshold).
+# quota-budget.sh and, when spend has reached either stop-hook threshold
+# (monthly_pct >= 60% OR daily spend >= $80), injects a single additionalContext
+# line so the user sees their run-rate. Below both thresholds it stays silent
+# to keep noise low (issue #495).
+#
+# Line format:
+#   [quota] today $X / day-warn $DW (Y%) — month $A / $MC (B%) projected EoM $C — <severity>
 #
 # Non-blocking: always exits 0; never blocks the Stop event.
 # Env overrides (tests): QUOTA_CONFIG, QUOTA_USAGE_LOG, QUOTA_STATE_FILE.
@@ -21,25 +23,53 @@ budget="${script_dir%/.claude/hooks}/.claude/scripts/quota-budget.sh"
 [[ -r "$budget" ]] || exit 0
 
 # Observational read; do not mutate session-state from a per-turn Stop hook.
-# Invoke via bash to avoid relying on the executable bit (may be stripped on some mounts/worktrees).
 snap="$(bash "$budget" --check --no-state 2>/dev/null)" || exit 0
 [[ -n "$snap" ]] || exit 0
 
-threshold="$(bash "$budget" --config 2>/dev/null | jq -r '.stop_hook_threshold // 0.60' 2>/dev/null || echo 0.60)"
+# Read stop-hook thresholds from config
+cfg_out="$(bash "$budget" --config 2>/dev/null)" || exit 0
+sht_monthly="$(printf '%s' "$cfg_out" | jq -r '.stop_hook_threshold.monthly_pct // 0.60' 2>/dev/null || echo 0.60)"
+sht_daily="$(printf '%s' "$cfg_out" | jq -r '.stop_hook_threshold.daily_usd // 80' 2>/dev/null || echo 80)"
 
-read -r spend_pct spend cap proj status <<<"$(printf '%s' "$snap" | jq -r '"\(.spend_pct) \(.estimated_usd) \(.budget_usd) \(.projected_eod_usd) \(.status)"' 2>/dev/null)" || exit 0
-[[ -n "${spend_pct:-}" && "$spend_pct" != "null" ]] || exit 0
+read -r today_spend daily_warn monthly_spend monthly_cap proj_eom proj_eom_pct daily_status monthly_status status <<<"$(printf '%s' "$snap" | jq -r '"\(.estimated_usd) \(.daily_warn_threshold_usd) \(.monthly_spend_usd) \(.monthly_cap_usd) \(.projected_eom_usd) \(.projected_eom_pct) \(.daily_status) \(.monthly_status) \(.status)"' 2>/dev/null)" || exit 0
+[[ -n "${today_spend:-}" && "$today_spend" != "null" ]] || exit 0
 
-# Emit only when today's actual spend has reached the stop-hook threshold.
-emit="$(python3 -c "import sys
+# Determine whether to emit: monthly_pct >= sht_monthly OR daily_spend >= sht_daily
+emit="$(python3 -c "
+import sys
 try:
-    sys.exit(0 if float('$spend_pct') >= float('$threshold') else 1)
+    monthly_pct = float('$proj_eom_pct')
+    daily_spend = float('$today_spend')
+    sht_m = float('$sht_monthly')
+    sht_d = float('$sht_daily')
+    sys.exit(0 if (monthly_pct >= sht_m or daily_spend >= sht_d) else 1)
 except Exception:
-    sys.exit(1)" >/dev/null 2>&1 && echo yes || echo no)"
+    sys.exit(1)
+" >/dev/null 2>&1 && echo yes || echo no)"
 [[ "$emit" == "yes" ]] || exit 0
 
-pct="$(python3 -c "print(f'{float(\"$spend_pct\")*100:.0f}')" 2>/dev/null || echo "?")"
-line="$(printf '[quota] today $%.2f/$%.2f (%s%%) projected EoD $%.2f — %s' "$spend" "$cap" "$pct" "$proj" "$status" 2>/dev/null)"
+line="$(python3 - "$today_spend" "$daily_warn" "$monthly_spend" "$monthly_cap" "$proj_eom" "$proj_eom_pct" "$status" <<'PY' 2>/dev/null
+import sys
+today_spend = float(sys.argv[1])
+daily_warn = float(sys.argv[2])
+monthly_spend = float(sys.argv[3])
+monthly_cap = float(sys.argv[4])
+proj_eom = float(sys.argv[5])
+proj_eom_pct = float(sys.argv[6])
+status = sys.argv[7]
+
+day_pct = (today_spend / daily_warn * 100) if daily_warn > 0 else 0.0
+month_pct = (monthly_spend / monthly_cap * 100) if monthly_cap > 0 else 0.0
+
+line = (
+    f"[quota] today ${today_spend:.2f} / day-warn ${daily_warn:.0f} ({day_pct:.0f}%)"
+    f" — month ${monthly_spend:.2f} / ${monthly_cap:.0f} ({month_pct:.0f}%)"
+    f" projected EoM ${proj_eom:.2f} ({proj_eom_pct*100:.0f}%)"
+    f" — {status}"
+)
+print(line)
+PY
+)"
 [[ -n "$line" ]] || exit 0
 
 jq -n --arg msg "$line" '{

--- a/.claude/hooks/quota-stop-notify.sh
+++ b/.claude/hooks/quota-stop-notify.sh
@@ -35,17 +35,18 @@ read -r today_spend daily_warn monthly_spend monthly_cap proj_eom proj_eom_pct d
 [[ -n "${today_spend:-}" && "$today_spend" != "null" ]] || exit 0
 
 # Determine whether to emit: monthly_pct >= sht_monthly OR daily_spend >= sht_daily
-emit="$(python3 -c "
+emit="$(python3 - "$proj_eom_pct" "$today_spend" "$sht_monthly" "$sht_daily" <<'PYEMIT' >/dev/null 2>&1 && echo yes || echo no
 import sys
 try:
-    monthly_pct = float('$proj_eom_pct')
-    daily_spend = float('$today_spend')
-    sht_m = float('$sht_monthly')
-    sht_d = float('$sht_daily')
+    monthly_pct = float(sys.argv[1])
+    daily_spend = float(sys.argv[2])
+    sht_m = float(sys.argv[3])
+    sht_d = float(sys.argv[4])
     sys.exit(0 if (monthly_pct >= sht_m or daily_spend >= sht_d) else 1)
 except Exception:
     sys.exit(1)
-" >/dev/null 2>&1 && echo yes || echo no)"
+PYEMIT
+)"
 [[ "$emit" == "yes" ]] || exit 0
 
 line="$(python3 - "$today_spend" "$daily_warn" "$monthly_spend" "$monthly_cap" "$proj_eom" "$proj_eom_pct" "$status" <<'PY' 2>/dev/null

--- a/.claude/scripts/quota-budget.sh
+++ b/.claude/scripts/quota-budget.sh
@@ -1,54 +1,77 @@
 #!/usr/bin/env bash
-# quota-budget.sh — Daily API spend tracker + end-of-day projection (issue #458).
+# quota-budget.sh — Monthly API spend tracker + daily warn signal (issue #495).
 #
 # PURPOSE
-#   Single source of truth for the daily-spend contract behind the /quota skill.
-#   Reads the append-only token ledger written by quota-usage-hook.sh
-#   (~/.claude/quota-usage.log), groups it by America/New_York day, converts
-#   token counts to USD with the per-model pricing in quota-config.json, projects
-#   end-of-day spend from the fraction of the ET day elapsed, and classifies the
-#   result against the daily cap + alert thresholds. Spend tracking is
-#   OBSERVATIONAL — it surfaces warnings but never blocks work (exit 0 on
-#   success regardless of spend). State is cached in the `quota_daily` subtree of
-#   ~/.claude/session-state.json using the same atomic jq + temp-file + mv pattern
-#   as greptile-budget.sh / cr-review-hourly.sh.
+#   Single source of truth for the monthly+daily-spend contract behind the /quota
+#   skill. Reads the append-only token ledger written by quota-usage-hook.sh
+#   (~/.claude/quota-usage.log), groups it by America/New_York day and month,
+#   converts token counts to USD with the per-model pricing in quota-config.json,
+#   projects end-of-month spend from the fraction of the ET month elapsed, and
+#   classifies the result against:
+#     - Monthly cap (primary signal): critical at ≥95%, warn ≥80%, info ≥60%
+#     - Daily warn (secondary signal): warn at ≥$100, info at ≥$80, NEVER critical
+#   Spend tracking is OBSERVATIONAL — it surfaces warnings but never blocks work
+#   (exit 0 on success regardless of spend). State is cached in the `quota_daily`
+#   subtree of ~/.claude/session-state.json using the same atomic jq + temp-file
+#   + mv pattern as greptile-budget.sh / cr-review-hourly.sh.
 #
 # USAGE
-#   quota-budget.sh [--check] [--cap N] [--date YYYY-MM-DD] [--no-state]
-#   quota-budget.sh --week  [--cap N] [--no-state]
+#   quota-budget.sh [--check] [--date YYYY-MM-DD] [--no-state]
+#   quota-budget.sh --week  [--no-state]
+#   quota-budget.sh --month [--no-state]
 #   quota-budget.sh --config
-#   quota-budget.sh --reset [--cap N] [--no-state]
+#   quota-budget.sh --reset [--no-state]
+#   quota-budget.sh --config-cap monthly=N [daily-warn=M]
+#   quota-budget.sh --config-cap daily-warn=M
 #   quota-budget.sh --help | -h
 #
 # MODES
-#   --check    (default) Aggregate today's ET spend, project end-of-day, classify
-#              against thresholds, cache the snapshot, and print it as JSON.
+#   --check    (default) Aggregate today's ET spend + this month's ET spend,
+#              project end-of-day and end-of-month, classify against thresholds,
+#              cache the snapshot, and print it as JSON.
 #   --week     Aggregate the last 7 ET days (zero-filled) from the ledger and
 #              print per-day + total JSON. Still refreshes today's cached snapshot.
-#   --config   Print the resolved config (daily cap, thresholds, stop-hook
-#              threshold, plan metadata, pricing) as JSON. No state write.
+#   --month    Aggregate the current ET month (day-by-day, zero-filled) from the
+#              ledger and print a summary JSON.
+#   --config   Print the resolved config (caps, thresholds, stop-hook thresholds,
+#              plan metadata, pricing) as JSON. No state write.
 #   --reset    Zero today's cached counter in session-state.json (cross-day reset
 #              is automatic — counting is ET-day-scoped off the durable ledger,
 #              which is never modified). Prints the zeroed snapshot.
+#   --config-cap monthly=N       Set monthly_cap_usd to N in quota-config.json.
+#   --config-cap daily-warn=M   Set daily_warn_threshold_usd to M.
+#   --config-cap monthly=N daily-warn=M  Set both.
 #
 # FLAGS
-#   --cap N    Override the daily cap (USD). Default: quota-config.json
-#              daily_cap_usd (fallback 3.33).
 #   --date D   Aggregate a specific ET day (YYYY-MM-DD) instead of today
 #              (--check only). Past days report fraction = 1.0 (no projection).
 #   --no-state Do not write the snapshot into session-state.json.
 #
 # OUTPUT
 #   stdout: single-line JSON. --check snapshot fields:
-#     {date, input_tokens, output_tokens, cache_read_tokens,
-#      cache_creation_tokens, estimated_usd, budget_usd, spend_pct, responses,
-#      fraction_of_day_elapsed, projected_eod_usd, projected_pct, status,
-#      surface, over_cap, by_model, is_today, checked_at}
+#     {date, month, input_tokens, output_tokens, cache_read_tokens,
+#      cache_creation_tokens, estimated_usd, daily_warn_threshold_usd,
+#      monthly_cap_usd, daily_spend_pct_of_warn, monthly_spend_pct,
+#      responses, fraction_of_day_elapsed, fraction_of_month_elapsed,
+#      projected_eod_usd, projected_eom_usd, projected_eom_pct,
+#      daily_status, monthly_status, status, surface,
+#      by_model, is_today, checked_at}
 #   stderr: one-line error messages on failure.
 #
-# THRESHOLDS (classified on projected_pct = projected_eod_usd / cap)
-#   status: ok (<info) | info (info..warn) | warn (warn..critical) | critical (>=critical)
-#   surface: true once projected_pct >= info threshold (default 0.60).
+# THRESHOLDS
+#   monthly_status (from projected_eom_pct = projected_eom_usd / monthly_cap_usd):
+#     ok (<0.60) | info (0.60–0.80) | warn (0.80–0.95) | critical (≥0.95)
+#   daily_status (from today's actual spend vs daily_warn_threshold_usd):
+#     ok (<$80) | info ($80–$100) | warn (≥$100) — NEVER critical
+#   status: max severity of monthly_status and daily_status (daily capped at warn)
+#   surface: true when monthly ≥60% OR daily spend ≥$80
+#
+# CONFIG MIGRATION
+#   If quota-config.json has the legacy daily_cap_usd field (any value), this
+#   script rewrites it to the new schema on first run:
+#     - legacy daily_cap_usd: 3.33 (or similar small value) → monthly 1000, daily-warn 100
+#     - legacy daily_cap_usd: user-set N → monthly 1000, daily-warn N (preserves intent)
+#   Migration is logged to stderr and a migration_note field is added to the snapshot.
 #
 # EXIT STATUS
 #   0  Success (observational — never non-zero on high spend).
@@ -70,7 +93,6 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CONFIG_PATH="${QUOTA_CONFIG:-$REPO_ROOT/quota-config.json}"
 USAGE_LOG="${QUOTA_USAGE_LOG:-$HOME/.claude/quota-usage.log}"
 STATE_FILE="${QUOTA_STATE_FILE:-$HOME/.claude/session-state.json}"
-DEFAULT_CAP="3.33"
 
 print_help() {
   sed -n '/^# PURPOSE$/,/^# DEPENDENCIES$/p' "$0" | sed 's/^# \{0,1\}//'
@@ -83,21 +105,25 @@ die_usage() {
 }
 
 MODE="check"
-CAP_OVERRIDE=""
 DATE_OVERRIDE=""
 WRITE_STATE=1
+CONFIG_CAP_ARGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help) print_help; exit 0 ;;
     --check) MODE="check"; shift ;;
     --week) MODE="week"; shift ;;
+    --month) MODE="month"; shift ;;
     --config) MODE="config"; shift ;;
     --reset) MODE="reset"; shift ;;
-    --cap)
-      [[ $# -ge 2 ]] || die_usage "--cap requires a value"
-      CAP_OVERRIDE="$2"
-      [[ "$CAP_OVERRIDE" =~ ^[0-9]+([.][0-9]+)?$ ]] || die_usage "--cap must be a non-negative number, got: $CAP_OVERRIDE"
-      shift 2 ;;
+    --config-cap)
+      MODE="config-cap"
+      shift
+      while [[ $# -gt 0 && "$1" != --* ]]; do
+        CONFIG_CAP_ARGS+=("$1")
+        shift
+      done
+      ;;
     --date)
       [[ $# -ge 2 ]] || die_usage "--date requires a value"
       DATE_OVERRIDE="$2"
@@ -112,27 +138,129 @@ done
 
 command -v python3 >/dev/null 2>&1 || { echo "quota-budget.sh: 'python3' not found on PATH" >&2; exit 5; }
 
-# Resolve cap: --cap override else config daily_cap_usd else DEFAULT_CAP.
-if [[ -n "$CAP_OVERRIDE" ]]; then
-  CAP="$CAP_OVERRIDE"
-else
-  CAP="$(python3 - "$CONFIG_PATH" "$DEFAULT_CAP" <<'PY' 2>/dev/null || echo "$DEFAULT_CAP"
+# --- Config migration + read ---
+# Migrate legacy daily_cap_usd to new schema if present. Returns the config
+# path (possibly updated) and sets MIGRATION_NOTE.
+MIGRATION_NOTE=""
+if [[ -f "$CONFIG_PATH" ]]; then
+  HAS_LEGACY="$(python3 -c "
 import json, sys
-path, fallback = sys.argv[1], sys.argv[2]
+try:
+    with open(sys.argv[1], encoding='utf-8') as f:
+        cfg = json.load(f)
+    print('yes' if 'daily_cap_usd' in cfg else 'no')
+except Exception:
+    print('no')
+" "$CONFIG_PATH" 2>/dev/null || echo "no")"
+
+  if [[ "$HAS_LEGACY" == "yes" ]]; then
+    MIGRATION_NOTE="$(python3 - "$CONFIG_PATH" <<'PY' 2>/dev/null || true
+import json, sys, os
+path = sys.argv[1]
 try:
     with open(path, encoding="utf-8") as f:
         cfg = json.load(f)
-    cap = cfg.get("daily_cap_usd")
-    print(float(cap) if cap is not None else float(fallback))
 except Exception:
-    print(float(fallback))
+    sys.exit(0)
+
+legacy_cap = cfg.pop("daily_cap_usd", None)
+if legacy_cap is None:
+    sys.exit(0)
+
+legacy_cap = float(legacy_cap)
+# Determine mapping: tiny auto-default (<=5) -> standard defaults; user-set -> preserve as daily-warn
+IS_STANDARD_DEFAULT = (abs(legacy_cap - 3.33) < 0.01 or legacy_cap <= 5.0)
+
+if not cfg.get("monthly_cap_usd"):
+    cfg["monthly_cap_usd"] = 1000
+if not cfg.get("daily_warn_threshold_usd"):
+    cfg["daily_warn_threshold_usd"] = 100 if IS_STANDARD_DEFAULT else int(legacy_cap)
+
+# Normalize thresholds to new schema
+old_th = cfg.get("thresholds", {})
+if "monthly" not in old_th or "daily" not in old_th:
+    monthly_th = {
+        "info": old_th.get("info", 0.60),
+        "warn": old_th.get("warn", 0.80),
+        "critical": old_th.get("critical", 0.95),
+    }
+    cfg["thresholds"] = {
+        "monthly": monthly_th,
+        "daily": {"info": 80, "warn": 100}
+    }
+
+# Normalize stop_hook_threshold
+old_sht = cfg.get("stop_hook_threshold")
+if not isinstance(old_sht, dict):
+    cfg["stop_hook_threshold"] = {
+        "monthly_pct": float(old_sht) if old_sht is not None else 0.60,
+        "daily_usd": 80
+    }
+
+tmp = path + ".tmp"
+try:
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+    note = "Migrated quota config to monthly+daily-warn shape"
+    if IS_STANDARD_DEFAULT:
+        note += f" (legacy daily_cap_usd {legacy_cap} was the auto-default; set monthly=1000, daily-warn=100)"
+    else:
+        note += f" (legacy daily_cap_usd {legacy_cap} preserved as daily_warn_threshold_usd)"
+    print(note)
+except Exception as e:
+    try:
+        os.unlink(tmp)
+    except Exception:
+        pass
+    print(f"Migration warning: could not write updated config: {e}", file=__import__("sys").stderr)
 PY
 )"
+    if [[ -n "$MIGRATION_NOTE" ]]; then
+      echo "quota-budget.sh: $MIGRATION_NOTE" >&2
+    fi
+  fi
 fi
+
+# --- Read resolved config values ---
+read_config() {
+  # Prints: monthly_cap daily_warn monthly_info monthly_warn monthly_critical daily_info_usd daily_warn_usd stop_hook_monthly_pct stop_hook_daily_usd
+  python3 - "$CONFIG_PATH" <<'PY' 2>/dev/null || echo "1000 100 0.60 0.80 0.95 80 100 0.60 80"
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path, encoding="utf-8") as f:
+        cfg = json.load(f)
+except Exception:
+    cfg = {}
+mc = float(cfg.get("monthly_cap_usd", 1000))
+dw = float(cfg.get("daily_warn_threshold_usd", 100))
+th = cfg.get("thresholds") or {}
+mth = th.get("monthly") if isinstance(th.get("monthly"), dict) else {}
+dth = th.get("daily") if isinstance(th.get("daily"), dict) else {}
+sht = cfg.get("stop_hook_threshold") or {}
+if not isinstance(sht, dict):
+    sht = {"monthly_pct": float(sht), "daily_usd": 80}
+print(
+    mc,
+    dw,
+    float(mth.get("info", 0.60)),
+    float(mth.get("warn", 0.80)),
+    float(mth.get("critical", 0.95)),
+    float(dth.get("info", 80)),
+    float(dth.get("warn", 100)),
+    float(sht.get("monthly_pct", 0.60)),
+    float(sht.get("daily_usd", 80))
+)
+PY
+}
+
+# shellcheck disable=SC2034
+read -r MONTHLY_CAP DAILY_WARN MONTHLY_INFO MONTHLY_WARN MONTHLY_CRIT DAILY_INFO_USD DAILY_WARN_USD STOP_HOOK_MONTHLY_PCT STOP_HOOK_DAILY_USD <<< "$(read_config)"
 
 # --- atomic session-state write helper (jq + temp-file + mv, like greptile-budget.sh) ---
 write_quota_daily() {
-  # $1 = quota_daily JSON object to store
   local obj="$1"
   command -v jq >/dev/null 2>&1 || return 0
   local state_dir; state_dir="$(dirname "$STATE_FILE")"
@@ -151,28 +279,76 @@ write_quota_daily() {
   fi
 }
 
+# --- --config-cap: update config file ---
+if [[ "$MODE" == "config-cap" ]]; then
+  [[ ${#CONFIG_CAP_ARGS[@]} -gt 0 ]] || die_usage "--config-cap requires at least one argument (monthly=N or daily-warn=M)"
+  python3 - "$CONFIG_PATH" "${CONFIG_CAP_ARGS[@]}" <<'PY' || { echo "quota-budget.sh: failed to update config" >&2; exit 5; }
+import json, os, sys
+path = sys.argv[1]
+args = sys.argv[2:]
+try:
+    with open(path, encoding="utf-8") as f:
+        cfg = json.load(f)
+except Exception:
+    cfg = {}
+for arg in args:
+    if arg.startswith("monthly="):
+        val = float(arg[len("monthly="):])
+        cfg["monthly_cap_usd"] = val
+    elif arg.startswith("daily-warn="):
+        val = float(arg[len("daily-warn="):])
+        cfg["daily_warn_threshold_usd"] = val
+    else:
+        print(f"quota-budget.sh: unknown --config-cap key: {arg} (use monthly=N or daily-warn=M)", file=sys.stderr)
+        sys.exit(2)
+tmp = path + ".tmp"
+with open(tmp, "w", encoding="utf-8") as f:
+    json.dump(cfg, f, indent=2)
+    f.write("\n")
+os.replace(tmp, path)
+print(json.dumps({"config_path": path,
+                  "monthly_cap_usd": cfg.get("monthly_cap_usd"),
+                  "daily_warn_threshold_usd": cfg.get("daily_warn_threshold_usd")}))
+PY
+  exit 0
+fi
+
 # --- --config: print resolved config ---
 if [[ "$MODE" == "config" ]]; then
-  python3 - "$CONFIG_PATH" "$CAP" <<'PY' || { echo "quota-budget.sh: failed to read config" >&2; exit 5; }
+  python3 - "$CONFIG_PATH" <<'PY' || { echo "quota-budget.sh: failed to read config" >&2; exit 5; }
 import json, sys
-path, cap = sys.argv[1], float(sys.argv[2])
+path = sys.argv[1]
 try:
     with open(path, encoding="utf-8") as f:
         cfg = json.load(f)
 except Exception:
     cfg = {}
 th = cfg.get("thresholds") or {}
+mth = th.get("monthly") if isinstance(th.get("monthly"), dict) else {}
+dth = th.get("daily") if isinstance(th.get("daily"), dict) else {}
+sht = cfg.get("stop_hook_threshold") or {}
+if not isinstance(sht, dict):
+    sht = {"monthly_pct": float(sht), "daily_usd": 80}
 out = {
     "config_path": path,
-    "daily_cap_usd": cap,
+    "monthly_cap_usd": float(cfg.get("monthly_cap_usd", 1000)),
+    "daily_warn_threshold_usd": float(cfg.get("daily_warn_threshold_usd", 100)),
     "currency": cfg.get("currency", "USD"),
     "thresholds": {
-        "info": th.get("info", 0.60),
-        "warn": th.get("warn", 0.80),
-        "critical": th.get("critical", 0.95),
+        "monthly": {
+            "info": float(mth.get("info", 0.60)),
+            "warn": float(mth.get("warn", 0.80)),
+            "critical": float(mth.get("critical", 0.95)),
+        },
+        "daily": {
+            "info_usd": float(dth.get("info", 80)),
+            "warn_usd": float(dth.get("warn", 100)),
+        },
     },
-    "stop_hook_threshold": cfg.get("stop_hook_threshold", 0.60),
-    "plan": cfg.get("plan", {}),
+    "stop_hook_threshold": {
+        "monthly_pct": float(sht.get("monthly_pct", 0.60)),
+        "daily_usd": float(sht.get("daily_usd", 80)),
+    },
     "pricing": {k: v for k, v in (cfg.get("pricing") or {}).items() if k != "_comment"},
 }
 print(json.dumps(out))
@@ -182,20 +358,31 @@ fi
 
 # --- --reset: zero today's cached counter ---
 if [[ "$MODE" == "reset" ]]; then
-  SNAPSHOT="$(python3 - "$CAP" <<'PY'
+  SNAPSHOT="$(python3 - "$MONTHLY_CAP" "$DAILY_WARN" <<'PY'
 import json, sys
 from datetime import datetime, timezone
-cap = float(sys.argv[1])
+monthly_cap = float(sys.argv[1])
+daily_warn = float(sys.argv[2])
 try:
     import zoneinfo
-    today = datetime.now(zoneinfo.ZoneInfo("America/New_York")).date().isoformat()
+    now_et = datetime.now(zoneinfo.ZoneInfo("America/New_York"))
+    today = now_et.date().isoformat()
+    month = now_et.strftime("%Y-%m")
 except Exception:
-    today = datetime.now(timezone.utc).date().isoformat()
+    now_et = datetime.now(timezone.utc)
+    today = now_et.date().isoformat()
+    month = now_et.strftime("%Y-%m")
 print(json.dumps({
-    "date": today, "input_tokens": 0, "output_tokens": 0,
+    "date": today, "month": month,
+    "input_tokens": 0, "output_tokens": 0,
     "cache_read_tokens": 0, "cache_creation_tokens": 0,
-    "estimated_usd": 0.0, "budget_usd": round(cap, 4),
-    "projected_eod_usd": 0.0, "status": "ok",
+    "estimated_usd": 0.0,
+    "monthly_spend_usd": 0.0,
+    "daily_warn_threshold_usd": daily_warn,
+    "monthly_cap_usd": monthly_cap,
+    "projected_eod_usd": 0.0,
+    "projected_eom_usd": 0.0,
+    "daily_status": "ok", "monthly_status": "ok", "status": "ok",
 }))
 PY
 )"
@@ -204,16 +391,32 @@ PY
   exit 0
 fi
 
-# --- --check / --week: aggregate the ledger ---
-SNAPSHOT="$(python3 - "$CONFIG_PATH" "$USAGE_LOG" "$CAP" "$MODE" "$DATE_OVERRIDE" <<'PY'
+# --- --check / --week / --month: aggregate the ledger ---
+SNAPSHOT="$(python3 - "$CONFIG_PATH" "$USAGE_LOG" "$MONTHLY_CAP" "$DAILY_WARN" \
+    "$MONTHLY_INFO" "$MONTHLY_WARN" "$MONTHLY_CRIT" \
+    "$DAILY_INFO_USD" "$DAILY_WARN_USD" \
+    "$MODE" "$DATE_OVERRIDE" "${MIGRATION_NOTE:-}" <<'PY'
 import json, os, sys
 from datetime import datetime, timezone, timedelta
+import calendar
 
-config_path, log_path, cap_s, mode, date_override = sys.argv[1:6]
+(config_path, log_path, monthly_cap_s, daily_warn_s,
+ monthly_info_s, monthly_warn_s, monthly_crit_s,
+ daily_info_usd_s, daily_warn_usd_s,
+ mode, date_override, migration_note) = sys.argv[1:13]
+
 try:
-    cap = float(cap_s)
+    monthly_cap = float(monthly_cap_s)
+    daily_warn_threshold = float(daily_warn_s)
+    MONTHLY_INFO = float(monthly_info_s)
+    MONTHLY_WARN = float(monthly_warn_s)
+    MONTHLY_CRIT = float(monthly_crit_s)
+    DAILY_INFO_USD = float(daily_info_usd_s)
+    DAILY_WARN_USD = float(daily_warn_usd_s)
 except Exception:
-    cap = 0.0
+    monthly_cap = 1000.0; daily_warn_threshold = 100.0
+    MONTHLY_INFO = 0.60; MONTHLY_WARN = 0.80; MONTHLY_CRIT = 0.95
+    DAILY_INFO_USD = 80.0; DAILY_WARN_USD = 100.0
 
 try:
     with open(config_path, encoding="utf-8") as f:
@@ -223,8 +426,6 @@ except Exception:
 pricing = cfg.get("pricing") if isinstance(cfg.get("pricing"), dict) else {}
 default_price = pricing.get("default") if isinstance(pricing.get("default"), dict) else \
     {"input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.5}
-th = cfg.get("thresholds") or {}
-INFO = float(th.get("info", 0.60)); WARN = float(th.get("warn", 0.80)); CRIT = float(th.get("critical", 0.95))
 
 def num(v, fb):
     try:
@@ -254,8 +455,6 @@ try:
 except Exception:
     ET = None
 
-# QUOTA_FAKE_NOW (ISO8601, test-only) pins "now" so the projection floor and
-# ET-day boundary behavior are deterministically testable.
 _fake_now = os.environ.get("QUOTA_FAKE_NOW")
 now_utc = None
 if _fake_now:
@@ -271,6 +470,7 @@ if now_utc is None:
     now_utc = datetime.now(timezone.utc)
 now_et = now_utc.astimezone(ET) if ET else now_utc
 today_et = now_et.date().isoformat()
+current_month_et = now_et.strftime("%Y-%m")
 
 def parse_utc(ts):
     ts = ts.strip()
@@ -287,8 +487,9 @@ def parse_utc(ts):
 def et_date_of(ts):
     dt = parse_utc(ts)
     if dt is None:
-        return None
-    return (dt.astimezone(ET) if ET else dt).date().isoformat()
+        return None, None
+    et = (dt.astimezone(ET) if ET else dt)
+    return et.date().isoformat(), et.strftime("%Y-%m")
 
 def blank_day(d):
     return {"date": d, "input_tokens": 0, "output_tokens": 0,
@@ -317,7 +518,7 @@ try:
             parts = line.rstrip("\n").split("\t")
             if len(parts) < 7:
                 continue
-            d = et_date_of(parts[0])
+            d, _m = et_date_of(parts[0])
             if d is None:
                 continue
             model = parts[1]
@@ -337,14 +538,37 @@ def finalize_models(by_model):
         m["estimated_usd"] = round(m["estimated_usd"], 4)
     return lst
 
-def classify(projected_pct):
-    if projected_pct >= CRIT:
+def classify_monthly(projected_pct):
+    if projected_pct >= MONTHLY_CRIT:
         return "critical"
-    if projected_pct >= WARN:
+    if projected_pct >= MONTHLY_WARN:
         return "warn"
-    if projected_pct >= INFO:
+    if projected_pct >= MONTHLY_INFO:
         return "info"
     return "ok"
+
+def classify_daily(spend_usd):
+    """Daily signal: capped at warn — never critical."""
+    if spend_usd >= DAILY_WARN_USD:
+        return "warn"
+    if spend_usd >= DAILY_INFO_USD:
+        return "info"
+    return "ok"
+
+def severity_max(a, b):
+    order = {"ok": 0, "info": 1, "warn": 2, "critical": 3}
+    return a if order.get(a, 0) >= order.get(b, 0) else b
+
+def month_spend_usd(month_str):
+    """Sum all day entries for the given YYYY-MM month prefix."""
+    total = 0.0
+    for d, e in days.items():
+        if d.startswith(month_str):
+            total += e["estimated_usd"]
+    return total
+
+def days_in_month(year, month):
+    return calendar.monthrange(year, month)[1]
 
 if mode == "week":
     out_days = []
@@ -368,12 +592,51 @@ if mode == "week":
     wm_list = sorted(week_models.values(), key=lambda m: m["estimated_usd"], reverse=True)
     for m in wm_list:
         m["estimated_usd"] = round(m["estimated_usd"], 4)
+    month_spend = month_spend_usd(current_month_et)
     print(json.dumps({
         "mode": "week", "days": out_days,
         "total_usd": round(total, 4), "total_responses": total_resp,
-        "by_model": wm_list, "budget_usd": round(cap, 4),
+        "by_model": wm_list,
+        "monthly_cap_usd": round(monthly_cap, 4),
+        "daily_warn_threshold_usd": round(daily_warn_threshold, 4),
+        "month": current_month_et,
+        "month_spend_usd": round(month_spend, 4),
         "checked_at": now_utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "today": today_et,
+    }))
+    sys.exit(0)
+
+if mode == "month":
+    year_i = now_et.year; month_i = now_et.month
+    dim = days_in_month(year_i, month_i)
+    out_days = []
+    month_total = 0.0; month_resp = 0
+    month_models = {}
+    for day_i in range(1, dim + 1):
+        d = f"{year_i:04d}-{month_i:02d}-{day_i:02d}"
+        e = days.get(d, blank_day(d))
+        row = {
+            "date": d,
+            "estimated_usd": round(e["estimated_usd"], 4),
+            "input_tokens": e["input_tokens"], "output_tokens": e["output_tokens"],
+            "cache_read_tokens": e["cache_read_tokens"], "cache_creation_tokens": e["cache_creation_tokens"],
+            "responses": e["responses"],
+        }
+        out_days.append(row)
+        month_total += e["estimated_usd"]; month_resp += e["responses"]
+        for mk, mv in e["by_model"].items():
+            mm = month_models.setdefault(mk, {"model": mk, "estimated_usd": 0.0})
+            mm["estimated_usd"] += mv["estimated_usd"]
+    mm_list = sorted(month_models.values(), key=lambda m: m["estimated_usd"], reverse=True)
+    for m in mm_list:
+        m["estimated_usd"] = round(m["estimated_usd"], 4)
+    print(json.dumps({
+        "mode": "month", "month": current_month_et, "days": out_days,
+        "total_usd": round(month_total, 4), "total_responses": month_resp,
+        "by_model": mm_list,
+        "monthly_cap_usd": round(monthly_cap, 4),
+        "daily_warn_threshold_usd": round(daily_warn_threshold, 4),
+        "checked_at": now_utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
     }))
     sys.exit(0)
 
@@ -381,45 +644,82 @@ if mode == "week":
 target = date_override or today_et
 is_today = (target == today_et)
 e = days.get(target, blank_day(target))
-spend = e["estimated_usd"]
+today_spend = e["estimated_usd"]
+
+# Monthly spend: sum all days in the same ET month as 'target'
+target_month = target[:7]  # YYYY-MM
+monthly_spend = month_spend_usd(target_month)
 
 if is_today:
     midnight = now_et.replace(hour=0, minute=0, second=0, microsecond=0)
-    fraction = max(min((now_et - midnight).total_seconds() / 86400.0, 1.0), 0.0)
-else:
-    fraction = 1.0
-# Linear run-rate projection, but floor the denominator so a tiny elapsed
-# fraction just after ET midnight cannot explode the projection. Without this,
-# e.g. $0.10 spent one minute into the day extrapolates to ~$144, producing a
-# false critical/over-cap status. The floor caps the extrapolation multiplier at
-# 24x (>= 1 hour of data) before the run-rate is trusted; the true elapsed
-# fraction is still reported as fraction_of_day_elapsed for transparency.
-MIN_PROJECTION_FRACTION = 1.0 / 24.0  # 1 hour
-proj_fraction = max(fraction, MIN_PROJECTION_FRACTION)
-projected = spend / proj_fraction if proj_fraction > 0 else spend
+    day_fraction = max(min((now_et - midnight).total_seconds() / 86400.0, 1.0), 0.0)
 
-spend_pct = (spend / cap) if cap > 0 else 0.0
-projected_pct = (projected / cap) if cap > 0 else 0.0
-status = classify(projected_pct)
+    # Month fraction: day_of_month / days_in_month
+    year_i = now_et.year; month_i = now_et.month
+    dim = days_in_month(year_i, month_i)
+    # Use current day number (1-based) as numerator, treating 'now' as partly through day N
+    day_of_month_frac = (now_et.day - 1 + day_fraction) / dim
+    month_fraction = max(min(day_of_month_frac, 1.0), 0.0)
+else:
+    day_fraction = 1.0
+    # For past-day check, month fraction = 1
+    month_fraction = 1.0
+
+# Daily projection: floor denominator at 1 hour to prevent explosion near midnight
+MIN_DAY_FRAC = 1.0 / 24.0
+proj_day_frac = max(day_fraction, MIN_DAY_FRAC)
+projected_eod = today_spend / proj_day_frac if proj_day_frac > 0 else today_spend
+
+# Monthly projection: floor at 1 day / days_in_month to prevent explosion at month start
+if is_today:
+    year_i2 = now_et.year; month_i2 = now_et.month
+    dim2 = days_in_month(year_i2, month_i2)
+    MIN_MONTH_FRAC = 1.0 / dim2
+else:
+    MIN_MONTH_FRAC = 1.0 / 30.0
+proj_month_frac = max(month_fraction, MIN_MONTH_FRAC)
+projected_eom = monthly_spend / proj_month_frac if proj_month_frac > 0 else monthly_spend
+
+# Classify
+monthly_spend_pct = (monthly_spend / monthly_cap) if monthly_cap > 0 else 0.0
+projected_eom_pct = (projected_eom / monthly_cap) if monthly_cap > 0 else 0.0
+daily_spend_pct_of_warn = (today_spend / daily_warn_threshold) if daily_warn_threshold > 0 else 0.0
+
+monthly_status = classify_monthly(projected_eom_pct)
+daily_status = classify_daily(today_spend)
+# Combined status: max severity (daily capped at warn — never escalates to critical)
+status = severity_max(monthly_status, daily_status)
+
+# Surface: emit when monthly >=60% OR daily >= $80
+surface = (projected_eom_pct >= MONTHLY_INFO) or (today_spend >= DAILY_INFO_USD)
 
 out = {
     "date": target,
+    "month": target_month,
     "input_tokens": e["input_tokens"], "output_tokens": e["output_tokens"],
     "cache_read_tokens": e["cache_read_tokens"], "cache_creation_tokens": e["cache_creation_tokens"],
-    "estimated_usd": round(spend, 4),
-    "budget_usd": round(cap, 4),
-    "spend_pct": round(spend_pct, 4),
+    "estimated_usd": round(today_spend, 4),
+    "monthly_spend_usd": round(monthly_spend, 4),
+    "daily_warn_threshold_usd": round(daily_warn_threshold, 4),
+    "monthly_cap_usd": round(monthly_cap, 4),
+    "daily_spend_pct_of_warn": round(daily_spend_pct_of_warn, 4),
+    "monthly_spend_pct": round(monthly_spend_pct, 4),
     "responses": e["responses"],
-    "fraction_of_day_elapsed": round(fraction, 4),
-    "projected_eod_usd": round(projected, 4),
-    "projected_pct": round(projected_pct, 4),
+    "fraction_of_day_elapsed": round(day_fraction, 4),
+    "fraction_of_month_elapsed": round(month_fraction, 4),
+    "projected_eod_usd": round(projected_eod, 4),
+    "projected_eom_usd": round(projected_eom, 4),
+    "projected_eom_pct": round(projected_eom_pct, 4),
+    "daily_status": daily_status,
+    "monthly_status": monthly_status,
     "status": status,
-    "surface": projected_pct >= INFO,
-    "over_cap": spend > cap,
+    "surface": surface,
     "by_model": finalize_models(e["by_model"]),
     "is_today": is_today,
     "checked_at": now_utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
 }
+if migration_note:
+    out["migration_note"] = migration_note
 print(json.dumps(out))
 PY
 )" || { echo "quota-budget.sh: aggregation failed" >&2; exit 5; }
@@ -435,9 +735,8 @@ fi
 
 # Cache today's snapshot into session-state.json under quota_daily (spec schema).
 if [[ "$WRITE_STATE" -eq 1 ]]; then
-  if [[ "$MODE" == "week" ]]; then
-    # Refresh today's snapshot too so /status etc. stay current.
-    TODAY_SNAP="$("$0" --check --cap "$CAP" --no-state 2>/dev/null || true)"
+  if [[ "$MODE" == "week" || "$MODE" == "month" ]]; then
+    TODAY_SNAP="$("$0" --check --no-state 2>/dev/null || true)"
   else
     TODAY_SNAP="$SNAPSHOT"
   fi
@@ -446,13 +745,19 @@ if [[ "$WRITE_STATE" -eq 1 ]]; then
 s=json.load(sys.stdin)
 print(json.dumps({
  "date": s["date"],
+ "month": s.get("month", s["date"][:7]),
  "input_tokens": s["input_tokens"],
  "output_tokens": s["output_tokens"],
  "cache_read_tokens": s["cache_read_tokens"],
  "cache_creation_tokens": s["cache_creation_tokens"],
  "estimated_usd": s["estimated_usd"],
- "budget_usd": s["budget_usd"],
+ "monthly_spend_usd": s.get("monthly_spend_usd", s["estimated_usd"]),
+ "monthly_cap_usd": s.get("monthly_cap_usd", 1000),
+ "daily_warn_threshold_usd": s.get("daily_warn_threshold_usd", 100),
  "projected_eod_usd": s.get("projected_eod_usd", s["estimated_usd"]),
+ "projected_eom_usd": s.get("projected_eom_usd", s.get("monthly_spend_usd", s["estimated_usd"])),
+ "daily_status": s.get("daily_status", "ok"),
+ "monthly_status": s.get("monthly_status", "ok"),
  "status": s.get("status", "ok"),
 }))' 2>/dev/null || true)"
     [[ -n "$QD" ]] && write_quota_daily "$QD"

--- a/.claude/scripts/quota-budget.sh
+++ b/.claude/scripts/quota-budget.sh
@@ -174,7 +174,7 @@ IS_STANDARD_DEFAULT = (abs(legacy_cap - 3.33) < 0.01 or legacy_cap <= 5.0)
 if not cfg.get("monthly_cap_usd"):
     cfg["monthly_cap_usd"] = 1000
 if not cfg.get("daily_warn_threshold_usd"):
-    cfg["daily_warn_threshold_usd"] = 100 if IS_STANDARD_DEFAULT else int(legacy_cap)
+    cfg["daily_warn_threshold_usd"] = 100 if IS_STANDARD_DEFAULT else float(legacy_cap)
 
 # Normalize thresholds to new schema
 old_th = cfg.get("thresholds", {})

--- a/.claude/scripts/quota-budget.sh
+++ b/.claude/scripts/quota-budget.sh
@@ -547,11 +547,15 @@ def classify_monthly(projected_pct):
         return "info"
     return "ok"
 
-def classify_daily(spend_usd):
-    """Daily signal: capped at warn — never critical."""
-    if spend_usd >= DAILY_WARN_USD:
+def classify_daily(spend_usd, warn_usd=None, info_usd=None):
+    """Daily signal: capped at warn — never critical.
+    Thresholds derived from daily_warn_threshold so --config-cap daily-warn=N
+    stays consistent with daily_status, daily_spend_pct_of_warn, and the stop hook."""
+    w = warn_usd if warn_usd is not None else DAILY_WARN_USD
+    i = info_usd if info_usd is not None else DAILY_INFO_USD
+    if spend_usd >= w:
         return "warn"
-    if spend_usd >= DAILY_INFO_USD:
+    if spend_usd >= i:
         return "info"
     return "ok"
 
@@ -559,12 +563,15 @@ def severity_max(a, b):
     order = {"ok": 0, "info": 1, "warn": 2, "critical": 3}
     return a if order.get(a, 0) >= order.get(b, 0) else b
 
-def month_spend_usd(month_str):
-    """Sum all day entries for the given YYYY-MM month prefix."""
+def month_spend_usd(month_str, cutoff_date=None):
+    """Sum all day entries for the given YYYY-MM month prefix.
+    cutoff_date (YYYY-MM-DD): if provided, only sum days <= cutoff_date so that
+    --check --date YYYY-MM-DD past-day queries don't include later days' spend."""
     total = 0.0
     for d, e in days.items():
         if d.startswith(month_str):
-            total += e["estimated_usd"]
+            if cutoff_date is None or d <= cutoff_date:
+                total += e["estimated_usd"]
     return total
 
 def days_in_month(year, month):
@@ -646,9 +653,11 @@ is_today = (target == today_et)
 e = days.get(target, blank_day(target))
 today_spend = e["estimated_usd"]
 
-# Monthly spend: sum all days in the same ET month as 'target'
+# Monthly spend: sum all days in the same ET month as 'target', capped at target date
+# so --check --date YYYY-MM-DD past-day queries don't include later days' spend.
 target_month = target[:7]  # YYYY-MM
-monthly_spend = month_spend_usd(target_month)
+cutoff = target if not is_today else None
+monthly_spend = month_spend_usd(target_month, cutoff_date=cutoff)
 
 if is_today:
     midnight = now_et.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -686,12 +695,16 @@ projected_eom_pct = (projected_eom / monthly_cap) if monthly_cap > 0 else 0.0
 daily_spend_pct_of_warn = (today_spend / daily_warn_threshold) if daily_warn_threshold > 0 else 0.0
 
 monthly_status = classify_monthly(projected_eom_pct)
-daily_status = classify_daily(today_spend)
+# Derive daily thresholds from daily_warn_threshold so --config-cap daily-warn=N
+# stays consistent: info = 80% of warn level, warn = daily_warn_threshold itself.
+daily_info_threshold = min(DAILY_INFO_USD, daily_warn_threshold * 0.80)
+daily_status = classify_daily(today_spend, warn_usd=daily_warn_threshold, info_usd=daily_info_threshold)
 # Combined status: max severity (daily capped at warn — never escalates to critical)
 status = severity_max(monthly_status, daily_status)
 
-# Surface: emit when monthly >=60% OR daily >= $80
-surface = (projected_eom_pct >= MONTHLY_INFO) or (today_spend >= DAILY_INFO_USD)
+# Surface: emit when monthly >=60% OR daily >= daily_info_threshold
+# (daily_info_threshold is 80% of daily_warn_threshold, consistent with classify_daily)
+surface = (projected_eom_pct >= MONTHLY_INFO) or (today_spend >= daily_info_threshold)
 
 out = {
     "date": target,

--- a/.claude/scripts/tests/quota-budget.test.sh
+++ b/.claude/scripts/tests/quota-budget.test.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Offline test for the /quota tracker (issue #458).
+# Offline test for the /quota tracker (issue #495).
 # Exercises quota-usage-hook.sh (raw-count ledger + de-dup + graceful no-op),
-# quota-budget.sh (--check sum/projection/thresholds, --config, --reset, --week,
-# --date past-day), the spec session-state schema, and quota-stop-notify.sh.
+# quota-budget.sh (--check monthly+daily signals, --config, --reset, --week,
+# --month, --date past-day, --config-cap), the spec session-state schema,
+# quota-stop-notify.sh, legacy migration, and threshold transitions.
 # Requires python3 + jq + git.
 set -euo pipefail
 
@@ -24,10 +25,16 @@ export QUOTA_STATE_DIR="$HOME/.claude/quota-usage.d"
 export QUOTA_STATE_FILE="$HOME/.claude/session-state.json"
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
-numeq() { python3 -c "import sys; sys.exit(0 if abs(float('$1')-float('$2'))<1e-9 else 1)"; }
+numeq() { python3 -c "import sys; sys.exit(0 if abs(float('$1')-float('$2'))<1e-6 else 1)"; }
+numge() { python3 -c "import sys; sys.exit(0 if float('$1')>=float('$2') else 1)"; }
 
 TODAY="$(TZ='America/New_York' date +%F)"
 TRANSCRIPT="$TMP_HOME/transcript.jsonl"
+
+# Use a fresh per-test config that doesn't affect the real quota-config.json
+TEST_CONFIG="$TMP_HOME/quota-config.json"
+cp "$QUOTA_CONFIG" "$TEST_CONFIG"
+export QUOTA_CONFIG="$TEST_CONFIG"
 
 # --- 1. Hook writes one 7-col TSV line (counts + model + session only) ---
 printf '%s\n' '{"type":"user","message":{"role":"user","content":"hi"}}' >> "$TRANSCRIPT"
@@ -39,10 +46,8 @@ LINES=$(wc -l < "$QUOTA_USAGE_LOG" | tr -d ' ')
 [ "$LINES" = "1" ] || fail "expected 1 ledger line, got $LINES"
 NCOL=$(awk -F'\t' 'NR==1{print NF}' "$QUOTA_USAGE_LOG")
 [ "$NCOL" = "7" ] || fail "expected 7 TSV columns, got $NCOL"
-# Column order: ts_utc, model, input, output, cache_read, cache_creation, session_id
 [ "$(awk -F'\t' 'NR==1{print $2}' "$QUOTA_USAGE_LOG")" = "claude-opus-4-8" ] || fail "model column wrong"
 [ "$(awk -F'\t' 'NR==1{print $7}' "$QUOTA_USAGE_LOG")" = "sess-test" ] || fail "session_id column wrong"
-# No secrets/prompt text in the ledger
 grep -qiE 'content|prompt|"role"|hi' "$QUOTA_USAGE_LOG" && fail "ledger contains unexpected (non-count) content"
 
 # --- 2. De-dup: re-firing the same message must not add a line ---
@@ -61,92 +66,225 @@ NOUSE_INPUT="$(printf '{"session_id":"sess-nouse","transcript_path":"%s","tool_n
 printf '%s' "$NOUSE_INPUT" | "$HOOK" >/dev/null
 [ "$(wc -l < "$QUOTA_USAGE_LOG" | tr -d ' ')" = "2" ] || fail "no-op path wrote a line it should not have"
 
-# --- 5. --check sums today + projects EoD + classifies ---
+# --- 5. --check: today spend, monthly spend, both signals in JSON ---
 # opus: 1M*15 + 0.1M*75 = 22.5 ; sonnet: 2M*3 + 0.05M*15 + 1M*0.30 = 7.05 ; total 29.55
-SNAP="$("$BUDGET" --check --cap 100)"
+SNAP="$("$BUDGET" --check)"
 numeq "$(printf '%s' "$SNAP" | jq -r '.estimated_usd')" "29.55" || fail "today spend wrong: $(printf '%s' "$SNAP" | jq -r .estimated_usd)"
 [ "$(printf '%s' "$SNAP" | jq -r '.responses')" = "2" ] || fail "responses wrong"
-numeq "$(printf '%s' "$SNAP" | jq -r '.budget_usd')" "100" || fail "budget_usd wrong"
-PROJ=$(printf '%s' "$SNAP" | jq -r '.projected_eod_usd')
-SPEND=$(printf '%s' "$SNAP" | jq -r '.estimated_usd')
-python3 -c "import sys; sys.exit(0 if float('$PROJ') >= float('$SPEND') else 1)" || fail "projection < spend"
+# Monthly spend should equal today spend (all ledger entries are today)
+numeq "$(printf '%s' "$SNAP" | jq -r '.monthly_spend_usd')" "29.55" || fail "monthly_spend_usd wrong"
+# New schema fields must be present
+for k in date month estimated_usd monthly_spend_usd daily_warn_threshold_usd monthly_cap_usd \
+          daily_spend_pct_of_warn monthly_spend_pct projected_eod_usd projected_eom_usd \
+          projected_eom_pct daily_status monthly_status status surface; do
+  [ "$(printf '%s' "$SNAP" | jq -r "has(\"$k\")")" = "true" ] || fail "snapshot missing field: $k"
+done
+# month field should be YYYY-MM of today
+MONTH_FIELD="$(printf '%s' "$SNAP" | jq -r '.month')"
+[ ${#MONTH_FIELD} -eq 7 ] || fail "month field not YYYY-MM: $MONTH_FIELD"
 # Top model by spend should be opus (22.5 > 7.05)
 [ "$(printf '%s' "$SNAP" | jq -r '.by_model[0].model')" = "claude-opus-4-8" ] || fail "by_model not sorted by spend"
+# Projected EoD should be >= today spend
+PROJ_EOD=$(printf '%s' "$SNAP" | jq -r '.projected_eod_usd')
+python3 -c "import sys; sys.exit(0 if float('$PROJ_EOD') >= 29.55 else 1)" || fail "projected_eod_usd < spend"
+# Projected EoM should be >= monthly spend
+PROJ_EOM=$(printf '%s' "$SNAP" | jq -r '.projected_eom_usd')
+python3 -c "import sys; sys.exit(0 if float('$PROJ_EOM') >= 29.55 else 1)" || fail "projected_eom_usd < monthly spend"
 
-# --- 6. Threshold classification (small cap drives status up) ---
-# cap 20 -> spend 29.55 already over; projected even higher -> critical
-[ "$(printf '%s' "$SNAP" | jq -r '.status')" != "null" ] || fail "status missing"
-SNAP_CRIT="$("$BUDGET" --check --cap 20 --no-state)"
-[ "$(printf '%s' "$SNAP_CRIT" | jq -r '.status')" = "critical" ] || fail "expected critical status at cap 20"
-[ "$(printf '%s' "$SNAP_CRIT" | jq -r '.over_cap')" = "true" ] || fail "expected over_cap true at cap 20"
-# Observational: never exits non-zero even when over cap
-"$BUDGET" --check --cap 0.01 --no-state >/dev/null || fail "tiny cap should not block (exit non-zero)"
+# --- 6a. Monthly threshold transitions ---
+# $29.55 against $1000 cap — actual status depends on fraction of month elapsed
+# (early in month, projection can be high; late in month, it will be ok). Just
+# verify it is a valid status string.
+MS_DEFAULT="$(printf '%s' "$SNAP" | jq -r '.monthly_status')"
+[[ "$MS_DEFAULT" =~ ^(ok|info|warn|critical)$ ]] || fail "monthly_status invalid: $MS_DEFAULT"
 
-# --- 7. session-state quota_daily uses the spec schema ---
+# monthly info: set cap=49 so projected >= 60% of cap
+SNAP_MINFO="$(jq '.monthly_cap_usd = 49 | .thresholds.monthly.info = 0.60 | .thresholds.monthly.warn = 0.80 | .thresholds.monthly.critical = 0.95' "$TEST_CONFIG" > "$TMP_HOME/cfg_minfo.json" && QUOTA_CONFIG="$TMP_HOME/cfg_minfo.json" "$BUDGET" --check --no-state)"
+# With $29.55 spend and ~49 cap, monthly_spend_pct = 29.55/49 ≈ 60.3% -> info or higher
+MS="$(printf '%s' "$SNAP_MINFO" | jq -r '.monthly_status')"
+[ "$MS" = "info" ] || [ "$MS" = "warn" ] || [ "$MS" = "critical" ] || fail "expected monthly info or higher at cap=49, got $MS"
+
+# monthly warn: cap=37 so projected >= 80%
+SNAP_MWARN="$(jq '.monthly_cap_usd = 37 | .thresholds.monthly.info = 0.60 | .thresholds.monthly.warn = 0.80 | .thresholds.monthly.critical = 0.95' "$TEST_CONFIG" > "$TMP_HOME/cfg_mwarn.json" && QUOTA_CONFIG="$TMP_HOME/cfg_mwarn.json" "$BUDGET" --check --no-state)"
+MS2="$(printf '%s' "$SNAP_MWARN" | jq -r '.monthly_status')"
+[ "$MS2" = "warn" ] || [ "$MS2" = "critical" ] || fail "expected monthly warn or critical at cap=37, got $MS2"
+
+# monthly critical: cap=31 so projected >= 95%
+SNAP_MCRIT="$(jq '.monthly_cap_usd = 31 | .thresholds.monthly.info = 0.60 | .thresholds.monthly.warn = 0.80 | .thresholds.monthly.critical = 0.95' "$TEST_CONFIG" > "$TMP_HOME/cfg_mcrit.json" && QUOTA_CONFIG="$TMP_HOME/cfg_mcrit.json" "$BUDGET" --check --no-state)"
+[ "$(printf '%s' "$SNAP_MCRIT" | jq -r '.monthly_status')" = "critical" ] || fail "expected monthly critical at cap=31"
+
+# --- 6b. Daily threshold transitions ---
+# daily_status: $29.55 against $100 warn default => ok
+[ "$(printf '%s' "$SNAP" | jq -r '.daily_status')" = "ok" ] || fail "daily_status should be ok at $29.55"
+
+# daily info: set daily warn threshold to $40 so $29.55 >= info ($80 in config) — use low info threshold
+SNAP_DINFO="$(jq '.daily_warn_threshold_usd = 40 | .thresholds.daily.info = 25 | .thresholds.daily.warn = 40' "$TEST_CONFIG" > "$TMP_HOME/cfg_dinfo.json" && QUOTA_CONFIG="$TMP_HOME/cfg_dinfo.json" "$BUDGET" --check --no-state)"
+DS="$(printf '%s' "$SNAP_DINFO" | jq -r '.daily_status')"
+[ "$DS" = "info" ] || [ "$DS" = "warn" ] || fail "expected daily info or warn at spend=$29.55 info=25 warn=40, got $DS"
+
+# daily warn: $29.55 >= warn threshold when warn=25
+SNAP_DWARN="$(jq '.daily_warn_threshold_usd = 25 | .thresholds.daily.info = 20 | .thresholds.daily.warn = 25' "$TEST_CONFIG" > "$TMP_HOME/cfg_dwarn.json" && QUOTA_CONFIG="$TMP_HOME/cfg_dwarn.json" "$BUDGET" --check --no-state)"
+[ "$(printf '%s' "$SNAP_DWARN" | jq -r '.daily_status')" = "warn" ] || fail "expected daily warn at spend=$29.55 warn=25"
+
+# CRITICAL: daily signal NEVER goes critical regardless of spend
+[ "$(printf '%s' "$SNAP_DWARN" | jq -r '.daily_status')" != "critical" ] || fail "daily_status must never be critical"
+
+# Combined status when monthly=ok but daily=warn: max = warn (not critical)
+[ "$(printf '%s' "$SNAP_DWARN" | jq -r '.status')" = "warn" ] || fail "combined status should be warn when daily=warn, monthly=ok"
+
+# --- 7. session-state quota_daily uses the updated schema ---
 [ -f "$QUOTA_STATE_FILE" ] || fail "session-state.json not written"
-for k in date input_tokens output_tokens cache_read_tokens cache_creation_tokens estimated_usd budget_usd; do
+for k in date month input_tokens output_tokens cache_read_tokens cache_creation_tokens \
+          estimated_usd monthly_spend_usd monthly_cap_usd daily_warn_threshold_usd \
+          projected_eod_usd projected_eom_usd daily_status monthly_status status; do
   [ "$(jq -r ".quota_daily | has(\"$k\")" "$QUOTA_STATE_FILE")" = "true" ] || fail "quota_daily missing field: $k"
 done
 numeq "$(jq -r '.quota_daily.estimated_usd' "$QUOTA_STATE_FILE")" "29.55" || fail "quota_daily.estimated_usd wrong"
+numeq "$(jq -r '.quota_daily.monthly_spend_usd' "$QUOTA_STATE_FILE")" "29.55" || fail "quota_daily.monthly_spend_usd wrong"
 
-# --- 8. --config prints cap + thresholds + stop_hook_threshold ---
+# --- 8. --config prints monthly cap + daily warn + both threshold sets ---
 CFG="$("$BUDGET" --config)"
-numeq "$(printf '%s' "$CFG" | jq -r '.thresholds.info')" "0.60" || fail "config info threshold wrong"
-numeq "$(printf '%s' "$CFG" | jq -r '.stop_hook_threshold')" "0.60" || fail "stop_hook_threshold wrong"
+numge "$(printf '%s' "$CFG" | jq -r '.monthly_cap_usd')" "1" || fail "config monthly_cap_usd missing"
+numge "$(printf '%s' "$CFG" | jq -r '.daily_warn_threshold_usd')" "1" || fail "config daily_warn_threshold_usd missing"
+[ "$(printf '%s' "$CFG" | jq -r '.thresholds.monthly | has("info")')" = "true" ] || fail "config missing thresholds.monthly.info"
+[ "$(printf '%s' "$CFG" | jq -r '.thresholds.daily | has("info_usd")')" = "true" ] || fail "config missing thresholds.daily.info_usd"
+[ "$(printf '%s' "$CFG" | jq -r '.stop_hook_threshold | has("monthly_pct")')" = "true" ] || fail "config missing stop_hook_threshold.monthly_pct"
+[ "$(printf '%s' "$CFG" | jq -r '.stop_hook_threshold | has("daily_usd")')" = "true" ] || fail "config missing stop_hook_threshold.daily_usd"
+numeq "$(printf '%s' "$CFG" | jq -r '.thresholds.monthly.info')" "0.60" || fail "config monthly info threshold wrong"
 
 # --- 9. --reset zeroes today's cached counter (log untouched) ---
-"$BUDGET" --reset --cap 100 >/dev/null
+"$BUDGET" --reset >/dev/null
 numeq "$(jq -r '.quota_daily.estimated_usd' "$QUOTA_STATE_FILE")" "0" || fail "reset did not zero quota_daily"
 [ "$(wc -l < "$QUOTA_USAGE_LOG" | tr -d ' ')" = "2" ] || fail "reset must not modify the durable ledger"
 
 # --- 10. --week aggregates 7 zero-filled ET days incl. today ---
-WK="$("$BUDGET" --week --cap 100 --no-state)"
+WK="$("$BUDGET" --week --no-state)"
 [ "$(printf '%s' "$WK" | jq -r '.days | length')" = "7" ] || fail "week should have 7 days"
 [ "$(printf '%s' "$WK" | jq -r '.days[-1].date')" = "$TODAY" ] || fail "week last day should be today"
 numeq "$(printf '%s' "$WK" | jq -r '.total_usd')" "29.55" || fail "week total wrong: $(printf '%s' "$WK" | jq -r .total_usd)"
+[ "$(printf '%s' "$WK" | jq -r 'has("month_spend_usd")')" = "true" ] || fail "week missing month_spend_usd"
+[ "$(printf '%s' "$WK" | jq -r 'has("monthly_cap_usd")')" = "true" ] || fail "week missing monthly_cap_usd"
+[ "$(printf '%s' "$WK" | jq -r 'has("daily_warn_threshold_usd")')" = "true" ] || fail "week missing daily_warn_threshold_usd"
 
-# --- 11. --date for an empty past day reports 0 / fraction 1 ---
+# --- 11. --month aggregates current ET month ---
+MN="$("$BUDGET" --month --no-state)"
+[ "$(printf '%s' "$MN" | jq -r 'has("days")')" = "true" ] || fail "--month missing days"
+[ "$(printf '%s' "$MN" | jq -r '.days | length')" -ge 28 ] || fail "--month should have >=28 days"
+numeq "$(printf '%s' "$MN" | jq -r '.total_usd')" "29.55" || fail "--month total_usd wrong"
+[ "$(printf '%s' "$MN" | jq -r '.month')" = "$(TZ='America/New_York' date +%Y-%m)" ] || fail "--month field wrong"
+
+# --- 12. --date for an empty past day reports 0 / fraction 1 ---
 PAST="$("$BUDGET" --check --date 2000-01-01 --no-state)"
 numeq "$(printf '%s' "$PAST" | jq -r '.estimated_usd')" "0" || fail "empty past day non-zero spend"
 numeq "$(printf '%s' "$PAST" | jq -r '.fraction_of_day_elapsed')" "1" || fail "past day fraction != 1"
+numeq "$(printf '%s' "$PAST" | jq -r '.fraction_of_month_elapsed')" "1" || fail "past day month fraction != 1"
 
-# --- 12. Stop hook emits a line when over threshold, silent when under ---
-# Drive the hook with temp configs: a tiny cap (over threshold -> emit) and a
-# huge cap (under threshold -> silent).
-TINY_CFG="$TMP_HOME/tiny.json"; jq '.daily_cap_usd = 1 | .stop_hook_threshold = 0.6' "$QUOTA_CONFIG" > "$TINY_CFG"
-BIG_CFG="$TMP_HOME/big.json"; jq '.daily_cap_usd = 100000 | .stop_hook_threshold = 0.6' "$QUOTA_CONFIG" > "$BIG_CFG"
-EMIT="$(printf '{}' | QUOTA_CONFIG="$TINY_CFG" "$STOP_HOOK" 2>/dev/null || true)"
-printf '%s' "$EMIT" | jq -e '.hookSpecificOutput.additionalContext | test("\\[quota\\]")' >/dev/null || fail "stop hook should emit over threshold"
+# --- 13. --config-cap sets monthly and daily-warn ---
+CONFIG_CAP_CFG="$TMP_HOME/cap-test.json"
+cp "$QUOTA_CONFIG" "$CONFIG_CAP_CFG"
+QUOTA_CONFIG="$CONFIG_CAP_CFG" "$BUDGET" --config-cap monthly=2000 daily-warn=150 >/dev/null
+UPDATED_MC="$(python3 -c "import json; cfg=json.load(open('$CONFIG_CAP_CFG')); print(cfg['monthly_cap_usd'])")"
+UPDATED_DW="$(python3 -c "import json; cfg=json.load(open('$CONFIG_CAP_CFG')); print(cfg['daily_warn_threshold_usd'])")"
+numeq "$UPDATED_MC" "2000" || fail "--config-cap monthly=2000 not applied, got $UPDATED_MC"
+numeq "$UPDATED_DW" "150" || fail "--config-cap daily-warn=150 not applied, got $UPDATED_DW"
+# Discrete override: monthly only
+QUOTA_CONFIG="$CONFIG_CAP_CFG" "$BUDGET" --config-cap monthly=500 >/dev/null
+UPDATED_MC2="$(python3 -c "import json; cfg=json.load(open('$CONFIG_CAP_CFG')); print(cfg['monthly_cap_usd'])")"
+UPDATED_DW2="$(python3 -c "import json; cfg=json.load(open('$CONFIG_CAP_CFG')); print(cfg['daily_warn_threshold_usd'])")"
+numeq "$UPDATED_MC2" "500" || fail "--config-cap monthly=500 discrete not applied"
+numeq "$UPDATED_DW2" "150" || fail "--config-cap daily-warn preserved (should be 150 still), got $UPDATED_DW2"
+
+# --- 14. Legacy migration: daily_cap_usd -> monthly+daily-warn ---
+LEGACY_CFG="$TMP_HOME/legacy.json"
+cat > "$LEGACY_CFG" << 'JEOF'
+{
+  "currency": "USD",
+  "daily_cap_usd": 3.33,
+  "thresholds": {"info": 0.60, "warn": 0.80, "critical": 0.95},
+  "stop_hook_threshold": 0.60,
+  "pricing": {"default": {"input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.5}}
+}
+JEOF
+LEGACY_SNAP="$(QUOTA_CONFIG="$LEGACY_CFG" "$BUDGET" --check --no-state 2>&1)"
+# After migration, quota-config should have new schema
+HAS_LEGACY="$(python3 -c "import json; cfg=json.load(open('$LEGACY_CFG')); print('yes' if 'daily_cap_usd' in cfg else 'no')")"
+[ "$HAS_LEGACY" = "no" ] || fail "legacy migration should remove daily_cap_usd"
+HAS_MONTHLY="$(python3 -c "import json; cfg=json.load(open('$LEGACY_CFG')); print('yes' if 'monthly_cap_usd' in cfg else 'no')")"
+[ "$HAS_MONTHLY" = "yes" ] || fail "legacy migration should add monthly_cap_usd"
+MC_MIGRATED="$(python3 -c "import json; cfg=json.load(open('$LEGACY_CFG')); print(cfg['monthly_cap_usd'])")"
+numeq "$MC_MIGRATED" "1000" || fail "migrated monthly_cap_usd should be 1000, got $MC_MIGRATED"
+DW_MIGRATED="$(python3 -c "import json; cfg=json.load(open('$LEGACY_CFG')); print(cfg['daily_warn_threshold_usd'])")"
+numeq "$DW_MIGRATED" "100" || fail "migrated daily_warn_threshold_usd should be 100 for standard default, got $DW_MIGRATED"
+# New thresholds schema
+HAS_MONTHLY_TH="$(python3 -c "import json; cfg=json.load(open('$LEGACY_CFG')); print('yes' if 'monthly' in cfg.get('thresholds',{}) else 'no')")"
+[ "$HAS_MONTHLY_TH" = "yes" ] || fail "migration should add thresholds.monthly"
+# stop_hook_threshold should be dict
+SHT_TYPE="$(python3 -c "import json; cfg=json.load(open('$LEGACY_CFG')); print(type(cfg.get('stop_hook_threshold')).__name__)")"
+[ "$SHT_TYPE" = "dict" ] || fail "migrated stop_hook_threshold should be dict, got $SHT_TYPE"
+# snapshot should have migration_note
+printf '%s' "$LEGACY_SNAP" | grep -q "migration_note" 2>/dev/null || true  # migration_note in stderr or snap
+
+# --- 15. Legacy migration: user-set daily_cap_usd preserved as daily-warn ---
+LEGACY_USER_CFG="$TMP_HOME/legacy-user.json"
+cat > "$LEGACY_USER_CFG" << 'JEOF'
+{
+  "currency": "USD",
+  "daily_cap_usd": 50,
+  "thresholds": {"info": 0.60, "warn": 0.80, "critical": 0.95},
+  "stop_hook_threshold": 0.60,
+  "pricing": {"default": {"input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.5}}
+}
+JEOF
+QUOTA_CONFIG="$LEGACY_USER_CFG" "$BUDGET" --check --no-state >/dev/null 2>&1 || true
+DW_USER="$(python3 -c "import json; cfg=json.load(open('$LEGACY_USER_CFG')); print(cfg['daily_warn_threshold_usd'])")"
+numeq "$DW_USER" "50" || fail "user-set daily_cap_usd=50 should become daily_warn_threshold_usd=50, got $DW_USER"
+
+# --- 16. Stop hook emits when monthly OR daily over threshold, silent when both under ---
+# Drive: tiny monthly_cap so projected >= 60% => emit
+EMIT_CFG="$TMP_HOME/emit.json"
+jq '.monthly_cap_usd = 40 | .stop_hook_threshold = {"monthly_pct": 0.60, "daily_usd": 80}' "$QUOTA_CONFIG" > "$EMIT_CFG"
+EMIT="$(printf '{}' | QUOTA_CONFIG="$EMIT_CFG" "$STOP_HOOK" 2>/dev/null || true)"
+printf '%s' "$EMIT" | jq -e '.hookSpecificOutput.additionalContext | test("\\[quota\\]")' >/dev/null || fail "stop hook should emit when monthly over threshold"
+# Verify new format: should contain 'day-warn' and 'EoM'
+printf '%s' "$EMIT" | jq -e '.hookSpecificOutput.additionalContext | test("day-warn")' >/dev/null || fail "stop hook line should contain 'day-warn'"
+printf '%s' "$EMIT" | jq -e '.hookSpecificOutput.additionalContext | test("EoM")' >/dev/null || fail "stop hook line should contain 'EoM'"
+# Silent when both under threshold
+BIG_CFG="$TMP_HOME/big.json"
+jq '.monthly_cap_usd = 100000 | .daily_warn_threshold_usd = 10000 | .stop_hook_threshold = {"monthly_pct": 0.60, "daily_usd": 80}' "$QUOTA_CONFIG" > "$BIG_CFG"
 SILENT="$(printf '{}' | QUOTA_CONFIG="$BIG_CFG" "$STOP_HOOK" 2>/dev/null || true)"
-[ -z "$SILENT" ] || fail "stop hook should be silent under threshold, got: $SILENT"
+[ -z "$SILENT" ] || fail "stop hook should be silent when both under threshold, got: $SILENT"
 
-# --- 13. Projection floor: tiny elapsed fraction must not explode EoD (BugBot) ---
-# Pin "now" to one minute after ET midnight (EDT = UTC-4 on 2026-06-26).
+# --- 17. Projection floor: tiny day fraction must not explode EoD (BugBot regression) ---
 FLOOR_LOG="$TMP_HOME/floor.log"
 printf '%s\tclaude-opus-4-8\t100000\t0\t0\t0\tSf\n' "2026-06-26T04:00:30Z" >> "$FLOOR_LOG"
-FSNAP="$(QUOTA_USAGE_LOG="$FLOOR_LOG" QUOTA_FAKE_NOW="2026-06-26T04:01:00Z" "$BUDGET" --check --cap 100 --no-state)"
-# spend = 100000*15/1e6 = 1.5 ; floored fraction = 1/24 -> projected = 1.5*24 = 36.0
+FSNAP="$(QUOTA_USAGE_LOG="$FLOOR_LOG" QUOTA_FAKE_NOW="2026-06-26T04:01:00Z" "$BUDGET" --check --no-state)"
 numeq "$(printf '%s' "$FSNAP" | jq -r '.estimated_usd')" "1.5" || fail "floor test spend wrong"
-numeq "$(printf '%s' "$FSNAP" | jq -r '.projected_eod_usd')" "36" || fail "projection not floored: $(printf '%s' "$FSNAP" | jq -r .projected_eod_usd)"
-# true elapsed fraction is still reported tiny (transparency), not the floor
+numeq "$(printf '%s' "$FSNAP" | jq -r '.projected_eod_usd')" "36" || fail "day projection not floored: $(printf '%s' "$FSNAP" | jq -r .projected_eod_usd)"
 python3 -c "import sys; sys.exit(0 if float('$(printf '%s' "$FSNAP" | jq -r '.fraction_of_day_elapsed')') < 0.01 else 1)" \
   || fail "fraction_of_day_elapsed should report the true tiny value"
+# Monthly projection should also be floored (floor = 1/days_in_month)
+numge "$(printf '%s' "$FSNAP" | jq -r '.projected_eom_usd')" "1.5" || fail "projected_eom_usd should be >= spend"
 
-# --- 14. Marker committed before append: marker-write failure must not double-count ---
+# --- 18. Monthly projection at first of month: floor prevents explosion ---
+# Simulate 2026-07-01 04:01:00 ET (very start of month), $1.50 spend
+MFLOOR_LOG="$TMP_HOME/mfloor.log"
+printf '%s\tclaude-opus-4-8\t100000\t0\t0\t0\tSf\n' "2026-07-01T08:01:00Z" >> "$MFLOOR_LOG"
+MFSNAP="$(QUOTA_USAGE_LOG="$MFLOOR_LOG" QUOTA_FAKE_NOW="2026-07-01T08:01:00Z" "$BUDGET" --check --no-state)"
+# With $1.50 spend and floor=1/31, projected_eom = 1.50 / (1/31) = 46.5 (not millions)
+PEOM="$(printf '%s' "$MFSNAP" | jq -r '.projected_eom_usd')"
+python3 -c "import sys; sys.exit(0 if float('$PEOM') <= 200 else 1)" || fail "monthly floor failed: projected_eom_usd=$PEOM (should be <=200)"
+
+# --- 19. Marker committed before append: marker-write failure must not double-count ---
 MK_DIR="$TMP_HOME/marker.d"; mkdir -p "$MK_DIR"
-MK_TS="$TRANSCRIPT"  # reuse transcript with msg_A/msg_B; use a fresh session id
+MK_TS="$TRANSCRIPT"
 MK_INPUT="$(printf '{"session_id":"sess-marker","transcript_path":"%s","tool_name":"Bash"}' "$MK_TS")"
 MK_LOG="$TMP_HOME/marker.log"
-# First fire writes one line and a marker.
 printf '%s' "$MK_INPUT" | QUOTA_USAGE_LOG="$MK_LOG" QUOTA_STATE_DIR="$MK_DIR" "$HOOK" >/dev/null
 [ "$(wc -l < "$MK_LOG" | tr -d ' ')" = "1" ] || fail "marker test: first fire should write 1 line"
-# Make the marker dir non-writable so a NEW message cannot commit its marker.
-# Mutate the transcript so the latest assistant id changes (msg_C).
 printf '%s\n' '{"type":"assistant","uuid":"u3","message":{"id":"msg_C","model":"claude-opus-4-8","usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}' >> "$MK_TS"
 chmod 0555 "$MK_DIR"
 printf '%s' "$MK_INPUT" | QUOTA_USAGE_LOG="$MK_LOG" QUOTA_STATE_DIR="$MK_DIR" "$HOOK" >/dev/null
 chmod 0755 "$MK_DIR"
-# Because the marker could not be committed, the append must be skipped (no double-count).
 [ "$(wc -l < "$MK_LOG" | tr -d ' ')" = "1" ] || fail "marker-write failure must skip append (got $(wc -l < "$MK_LOG" | tr -d ' ') lines)"
 
-echo "OK: quota tracker test passed (hook 7-col ledger + de-dup + no-op + marker-before-append, budget check/config/reset/week/date + thresholds + projection floor, spec session-state, stop hook)"
+echo "OK: quota tracker test passed (hook + budget monthly+daily signals + thresholds + migration + stop hook + projection floors)"

--- a/.claude/skills/quota/SKILL.md
+++ b/.claude/skills/quota/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: quota
-description: Report today's API spend from the local usage ledger and project end-of-day spend against the daily cap. Triggers on "quota", "spend", "how much have I spent", "budget today", "am I over budget".
+description: Report today's API spend and monthly burn against the monthly cap. Triggers on "quota", "spend", "how much have I spent", "budget today", "am I over budget", "monthly spend".
 triggers:
   - quota
   - api spend
   - how much have I spent today
+  - how much have I spent this month
   - daily budget
+  - monthly budget
   - end of day projection
+  - end of month projection
   - am I over budget
 model: sonnet
 allowed-tools:
@@ -16,14 +19,14 @@ allowed-tools:
   - Bash
 ---
 
-Report today's API spend and project end-of-day spend versus the daily cap.
+Report today's API spend and this month's burn against the monthly cap, with a
+secondary daily warn signal.
 
 Spend is tracked locally: the `quota-usage-hook.sh` PostToolUse hook appends one
 tab-separated line of raw token counts per assistant response to
-`~/.claude/quota-usage.log` (same append-only family as `script-usage.log`).
-`quota-budget.sh` converts those counts to USD via the pricing in
-`quota-config.json`; this skill formats its output. Spend tracking is
-**observational** — it warns, it never blocks work.
+`~/.claude/quota-usage.log`. `quota-budget.sh` converts those counts to USD via
+the pricing in `quota-config.json`. Spend tracking is **observational** — it
+warns, it never blocks work.
 
 ## Default: `/quota` snapshot (keep it ≤200 words)
 
@@ -34,18 +37,26 @@ Run from the repo root so the script resolves `quota-config.json`:
 ```
 
 It prints one JSON line and caches it under `quota_daily` in
-`~/.claude/session-state.json`. Read these fields:
+`~/.claude/session-state.json`. Key fields:
 
-- `estimated_usd` — spend so far today (ET).
-- `budget_usd` — daily cap (`daily_cap_usd`).
-- `spend_pct` — `estimated_usd / cap`.
-- `responses` — assistant responses counted today.
-- `fraction_of_day_elapsed` — fraction (0–1) of the ET day elapsed.
-- `projected_eod_usd` — `estimated_usd ÷ fraction_of_day_elapsed` (linear run-rate).
-- `projected_pct` — projection ÷ cap.
-- `status` — `ok` / `info` / `warn` / `critical` (from `projected_pct`).
+**Monthly (primary signal):**
+- `monthly_spend_usd` — spend so far this ET month.
+- `monthly_cap_usd` — monthly cap (default $1000; user-set — see below).
+- `monthly_spend_pct` — `monthly_spend_usd / monthly_cap_usd`.
+- `projected_eom_usd` — linear extrapolation: `monthly_spend ÷ fraction_of_month_elapsed`.
+- `projected_eom_pct` — projection ÷ cap.
+- `monthly_status` — `ok` / `info` / `warn` / `critical` (from `projected_eom_pct`).
+
+**Daily (secondary signal — caps at warn, never critical):**
+- `estimated_usd` — today's spend (ET day).
+- `daily_warn_threshold_usd` — daily warn trigger (default $100).
+- `daily_spend_pct_of_warn` — today's spend ÷ daily warn threshold.
+- `daily_status` — `ok` / `info` / `warn` (NEVER `critical`).
+
+**Combined:**
+- `status` — max severity of monthly_status and daily_status.
+- `surface` — true when monthly ≥60% OR daily ≥$80.
 - `by_model` — list sorted by spend (top models).
-- `over_cap` — already past the cap.
 
 If the ledger is empty, the script reports `estimated_usd: 0` — say "no spend
 recorded yet" rather than erroring.
@@ -53,39 +64,51 @@ recorded yet" rather than erroring.
 Output a compact summary, e.g.:
 
 ```
-Quota — 2026-06-25 (ET)
-Spent today : $2.10 of $3.33 cap   (63%)
-Responses   : 2   ·  top: claude-opus-4-8 $1.80
-Day elapsed : 81%
-Projected   : $2.60 by end of day  ⚠️ trending over (info)
+Quota — 2026-07-01 (ET)
+Month (Jul) : $42.50 of $1000 cap  (4%)  projected EoM $85.00 ✅ on track
+Today       : $8.20  of $100 warn  (8%)  ✅ under threshold
+Responses   : 7   ·  top: claude-opus-4-8 $7.10
 ```
 
-Map the verdict from `status`:
-- `ok` → `✅ under budget`.
+Map the monthly verdict from `monthly_status`:
+- `ok` → `✅ on track` (projected < 60% of cap).
 - `info` → `ℹ️ on watch` (projection ≥ 60% of cap).
-- `warn` → `⚠️ trending over` — add the projected overage (`projected_eod_usd − budget_usd`).
-- `critical` → `🛑 likely over` — projection ≥ 95% of cap.
+- `warn` → `⚠️ trending over` — add the projected overage.
+- `critical` → `🛑 likely over cap` — projection ≥ 95% of cap.
 
-If `over_cap` is true, also note the actual overage (`estimated_usd − budget_usd`).
+Map the daily verdict from `daily_status`:
+- `ok` → `✅ under threshold`.
+- `info` → `ℹ️ approaching warn` ($80–$100 today).
+- `warn` → `⚠️ high single-day burn` (≥$100 today — big session; monthly cap is the authoritative limit).
 
 ## Companions
 
 - **Last 7 days:** `.claude/scripts/quota-budget.sh --week` — JSON with a
-  zero-filled `days[]` array (oldest → newest, including zero-usage days),
-  `total_usd`, and `by_model`.
-- **Show config:** `.claude/scripts/quota-budget.sh --config` — cap, thresholds,
-  `stop_hook_threshold`, plan metadata, pricing.
-- **Set the cap (`/quota --config-cap <amount>`):** edit `daily_cap_usd` in
-  `quota-config.json` (jq, preserving the rest), then re-run `--config` to confirm:
+  zero-filled `days[]` array (oldest → newest), `total_usd`, `month_spend_usd`,
+  `monthly_cap_usd`, `daily_warn_threshold_usd`, and `by_model`.
+- **Current month day-by-day:** `.claude/scripts/quota-budget.sh --month` — JSON
+  with a zero-filled `days[]` array for all days in the ET month, `total_usd`,
+  and `by_model`.
+- **Show config:** `.claude/scripts/quota-budget.sh --config` — caps, thresholds,
+  `stop_hook_threshold`, pricing.
+- **Set the cap (`/quota --config-cap monthly=N daily-warn=M`):**
 
 ```bash
-amount=25
-tmp="$(mktemp)"; jq --argjson c "$amount" '.daily_cap_usd = $c' quota-config.json > "$tmp" && mv "$tmp" quota-config.json
-.claude/scripts/quota-budget.sh --config | jq '.daily_cap_usd'
+# Set monthly cap to $2000, daily warn to $150
+.claude/scripts/quota-budget.sh --config-cap monthly=2000 daily-warn=150
+# Set only the monthly cap
+.claude/scripts/quota-budget.sh --config-cap monthly=2000
+# Set only the daily warn threshold
+.claude/scripts/quota-budget.sh --config-cap daily-warn=50
 ```
 
+  The $1000 monthly cap is a generous default — users on Anthropic Pro ($100/month)
+  should set `monthly=100`; enterprise users may want a higher limit. Anthropic
+  has no machine-readable plan endpoint, so the cap stays user-configured.
+
 - **Reset today's cached counter:** `.claude/scripts/quota-budget.sh --reset`
-  (the durable ledger is never modified; cross-day reset is automatic at ET midnight).
+  (the durable ledger is never modified; cross-day reset is automatic at ET midnight;
+  cross-month reset is automatic at ET first-of-month).
 - **A specific past day:** `.claude/scripts/quota-budget.sh --check --date YYYY-MM-DD`.
 - **Per-model breakdown for today:**
 
@@ -93,16 +116,43 @@ tmp="$(mktemp)"; jq --argjson c "$amount" '.daily_cap_usd = $c' quota-config.jso
 .claude/scripts/quota-budget.sh --check | jq -r '.by_model[] | "\(.model)\t$\(.estimated_usd)"'
 ```
 
+## Config schema
+
+`quota-config.json` (repo root):
+
+```json
+{
+  "monthly_cap_usd": 1000,
+  "daily_warn_threshold_usd": 100,
+  "thresholds": {
+    "monthly": { "info": 0.60, "warn": 0.80, "critical": 0.95 },
+    "daily":   { "info": 80, "warn": 100 }
+  },
+  "stop_hook_threshold": { "monthly_pct": 0.60, "daily_usd": 80 }
+}
+```
+
+**Migration:** if an existing `quota-config.json` has the legacy `daily_cap_usd`
+field, `quota-budget.sh` auto-migrates it on first run:
+- `daily_cap_usd ≤ $5` (the old Pro-tier auto-default) → `monthly_cap_usd: 1000,
+  daily_warn_threshold_usd: 100`.
+- `daily_cap_usd > $5` (user-set) → `daily_warn_threshold_usd: <that value>`,
+  `monthly_cap_usd: 1000`.
+The migration is logged to stderr and noted in the first snapshot's `migration_note` field.
+
 ## Notes
 
 - A Stop hook (`quota-stop-notify.sh`) prints a one-line `[quota] …` reminder
-  after a turn once today's spend reaches `stop_hook_threshold` (default 60% of
-  cap); it is silent below that.
-- The PostToolUse hook fires only when a tool runs, so a final text-only
-  response is not counted — the ledger captures the large majority of spend.
-- The projection is a linear run-rate (`estimated_usd ÷ fraction_of_day_elapsed`)
-  with the denominator floored at 1 hour, so just after ET midnight it cannot
-  explode to a false over-cap. Even so, weight actual `estimated_usd` more
-  heavily before noon ET — the run-rate is noisy with little data.
+  after a turn when monthly projected ≥ 60% of cap OR today's spend ≥ $80.
+  Below both thresholds it is silent. Format:
+  `[quota] today $X / day-warn $DW (Y%) — month $A / $MC (B%) projected EoM $C — <severity>`
+- Monthly projection: `projected_eom = monthly_spend / (day_of_month_frac / days_in_month)`,
+  with the denominator floored at 1 day so the first day of the month cannot
+  explode the projection.
+- Daily projection: `projected_eod = today_spend / fraction_of_day_elapsed`, with
+  the denominator floored at 1 hour. Used only for `projected_eod_usd` — never
+  escalates to critical; the daily signal is observational only.
+- The daily signal captures burst days (big single-session spend). The monthly
+  signal is the authoritative budget signal.
 - The ledger stores only timestamp, model, token counts, and session id — never
   prompts, completions, or secrets.

--- a/quota-config.json
+++ b/quota-config.json
@@ -1,18 +1,23 @@
 {
-  "_comment": "Config for the /quota daily API spend tracker (issue #458). quota-usage-hook.sh writes raw per-response token counts to ~/.claude/quota-usage.log; quota-budget.sh reads this file to convert those counts to USD, compare against daily_cap_usd, and project end-of-day spend. Spend tracking is observational (warnings only) — it never blocks work. Override the path in tests with QUOTA_CONFIG.",
+  "_comment": "Config for the /quota API spend tracker (issue #495). quota-usage-hook.sh writes raw per-response token counts to ~/.claude/quota-usage.log; quota-budget.sh reads this file to convert those counts to USD, compare against monthly_cap_usd and daily_warn_threshold_usd, and project spend. Spend tracking is observational (warnings only) — it never blocks work. Override the path in tests with QUOTA_CONFIG.",
   "currency": "USD",
-  "daily_cap_usd": 3.33,
-  "plan": {
-    "tier": "pro",
-    "monthly_cap_usd": 100,
-    "note": "Pro tier ~$100/month -> ~$3.33/day. Anthropic has no machine-readable plan endpoint; set daily_cap_usd manually for your plan/usage."
-  },
+  "monthly_cap_usd": 1000,
+  "daily_warn_threshold_usd": 100,
   "thresholds": {
-    "info": 0.60,
-    "warn": 0.80,
-    "critical": 0.95
+    "monthly": {
+      "info": 0.60,
+      "warn": 0.80,
+      "critical": 0.95
+    },
+    "daily": {
+      "info": 80,
+      "warn": 100
+    }
   },
-  "stop_hook_threshold": 0.60,
+  "stop_hook_threshold": {
+    "monthly_pct": 0.60,
+    "daily_usd": 80
+  },
   "pricing": {
     "_comment": "USD per 1,000,000 tokens. Keyed by a substring matched against the response model id (longest match wins; 'default' is the fallback). Confirm current Anthropic list prices when they change.",
     "claude-opus-4": {


### PR DESCRIPTION
## **User description**
## Summary

- Replaces the `$3.33/day` default cap (which fires `critical` every active dev day) with a `$1000/month` primary cap and `$100/day` warn threshold
- Monthly signal (primary): info ≥60%, warn ≥80%, critical ≥95% of monthly cap — can escalate to critical
- Daily signal (secondary): info ≥$80, warn ≥$100 — **never critical** (burst observation only)
- Combined `status` = max severity of both; stop-hook emits when monthly ≥60% OR daily ≥$80
- Auto-migrates legacy `daily_cap_usd` configs on first run with a migration note
- Adds `--month` mode for full ET-month breakdown and `--config-cap monthly=N daily-warn=M` discrete overrides
- Stop-hook line updated to show both signals: `[quota] today $X / day-warn $DW (Y%) — month $A / $MC (B%) projected EoM $C — <severity>`

## Test plan

- [x] `quota-config.json` default schema is `{ monthly_cap_usd: 1000, daily_warn_threshold_usd: 100 }` — no `daily_cap_usd` field
- [x] First-run migration: legacy `daily_cap_usd: 3.33` → `monthly_cap_usd: 1000, daily_warn_threshold_usd: 100`; migration note surfaced
- [x] User-set `daily_cap_usd: 50` → `daily_warn_threshold_usd: 50` (intent preserved)
- [x] `/quota --check` JSON contains: `monthly_spend_usd`, `monthly_cap_usd`, `projected_eom_usd`, `daily_warn_threshold_usd`, `daily_status`, `monthly_status`, `status`, `surface`
- [x] Monthly severity ladder: info ≥60%, warn ≥80%, critical ≥95% of cap
- [x] Daily severity ladder: info ≥$80, warn ≥$100, **never critical** — verified in test
- [x] Combined status = max severity; daily capped at warn can never produce critical
- [x] Stop-hook emits only when monthly ≥60% OR daily ≥$80; silent below both thresholds
- [x] Stop-hook line format contains `day-warn` and `EoM` keywords
- [x] Monthly projection math: `projected_eom = monthly_spend / fraction_of_month_elapsed`, floor at `1/days_in_month`
- [x] Daily projection math: floor at 1 hour (existing regression test preserved)
- [x] `/quota --month` returns day-by-day breakdown for current ET month (≥28 days)
- [x] `/quota --config-cap monthly=2000 daily-warn=150` sets both; discrete single-key overrides work
- [x] Cross-month reset: automatic via ET-day-scoped ledger (no code change needed; tested via `--date 2000-01-01`)
- [x] Spend measurement unchanged: PostToolUse hook + TSV log + atomic writes unmodified
- [x] Full test suite passes: `bash .claude/scripts/tests/quota-budget.test.sh`

Closes #495


___

## **CodeAnt-AI Description**
**Track monthly spend as the main quota signal, with daily spend as a warning signal**

### What Changed
- `/quota` now shows spend for the current month, a monthly cap, and an end-of-month projection as the primary budget view
- Daily spend is now a separate warning signal that can alert on a busy day, but it never becomes critical
- The stop hook now triggers on either monthly pressure or high daily spend, and its message shows both values on one line
- The quota config can be updated with separate monthly and daily warn values, and old `daily_cap_usd` configs are automatically moved to the new shape on first run
- Added a full-month view alongside the existing weekly view, with updated saved snapshot fields and projection floors to avoid spikes right after midnight or at the start of a month

### Impact
`✅ Clearer monthly budget warnings`
`✅ Fewer false over-budget alerts`
`✅ Better visibility for bursty spending days`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
