### PR TITLE
docs(prompt): refresh model tier recommendations for Sonnet 5 lineup (#498)

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -40,7 +40,7 @@ Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the par
 
 Each agent definition declares a default `model` in frontmatter. The parent must also set `model` explicitly at every Agent tool call site per `.claude/rules/subagent-orchestration.md` "Model Selection" — the call-site parameter overrides the frontmatter default and keeps cost decisions visible at every spawn point.
 
-**Current alias resolution (verified 2026-06):** `opus` → Opus 4.8, `sonnet` → Sonnet 4.6, `haiku` → Haiku 4.5. Frontmatter intentionally uses bare aliases — Claude Code resolves them to the latest non-legacy model of each family, so agent definitions don't need editing when Anthropic ships a new version. If the runtime ever stops resolving bare aliases, switch frontmatter to explicit versioned IDs (e.g., `claude-opus-4-8`, `claude-sonnet-4-6`) and update this note.
+**Current alias resolution (verified 2026-07):** `opus` → Opus 4.8, `sonnet` → Sonnet 5, `haiku` → Haiku 4.5. Frontmatter intentionally uses bare aliases — Claude Code resolves them to the latest non-legacy model of each family, so agent definitions don't need editing when Anthropic ships a new version. If the runtime ever stops resolving bare aliases, switch frontmatter to explicit versioned IDs (e.g., `claude-opus-4-8`, `claude-sonnet-5`) and update this note.
 
 **Per-phase rationale:**
 

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -35,7 +35,7 @@ If agent definitions are unavailable (e.g., repo without `.claude/agents/`):
 | `pm-worker` | `sonnet` |
 | Read-only review agents (e.g., `/pr-review-help`) | `sonnet` |
 
-Aliases currently resolve to: `opus` = Opus 4.8, `sonnet` = Sonnet 4.6, `haiku` = Haiku 4.5 (resolution notes: `.claude/agents/README.md`).
+Aliases currently resolve to: `opus` = Opus 4.8, `sonnet` = Sonnet 5, `haiku` = Haiku 4.5 (resolution notes: `.claude/agents/README.md`).
 
 Rules: set `model` explicitly on every spawn; call-site value overrides frontmatter. `CLAUDE_CODE_SUBAGENT_MODEL=opus` is only a legacy safety net. If a Sonnet-tier agent underperforms, escalate to `opus` and document why.
 

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -491,7 +491,7 @@ The **user** decides when and where to paste the prompts. The user starts the co
 
 **Model selection for spawned subagents:**
 
-- **Coding subagents** (Phase A/B executing a selected issue): prefer the `/subagent` skill, which already enforces per-phase model selection (`opus` for Phase A/B, `sonnet` for Phase C; these aliases currently resolve to Opus 4.8 and Sonnet 4.6). See `.claude/rules/subagent-orchestration.md` "Model Selection".
+- **Coding subagents** (Phase A/B executing a selected issue): prefer the `/subagent` skill, which already enforces per-phase model selection (`opus` for Phase A/B, `sonnet` for Phase C; these aliases currently resolve to Opus 4.8 and Sonnet 5). See `.claude/rules/subagent-orchestration.md` "Model Selection".
 - **Read-only PM data-gathering subagents** (e.g., scanning GitHub for backlog context, summarizing recent PR activity, reviewing progress on in-flight threads): spawn with `subagent_type: "pm-worker"`, `mode: "bypassPermissions"`, and `model: "sonnet"`. These tasks are template-driven data collection — Sonnet is the right cost tier and the frontmatter default on `pm-worker` matches.
 - **Never omit `model`** at the call site. Explicit model selection keeps cost decisions visible at every spawn point and prevents silent Opus usage for lightweight work.
 

--- a/.claude/skills/pr-review-help/SKILL.md
+++ b/.claude/skills/pr-review-help/SKILL.md
@@ -84,7 +84,7 @@ If a PR doesn't exist, note it in the output and skip. If ALL PR numbers are inv
 
 Spawn one subagent per valid PR using the Agent tool. All subagents run in parallel.
 
-**Each subagent invocation MUST use `mode: "bypassPermissions"` and `model: "sonnet"`** (the `sonnet` alias currently resolves to Sonnet 4.6). This is a read-only strategic review — analysis from a well-defined template, no code modification. Sonnet keeps per-review cost low so parallel portfolio reviews stay economical. See `.claude/rules/subagent-orchestration.md` "Model Selection" for the rationale.
+**Each subagent invocation MUST use `mode: "bypassPermissions"` and `model: "sonnet"`** (the `sonnet` alias currently resolves to Sonnet 5). This is a read-only strategic review — analysis from a well-defined template, no code modification. Sonnet keeps per-review cost low so parallel portfolio reviews stay economical. See `.claude/rules/subagent-orchestration.md` "Model Selection" for the rationale.
 
 **Each subagent prompt must include:**
 - The PR number to analyze (substitute `{NUMBER}` in the template below)

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -8,15 +8,15 @@ triggers:
 argument-hint: "[#123 #124 ...] (issue numbers, or omit for PM auto-detect)"
 ---
 
-Analyze one or more GitHub issues, classify complexity, and produce a copy-paste-ready prompt with a model recommendation. The goal is quality-conservative right-sizing — never under-resource a task, but don't waste Opus 4.8 (1M context) tokens on a typo fix.
+Analyze one or more GitHub issues, classify complexity, and produce a copy-paste-ready prompt with a model recommendation. The goal is quality-conservative right-sizing — never under-resource a task, but don't waste Opus 4.8 tokens on a typo fix.
 
-## Model Lineup & Effort Levels (current as of 2026-06)
+## Model Lineup & Effort Levels (current as of 2026-07)
 
-The Claude Code picker offers: **Sonnet 4.6** (default), **Opus 4.8**, **Opus 4.8 (1M context)**, and **Haiku 4.5**. Opus 4.7 / 4.7 (1M) / 4.6 are Legacy — never recommend them. Bare aliases used elsewhere (agent frontmatter, spawn sites) currently resolve as: `opus` → Opus 4.8, `sonnet` → Sonnet 4.6, `haiku` → Haiku 4.5 (see `.claude/rules/subagent-orchestration.md` "Model Selection" and `.claude/agents/README.md`).
+The Claude Code picker offers: **Sonnet 5** (default), **Opus 4.8**, **Fable 5**, and **Haiku 4.5**. Opus 4.8 (1M context) / Opus 4.7 / Sonnet 4.6 / 4.7 (1M) are Legacy — never recommend them. Opus 4.8 and Sonnet 5 ship with a native 1M context window; there is no separate "(1M context)" picker option. Bare aliases used elsewhere (agent frontmatter, spawn sites) currently resolve as: `opus` → Opus 4.8, `sonnet` → Sonnet 5, `haiku` → Haiku 4.5 (see `.claude/rules/subagent-orchestration.md` "Model Selection" and `.claude/agents/README.md`).
 
-The picker also exposes **effort levels** (`low`, `medium`, `high`, `extra`, `max`, `ultracode`). This skill keeps its internal Heavy/Standard/Light tier vocabulary and decision tree unchanged, and maps each tier to a recommended effort level in the output: **Heavy → `max`**, **Standard → `high`**, **Light → `low`**. Users may adjust within a tier's range — e.g., a Heavy task that needs multi-agent orchestration can step up to `ultracode`; a borderline Standard task can step down to `medium`.
+The picker also exposes **effort levels** (`low`, `medium`, `high`, `xhigh`, `max`, plus session-only `ultracode`). This skill keeps its internal Heavy/Standard/Light tier vocabulary and decision tree unchanged, and maps each tier to a recommended effort level in the output: **Heavy → `max`**, **Standard → `high`**, **Light → `low`**. Users may adjust within a tier's range — e.g., a Heavy task that needs multi-agent orchestration can step up to `ultracode`; a borderline Standard task can step up to `xhigh` or step down to `medium`.
 
-**Fast mode:** the picker has a Fast mode toggle that trades depth for speed. `/prompt` does NOT accept a `--fast` flag and does not factor Fast mode into recommendations — it is a user-toggled picker option. For Light-tier work, **Haiku 4.5** (with or without Fast mode) is a valid cheaper alternative to Sonnet 4.6; the output notes this on Light-tier recommendations. A `--fast` flag is a possible follow-up, not part of this skill.
+**Fast mode:** the picker has a Fast mode toggle that trades depth for speed. `/prompt` does NOT accept a `--fast` flag and does not factor Fast mode into recommendations — it is a user-toggled picker option. For Light-tier work, **Haiku 4.5** (with or without Fast mode) is a valid cheaper alternative to Sonnet 5; the output notes this on Light-tier recommendations. A `--fast` flag is a possible follow-up, not part of this skill.
 
 **MANDATORY OUTPUT FORMAT:** Every per-issue prompt block MUST open and close with `~~~` tilde fences. NEVER use backtick fences as the outer prompt-block delimiter.
 
@@ -131,7 +131,7 @@ Apply this decision tree. When signals conflict, choose the **higher** tier (con
 
 **Batch handling rule:** First classify each issue independently to produce a per-issue tier (`issue_tier`). Then compute a batch tier from the most complex `issue_tier` in the set. A batch of 3 issues where one is Heavy makes the batch tier Heavy. The batch tier is used for thread-prompt output formatting and checkpoint inheritance, while per-issue decisions (like Step 5.5 subagent partitioning) must use `issue_tier`.
 
-### Heavy — Opus 4.8 (1M context), effort `max`
+### Heavy — Opus 4.8, effort `max`
 
 Assign Heavy if ANY of these are true:
 - `touches_rules` is true (rule files are highest-stakes)
@@ -150,7 +150,7 @@ Assign Standard if ANY of these are true (and Heavy was not triggered):
 - Issue body is >200 words with structural patterns (includes a user story, describes a new feature via keywords like "implement", "add", "support")
 - `is_multi_issue` with mixed complexity (at least one non-trivial issue that didn't trigger Heavy)
 
-### Light — Sonnet 4.6 (or Haiku 4.5), effort `low`
+### Light — Sonnet 5 (or Haiku 4.5), effort `low`
 
 Assign Light if ANY of these are true (and Heavy/Standard were not triggered):
 - `file_count` is 0–1
@@ -240,9 +240,9 @@ Rationale: {1-line explanation of why this tier was selected, citing the dominan
 **OUTPUT MUST USE `~~~` FENCES, NOT BACKTICKS.** The opening and closing lines of every per-issue prompt block must be exactly `~~~`.
 
 **Map tier to `{MODEL}` and `{EFFORT}` strings** (same Heavy / Standard / Light mapping for both the batch **Tier Recommendation** line and each per-issue `**Model:**` line — use **batch tier** for Tier Recommendation and **per-issue `issue_tier`** for each block):
-- **Heavy** → `Opus 4.8 (1M context)`, effort `max` (step up to `ultracode` for multi-agent orchestration work)
-- **Standard** → `Opus 4.8`, effort `high`
-- **Light** → `Sonnet 4.6`, effort `low` (Haiku 4.5 is a valid cheaper alternative — append "(or Haiku 4.5)" to Light-tier recommendations)
+- **Heavy** → `Opus 4.8`, effort `max` (step up to `ultracode` for multi-agent orchestration work)
+- **Standard** → `Opus 4.8`, effort `high` (step up to `xhigh` for demanding coding work)
+- **Light** → `Sonnet 5`, effort `low` (Haiku 4.5 is a valid cheaper alternative — append "(or Haiku 4.5)" to Light-tier recommendations)
 
 **`{REASON}` construction:** Choose a short phrase (≤10 words) that names the main complexity driver for **this issue alone** — e.g. touches `.claude/rules`, touches `CLAUDE.md`, orchestration keywords, dependency web, many files from the CR plan, high `ac_count`, skill paths, multi-file feature work, or Light-scope keywords. Do not copy the batch Tier Recommendation rationale into every block when reasons differ per issue.
 

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -474,7 +474,7 @@ worktree directory at all times.
 **Phase C Agent tool call parameters:**
 - `subagent_type: "phase-c-merger"`
 - `mode: "bypassPermissions"`
-- `model: "sonnet"` (currently resolves to Sonnet 4.6; Phase C is lightweight verification plus the mechanical `/wrap` flow — see `subagent-orchestration.md` "Model Selection")
+- `model: "sonnet"` (currently resolves to Sonnet 5; Phase C is lightweight verification plus the mechanical `/wrap` flow — see `subagent-orchestration.md` "Model Selection")
 - `isolation: "worktree"` (same as Phase A — Phase C fetches and checks out the PR branch inside its own fresh worktree)
 - `run_in_background: true`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ These files auto-load for the parent agent session. **Subagents do NOT auto-load
 
 ### Rule File Size Guidelines
 
-Rules load every turn. With the current 1M-token fleet (Opus 4.8, Fable 5, Sonnet 4.6) the corpus is ~1.5% of the window (~$0.015/turn cached on Opus 4.8), so the budget now exists for **instruction adherence and maintainability** — redundant or contradictory rules misfire on literal-following models — not context pressure. Limits apply to CLAUDE.md + `.claude/rules/*.md`:
+Rules load every turn. With the current 1M-token fleet (Opus 4.8, Fable 5, Sonnet 5) the corpus is ~1.5% of the window (~$0.015/turn cached on Opus 4.8), so the budget now exists for **instruction adherence and maintainability** — redundant or contradictory rules misfire on literal-following models — not context pressure. Limits apply to CLAUDE.md + `.claude/rules/*.md`:
 
 - **Soft warning:** 12,000 words.
 - **Ratchet cap:** `.claude/rules/.budget-soft-cap` must equal `max(current_count + 750, 8500)`. `rule-lint.sh` fails when the corpus exceeds this committed cap, independent of soft/hard checks; run `rule-lint.sh --update-cap` only after intentional cuts.


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refreshes `/prompt` model tier recommendations and alias-resolution notes for the current Claude Code lineup, following the same sweep pattern as #459.

**Verification source:** Claude Code [model-config docs](https://code.claude.com/docs/en/model-config) and Anthropic model overview (checked 2026-07).

### Verified lineup changes

| Aspect | Before (#459) | After (verified) |
|--------|---------------|------------------|
| Default model | Sonnet 4.6 | **Sonnet 5** |
| `sonnet` alias | Sonnet 4.6 | **Sonnet 5** |
| Opus 1M context | Separate "Opus 4.8 (1M context)" picker option | **Consolidated** — Opus 4.8 and Sonnet 5 ship native 1M |
| Effort levels | `low/medium/high/extra/max/ultracode` | **`low/medium/high/xhigh/max`** + session-only `ultracode` |
| Picker models | Sonnet 4.6, Opus 4.8, Opus 4.8 (1M), Haiku 4.5 | **Sonnet 5, Opus 4.8, Fable 5, Haiku 4.5** |

### Tier mapping (unchanged shape, updated strings)

- **Heavy** → Opus 4.8, effort `max` (step up to `ultracode` for orchestration)
- **Standard** → Opus 4.8, effort `high` (step up to `xhigh` for demanding coding)
- **Light** → Sonnet 5, effort `low` (Haiku 4.5 as cheaper alternative)

### Files touched

- `.claude/skills/prompt/SKILL.md` — tier table, effort taxonomy, decision-tree headers, mapping restatement
- `.claude/rules/subagent-orchestration.md` — alias resolution note
- `.claude/agents/README.md` — alias resolution note (verified 2026-07)
- `.claude/skills/pm/SKILL.md`, `.claude/skills/pr-review-help/SKILL.md`, `.claude/skills/subagent/SKILL.md` — cross-reference clarifications
- `CLAUDE.md` — fleet parenthetical (Sonnet 4.6 → Sonnet 5)

Agent frontmatter (`model: opus` / `model: sonnet`) confirmed still valid — bare aliases resolve correctly; no frontmatter changes needed.

Closes #498

## Test Plan

- [x] Verified current model lineup and effort levels against Claude Code model-config docs before editing
- [x] `.claude/skills/prompt/SKILL.md` tier table updated — Opus 4.7 / Opus 4.8 (1M context) / Sonnet 4.6 replaced with verified lineup
- [x] Sample outputs in `/prompt` SKILL.md updated to current model strings
- [x] Effort-level taxonomy updated: `extra` → `xhigh`; 5 API levels + session-only `ultracode`
- [x] Sonnet 5 surfaced as Light-tier default; documented in tier table and alias resolution
- [x] `.claude/rules/subagent-orchestration.md` tier-table notes updated
- [x] `.claude/agents/README.md` resolved-model notes updated (verified 2026-07)
- [x] Cross-references in `pm/SKILL.md`, `pr-review-help/SKILL.md`, `subagent/SKILL.md` clarified
- [x] Opus 4.8 "(1M context)" qualifier removed from tier recommendations (consolidated into base Opus 4.8)
- [x] Fast-mode decision from #459 preserved unchanged
- [x] Agent frontmatter confirmed still resolves via bare aliases — no frontmatter edits
- [x] Post-edit grep: `Opus 4.7`, `Opus 4.8 (1M context)`, `Sonnet 4.6` appear only in legacy callouts and untouched `.claude/reference/` snapshots

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c05aebd-e163-4653-b825-57d7f7794f39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c05aebd-e163-4653-b825-57d7f7794f39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Refresh model recommendations and alias notes for the current Claude Code lineup**

### What Changed
- Updated the documented default and alias target from Sonnet 4.6 to Sonnet 5 across prompt, review, PM, and subagent guidance
- Removed the separate “1M context” picker option from the recommendations and noted that Opus 4.8 and Sonnet 5 now include native 1M context
- Updated the effort-level guidance to reflect the current `xhigh` and session-only `ultracode` options
- Reworded model selection notes in the shared docs so spawned subagents use the current lineup

### Impact
`✅ Clearer model recommendations`
`✅ Fewer outdated prompt suggestions`
`✅ Easier subagent setup with current aliases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
