### PR TITLE
docs(adherence): prohibit inline resolveReviewThread; mandate resolve-review-threads.sh

### DIFF
--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -82,10 +82,12 @@ Exit codes: `0` inline reply posted; `1` fallback PR-level reply posted (still a
 
 After replying, resolve **only** the threads whose first-comment author is `coderabbitai`, `cursor`, or `greptile-apps` (the bots you actually handled in Step 2). Do NOT resolve threads authored by human reviewers or other bots — those may be active discussion threads unrelated to your fix work.
 
-Use the shared helper (falls back to `minimizeComment` if `resolveReviewThread` fails):
+Use the shared helper — **NEVER call `resolveReviewThread` inline**. Always use:
 
 ```bash
 bash .claude/scripts/resolve-review-threads.sh {{PR_NUMBER}}
+# or, when you already have thread IDs from a prior gh api call:
+bash .claude/scripts/resolve-review-threads.sh {{PR_NUMBER}} --thread-ids <id1,id2>
 ```
 
 The script defaults to `--authors coderabbitai,cursor,greptile-apps`. If a thread's first-comment author is anything other than those logins (e.g., a human reviewer), the script leaves it alone. Exit 1 means at least one thread failed both mutations — still write the Step 6 handoff file (include `"notes": "thread resolution partial failure"` so Phase B knows), then report the failure to the parent. Do not proceed to Phase B with unresolved bot threads.

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -241,7 +241,7 @@ jq '.check_runs.in_progress_runs' "$STATE"
 1. Verify each finding against actual code before fixing
 2. Fix ALL valid findings in one commit, push once
 3. Reply to every thread (CR: include `@coderabbitai`; BugBot: plain text only, no `@cursor`; Greptile: plain text only, no `@greptileai`)
-4. Resolve threads via GraphQL
+4. Resolve threads via `resolve-review-threads.sh` — **NEVER call `resolveReviewThread` inline**; use `bash .claude/scripts/resolve-review-threads.sh {{PR_NUMBER}} --thread-ids <id1,id2>` (or `--thread-ids-file`)
 5. Resume polling
 
 > **"Duplicate" findings are NOT resolved.** Always verify against actual code before dismissing.

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -119,7 +119,11 @@ CodeAnt and Graphite are parallel supplements; the primary chain stays CR → Bu
 1. Fetch latest CR comments via `gh api`, verify each finding against the actual file
 2. Fix **all valid findings**, commit and push **once**
 3. **Reply to every thread** ("Fixed in `abc1234`: <what changed>"). Try inline reply; on 404, PR-level comment with `@coderabbitai Fixed in ...`
-4. **Resolve each thread via GraphQL** after replying — replies alone don't resolve threads. Use `resolveReviewThread(threadId)`; fallback: `minimizeComment(subjectId, classifier: RESOLVED)`. Full mutations: `.claude/reference/graphql-thread-resolution.md`
+4. **Resolve each thread via the shared helper** — **NEVER call `resolveReviewThread` inline** (e.g., `for TID in ...; do gh api graphql ...; done`). Always use:
+   ```bash
+   bash .claude/scripts/resolve-review-threads.sh <PR> --thread-ids <id1,id2>
+   ```
+   or `--thread-ids-file <file>` for a list. The script handles retries and the `minimizeComment` fallback. Full mutations: `.claude/reference/graphql-thread-resolution.md`
 5. **Re-query `pullRequest.reviewThreads` and verify every touched thread has `isResolved: true`** before requesting a new review. Retry with the minimize fallback; surface any still-dangling URLs — do not declare success.
 6. Resume polling; repeat until CR has no more findings
 

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -544,6 +544,8 @@ THREAD_RESOLUTION_OUTPUT=$(bash .claude/scripts/resolve-review-threads.sh "$PR_N
 echo "$THREAD_RESOLUTION_OUTPUT"
 ```
 
+> **NEVER call `resolveReviewThread` inline** (e.g., `for TID in ...; do gh api graphql resolveReviewThread ...; done`). Always use `resolve-review-threads.sh <PR> --thread-ids <id1,id2>` (or `--thread-ids-file`). The script handles retries and the `minimizeComment` fallback automatically.
+
 **Unchanged-line threads:** GitHub only auto-resolves a review thread when the **exact** commented line changes. If `/fixpr` fixed the issue by editing nearby code (or declined/OBE), the thread can stay `isResolved: false` after Step 4b until the script runs `resolveReviewThread` / `minimizeComment` on that thread id. The explicit `--thread-ids-file` set forces resolution for **every** addressed thread, not only those GitHub auto-closed.
 
 The script re-fetches `pullRequest.reviewThreads` via GraphQL after each mutation pass and again before exit. For any touched thread still reporting `isResolved: false`, it retries `resolveReviewThread` and falls back to `minimizeComment(classifier: RESOLVED)`. Exit codes: `0` means every touched thread was verified resolved; `1` means at least one dangling thread remains and `/fixpr` must not declare success; `3` PR not found; `4` gh error. It prints `[VERIFY] addressed=N resolved=M dangling=K` plus `[STUCK]` lines with URLs/reasons for every dangling thread.


### PR DESCRIPTION
## **User description**
## Summary

- Add explicit hard rule to `cr-github-review.md` "Processing CR Feedback" Step 4: **never call `resolveReviewThread` inline** — always use `resolve-review-threads.sh <PR> --thread-ids <id1,id2>` (or `--thread-ids-file`)
- Add the same prohibition to `fixpr/SKILL.md` Step 4b, immediately after the `resolve-review-threads.sh` invocation block
- Add the same prohibition to `phase-a-fixer.md` Step 5 and `phase-b-reviewer.md` "Processing Findings" step 4, which are the two phase agent definitions most likely to compose inline mutations

The `--thread-ids-stdin` flag from the issue spec is noted as a follow-up — the existing `--thread-ids` and `--thread-ids-file` flags already cover the identified bypass pattern, and adding stdin support is a separate script change with its own testing surface.

Closes #489

## Test plan

- [x] `cr-github-review.md` Step 4 explicitly prohibits inline `resolveReviewThread` mutations and mandates `resolve-review-threads.sh <PR> --thread-ids`
- [x] `fixpr/SKILL.md` Step 4b has the explicit prohibition immediately after the script invocation block
- [x] `phase-a-fixer.md` Step 5 has the explicit prohibition and shows `--thread-ids` as the path when IDs are already known
- [x] `phase-b-reviewer.md` "Processing Findings" step 4 names `resolve-review-threads.sh` with `--thread-ids` instead of bare "GraphQL"
- [x] Rule corpus word count is within the ratchet cap (11,374 / 11,692 after edits)


___

## **CodeAnt-AI Description**
**Require review threads to be resolved through the shared script, not inline GraphQL calls**

### What Changed
- Review and fix workflows now instruct users to resolve threads with `resolve-review-threads.sh` instead of calling `resolveReviewThread` directly
- The guidance now calls out that the script should be used with thread IDs or a file of thread IDs when threads are already known
- The docs now state that the script handles retries and fallback resolution automatically

### Impact
`✅ Fewer unresolved review threads`
`✅ Clearer thread-closing steps`
`✅ Safer review cleanup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>