### PR TITLE
fix(setup): parse hook command argv0 in Step 7 + find_existing_hook (#507)

### DIFF
--- a/setup-skills-worktree.sh
+++ b/setup-skills-worktree.sh
@@ -295,6 +295,30 @@ hooks = settings["hooks"]
 def command_path(script_name):
     return os.path.join(hooks_dir, script_name)
 
+def command_parts(cmd):
+    """Tokenize a hook command into argv, ignoring nothing. Returns [] for a
+    non-string command (malformed settings.json) and falls back to a whitespace
+    split when the command is not valid shell syntax."""
+    if not isinstance(cmd, str):
+        return []
+    try:
+        return shlex.split(cmd)
+    except ValueError:
+        return cmd.split()
+
+def command_argv0(cmd):
+    """Return the executable path from a hook command, ignoring any arguments
+    (e.g. 'foo.sh --check' -> 'foo.sh')."""
+    parts = command_parts(cmd)
+    return parts[0] if parts else ""
+
+def command_args_tail(cmd):
+    """Return the argument portion of a hook command (everything after argv0),
+    reconstructed as a shell-safe string, or '' when there are no arguments.
+    Lets path migration fix the executable path without dropping the args."""
+    parts = command_parts(cmd)
+    return " ".join(shlex.quote(p) for p in parts[1:])
+
 def is_placeholder_path(path):
     """Detect placeholder paths from global-settings.json templates."""
     return "/path/to/" in path or not os.path.isabs(path)
@@ -321,12 +345,16 @@ def find_existing_hook(event_entries, cmd_path, matcher):
         for h in hook_list:
             if not isinstance(h, dict):
                 continue
-            existing_cmd = h.get("command", "")
-            if os.path.basename(existing_cmd) != basename:
+            # Compare by argv0 so an args-bearing registration (e.g.
+            # "foo.sh --check") still matches its manifest entry — the raw
+            # command string would basename to "--check" and never match,
+            # duplicating the hook or stripping its args on migration.
+            existing_argv0 = command_argv0(h.get("command", ""))
+            if os.path.basename(existing_argv0) != basename:
                 continue
-            if is_placeholder_path(existing_cmd):
+            if is_placeholder_path(existing_argv0):
                 return ("placeholder", h)
-            if existing_cmd == cmd_path:
+            if existing_argv0 == cmd_path:
                 return ("exact", None)
             # Same script name, different valid path — needs migration
             return ("migrate", h)
@@ -355,16 +383,12 @@ for item in manifest:
     if status == "exact":
         already_present.append(script)
         continue
-    elif status == "migrate":
-        # Update path in-place (e.g., root-repo -> skills-worktree)
-        old_path = hook_ref["command"]
-        hook_ref["command"] = cmd
-        hook_ref["timeout"] = timeout
-        migrated.append(script)
-        continue
-    elif status == "placeholder":
-        # Replace placeholder with real path in-place
-        hook_ref["command"] = cmd
+    elif status in ("migrate", "placeholder"):
+        # Fix the executable path in-place (root-repo -> skills-worktree, or
+        # placeholder -> real path) while preserving any args the registration
+        # carried, so migration never silently drops "foo.sh --check" -> "foo.sh".
+        args_tail = command_args_tail(hook_ref.get("command", ""))
+        hook_ref["command"] = f"{cmd} {args_tail}" if args_tail else cmd
         hook_ref["timeout"] = timeout
         migrated.append(script)
         continue
@@ -402,16 +426,6 @@ managed_hook_roots = {
     for root in (hooks_dir, os.environ.get("MANAGED_LEGACY_HOOKS_DIR", ""))
     if root
 }
-
-def command_argv0(cmd):
-    """Return the executable path from a hook command, ignoring any arguments
-    (e.g. 'foo.sh --check' -> 'foo.sh'). Falls back to whitespace split if the
-    command is not valid shell syntax."""
-    try:
-        parts = shlex.split(cmd)
-    except ValueError:
-        parts = cmd.split()
-    return parts[0] if parts else ""
 
 def is_managed_hooks_path(path):
     return os.path.normpath(os.path.dirname(path)) in managed_hook_roots

--- a/setup.sh
+++ b/setup.sh
@@ -381,13 +381,16 @@ echo "Step 7: Verifying hook registration..."
 # setup-skills-worktree.sh Step 6 should have registered all hooks.
 # Verify that hook paths exist, are executable, and point to the skills worktree.
 hook_verify_errors=0
-while IFS= read -r hook_path; do
-  [[ -z "$hook_path" ]] && continue
-  if [[ ! -f "$hook_path" ]]; then
-    echo "  ERROR: Hook not found: $hook_path" >&2
+while IFS=$'\t' read -r hook_kind hook_value; do
+  [[ -z "$hook_kind" ]] && continue
+  if [[ "$hook_kind" == "invalid" ]]; then
+    echo "  ERROR: Hook has invalid command value: $hook_value" >&2
     hook_verify_errors=$((hook_verify_errors + 1))
-  elif [[ ! -x "$hook_path" ]]; then
-    echo "  ERROR: Hook not executable: $hook_path" >&2
+  elif [[ ! -f "$hook_value" ]]; then
+    echo "  ERROR: Hook not found: $hook_value" >&2
+    hook_verify_errors=$((hook_verify_errors + 1))
+  elif [[ ! -x "$hook_value" ]]; then
+    echo "  ERROR: Hook not executable: $hook_value" >&2
     hook_verify_errors=$((hook_verify_errors + 1))
   fi
 done < <(python3 - "$SETTINGS_DST" <<'PYTHON_HOOK_PATHS'
@@ -397,6 +400,14 @@ with open(sys.argv[1]) as f:
 hooks = data.get("hooks", {})
 if not isinstance(hooks, dict):
     sys.exit(0)
+# Emit one TAB-separated "kind<TAB>value" record per command-type hook:
+#   path<TAB><argv0>    -> caller checks the executable exists and is runnable
+#   invalid<TAB><repr>  -> malformed command value; caller counts a failure
+# Verify the executable path (argv0), not the whole command string, so a hook
+# registered with args ("foo.sh --check") is not misread as a bare path. A
+# command-type hook whose command is missing, blank, non-string, or all
+# whitespace is malformed and must FAIL verification — Step 7 verifies hook
+# registrations, so silently skipping an unusable entry would report a false pass.
 for event_entries in hooks.values():
     if not isinstance(event_entries, list):
         continue
@@ -404,19 +415,20 @@ for event_entries in hooks.values():
         if not isinstance(group, dict):
             continue
         for hook in group.get("hooks", []):
-            if isinstance(hook, dict) and hook.get("type") == "command":
-                cmd = hook.get("command", "")
-                if not isinstance(cmd, str) or not cmd:
-                    continue
-                # Verify the executable path, not the whole command string —
-                # a hook registered with args (e.g. "foo.sh --check") must not
-                # be misread as a bare filesystem path that never exists.
-                try:
-                    argv = shlex.split(cmd)
-                except ValueError:
-                    argv = cmd.split()
-                if argv:
-                    print(argv[0])
+            if not isinstance(hook, dict) or hook.get("type") != "command":
+                continue
+            cmd = hook.get("command", "")
+            if not isinstance(cmd, str) or not cmd:
+                print(f"invalid\t{cmd!r}")
+                continue
+            try:
+                argv = shlex.split(cmd)
+            except ValueError:
+                argv = cmd.split()
+            if argv:
+                print(f"path\t{argv[0]}")
+            else:
+                print(f"invalid\t{cmd!r}")
 PYTHON_HOOK_PATHS
 )
 

--- a/setup.sh
+++ b/setup.sh
@@ -391,7 +391,7 @@ while IFS= read -r hook_path; do
     hook_verify_errors=$((hook_verify_errors + 1))
   fi
 done < <(python3 - "$SETTINGS_DST" <<'PYTHON_HOOK_PATHS'
-import json, sys
+import json, shlex, sys
 with open(sys.argv[1]) as f:
     data = json.load(f)
 hooks = data.get("hooks", {})
@@ -406,8 +406,17 @@ for event_entries in hooks.values():
         for hook in group.get("hooks", []):
             if isinstance(hook, dict) and hook.get("type") == "command":
                 cmd = hook.get("command", "")
-                if cmd:
-                    print(cmd)
+                if not isinstance(cmd, str) or not cmd:
+                    continue
+                # Verify the executable path, not the whole command string —
+                # a hook registered with args (e.g. "foo.sh --check") must not
+                # be misread as a bare filesystem path that never exists.
+                try:
+                    argv = shlex.split(cmd)
+                except ValueError:
+                    argv = cmd.split()
+                if argv:
+                    print(argv[0])
 PYTHON_HOOK_PATHS
 )
 

--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -388,18 +388,18 @@ print('Seeded stale + external + args hook registrations')
   assert "settings.json still valid JSON" "python3 -c \"import json; json.load(open('$HOME/.claude/settings.json'))\""
   assert "Active hook still registered (trust-flag-repair.sh)" "grep -q 'trust-flag-repair.sh' '$HOME/.claude/settings.json'"
 
-  # setup.sh Step 7 checks each hook command as a raw path, so the intentionally
-  # seeded test artifacts (the non-managed external hook, and the args-bearing
-  # entry whose literal string is not a file) would trip it. Remove both before
-  # the full setup run so the suite ends green — the prune assertions above have
-  # already verified the behavior under test.
+  # setup.sh Step 7 now extracts argv0 from each hook command, so the args-bearing
+  # entry (whose argv0 trust-flag-repair.sh IS a real file) must pass a full setup
+  # run untouched. Only the non-managed external hook — whose argv0 file genuinely
+  # does not exist — would (correctly) trip Step 7, so remove just that one
+  # artifact and keep the args-bearing entry to exercise the argv0 path check.
   python3 -c "
 import json
 path = '$HOME/.claude/settings.json'
 with open(path, encoding='utf-8') as f:
     data = json.load(f)
 def is_artifact(cmd):
-    return 'external-hook.sh' in cmd or 'trust-flag-repair.sh --check' in cmd
+    return 'external-hook.sh' in cmd
 for ev, groups in list(data.get('hooks', {}).items()):
     groups[:] = [g for g in groups
                  if not any(is_artifact(h.get('command', '')) for h in g.get('hooks', []))]
@@ -407,11 +407,15 @@ with open(path, 'w', encoding='utf-8') as f:
     json.dump(data, f, indent=2)
 "
 
-  # Full setup.sh now passes Step 7 (no missing hook paths)
+  # Full setup.sh passes Step 7 even with the args-bearing hook still registered:
+  # Step 7 checks argv0 (the real trust-flag-repair.sh), not the raw command.
   local output exit_code
   output=$(run_setup)
   exit_code=$?
-  assert "setup.sh exits 0 after prune" "[ $exit_code -eq 0 ]"
+  echo "$output" | tail -40
+  assert "setup.sh exits 0 with args-bearing hook registered" "[ $exit_code -eq 0 ]"
+  # Step 7 tolerated the args-bearing hook — it survives the full setup run.
+  assert "Args-bearing hook survives full setup (Step 7 checks argv0)" "grep -q 'trust-flag-repair.sh --check' '$HOME/.claude/settings.json'"
 }
 
 # ── Main ─────────────────────────────────────────────────────────────────────

--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -416,6 +416,36 @@ with open(path, 'w', encoding='utf-8') as f:
   assert "setup.sh exits 0 with args-bearing hook registered" "[ $exit_code -eq 0 ]"
   # Step 7 tolerated the args-bearing hook — it survives the full setup run.
   assert "Args-bearing hook survives full setup (Step 7 checks argv0)" "grep -q 'trust-flag-repair.sh --check' '$HOME/.claude/settings.json'"
+
+  # Negative case (#507): a command-type hook with a blank/non-string command is
+  # malformed. Step 7 must FLAG it as a verification failure, not silently skip it
+  # — otherwise setup.sh reports success on an unusable registration. Seed one
+  # under a custom event (not in the manifest, so registration/prune leave it be).
+  python3 -c "
+import json
+path = '$HOME/.claude/settings.json'
+with open(path, encoding='utf-8') as f:
+    data = json.load(f)
+data.setdefault('hooks', {}).setdefault('CustomEvent', []).append(
+    {'hooks': [{'type': 'command', 'command': ''}]})
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(data, f, indent=2)
+"
+  local malformed_out malformed_exit
+  malformed_out=$(run_setup)
+  malformed_exit=$?
+  assert "setup.sh FAILS Step 7 on a malformed (blank) command hook" "[ $malformed_exit -ne 0 ]"
+  assert "Step 7 reports the invalid command value" "printf '%s' \"\$malformed_out\" | grep -qi 'invalid command value'"
+  # Restore a clean state so the suite ends green.
+  python3 -c "
+import json
+path = '$HOME/.claude/settings.json'
+with open(path, encoding='utf-8') as f:
+    data = json.load(f)
+data.get('hooks', {}).pop('CustomEvent', None)
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(data, f, indent=2)
+"
 }
 
 # ── Main ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two places treated a hook's full `command` string as a filesystem path, so any hook registered **with arguments** (e.g. `/abs/.claude/hooks/foo.sh --check`) was mishandled. This applies the same `shlex`-argv0 treatment already used by PR #506's Step 6 prune (`command_argv0`) and the Step 7 drift check, so the whole installer handles argument-bearing hook commands consistently.

**Latent-robustness fix** — no repo hook uses args today.

Closes #507.

## Changes

- **`setup.sh` Step 7** — the hook-path extraction now emits a TAB-separated `kind<TAB>value` record per command-type hook: `path<TAB><argv0>` (checked `-f`/`-x` as before) or `invalid<TAB><repr>` for a malformed command. `argv[0]` is used instead of the raw command, so `foo.sh --check` no longer produces a false "Hook not found".
- **`setup.sh` Step 7 — malformed-command hardening** (CodeAnt on this PR): a command-type hook whose `command` is missing/blank/non-string/whitespace-only is now **flagged as a verification failure** (setup.sh fails Step 7 → exit 1) instead of being silently skipped, which would have reported a false pass on an unusable registration.
- **`setup-skills-worktree.sh` `find_existing_hook()`** — compares by `argv0` for basename/placeholder/exact checks, so an args-bearing registration matches its manifest entry and is not duplicated.
- **`setup-skills-worktree.sh` migrate/placeholder branches** — preserve the arg tail when rewriting the path instead of silently dropping `foo.sh --check` → `foo.sh`.
- **Helpers** — hoisted `command_argv0` above `find_existing_hook` (removed the duplicate in the Step 6 prune); added `command_parts`/`command_args_tail`, guarded against a non-string `command`.
- **`tests/test-setup.sh` Test 8** — keeps the args-bearing hook through the full `run_setup` and asserts Step 7 tolerates it; adds a negative case asserting a blank-command hook makes setup.sh fail Step 7 with an "invalid command value" error.

## Test plan

- [x] `setup.sh` Step 7 extracts `argv0` before the `-f`/`-x` checks; an args-bearing hook whose `argv0` exists passes (validated in isolation).
- [x] Step 7 flags a malformed command value (missing/blank/non-string/whitespace) as a verification failure; valid `path` records still check `-f`/`-x` (validated in isolation: 6/6 error accounting).
- [x] `find_existing_hook` compares by `argv0`; an args-only registration is detected as `exact` (no duplicate) — validated in isolation.
- [x] migrate/placeholder preserve the arg tail; no-arg paths stay bare — validated in isolation.
- [x] `command_argv0`/`command_args_tail` return `""` for a non-string command without crashing — validated in isolation.
- [x] `command_argv0` defined once, above `find_existing_hook`, reused by the Step 6 prune (no duplicate).
- [x] `bash -n` clean on all changed files.
- [ ] Full `tests/test-setup.sh` suite passes end-to-end. **Not run in this environment** — the suite is Docker-only (`clean_slate()` does `rm -rf "$HOME/.claude"`), Docker is unavailable here, and CI's `hook-scripts.yml` does not run it. Changed logic verified via isolated unit harnesses instead.

## Notes

The setup test suite is Docker-only by design and is not part of CI. All changed Python/bash logic was verified with isolated harnesses (argv0 emission, kind/value protocol + malformed flagging, exact/migrate/placeholder matching, arg-tail preservation, non-string guards).