### PR TITLE
docs(pmm): clarify parent vs subagent scope; dispatch CONFLICTING (#524)

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -30,7 +30,7 @@ Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the par
 
 | Agent | Phase | Purpose | Tool Restrictions | Default Model |
 |-------|-------|---------|-------------------|---------------|
-| `phase-a-fixer` | A | Fix findings, push, write handoff | Full access | `opus` |
+| `phase-a-fixer` | A | Fix findings, resolve merge conflicts, push, write handoff | Full access | `opus` |
 | `phase-b-reviewer` | B | Poll reviews, fix findings, update handoff | Full access | `opus` |
 | `phase-c-merger` | C | Verify merge gate and AC, then run `/wrap` when authorized | Read-only + Bash (for `gh`/git) | `sonnet` |
 | `pm-worker` | — | Issue management, repo bootstrap | Full access | `sonnet` |

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -5,7 +5,27 @@ model: opus
 
 # Phase A: Fix + Push
 
-You are a Phase A subagent. Your job: read review findings, fix the code, commit, push, reply to review threads, write a handoff file, and print an exit report. Then EXIT — do not enter a polling loop.
+You are a Phase A subagent. Your job: read review findings **or resolve merge conflicts** (depending on the task type in your spawn prompt), fix the code, commit, push, reply to review threads, write a handoff file, and print an exit report. Then EXIT — do not enter a polling loop.
+
+## Task Types
+
+The parent specifies one of these in your spawn prompt:
+
+1. **`fixpr` (default)** — fix CR/CI review findings per Steps 1-7 below.
+2. **`merge-conflict`** — resolve merge conflicts against `origin/main` per the Merge-Conflict Workflow below. Skip Steps 1-2 (findings) and Step 4-5 (thread reply/resolve) unless findings also exist after the rebase.
+
+## Merge-Conflict Workflow (when `TASK_TYPE: merge-conflict`)
+
+Run the `/merge-conflict` skill workflow:
+
+1. `git fetch origin main`
+2. `git rebase origin/main` (or continue mid-rebase if already stopped on conflicts)
+3. Run `resolve_merge_conflicts.py` from `.claude/skills/merge-conflict/` for safe hunks
+4. For each **complex** hunk: read both sides, apply judgment, resolve manually
+5. If **all** conflicts are resolved: `git add` each resolved file, `git rebase --continue`, then `git push --force-with-lease`
+6. If conflicts are **genuinely unresolvable** (semantic conflict requiring design decision, unresolvable complex-only hunks): abort safely (`git rebase --abort` if mid-rebase), write handoff file with notes, print exit report with `OUTCOME: blocked` and a prose reason above the report block, then EXIT — do NOT force-push a partial resolution
+
+Stay within Safety Rules and the single-commit/push discipline where possible (one rebase resolution = one commit after rebase completes).
 
 ## Runtime Context
 
@@ -132,16 +152,17 @@ PHASE_COMPLETE: A
 PR_NUMBER: {{PR_NUMBER}}
 HEAD_SHA: <pushed commit SHA for pushed_fixes, or current HEAD for no_findings/exhaustion>
 REVIEWER: <cr, bugbot, or greptile>
-OUTCOME: <pushed_fixes|no_findings|exhaustion>
+OUTCOME: <pushed_fixes|no_findings|exhaustion|blocked>
 FILES_CHANGED: <comma-separated file paths, empty if none>
 NEXT_PHASE: <B for pushed_fixes or no_findings, A for exhaustion>
 HANDOFF_FILE: ~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json
 ```
 
 **Valid OUTCOME values for Phase A** (with required `NEXT_PHASE` and `HEAD_SHA` pairing):
-- `pushed_fixes` — findings fixed, code pushed. Set `NEXT_PHASE: B` and `HEAD_SHA` to the new pushed commit SHA.
+- `pushed_fixes` — findings fixed or conflicts resolved, code pushed. Set `NEXT_PHASE: B` and `HEAD_SHA` to the new pushed commit SHA.
 - `no_findings` — review was already clean; no code changes and no new push were required. Set `NEXT_PHASE: B` and `HEAD_SHA` to the current (unchanged) HEAD.
 - `exhaustion` — token budget running low, partial fixes applied. Set `NEXT_PHASE: A` (replacement Phase A) and `HEAD_SHA` to the current HEAD (may or may not reflect a partial push).
+- `blocked` — unresolvable merge conflict or other fix blocker requiring human judgment. Set `NEXT_PHASE: none` and `HEAD_SHA` to the current HEAD. Print a freeform reason above the exit report block explaining why (e.g., semantic conflict in `src/foo.ts` requiring design decision).
 
 ## Token Exhaustion Protocol
 

--- a/.claude/reference/exit-report-format.md
+++ b/.claude/reference/exit-report-format.md
@@ -41,6 +41,7 @@ The three `FIXPR_*` fields are required whenever the phase executed the `/fixpr`
 | A | `pushed_fixes` | Findings fixed, code pushed |
 | A | `no_findings` | Review already clean, code pushed as-is |
 | A | `exhaustion` | Token budget low — partial fixes, replacement needed |
+| A | `blocked` | Unresolvable merge conflict or other fix blocker — needs human judgment (freeform reason above the report) |
 | B | `clean` | Review passed with no findings |
 | B | `fixes_pushed` | Fixed findings, pushed — needs re-review |
 | B | `merge_ready` | All checks green, merge gate satisfied |

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -164,6 +164,15 @@ Before Step 3 re-classifies the fleet, process any **PMM-owned** `phase-a-fixer`
 
 **Initialize `EXHAUSTION_RESPAWN_PRS='[]'` at the start of this step, every tick — never carry it over.** Like `GATE_BY_PR`, it is a plain in-memory variable scoped to the current tick's execution (each `/loop` re-invocation is a fresh run of this skill from Step 1), not a durable field in `session-state.json` — so there is nothing to reset from a *prior* tick's memory, but the step must still start from an explicitly empty list rather than an implicit/undefined one, so a tick with zero exhaustion outcomes never accidentally inherits stale entries from a bug elsewhere in this skill's execution.
 
+**Load persisted hard blocks at tick start** so a `blocked` merge-conflict outcome from a prior tick is not re-dispatched when Step 3 still sees `mergeable == CONFLICTING`:
+
+```bash
+PERSISTED_HARD_BLOCK=$(.claude/scripts/session-state.sh --get '.pmm_hard_block // {}' 2>/dev/null || echo '{}')
+HARD_BLOCK_JSON="$PERSISTED_HARD_BLOCK"   # map PR number → reason; survives across ticks
+```
+
+When Step 2.5 (or Step 5e) adds a PR to `HARD_BLOCK[]`, also persist it: `.claude/scripts/session-state.sh --set ".pmm_hard_block.\"$N\"=\"$REASON\""`. Clear the entry only when the user explicitly approves a respawn or the PR merges/closes (Step 3 sets `VERDICT=gone` → `--set ".pmm_hard_block.\"$N\"=null"`).
+
 For each completed subagent, run steps 1-3 **unconditionally first** (cleanup must finish before any respawn, so a replacement's fresh record can never be clobbered by the completed agent's own removal):
 
 1. **Parse the Structured Exit Report** from its output (`EXIT_REPORT` block per `.claude/reference/exit-report-format.md`). No exit report = silent failure — check GitHub for the PR's current HEAD and surface `failed` in the Subagent column.
@@ -179,7 +188,7 @@ For each completed subagent, run steps 1-3 **unconditionally first** (cleanup mu
    This must be a real read-filter-write, not a no-op comment — Step 3's concurrency cap and idempotency check both count live entries in this array.
 4. **Branch on OUTCOME** (steps 1-3 above are already done, so this branch never races the cleanup):
    - `pushed_fixes` or `no_findings` → verify push SHA matches `HEAD_SHA` in the report (`gh pr view N --json commits --jq '.commits[-1].oid'`). Verify handoff file exists at `~/.claude/handoffs/pr-{N}-handoff.json` with `phase_completed: "A"`. When OUTCOME is `pushed_fixes`, run **Step 5b dismiss helper + Step 5b′ owning-bot re-trigger** on `#N` immediately (same contract as `/fixpr` Steps 3a/3b — a push without dismissal leaves obsolete bot `CHANGES_REQUESTED` on old SHAs and the gate never clears). Step 5e's inline completion path (item 2) runs the same pair when a subagent exits mid-tick.
-   - `blocked` → add `#N` to `HARD_BLOCK[]` with reason from the exit report (e.g. `conflicts(needs-human)` for unresolvable merge conflicts). Report once and drop from the actionable fleet this tick — the subagent already attempted resolution; do not re-dispatch silently.
+   - `blocked` → add `#N` to `HARD_BLOCK[]` with reason from the exit report (e.g. `conflicts(needs-human)` for unresolvable merge conflicts). **Persist** the same reason to `pmm_hard_block` in `session-state.json` (see tick-start load above). Report once and drop from the actionable fleet this tick — the subagent already attempted resolution; do not re-dispatch silently.
    - `exhaustion` → **do not launch the replacement inline here.** Step 2.5 runs before Step 3 every tick, so `GATE_BY_PR`/pre-fetched `FINDINGS_JSON` (both populated in Step 3) are not available yet — Step 5c's full spawn pattern needs them. Instead, rely on step 3 above already clearing this PR's `active_agents`/`pmm_in_flight[N]` entries: the PR falls through into Step 3's classification with a clean slate later in this same tick, and if the underlying condition (CI failing, unresolved threads, stale bot review, merge conflicts) still holds, Step 3 naturally re-verdicts it `fixpr` and Step 5c's normal per-tick spawn respawns it — using this tick's freshly-computed `GATE_BY_PR`/`FINDINGS_JSON`. This still satisfies `subagent-orchestration.md`'s 60s Token/Turn Exhaustion Protocol SLA: Step 3 and Step 5c run seconds later in the same continuous tick execution, not on a separate `/loop` cycle. **Record `$N` into `EXHAUSTION_RESPAWN_PRS` for this tick** — Step 3's cap check (item 2) must never let this PR lose its slot to a competing fresh `fixpr` PR, since `subagent-orchestration.md` treats exhaustion-with-handoff respawn as mandatory, not slot-competitive. Report to user.
    - Missing/corrupt report, or a crash with no handoff file → mark `failed` and add `#N` to `HARD_BLOCK[]` with reason `crashed(needs-approval)`. **Do NOT leave it eligible for silent re-dispatch** — `subagent-orchestration.md`'s Phase Transition Autonomy table requires user permission before respawning a crashed/no-handoff subagent. Reported once and dropped from the actionable fleet this tick (Step 3's `HARD_BLOCK[]` handling — it does not force-stop the fleet); the user can explicitly approve a respawn.
 5. **Record per-PR outcome** in a `SUBAGENT_STATUS[N]` map (`complete` / `failed`) for the Step 4 table.
@@ -240,6 +249,7 @@ Read `merge_state` / `mergeable` **literally** from the gate JSON. **Do NOT infe
 
 | Condition (checked in order) | `VERDICT` | Acted on in Step 5 as |
 |------------------------------|-----------|------------------------|
+| PR in persisted `pmm_hard_block` (prior-tick `blocked` / `crashed` — load at Step 2.5) | `BLOCKED:<reason>` | **Hard block** → reported, dropped; **overrides** `mergeable == CONFLICTING` so Step 5c does not re-dispatch silently |
 | `human_changes_requested` non-empty (human CR on HEAD) | `BLOCKED:human(@login)` | **Hard block** → reported, dropped from actionable fleet (name each login; never auto-dismiss) |
 | `mergeable == CONFLICTING` | `fixpr` (`merge-conflict`) | Spawn `phase-a-fixer` subagent tasked with `/merge-conflict` workflow (Step 5c) — resolves and pushes; never auto-merge |
 | `merge_state == BEHIND` | `rebase` | Rebase + force-push + stale-bot dismissal (Step 5a/5b) |
@@ -380,9 +390,12 @@ else
   else
     git rebase --abort
     echo "[PMM] PR #$N rebase hit conflicts — routing to merge-conflict fixer dispatch (Step 5c)"
+    # Override Step 3's `rebase` verdict so Step 5c includes this PR in the *same* tick
+    # (Step 5c only dispatches PRs whose refined verdict is `fixpr`, not `rebase`):
+    VERDICTS_JSON=$(jq --arg n "$N" '.[$n] = {verdict: "fixpr", tag: "merge-conflict", refined: "fixpr"}' <<<"${VERDICTS_JSON:-{}}")
+    REFINED_VERDICT[$N]="fixpr"
     # Do NOT add to HARD_BLOCK[] — spawn a phase-a-fixer subagent tasked with the
-    # /merge-conflict workflow instead. Set verdict to fixpr (merge-conflict) for
-    # Step 5c dispatch this tick (or next tick if in-flight/cap constraints apply).
+    # /merge-conflict workflow instead. Step 5c dispatch runs later this tick.
   fi
 fi
 ```
@@ -498,7 +511,7 @@ Fix work runs in **parallel** via one `phase-a-fixer` subagent per PR, capped at
 
 Conflict dispatches participate in the same parallel cap, batched `session-state.sh --set` write, and `pmm-fix-$N` tracking as CR/CI fixers. Set the Subagent column to `dispatched (merge-conflict)` when spawning for conflict resolution.
 
-**Idempotency and concurrency are already resolved in Step 3's refinement pass** (in-flight check + cap slot allocation), so the table printed in Step 4 already reflects which PRs will dispatch this tick. Step 5c dispatches every PR whose *refined* verdict is still `fixpr` **and** Step 5b′ did not re-gate it to `wrap`/`waiting` — it does not re-check `active_agents` or recompute slots. PRs refined to `awaiting fix subagent` or `queued (cap)` are skipped here with no further action; they are eligible again once Step 3 re-evaluates on a later tick.
+**Idempotency and concurrency are already resolved in Step 3's refinement pass** (in-flight check + cap slot allocation), so the table printed in Step 4 already reflects which PRs will dispatch this tick. Step 5c dispatches every PR whose *refined* verdict is still `fixpr` **and** Step 5b′ did not re-gate it to `wrap`/`waiting` — it does not re-check `active_agents` or recompute slots. **Exception:** PRs whose Step 5a rebase aborted on conflicts override their refined verdict to `fixpr (merge-conflict)` in-place (see Step 5a) and are eligible for Step 5c dispatch in the same tick even though Step 4 already printed `rebase`. PRs refined to `awaiting fix subagent` or `queued (cap)` are skipped here with no further action; they are eligible again once Step 3 re-evaluates on a later tick.
 
 **CR hourly cap (fleet-wide).** Before spawning, snapshot the budget:
 

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -264,7 +264,7 @@ Read `merge_state` / `mergeable` **literally** from the gate JSON. **Do NOT infe
 | `MET == true` (clean review on HEAD + CI green + 0 unresolved threads + no blockers) | `wrap` | Dispatch `/wrap` sequentially (Step 5d) |
 | Otherwise (CI in-progress, reviewer genuinely pending, `REVIEW_REQUIRED` with no bot signal yet, `UNKNOWN`) | `waiting` | No-op — reviewer/CI owns the next move |
 
-`merge-gate.sh` exit `3` (PR gone — merged/closed between Step 2 and now) → `VERDICT=gone` (drop from the fleet this tick). Exit `2`/`4` (tooling/network) → `VERDICT=error` (do not act; retry next tick).
+`merge-gate.sh` exit `3` (PR gone — merged/closed between Step 2 and now) → `VERDICT=gone`, clear persisted block (`.claude/scripts/session-state.sh --set ".pmm_hard_block.\"$N\"=null"`), drop from fleet. When the user explicitly approves respawn of a `crashed(needs-approval)` or `conflicts(needs-human)` PR, clear the same `pmm_hard_block` key before dispatch. Exit `2`/`4` (tooling/network) → `VERDICT=error` (do not act; retry next tick).
 
 **Accumulate `VERDICTS_JSON` as each PR is classified — this is what Step 5.0's pre-flight gone/error skip reads.** Without this, `VERDICTS_JSON` stays an implicit empty object, the skip check never matches, and pre-flight runs against merged/errored PRs it should have skipped:
 

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -269,7 +269,16 @@ Read `merge_state` / `mergeable` **literally** from the gate JSON. **Do NOT infe
 **Accumulate `VERDICTS_JSON` as each PR is classified — this is what Step 5.0's pre-flight gone/error skip reads.** Without this, `VERDICTS_JSON` stays an implicit empty object, the skip check never matches, and pre-flight runs against merged/errored PRs it should have skipped:
 
 ```bash
-VERDICTS_JSON=$(jq --arg n "$N" --arg v "$VERDICT" '.[$n] = {verdict: $v}' <<<"${VERDICTS_JSON:-{}}")
+TAG=""
+if [[ "$VERDICT" == "fixpr" && "$MERGEABLE" == "CONFLICTING" ]]; then
+  TAG="merge-conflict"
+fi
+if [[ -n "$TAG" ]]; then
+  VERDICTS_JSON=$(jq --arg n "$N" --arg v "$VERDICT" --arg tag "$TAG" \
+    '.[$n] = {verdict: $v, tag: $tag}' <<<"${VERDICTS_JSON:-{}}")
+else
+  VERDICTS_JSON=$(jq --arg n "$N" --arg v "$VERDICT" '.[$n] = {verdict: $v}' <<<"${VERDICTS_JSON:-{}}")
+fi
 ```
 
 **Collect hard blocks for reporting, but do not force-stop the fleet.** Push every PR with a `BLOCKED:*` verdict onto a `HARD_BLOCK[]` list (with its reason). These PRs are **reported once and dropped from the actionable fleet** for this tick — they do not trigger Stop & Clean Exit. A fleet of only hard-blocked/waiting PRs converges to auto-Pause via the idle counter (Step 6/7). The `rebase`/`fixpr`/`wrap` verdicts are executed in Step 5.

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -17,7 +17,7 @@ Thread-level **PR fleet manager**. This skill turns the current thread into a de
 
 > **Per-PR dispatch is inlined below.** `TODO: refactor to call /babysit-pr per discovered PR after #456 lands.` Until #456 merges, Step 3's decision tree is the single owner of per-PR logic. When `/babysit-pr` exists, replace Step 3's inline branches with one `/babysit-pr <PR>` dispatch per discovered PR — the table, discovery, idempotency, and backoff scaffolding here stay unchanged.
 
-This is a **set-and-monitor** command. Once invoked it acknowledges the mode, establishes a `/loop`, and at every tick reprints the fleet table and acts. It never writes feature code and never drifts into unrelated work.
+This is a **set-and-monitor** command. Once invoked it acknowledges the mode, establishes a `/loop`, and at every tick reprints the fleet table and acts. The **parent thread** never edits feature code directly — it dispatches subagents to do that work — and never drifts into unrelated work.
 
 ---
 
@@ -49,20 +49,33 @@ A stale marker left by a killed session is safely reconciled here: the next `/pr
 
 On the **first** invocation in a thread (and after any resume), acknowledge the mode up front so the constraints are explicit and survive context compaction:
 
-> **PR-fleet-manager mode active.** My only job in this thread is to watch and manage your open PRs as a fleet — rediscover them each tick, print a status table, and dispatch rebase / parallel `phase-a-fixer` subagents (fix work) / sequential `/wrap` (merge-ready) per the decision tree. Merge-ready PRs are landed autonomously via inline `/wrap` dispatch (unless `--confirm-merges` is set). I will not write feature code, start issues, or do unrelated work here.
+> **PR-fleet-manager mode active.** My only job in **this parent thread** is to watch and manage your open PRs as a fleet — rediscover them each tick, print a status table, and dispatch rebase / parallel `phase-a-fixer` subagents (fix work, including merge conflicts) / sequential `/wrap` (merge-ready) per the decision tree. Merge-ready PRs are landed autonomously via inline `/wrap` dispatch (unless `--confirm-merges` is set). I will not edit feature code **directly in this thread**, start issues, or do unrelated work here — but I **will** dispatch subagents that edit code, resolve conflicts, fix findings, push, and reply/resolve threads.
 
-**Prohibited in this thread (refuse and redirect):**
+### Parent scope vs Subagent scope
 
-- Writing or editing **feature code** of any kind.
-- Invoking `/start-issue`, `/prompt`, or spawning coding subagents for new work.
+| Scope | Role | Allowed | Disallowed |
+|-------|------|---------|------------|
+| **Parent (this thread)** | Fleet orchestrator | Discover PRs, classify state, dispatch subagents, aggregate exit reports, update the fleet table, decide next tick; git rebase/force-push for `BEHIND` (Step 5a); stale-bot dismiss + re-trigger (Steps 5b/5b′); inline `/wrap` for merge-ready PRs | Direct code edits; direct git beyond discovery/rebase/dismiss; direct merges (`gh pr merge`); starting new issues; unrelated work |
+| **Subagents (spawned per PR)** | Fix worker | Edit files, resolve merge conflicts, fix CR/CI findings, push commits, reply to threads, resolve bot threads — one PR each, per `.claude/rules/subagent-orchestration.md` and #509 (parallel subagents) | Modify branch protection; dismiss human reviews; bypass SAFETY rules |
+
+Spawn pattern reference: `.claude/rules/subagent-orchestration.md` (Phase A fixer / Phase C merger). Every spawn includes the verbatim `SAFETY:` block from `.claude/rules/safety.md`.
+
+**Prohibited for the parent thread (refuse and redirect):**
+
+- Writing or editing **feature code directly** — dispatch a `phase-a-fixer` subagent instead (merge conflicts, CR findings, CI failures are all dispatch cases, not refusal cases).
+- Invoking `/start-issue`, `/prompt`, or spawning subagents for **new work unrelated to the discovered fleet**.
 - Creating issues or PRs (other than the follow-ups `/wrap` itself creates on merge).
 - Any task unrelated to managing the discovered PR fleet.
 
-**Refusal template** when asked for a prohibited activity:
+**Refusal template** when asked for genuinely out-of-scope *parent* work (not dispatchable fleet fix work):
 
 > That's outside PR-fleet-manager mode. I'm keeping this thread focused on monitoring your open PRs. Start a separate thread (e.g. `/start-issue`) for that work — say `/pmm-stop` first if you want me to stop monitoring here.
 
-This skill is read-only with respect to source: the only writes it performs are git rebase/force-push (Step 5a), stale-bot review dismissal + owning-bot re-trigger (Steps 5b/5b′), and the bounded mutations that `phase-a-fixer` subagents and `/wrap` already own. Fix work is delegated to parallel `phase-a-fixer` subagents (`.claude/agents/phase-a-fixer.md`); merge work stays sequential via `/wrap`. The parent never reimplements fix/merge logic beyond the shared dismiss/re-trigger helpers that `/fixpr` also uses.
+### Common misreads / Anti-patterns
+
+> If you catch yourself telling the user "I can't edit code in this thread" as a reason to **stop** rather than **dispatch**, that's wrong — the parent doesn't edit code, but its subagents do, and that's the whole point. Merge conflicts, CR findings, and CI failures are all handled by spawning fix subagents, not by refusing or hard-blocking pre-dispatch.
+
+The parent is orchestration-only with respect to source edits: the only direct writes it performs are git rebase/force-push (Step 5a), stale-bot review dismissal + owning-bot re-trigger (Steps 5b/5b′), and the bounded mutations that `phase-a-fixer` subagents and `/wrap` already own. Fix work — including merge-conflict resolution — is delegated to parallel `phase-a-fixer` subagents (`.claude/agents/phase-a-fixer.md`); merge work stays sequential via `/wrap`. The parent never reimplements fix/merge logic beyond the shared dismiss/re-trigger helpers that `/fixpr` also uses.
 
 ---
 
@@ -166,7 +179,8 @@ For each completed subagent, run steps 1-3 **unconditionally first** (cleanup mu
    This must be a real read-filter-write, not a no-op comment — Step 3's concurrency cap and idempotency check both count live entries in this array.
 4. **Branch on OUTCOME** (steps 1-3 above are already done, so this branch never races the cleanup):
    - `pushed_fixes` or `no_findings` → verify push SHA matches `HEAD_SHA` in the report (`gh pr view N --json commits --jq '.commits[-1].oid'`). Verify handoff file exists at `~/.claude/handoffs/pr-{N}-handoff.json` with `phase_completed: "A"`. When OUTCOME is `pushed_fixes`, run **Step 5b dismiss helper + Step 5b′ owning-bot re-trigger** on `#N` immediately (same contract as `/fixpr` Steps 3a/3b — a push without dismissal leaves obsolete bot `CHANGES_REQUESTED` on old SHAs and the gate never clears). Step 5e's inline completion path (item 2) runs the same pair when a subagent exits mid-tick.
-   - `exhaustion` → **do not launch the replacement inline here.** Step 2.5 runs before Step 3 every tick, so `GATE_BY_PR`/pre-fetched `FINDINGS_JSON` (both populated in Step 3) are not available yet — Step 5c's full spawn pattern needs them. Instead, rely on step 3 above already clearing this PR's `active_agents`/`pmm_in_flight[N]` entries: the PR falls through into Step 3's classification with a clean slate later in this same tick, and if the underlying condition (CI failing, unresolved threads, stale bot review) still holds, Step 3 naturally re-verdicts it `fixpr` and Step 5c's normal per-tick spawn respawns it — using this tick's freshly-computed `GATE_BY_PR`/`FINDINGS_JSON`. This still satisfies `subagent-orchestration.md`'s 60s Token/Turn Exhaustion Protocol SLA: Step 3 and Step 5c run seconds later in the same continuous tick execution, not on a separate `/loop` cycle. **Record `$N` into `EXHAUSTION_RESPAWN_PRS` for this tick** — Step 3's cap check (item 2) must never let this PR lose its slot to a competing fresh `fixpr` PR, since `subagent-orchestration.md` treats exhaustion-with-handoff respawn as mandatory, not slot-competitive. Report to user.
+   - `blocked` → add `#N` to `HARD_BLOCK[]` with reason from the exit report (e.g. `conflicts(needs-human)` for unresolvable merge conflicts). Report once and drop from the actionable fleet this tick — the subagent already attempted resolution; do not re-dispatch silently.
+   - `exhaustion` → **do not launch the replacement inline here.** Step 2.5 runs before Step 3 every tick, so `GATE_BY_PR`/pre-fetched `FINDINGS_JSON` (both populated in Step 3) are not available yet — Step 5c's full spawn pattern needs them. Instead, rely on step 3 above already clearing this PR's `active_agents`/`pmm_in_flight[N]` entries: the PR falls through into Step 3's classification with a clean slate later in this same tick, and if the underlying condition (CI failing, unresolved threads, stale bot review, merge conflicts) still holds, Step 3 naturally re-verdicts it `fixpr` and Step 5c's normal per-tick spawn respawns it — using this tick's freshly-computed `GATE_BY_PR`/`FINDINGS_JSON`. This still satisfies `subagent-orchestration.md`'s 60s Token/Turn Exhaustion Protocol SLA: Step 3 and Step 5c run seconds later in the same continuous tick execution, not on a separate `/loop` cycle. **Record `$N` into `EXHAUSTION_RESPAWN_PRS` for this tick** — Step 3's cap check (item 2) must never let this PR lose its slot to a competing fresh `fixpr` PR, since `subagent-orchestration.md` treats exhaustion-with-handoff respawn as mandatory, not slot-competitive. Report to user.
    - Missing/corrupt report, or a crash with no handoff file → mark `failed` and add `#N` to `HARD_BLOCK[]` with reason `crashed(needs-approval)`. **Do NOT leave it eligible for silent re-dispatch** — `subagent-orchestration.md`'s Phase Transition Autonomy table requires user permission before respawning a crashed/no-handoff subagent. Reported once and dropped from the actionable fleet this tick (Step 3's `HARD_BLOCK[]` handling — it does not force-stop the fleet); the user can explicitly approve a respawn.
 5. **Record per-PR outcome** in a `SUBAGENT_STATUS[N]` map (`complete` / `failed`) for the Step 4 table.
 
@@ -227,7 +241,7 @@ Read `merge_state` / `mergeable` **literally** from the gate JSON. **Do NOT infe
 | Condition (checked in order) | `VERDICT` | Acted on in Step 5 as |
 |------------------------------|-----------|------------------------|
 | `human_changes_requested` non-empty (human CR on HEAD) | `BLOCKED:human(@login)` | **Hard block** → reported, dropped from actionable fleet (name each login; never auto-dismiss) |
-| `mergeable == CONFLICTING` | `BLOCKED:conflicts` | **Hard block** → reported, dropped from actionable fleet (recommend `/merge-conflict`; never auto-merge) |
+| `mergeable == CONFLICTING` | `fixpr` (`merge-conflict`) | Spawn `phase-a-fixer` subagent tasked with `/merge-conflict` workflow (Step 5c) — resolves and pushes; never auto-merge |
 | `merge_state == BEHIND` | `rebase` | Rebase + force-push + stale-bot dismissal (Step 5a/5b) |
 | `CI_FAILING > 0` **or** `UNRESOLVED > 0` | `fixpr` (`has-recoverable-blockers`) | Spawn `phase-a-fixer` subagent (Step 5c) |
 | `MET == false` **and** (`STALE_BOT_CR > 0` **or** `REVIEW_DECISION == CHANGES_REQUESTED` with no human CR) | `fixpr` (`has-recoverable-blockers`) | Step 5b′ (when `STALE_BOT_CR > 0` only) dismisses stale bot reviews + re-triggers the owning bot, re-gates; spawn `phase-a-fixer` (Step 5c) when fix work remains (`CI_FAILING > 0`, `UNRESOLVED > 0`, or fresh bot CR on HEAD) |
@@ -292,12 +306,12 @@ echo "[$TS] PMM tick — $PR_COUNT PR(s) in fleet (author:$PMM_AUTHOR)"
 | #<issue or —> | #<N> | <merge_state> | <review_decision> | <pass>/<fail>/<prog> | <count> | <VERDICT from Step 3> | <SUBAGENT_STATUS> |
 
 - **Issue** — from `pr-issue-ref.sh`, or `—` when the PR body has no closing keyword.
-- **State** — literal `merge_state` (`CLEAN`/`BEHIND`/`BLOCKED`/`CONFLICTING`/`UNKNOWN`).
+- **State** — literal `merge_state` (`CLEAN`/`BEHIND`/`BLOCKED`/`UNKNOWN`); when `mergeable == CONFLICTING`, append `(CONFLICTING)` to the State cell so the conflict signal is visible (CONFLICTING is a `mergeable` value, not a `merge_state` value).
 - **Reviews** — literal `review_decision` (`APPROVED`/`CHANGES_REQUESTED`/`REVIEW_REQUIRED`).
 - **CI** — `passing`/`failing`/`in_progress` counts from the gate.
 - **Unresolved Threads** — count of `isResolved == false` (or `?` if the GraphQL fetch failed).
-- **Verdict** — the Step 3 verdict: `rebase`, `fixpr`, `wrap`, `waiting`, `awaiting fix subagent`, `queued (cap)`, `rate-limited`, `BLOCKED:human(@x)`, `BLOCKED:conflicts`, `gone`, `error`.
-- **Subagent** — per-PR agent state for fix work: `—` (not spawned / no fix dispatch this tick), `spawned`, `working`, `complete`, `failed`, `deferred(foreign-agent)` (Step 5d/5e deferral gate closed because a foreign Phase A entry blocks this PR), `foreign-agent-stale` (Step 5e staleness timeout fired on a silent foreign entry — gate treated as drained). Populated from `active_agents` + Step 2.5 outcomes (PMM-owned only) + Step 5e foreign-drain polling. Merge-ready `/wrap` dispatches show `—` (wrap is parent-inline, not a subagent).
+- **Verdict** — the Step 3 verdict: `rebase`, `fixpr`, `wrap`, `waiting`, `awaiting fix subagent`, `queued (cap)`, `rate-limited`, `BLOCKED:human(@x)`, `BLOCKED:conflicts(needs-human)`, `gone`, `error`.
+- **Subagent** — per-PR agent state for fix work: `—` (not spawned / no fix dispatch this tick), `dispatched (merge-conflict)` (conflict-resolution fixer spawned this tick — transitions to `spawned`/`working`/`complete`/`failed` as the subagent runs), `spawned`, `working`, `complete`, `failed`, `deferred(foreign-agent)` (Step 5d/5e deferral gate closed because a foreign Phase A entry blocks this PR), `foreign-agent-stale` (Step 5e staleness timeout fired on a silent foreign entry — gate treated as drained). Populated from `active_agents` + Step 2.5 outcomes (PMM-owned only) + Step 5e foreign-drain polling. Merge-ready `/wrap` dispatches show `—` (wrap is parent-inline, not a subagent).
 
 A PR merged this tick is reported via the per-tick `merged #N` line (Step 5d) and then naturally disappears from the fleet on the next `gh pr list` discovery — no table row lingers.
 
@@ -365,8 +379,10 @@ else
     # then run Step 5b (dismiss stale bot reviews on the new SHA)
   else
     git rebase --abort
-    echo "[PMM] PR #$N rebase hit conflicts — hard block, recommend /merge-conflict"
-    # add #N to HARD_BLOCK[] with reason "conflicts"
+    echo "[PMM] PR #$N rebase hit conflicts — routing to merge-conflict fixer dispatch (Step 5c)"
+    # Do NOT add to HARD_BLOCK[] — spawn a phase-a-fixer subagent tasked with the
+    # /merge-conflict workflow instead. Set verdict to fixpr (merge-conflict) for
+    # Step 5c dispatch this tick (or next tick if in-flight/cap constraints apply).
   fi
 fi
 ```
@@ -471,9 +487,16 @@ Never batch mention strings; never auto-trigger Greptile. Set `TICK_HAD_ACTION=t
    - **`CI_FAILING > 0` or `UNRESOLVED > 0`** → proceed to Step 5c spawn (real fix work remains).
    - **Otherwise** (reviewer pending on fresh trigger, no CI/thread fix work) → skip Step 5c; verdict becomes `waiting` on the next tick when the bot lands.
 
-### Step 5c: Parallel `phase-a-fixer` dispatch (verdict `fixpr` — has-recoverable-blockers)
+### Step 5c: Parallel `phase-a-fixer` dispatch (verdict `fixpr` — has-recoverable-blockers or merge-conflict)
 
 Fix work runs in **parallel** via one `phase-a-fixer` subagent per PR, capped at `$PMM_MAX_PARALLEL` (default 3). Merge dispatch stays sequential (Step 5d) — merges affect main and must not race.
+
+**Two fixer task types share this dispatch path:**
+
+1. **CR/CI/thread fix work** (`fixpr` from CI failing, unresolved threads, or stale bot CR) — standard Phase A fixer workflow per `.claude/agents/phase-a-fixer.md`.
+2. **Merge-conflict resolution** (`fixpr` with `merge-conflict` tag from `mergeable == CONFLICTING`, or from Step 5a rebase hitting conflicts) — same spawn shape, but the subagent prompt directs it to run the `/merge-conflict` skill workflow: rebase onto base → `resolve_merge_conflicts.py` for safe hunks → apply judgment to complex hunks → commit + force-push. Unresolvable conflicts exit with `OUTCOME: blocked` (see Step 2.5); the parent surfaces them as `BLOCKED:conflicts(needs-human)`.
+
+Conflict dispatches participate in the same parallel cap, batched `session-state.sh --set` write, and `pmm-fix-$N` tracking as CR/CI fixers. Set the Subagent column to `dispatched (merge-conflict)` when spawning for conflict resolution.
 
 **Idempotency and concurrency are already resolved in Step 3's refinement pass** (in-flight check + cap slot allocation), so the table printed in Step 4 already reflects which PRs will dispatch this tick. Step 5c dispatches every PR whose *refined* verdict is still `fixpr` **and** Step 5b′ did not re-gate it to `wrap`/`waiting` — it does not re-check `active_agents` or recompute slots. PRs refined to `awaiting fix subagent` or `queued (cap)` are skipped here with no further action; they are eligible again once Step 3 re-evaluates on a later tick.
 
@@ -501,9 +524,10 @@ run_in_background: true
 
 - PR number, branch name (`headRefName`), repo (`$OWNER/$REPO`), linked issue number (if any)
 - Current HEAD SHA from the tick's gate JSON
-- Reviewer classification (`cr`, `bugbot`, or `greptile`)
+- Reviewer classification (`cr`, `bugbot`, or `greptile`) — omit or set to `none` for merge-conflict-only dispatches
+- **Task type:** `fixpr` (CR/CI findings) or `merge-conflict` (conflict resolution) — for `merge-conflict`, include: "Run the `/merge-conflict` skill workflow: fetch main, rebase, run `resolve_merge_conflicts.py`, resolve complex hunks with judgment, commit + force-push. Exit with `OUTCOME: blocked` if conflicts are genuinely unresolvable."
 - Handoff file path: `~/.claude/handoffs/pr-{N}-handoff.json`
-- Pre-fetched findings from Step 3 (`FINDINGS_JSON[N]`)
+- Pre-fetched findings from Step 3 (`FINDINGS_JSON[N]`) — omit for merge-conflict-only dispatches
 - `SKIP_CR_TRIGGER=1` when `$CR_BUDGET_OK == 0`
 - The verbatim `SAFETY:` block from `.claude/rules/safety.md`:
 
@@ -595,7 +619,7 @@ On completion:
 
 ### Step 5e: Dedicated monitor mode while fix subagents are active
 
-If any **blocking** fix subagents are active this tick (per Step 5's shared gate idiom and the deferral-gate definition in Step 5d — spawned now or carried over from a prior tick), **immediately enter an orchestration-only posture borrowing `monitor-mode.md`'s Dedicated Monitor Mode discipline** — the parent's ONLY job until every blocking fix subagent completes, fails, or is drained (foreign: disappearance / terminal `status` / `PMM_LOCK_STALE_SECS` staleness timeout) is orchestration (poll, verify, heartbeat); no feature code, no local CR review, no substantive source analysis. **PMM does NOT execute `monitor-mode.md`'s Monitor Loop Per-Cycle Checklist verbatim** — specifically, it never runs `phase-protocols.md`'s Phase Completion Protocols, which would otherwise auto-launch Phase B after Phase A. Step 2.5's aggregation fully replaces that: PMM fixes and pushes only, per Step 0's contract ("PMM does not launch Phase B/C after Phase A").
+If any **blocking** fix subagents are active this tick (per Step 5's shared gate idiom and the deferral-gate definition in Step 5d — spawned now or carried over from a prior tick), **immediately enter an orchestration-only posture borrowing `monitor-mode.md`'s Dedicated Monitor Mode discipline** — the **parent's** ONLY job until every blocking fix subagent completes, fails, or is drained (foreign: disappearance / terminal `status` / `PMM_LOCK_STALE_SECS` staleness timeout) is orchestration (poll, verify, heartbeat); the parent does no direct feature-code edits, no local CR review, no substantive source analysis — but its subagents edit code, resolve conflicts, and push as designed. **PMM does NOT execute `monitor-mode.md`'s Monitor Loop Per-Cycle Checklist verbatim** — specifically, it never runs `phase-protocols.md`'s Phase Completion Protocols, which would otherwise auto-launch Phase B after Phase A. Step 2.5's aggregation fully replaces that: PMM fixes and pushes only, per Step 0's contract ("PMM does not launch Phase B/C after Phase A").
 
 **PMM's own monitor loop (~60s cadence — replaces, not layers on, `monitor-mode.md`'s checklist):**
 
@@ -618,6 +642,7 @@ If any **blocking** fix subagents are active this tick (per Step 5's shared gate
 2. **On PMM-owned completion** — success, exhaustion, or crash — **run Step 2.5's steps 1-3 in full** (parse exit report, worktree cleanup, remove this agent's own `active_agents` record + clear `pmm_in_flight[N]`) before branching on outcome. When OUTCOME is `pushed_fixes`, also run **Step 5b dismiss helper + Step 5b′ owning-bot re-trigger** on that PR (issue #514 — mirrors `/fixpr` 3a/3b; set `TICK_HAD_ACTION=true` if dismissal or re-trigger posts). This is unconditional, not just the success path — a failure that skips clearing `pmm_in_flight[N]` would otherwise leave a stale lock blocking Step 3's idempotency check until `PMM_LOCK_STALE_SECS` expires. Foreign entries are out of scope for this item — they drain per item 1's poll/staleness signal only.
 3. Branch on outcome for **PMM-owned** entries only (per Step 2.5's step 4, cleanup from item 2 above already done):
    - **Crash / no exit report / stale >15 min:** mark `failed` in the table and add `#N` to `HARD_BLOCK[]` with reason `crashed(needs-approval)` — never re-dispatch silently. Reported once and dropped from the actionable fleet this tick (do **not** force-stop — see Step 3's `HARD_BLOCK[]` handling); the user can explicitly approve a respawn (`subagent-orchestration.md`: "Ask first only: ... respawning a crashed/no-handoff subagent").
+   - **`blocked` (unresolvable merge conflict or other fix blocker):** add `#N` to `HARD_BLOCK[]` with reason from the exit report (e.g. `conflicts(needs-human)`). Report once and drop from the actionable fleet — do not re-dispatch silently.
    - **Token/turn exhaustion with a valid handoff file:** respawn immediately **using Step 5c's spawn pattern**, but with **freshly re-fetched** gate and findings data for this PR — do NOT reuse tick-start `GATE_BY_PR[$N]`/`FINDINGS_JSON[$N]` verbatim. Real time has passed since Step 3 computed them, and the exhausted subagent may have pushed partial progress before running out of tokens, moving the PR's actual HEAD SHA and review state past that tick-start snapshot; a respawn using the stale SHA/findings would hand the replacement outdated context. Re-run `.claude/scripts/merge-gate.sh "$N"` (and re-fetch findings from the three endpoints, same as Step 3's pre-fetch) immediately before building the replacement's spawn record, and use *that* fresh result — not the cached tick-start one — for its `head_sha`, `GATE_BY_PR[$N]` update, and prompt findings. This is an "Always do" action per `subagent-orchestration.md`'s Token/Turn Exhaustion Protocol — do not wait for the next tick, and do NOT defer to Step 2.5's exhaustion handling here (Step 2.5's deferral only works at tick-*start*, before Step 3 has run; Step 5e is mid-tick, after Step 3 already ran, so an inline respawn is possible here — it just needs fresh data, not the tick-start cache).
 4. Send heartbeat if >5 min since last user message (timestamp prefix required).
 5. Investigate stale **PMM-owned** agents (>15 min Phase A without progress). Foreign staleness is handled by item 1's `PMM_LOCK_STALE_SECS` fallback.
@@ -847,8 +872,9 @@ Hard-blocked PRs are reported here for visibility; the fleet may auto-pause afte
 
 ## Safety boundaries (HARD STOPS — `safety.md`, `cr-merge-gate.md`)
 
-This skill is an **orchestrator**. It rebases/force-pushes, spawns parallel `phase-a-fixer` subagents for fix work, and dispatches `/wrap` sequentially for merges. It never reimplements fix/merge/resolve logic. The following are absolute:
+This skill is a **parent orchestrator**. The parent rebases/force-pushes (Step 5a), spawns parallel `phase-a-fixer` subagents for fix work (including merge conflicts), and dispatches `/wrap` sequentially for merges. Subagents edit code, resolve conflicts, fix findings, push, and reply/resolve threads — that is their purpose. The parent never reimplements fix/merge/resolve logic directly. The following are absolute:
 
+- **Parent never edits feature code directly** — dispatch a `phase-a-fixer` subagent instead. Subagents are explicitly permitted and expected to edit feature code.
 - **Never modify branch protection** — no calls to `.../branches/.../protection`. Subagents inherit this prohibition.
 - **Never dismiss human reviews** — only Bot-allowlist `CHANGES_REQUESTED` on a stale `commit_id` (Steps 5b and 5b′, plus post-subagent dismiss in Step 2.5/5e after a push). Human CR is a hard block. Subagents must not dismiss human-authored reviews.
 - **Never resolve a review thread without code-verification** — thread resolution happens only inside `phase-a-fixer` Step 5 after verifying the fix. This skill only *counts* unresolved threads.

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -190,7 +190,7 @@ For each completed subagent, run steps 1-3 **unconditionally first** (cleanup mu
    - `pushed_fixes` or `no_findings` → verify push SHA matches `HEAD_SHA` in the report (`gh pr view N --json commits --jq '.commits[-1].oid'`). Verify handoff file exists at `~/.claude/handoffs/pr-{N}-handoff.json` with `phase_completed: "A"`. When OUTCOME is `pushed_fixes`, run **Step 5b dismiss helper + Step 5b′ owning-bot re-trigger** on `#N` immediately (same contract as `/fixpr` Steps 3a/3b — a push without dismissal leaves obsolete bot `CHANGES_REQUESTED` on old SHAs and the gate never clears). Step 5e's inline completion path (item 2) runs the same pair when a subagent exits mid-tick.
    - `blocked` → add `#N` to `HARD_BLOCK[]` with reason from the exit report (e.g. `conflicts(needs-human)` for unresolvable merge conflicts). **Persist** the same reason to `pmm_hard_block` in `session-state.json` (see tick-start load above). Report once and drop from the actionable fleet this tick — the subagent already attempted resolution; do not re-dispatch silently.
    - `exhaustion` → **do not launch the replacement inline here.** Step 2.5 runs before Step 3 every tick, so `GATE_BY_PR`/pre-fetched `FINDINGS_JSON` (both populated in Step 3) are not available yet — Step 5c's full spawn pattern needs them. Instead, rely on step 3 above already clearing this PR's `active_agents`/`pmm_in_flight[N]` entries: the PR falls through into Step 3's classification with a clean slate later in this same tick, and if the underlying condition (CI failing, unresolved threads, stale bot review, merge conflicts) still holds, Step 3 naturally re-verdicts it `fixpr` and Step 5c's normal per-tick spawn respawns it — using this tick's freshly-computed `GATE_BY_PR`/`FINDINGS_JSON`. This still satisfies `subagent-orchestration.md`'s 60s Token/Turn Exhaustion Protocol SLA: Step 3 and Step 5c run seconds later in the same continuous tick execution, not on a separate `/loop` cycle. **Record `$N` into `EXHAUSTION_RESPAWN_PRS` for this tick** — Step 3's cap check (item 2) must never let this PR lose its slot to a competing fresh `fixpr` PR, since `subagent-orchestration.md` treats exhaustion-with-handoff respawn as mandatory, not slot-competitive. Report to user.
-   - Missing/corrupt report, or a crash with no handoff file → mark `failed` and add `#N` to `HARD_BLOCK[]` with reason `crashed(needs-approval)`. **Do NOT leave it eligible for silent re-dispatch** — `subagent-orchestration.md`'s Phase Transition Autonomy table requires user permission before respawning a crashed/no-handoff subagent. Reported once and dropped from the actionable fleet this tick (Step 3's `HARD_BLOCK[]` handling — it does not force-stop the fleet); the user can explicitly approve a respawn.
+   - Missing/corrupt report, or a crash with no handoff file → mark `failed` and add `#N` to `HARD_BLOCK[]` with reason `crashed(needs-approval)`. **Persist** the same reason to `pmm_hard_block` in `session-state.json`. **Do NOT leave it eligible for silent re-dispatch** — `subagent-orchestration.md`'s Phase Transition Autonomy table requires user permission before respawning a crashed/no-handoff subagent. Reported once and dropped from the actionable fleet this tick (Step 3's `HARD_BLOCK[]` handling — it does not force-stop the fleet); the user can explicitly approve a respawn.
 5. **Record per-PR outcome** in a `SUBAGENT_STATUS[N]` map (`complete` / `failed`) for the Step 4 table.
 
 PMM does **not** launch Phase B/C after Phase A — it only fixes and pushes. Step 5e's monitor posture borrows `monitor-mode.md`'s orchestration-only discipline but explicitly skips `phase-protocols.md`'s Phase Completion Protocols (which would otherwise auto-launch Phase B). The next tick re-classifies each PR on its new SHA (may become `waiting`, `wrap`, or `fixpr` again).
@@ -200,6 +200,12 @@ PMM does **not** launch Phase B/C after Phase A — it only fixes and pushes. St
 ---
 
 ## Step 3: Gather per-PR state + classify (compute verdicts — NO actions)
+
+**Refresh `HARD_BLOCK_JSON` immediately before the per-PR loop** so Step 2.5 `blocked`/`crashed` persists from earlier in this same tick are visible to the decision tree (the Step 2.5 tick-start load is stale once Step 2.5 writes new entries):
+
+```bash
+HARD_BLOCK_JSON=$(.claude/scripts/session-state.sh --get '.pmm_hard_block // {}' 2>/dev/null || echo '{}')
+```
 
 This step is **side-effect-free**: it gathers state and computes a verdict per PR, but performs **no** rebases or dispatches. Actions happen in **Step 5**, after the table prints (Step 4). This ordering is required so the heartbeat table always shows the classification *before* any long-running dispatch.
 
@@ -522,7 +528,7 @@ CR_BUDGET_OK=1
 
 If `$CR_BUDGET_OK == 0`, still spawn subagents but include `SKIP_CR_TRIGGER=1` in each prompt — subagents proceed without posting `@coderabbitai full review`. The skip surfaces in each subagent's exit report / handoff `notes`. Do **not** block spawn entirely when the cap is exhausted (unlike deferring all fix work).
 
-**Bulk spawn (one Agent call per PR, all in parallel up to the cap).** For each PR allocated a slot, invoke the Agent tool with:
+**Bulk spawn (one Agent call per PR, all in parallel up to the cap).** For each PR allocated a slot, read `VERDICTS_JSON[$N].tag` — when it is `merge-conflict` (from Step 3 `mergeable == CONFLICTING` **or** Step 5a rebase abort), set `TASK_TYPE=merge-conflict` even if GitHub still reports `BEHIND`/`MERGEABLE`. Otherwise use `TASK_TYPE=fixpr`. Invoke the Agent tool with:
 
 ```text
 subagent_type: "phase-a-fixer"


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clarifies `/pr-monitor-and-manage` (PMM) scope so the **parent thread** stays orchestration-only while **spawned subagents** edit code — fixing the live confusion where PMM refused to dispatch merge-conflict fixes because "writing/editing feature code is prohibited here."

Also promotes `mergeable == CONFLICTING` from a hard block to a first-class `fixpr` dispatch case via `phase-a-fixer` running the `/merge-conflict` workflow.

Closes #524

## Changes

### `.claude/skills/pr-monitor-and-manage/SKILL.md`
- Added **Parent scope vs Subagent scope** contract table with cross-refs to `#509` and `subagent-orchestration.md`
- Added **Common misreads / Anti-patterns** callout (don't refuse dispatch with "I can't edit code")
- Rewrote 6 scope-language touchpoints to parent-scoped disallowances
- Decision tree: `CONFLICTING` → `fixpr (merge-conflict)` dispatch instead of `BLOCKED:conflicts`
- Step 5a: rebase conflicts route to fixer dispatch, not hard block
- Step 5c: documents merge-conflict task type alongside CR/CI fix work
- Step 2.5/5e: `blocked` exit outcome → `BLOCKED:conflicts(needs-human)`
- Fleet table: `dispatched (merge-conflict)` subagent state; fixed CONFLICTING column placement

### `.claude/agents/phase-a-fixer.md`
- Added merge-conflict task type and workflow branch
- Added `blocked` outcome for unresolvable conflicts

### `.claude/reference/exit-report-format.md`
- Added Phase A `blocked` outcome

### `.claude/agents/README.md`
- Updated phase-a-fixer inventory description

## Test Plan

### Acceptance Criteria
- [x] Opening constraints explicitly name PARENT scope vs SUBAGENT scope
- [x] Feature-code editing permitted for spawned subagents; disallowed for parent
- [x] Decision-tree includes `CONFLICTING` as first-class dispatch case
- [x] CONFLICTING dispatch uses phase-a-fixer with `/merge-conflict` workflow
- [x] Anti-pattern callout added
- [x] Ambiguous "no code edits ever" prose rewritten to parent vs subagent scope
- [x] Safety boundaries preserved (parent no direct edits; subagents no branch-protection/human-review dismissal; SAFETY block on every spawn)
- [x] Cross-references to #509 and `subagent-orchestration.md`
- [x] Hardcoded pre-dispatch refusal for conflicts removed
- [x] Fleet table shows `dispatched (merge-conflict)` state

### Manual / Integration Tests
- [ ] Fleet with 1 PR in CONFLICTING state → PMM dispatches subagent, PR moves out of CONFLICTING on next tick
- [ ] Fleet with 2 CONFLICTING PRs → both dispatched in parallel
- [ ] Fleet with CONFLICTING + BEHIND + CI-failing → all three dispatched on same tick
- [ ] Read updated SKILL.md end-to-end — no prose misread as "PMM never edits code" (only parent-scope disallowances)
- [ ] Simulated conflict on test PR → decision tree routes to CONFLICTING dispatch, exit report parsed
- [ ] Unresolvable conflict → subagent exits `blocked`, parent surfaces `needs human`
- [ ] Safety: no subagent modifies branch protection or dismisses human reviews; SAFETY block in every spawn
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-583affdb-02ea-486c-9145-136f9f89ae02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-583affdb-02ea-486c-9145-136f9f89ae02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Clarify parent orchestration scope and add merge-conflict dispatch**

### What Changed
- The parent PR manager is now described as orchestration-only: it can monitor, classify, and dispatch work, but not edit code directly.
- Code edits, conflict resolution, and review fixes are now explicitly assigned to spawned subagents, including merge-conflict cases that should be dispatched instead of rejected.
- Merge conflicts can now be handled as a normal fix task, and unresolved conflicts can exit as a blocked result that is recorded and not silently retried.
- Status reporting now distinguishes merge-conflict handling in the PR table and preserves hard blocks across ticks so the same conflict is not dispatched again.

### Impact
`✅ Fewer merge-conflict dead ends`
`✅ Clearer PR status reporting`
`✅ Fewer repeated conflict retries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
