### PR TITLE
docs(rules): align thread-resolution guidance with resolve-review-threads.sh (#520)

### DIFF
--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -39,7 +39,7 @@ Verify all findings against actual code. Fix all valid findings in one commit, p
 
 **Reply format:** Use plain text only in replies — do NOT include `@cursor` in reply comments (may trigger a re-review). This matches Greptile's reply behavior.
 
-**Thread resolution:** Same GraphQL mutations as CR/Greptile — `resolveReviewThread(threadId)` or `minimizeComment(subjectId, classifier: RESOLVED)`.
+**Thread resolution:** `resolve-review-threads.sh <PR> --thread-ids <id1,id2>` (retries + `minimizeComment` fallback).
 
 ## Merge Gate
 

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -77,7 +77,7 @@ This applies to ALL merge paths: manual `gh pr merge`, the `/merge` skill, the `
 
 ## Step 1c — All Review Threads Resolved (NON-NEGOTIABLE)
 
-Every thread must be `isResolved: true` via GraphQL `reviewThreads` (REST misses cursor/copilot bots). `merge-gate.sh` enforces this — any unresolved thread blocks, regardless of author. **If any unresolved: DO NOT MERGE.** Reply + `resolveReviewThread`, then re-check.
+Every thread must be `isResolved: true` via GraphQL `reviewThreads` (REST misses cursor/copilot bots). `merge-gate.sh` enforces this — any unresolved thread blocks, regardless of author. **If any unresolved: DO NOT MERGE.** Reply, then `resolve-review-threads.sh <PR>`, re-check.
 
 ## Step 1d — `mergeStateStatus` and branch sync (NON-NEGOTIABLE)
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes guidance drift found in #462's July 2026 instruction-set audit: `cr-merge-gate.md` Step 1c and `bugbot.md` now reference the shared `resolve-review-threads.sh` helper instead of inline `resolveReviewThread` GraphQL mutations, matching the canonical pattern in `cr-github-review.md` (post-#489).

## Changes

- **`cr-merge-gate.md` Step 1c:** Replace "Reply + `resolveReviewThread`" with `resolve-review-threads.sh <PR>`
- **`bugbot.md` Thread resolution:** Replace inline mutation list with `resolve-review-threads.sh <PR> --thread-ids <id1,id2>` (retries + `minimizeComment` fallback preserved via script)

Word count: 11457 → 11454 (−3 words, within neutral/slightly-negative budget).

## Test plan

- [x] `grep -rn 'resolveReviewThread' .claude/rules/` returns only the prohibition example in `cr-github-review.md`
- [x] Merge gate + BugBot paths reference the shared helper (`resolve-review-threads.sh`)
- [x] `.github/scripts/rule-lint.sh` passes
- [x] No semantics lost (retries, `minimizeComment` fallback preserved via script reference)
- [x] Net word change neutral or slightly negative (11457 → 11454)

Closes #520
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e797e3c7-a6df-4538-b921-00eb66dd6833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e797e3c7-a6df-4538-b921-00eb66dd6833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Align thread-resolution guidance with the shared helper**

### What Changed
- Replaces manual review-thread resolution instructions with the shared `resolve-review-threads.sh` command in bot and merge-gate guidance
- Keeps the same retry behavior and comment-resolution fallback, but points readers to one standard way to resolve threads
- Updates merge instructions so unresolved review threads remain a clear block before merging

### Impact
`✅ Fewer missed review threads`
`✅ Clearer merge checks`
`✅ Consistent thread-resolution guidance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
