### PR TITLE
feat(pm): drop Step 2 polling offer — cede to /pr-monitor-and-manage

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -27,7 +27,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 
 - `phase-decomposition.md` — phase split reference material
 - `pm-data-patterns.md` — PM skills data patterns and bot filters
-- `pm-monitoring-decision.md` — `/loop` vs `CronCreate` hybrid decision
+- `pm-monitoring-decision.md` — `/pm` vs `/pr-monitor-and-manage` division of responsibility
 - `scheduling-failure-modes.md` — recurring poll failure analysis
 - `skill-sync-hooks.md` — skills worktree sync and hook registration narrative
 - `double-loading-fix.md` — decision record for suppressing the duplicate global CLAUDE.md + rules copy via project-local `claudeMdExcludes` (#461)

--- a/.claude/reference/pm-monitoring-decision.md
+++ b/.claude/reference/pm-monitoring-decision.md
@@ -2,79 +2,57 @@
 
 ## Decision
 
-Use a **hybrid** PM monitoring model:
+Division of responsibility between orchestration and fleet monitoring:
 
-- **`/loop` is canonical for user-requested or session-scoped PM monitoring**, especially 1-2 active worker threads where the PM thread remains open and the user wants quick status checks.
-- **`CronCreate` is canonical for PM-initiated autonomous campaigns** when either:
-  - 3 or more worker threads/PRs are active, or
-  - the user asks monitoring to survive session exit/context turnover, or
-  - the PM starts work that is expected to outlive the current interactive session.
-- **Passive monitoring is only valid when there are no active worker threads, or when the user explicitly chooses passive mode.**
-
-This keeps `/loop` as the default recurring-poll primitive from `scheduling-reliability.md`, while using `CronCreate` only where its durability and fleet-management properties matter.
+- **`/pm` never creates polls.** It is a strictly on-demand orchestrator: cold-start scan, prompt generation, on-demand status when the user asks, and handoff generation. At ≥3 active threads it redirects to `/pr-monitor-and-manage`; it does not offer `CronCreate` or `/loop`.
+- **`/pr-monitor-and-manage` owns PR-fleet between-message polling.** It establishes `/loop` at the configured cadence, optionally registers `CronCreate` auto-wake on idle pause, and dispatches per-PR fixes/merges.
+- **`/loop` remains valid for explicit user-invoked "poll every N"** that is not PR-fleet-specific (e.g., "poll every 5m /status" on a single thread). Hand-rolled one-shot `ScheduleWakeup` chains are forbidden for recurring polls.
+- **`CronCreate` is for cross-session durability or fleet jobs owned by dedicated skills** (`/pr-monitor-and-manage` auto-wake, `/babysit-pr --durable`, etc.) — not `/pm`.
 
 ## Rationale
 
-The canonical PM manager use case is **tracking worker output across GitHub-visible artifacts**: issues, feature branches, PRs, review findings, CI state, handoff files, and Phase A/B/C state. The PM may be coordinating multiple coding threads or `/subagent`-launched Phase agents, but the monitoring loop should not depend on in-memory conversation state.
+The canonical PM manager use case is **tracking worker output across GitHub-visible artifacts**: issues, feature branches, PRs, review findings, CI state, handoff files, and Phase A/B/C state. The PM may be coordinating multiple coding threads or `/subagent`-launched Phase agents, but `/pm` itself should not arm a recurring poll — that overlaps with `/pr-monitor-and-manage`, which adds per-PR state classification, auto-dispatch to `/fixpr` and `/wrap`, and idle auto-pause.
 
-`/loop` is best when the PM is actively in-session:
+`/pr-monitor-and-manage` is the built, canonical fleet monitor. Before it existed, `/pm` offered its own `CronCreate`/`/loop` poll; that offer is retired (#522).
+
+`/loop` is still best when the user explicitly requests a session-scoped recurring command:
 
 - lower setup cost,
 - easy cancellation,
-- tighter 5-15 minute cadence for active review/merge windows,
-- already mandated for explicit "poll/check/watch every N" user requests.
+- already mandated for explicit "poll/check/watch every N" user requests per `scheduling-reliability.md`.
 
-`CronCreate` is best once PM monitoring becomes a small fleet operation:
-
-- runtime-owned cadence survives between user messages,
-- optional durable mode can survive session turnover,
-- one scheduled PM scan can summarize many PRs without hand-rolled wake-up chains,
-- the 7-day expiry bounds stale-job risk.
-
-The threshold is therefore not "PM work always uses Cron"; it is **"PM owns >=3 concurrent worker polls or needs cross-session durability."**
+`CronCreate` remains best for skill-owned durable jobs that must survive session turnover.
 
 ## State contract: `session-state.json`
 
-PM monitoring reads and writes `~/.claude/session-state.json`. Unknown fields must be preserved. The monitoring loop treats GitHub and handoff files as authoritative when state is stale.
+PM orchestration reads and writes `~/.claude/session-state.json`. Unknown fields must be preserved. GitHub and handoff files are authoritative when state is stale.
 
 ### Fields read
 
-- `monitoring_active`: whether any monitor loop should be active.
-- `monitoring_mode`: `loop`, `cron`, or `passive`.
-- `monitoring_command`: command/prompt to run each tick, usually `/status` until a PM-specific command exists.
-- `monitoring_interval_minutes`: intended cadence for `/loop` or human-readable cron cadence.
-- `monitoring_durable`: whether the monitor is expected to survive session exit.
-- `monitoring_started_at`, `last_poll_at`, `next_expected_poll_at`: timing watermarks.
+- `monitoring_active`: whether `/pm` is tracking in-flight work (passive/on-demand, not a recurring poll).
+- `monitoring_mode`: for `/pm`, always `passive`.
 - `root_repo`: absolute path to the **git root** of the repo where PR helpers run (must match `git rev-parse --show-toplevel` for that checkout). Also store the same path on `.prs["N"].root_repo` when multiple PRs/repos share one session file — validate equality before polling so a wrong-repo hazard cannot silently use another checkout.
 - `prs`: tracked PR map. Each entry may include `issue`, `phase`, `head_sha`, `reviewer`, `needs`, `status`, `worker`, and `updated_at`.
 - `active_agents`: subagent records. Each entry should include `id`, `task`, `issue`, `pr`, `phase`, `launched`, and optional `last_seen_at`.
-- `polling_jobs`: active scheduled jobs. Each entry should include `primitive`, `id`, `cron`, `prompt`, `recurring`, `durable`, `created_at`, and `expires_at` when known.
+- `polling_jobs`: active scheduled jobs **owned by other skills** (`/pr-monitor-and-manage`, `/babysit-pr`, etc.). Each entry should include `primitive`, `id`, `cron`, `prompt`, `recurring`, `durable`, `created_at`, and `expires_at` when known. `/pm` does not create or clear this array.
 - `polling_failures`: prior dropped-loop recoveries.
 - `cr_quota` and `greptile_daily`: review-budget state used by Phase B decisions.
+- `pmm_*` fields: owned by `/pr-monitor-and-manage`.
 
 ### Fields written
 
-Every polling turn updates:
+`/pm` updates on demand:
 
 - `last_updated`
-- `last_poll_at`
-- `next_expected_poll_at`
 - `monitoring_active`
-- `monitoring_mode`
-- `monitoring_command`
-- `monitoring_interval_minutes` or `polling_jobs[].cron`
-- `monitoring_durable`
+- `monitoring_mode` (`passive`)
+- tracked `prs` and `active_agents` when work changes
 
-When work changes, the loop also updates:
-
-- `prs[PR].phase`, `head_sha`, `reviewer`, `needs`, `status`, `updated_at`
-- `active_agents[]` on launch, completion, exhaustion, or failure
-- `polling_jobs[]` after `CronCreate`/`CronDelete`/recovery
-- `polling_failures[]` when a dropped loop is detected and re-established
+Skill-owned polling (`/pr-monitor-and-manage`, `/babysit-pr`) updates timing watermarks, `polling_jobs[]`, and `polling_failures[]` per their own contracts.
 
 ## Recovery protocol
 
-When a PM monitoring loop drops mid-campaign:
+When a PM session resumes after context turnover:
 
 1. Run the post-compaction/session-start recovery from `monitor-mode.md`: timestamp the first message, read `session-state.json`, read handoff files, then reconcile with live GitHub.
 2. Rebuild the active work table from:
@@ -84,28 +62,23 @@ When a PM monitoring loop drops mid-campaign:
    - open PRs and recent merged PRs,
    - open/closed issues referenced by the tracked PRs.
 3. If no active workers/PRs remain, set `monitoring_active=false` and stop.
-4. If active work remains and the prior mode was:
-   - `loop`: re-establish `/loop` with the recorded cadence, unless the user explicitly chose passive mode.
-   - `cron` with `durable=true`: verify the job with `CronList`; create a replacement only if missing.
-   - `cron` with `durable=false`: verify with `CronList` first; only create a fresh session-scoped `CronCreate` job if the recorded ID is absent or expired.
-   - `passive`: keep passive and report that active work exists but monitoring is user-triggered.
-5. Append a `polling_failures[]` entry with detection time, prior expected tick, recovery action, and remaining active work.
-6. Send a concise heartbeat identifying the recovered PRs/workers and the re-armed primitive.
+4. `/pm` does **not** restart a `/loop` or `CronCreate` on its own behalf. For between-message PR monitoring, point the user at `/pr-monitor-and-manage`. Jobs in `polling_jobs[]` owned by other skills recover per that skill's contract.
+5. Send a concise heartbeat identifying the recovered PRs/workers.
 
 This extends existing recovery; it does not create a second PM-specific recovery path.
 
 ## Rule placement
 
-- `scheduling-reliability.md` owns primitive selection and pre-exit checks.
-- `monitor-mode.md` owns in-turn subagent monitoring and recovery behavior.
+- `scheduling-reliability.md` owns primitive selection for user-invoked recurring commands and pre-exit checks.
+- `monitor-mode.md` owns in-turn subagent monitoring and PM orchestration recovery.
 - This reference doc records the rationale and state contract.
 - No new rule file is needed.
 
 ## Skill integration decision
 
-- `/pm`: detects active worker threads after cold start/resume. It recommends passive for zero active workers, `/loop` for 1-2 active workers, and `CronCreate` for 3+ workers or requested durability. It should record the selected primitive in `session-state.json`.
-- `/subagent`: when it spawns Phase A/B/C agents, it immediately enters Dedicated Monitor Mode for in-turn orchestration and records state. If the user requests between-turn monitoring or the campaign crosses 3 active PRs/workers, it should arm `CronCreate`; otherwise a session `/loop` is sufficient for user-facing recurring status.
-- `/status`: remains the default polling command because it already reconciles PRs, review state, checks, session state, and active agents.
-- `/pm-handoff`: captures active polling jobs and instructs the next PM thread how to re-establish them.
+- `/pm`: detects active worker threads after cold start/resume. At ≥3 threads, redirects to `/pr-monitor-and-manage`. Never creates polls. Records passive tracking in `session-state.json`.
+- `/pr-monitor-and-manage`: owns PR-fleet between-message polling with `/loop`, optional `CronCreate` auto-wake, per-PR dispatch, and idle auto-pause.
+- `/subagent`: when it spawns Phase A/B/C agents, it immediately enters Dedicated Monitor Mode for in-turn orchestration and records state. For between-turn PR fleet monitoring, point the user at `/pr-monitor-and-manage`; for explicit user "poll every N" on non-PR work, use `/loop` per `scheduling-reliability.md`.
+- `/status`: remains the default on-demand scan command because it already reconciles PRs, review state, checks, session state, and active agents.
+- `/pm-handoff`: captures orchestration state for resume; snapshots any live `polling_jobs[]` owned by other skills for informational continuity but does not instruct the new thread to recreate `/pm` polls.
 - `/start-issue`: does not auto-arm monitoring. It creates/starts one coding workflow; monitoring becomes relevant only after a PR, worker thread, or `/subagent` campaign exists.
-- New `/pm-monitor` skill: defer. Add it only if `/status` plus `/pm` setup becomes too large or needs a dedicated implementation surface.

--- a/.claude/reference/session-state-schema.json
+++ b/.claude/reference/session-state-schema.json
@@ -60,7 +60,7 @@
     {"id": "a3f8d26fa75eddcb3", "task": "PR #620 Phase C", "issue": 503, "pr": 620, "phase": "C", "launched": "2026-03-16T15:55:00Z", "last_seen_at": "2026-03-16T15:58:00Z"}
   ],
   "polling_jobs": [
-    {"primitive": "CronCreate", "id": "cron_abc123", "cron": "17 * * * *", "prompt": "/status", "recurring": true, "durable": false, "created_at": "2026-03-16T15:00:00Z", "expires_at": "2026-03-23T15:00:00Z"}
+    {"primitive": "CronCreate", "id": "cron_abc123", "cron": "17 * * * *", "prompt": "/pr-monitor-and-manage-wake --auto-check", "recurring": true, "durable": true, "created_at": "2026-03-16T15:00:00Z", "expires_at": "2026-03-23T15:00:00Z"}
   ],
   "polling_failures": [
     {"detected_at": "2026-03-16T15:58:00Z", "expected_at": "2026-03-16T15:57:00Z", "context": "PM tick dropped at 11:57 AM ET", "recovery": "restarted via /loop 5m /status", "active_work": ["PR #618", "PR #619", "PR #620"]}

--- a/.claude/rules/monitor-mode.md
+++ b/.claude/rules/monitor-mode.md
@@ -50,15 +50,14 @@ If a summary block references prior work you do not remember, recover before all
 
 ## PM Monitoring Recovery
 
-If `monitoring_active=true` or passive mode with non-empty `prs`, rebuild from `prs`, `active_agents`, handoffs, and GitHub before re-arming.
+If `monitoring_active=true` or passive mode with non-empty `prs`/`active_agents`, rebuild from `prs`, `active_agents`, handoffs, and GitHub before continuing.
 
 - No workers left → `monitoring_active=false`, report done.
-- Was `loop` → restart recorded `/loop` unless user chose passive.
-- Was `cron` + durable → `CronList`; recreate if missing.
-- Was `cron` + not durable → recreate expired session jobs.
-- Was passive → stay passive; note user-triggered work remains.
+- `/pm`-owned monitoring is always passive — do **not** restart a `/loop` or `CronCreate` on `/pm`'s behalf.
+- For between-message PR fleet monitoring → point user at `/pr-monitor-and-manage`.
+- Jobs in `polling_jobs[]` owned by other skills (`/pr-monitor-and-manage`, `/babysit-pr`) → recover per that skill's contract, not `/pm`'s.
 
-Log drops in `polling_failures[]`. Contract: `pm-monitoring-decision.md`.
+Log drops in `polling_failures[]` when a skill-owned poll drops. Contract: `pm-monitoring-decision.md`.
 
 ### Pre-Compaction Checkpointing (Preventive)
 

--- a/.claude/rules/scheduling-reliability.md
+++ b/.claude/rules/scheduling-reliability.md
@@ -18,13 +18,14 @@ The 5-minute heartbeat rule catches silence during turns; this file covers betwe
 
 ## PM Monitoring Primitive
 
-PM manager monitoring uses the hybrid decision recorded in `.claude/reference/pm-monitoring-decision.md`:
+Division of responsibility (see `.claude/reference/pm-monitoring-decision.md`):
 
-- `/loop` is canonical for explicit user-requested polling and 1-2 session-scoped PM worker threads.
-- `CronCreate` is canonical for 3+ active threads/PRs, cross-session durability, or campaigns outliving the session.
-- Passive mode is valid only with zero active workers or when the user explicitly chooses it.
+- `/pm` never creates polls — on-demand orchestration only.
+- `/pr-monitor-and-manage` owns PR-fleet between-message polling (`/loop` + optional `CronCreate` auto-wake).
+- `/loop` remains valid for explicit user-invoked "poll every N" that is not PR-fleet-specific.
+- `CronCreate` for cross-session durability or fleet jobs owned by dedicated skills.
 
-Each polling turn: update `session-state.json` monitoring fields. If a loop drops, run `monitor-mode.md` **PM Monitoring Recovery** (and apply dropped-tick handling in this file).
+Each skill-owned polling turn: update `session-state.json` as that skill's contract requires. If orchestration state is stale, run `monitor-mode.md` **PM Monitoring Recovery** (and apply dropped-tick handling in this file for skill-owned polls).
 
 ## Forbidden Pattern: Hand-Rolled One-Shot Chains
 

--- a/.claude/scripts/off-peak-minute.sh
+++ b/.claude/scripts/off-peak-minute.sh
@@ -2,12 +2,13 @@
 # off-peak-minute.sh — Deterministic per-repo off-peak cron minute selector.
 #
 # PURPOSE
-#   Centralizes the minute-selection contract used by `/pm` Step 2.3 when
-#   scheduling CronCreate polling jobs. Each repo gets a stable minute in
-#   [0, 59] derived from its `owner/name` string, then nudged off the
-#   fleet pile-up minutes (0, 5, 30, 55) where every agent's schedule
-#   collides on the API. Deterministic so the same repo always lands on
-#   the same minute; spread so different repos fan out across the hour.
+#   Centralizes the minute-selection contract used by skills that schedule
+#   CronCreate jobs (e.g. `/pr-monitor-and-manage` auto-wake, `/babysit-pr
+#   --durable`). Each repo gets a stable minute in [0, 59] derived from its
+#   `owner/name` string, then nudged off the fleet pile-up minutes (0, 5, 30,
+#   55) where every agent's schedule collides on the API. Deterministic so
+#   the same repo always lands on the same minute; spread so different repos
+#   fan out across the hour.
 #
 #   With --every-n-min N the script also emits a cron-friendly step-range
 #   string like "7-59/10". The base minute is first reduced to its ones-
@@ -71,8 +72,8 @@ usage_error() {
 
 # Nudge MINUTE off the fleet pile-up minutes 0, 5, 30, 55 by adding 2
 # (mod 60). The +2 pattern is the same one used historically inline in
-# `/pm` Step 2.3 — kept for compatibility with any existing crons whose
-# minutes were computed that way.
+# skill cron scheduling — kept for compatibility with any existing crons
+# whose minutes were computed that way.
 nudge_pileup() {
   local m="$1"
   case "$m" in

--- a/.claude/skills/pm-handoff/SKILL.md
+++ b/.claude/skills/pm-handoff/SKILL.md
@@ -160,11 +160,7 @@ You are continuing from a previous PM session. The state below reflects where th
 
 ## Bootstrap steps for this new thread
 1. Run `/pm` (without `resume`) to load config and re-scan GitHub state.
-2. **Re-establish polling.** Check the "Active Polling Jobs" table below:
-   - If it lists `durable: true` jobs → run `CronList` to confirm they're still active; skip creating duplicates.
-   - If it lists `durable: false` (session-only) jobs → those died with the previous session. Create fresh `CronCreate` job(s) with the same `cron` and `prompt` values from the table. Cite the new job ID(s) back to the user.
-   - If the table is empty and there are active cloud threads → `/pm` Step 2 will offer a fresh poll — accept the recommended option.
-3. Review the in-flight work table and verify each PR's state before taking action.
+2. **Restore orchestration state.** Review the in-flight work table and verify each PR's state before taking action. PR fleet polling is handled separately via `/pr-monitor-and-manage` if needed — `/pm` does not re-arm polls on resume.
 
 ## Your Role
 {Role section from config}
@@ -192,7 +188,7 @@ Do NOT spawn subagents or use the Agent tool to execute work yourself. Write the
 {From Step 5b — or "No in-flight work detected" if empty}
 
 ## Active Polling Jobs
-{From Step 5b2 — or "No active polling. On resume, `/pm` Step 2 will offer a fresh poll." if empty}
+{From Step 5b2 — or "No active polling jobs from other skills. For PR fleet monitoring, run `/pr-monitor-and-manage`." if empty}
 
 ## Lessons & Context
 {From Step 5c — or omit if no memory index found}
@@ -258,11 +254,11 @@ Format as a readable summary:
 
 If no state files exist, output: "No in-flight work detected. Starting fresh."
 
-### Step 5b2: Capture active polling jobs
+### Step 5b2: Capture active polling jobs (informational)
 
-The PM agent uses `CronCreate` or `/loop` to poll GitHub between user messages (see `/pm` Step 2). Capture any active polling so the new thread can re-establish it rather than falling back to passive mode.
+Snapshot any live scheduled jobs owned by **other skills** (`/pr-monitor-and-manage`, `/babysit-pr`, etc.) for informational continuity. `/pm` no longer arms its own polls — do not instruct the new thread to recreate `/pm` polls.
 
-Call the `CronList` tool to list all cron jobs scheduled in this session. For each job, record: `id`, `cron`, `prompt`, `recurring`, `durable`, and — if available from the PM's own session notes — the last heartbeat time and cycle interval.
+Call the `CronList` tool to list all cron jobs scheduled in this session. For each job, record: `id`, `cron`, `prompt`, `recurring`, `durable`, and — if available — the last heartbeat time and cycle interval.
 
 Format as:
 
@@ -271,12 +267,12 @@ Format as:
 
 | Job ID | Schedule | Prompt | Recurring | Durable | Last heartbeat |
 |--------|----------|--------|-----------|---------|----------------|
-| abc123 | 17 * * * * | /status | true | false (session-only) | {time} ET |
+| abc123 | 17 * * * * | /pr-monitor-and-manage-wake --auto-check | true | true | {time} ET |
 
-**Re-establish on resume:** Session-only jobs (`durable: false`) die with this session — the new thread must create a fresh `CronCreate` with the same `cron`, `prompt`, and `durable` values (cite this table for exact values). Durable jobs survive automatically; verify with `CronList` on resume before creating duplicates. If no jobs are active and ≥1 cloud thread is in flight, `/pm` Step 2 will offer a fresh poll.
+**On resume:** Durable jobs survive session turnover — verify with `CronList` before creating duplicates. Session-only jobs died with the previous session; re-arm via the owning skill if needed. For PR fleet monitoring, run `/pr-monitor-and-manage`.
 ```
 
-If `CronList` returns no jobs, output: "No active polling. On resume, `/pm` Step 2 will offer a fresh poll."
+If `CronList` returns no jobs, output: "No active polling jobs from other skills. For PR fleet monitoring, run `/pr-monitor-and-manage`."
 
 ### Step 5c: Memory summary
 

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -298,7 +298,7 @@ Cross-reference the open-issue list (already fetched in Step 1) against open PRs
 
 When `ACTIVE_COUNT ≥ 3`, surface a one-line redirect (do NOT offer `CronCreate` or `/loop`):
 
-> "You have {N} active cloud threads. Once PRs start opening, run `/pr-monitor-and-manage` to auto-dispatch fixes and merges across the fleet with per-PR state tracking."
+> "You have {N} active cloud threads. Run `/pr-monitor-and-manage` to auto-dispatch fixes and merges across the fleet with per-PR state tracking."
 
 For 0–2 active threads, emit no polling offer — proceed with the assignments table and status only.
 

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -132,7 +132,7 @@ Show the user:
 
 Proceed with current assignments by default. State: "Continuing with current assignments. Say 're-prioritize' to change strategy."
 
-Then proceed to **Step 2: Active Monitoring Setup** (resume mode must re-establish polling — see Step 2).
+Then proceed to **Step 2: Active Monitoring Setup** (resume mode restores passive tracking — see Step 2).
 
 ---
 
@@ -279,11 +279,11 @@ Then proceed to **Step 2: Active Monitoring Setup**.
 
 ## Step 2: Active Monitoring Setup
 
-After Step 1 presents assignments/suggestions, detect whether any **active cloud threads** exist and offer (do NOT auto-start) a polling loop. The PM agent can't autonomously poll GitHub between user messages without a timer — this step wires one up so state changes (new PRs, CR findings, merges, CI failures) get surfaced without the user having to ping.
+After Step 1 presents assignments/suggestions, detect whether any **active cloud threads** exist and configure on-demand tracking. `/pm` is a strictly on-demand orchestrator — it does **not** propose or arm any recurring poll (`CronCreate`, `/loop`, or hand-rolled wake chains). PR fleet monitoring between messages is owned by `/pr-monitor-and-manage`.
 
-Resume mode passes through this step too — polling needs to be re-established after context turnover.
+Resume mode passes through this step too — restore passive tracking state; do **not** re-arm a poll.
 
-**Primitive selection (MANDATORY):** Use the hybrid decision in `.claude/reference/pm-monitoring-decision.md`. For any user-initiated "poll every N" request, `/loop` is **mandatory** — not just recommended. `CronCreate` is reserved for PM-initiated autonomous monitoring across ≥3 concurrent threads, cross-session durability, or campaigns expected to outlive the current interactive session. Hand-rolled one-shot `ScheduleWakeup` chains are forbidden for recurring polls — they drop silently when the model forgets to re-schedule. For the full decision tree and the pre-exit checklist that every polling turn must run, see `.claude/rules/scheduling-reliability.md`.
+For explicit user-initiated "poll every N" requests that are not PR-fleet-specific, `/loop` remains the canonical primitive per `.claude/rules/scheduling-reliability.md`. `/pm` itself never sets one up.
 
 ### 2.1: Detect active threads
 
@@ -294,82 +294,33 @@ An active cloud thread is an open issue (assigned to `$GH_USER` if set, otherwis
 
 Cross-reference the open-issue list (already fetched in Step 1) against open PRs and `git branch -r` / `git worktree list`. Count the result as `ACTIVE_COUNT`.
 
-### 2.2: Offer a polling option (do NOT auto-start)
+### 2.2: Fleet monitoring redirect (≥3 active threads)
 
-Based on `ACTIVE_COUNT`, recommend one of three options:
+When `ACTIVE_COUNT ≥ 3`, surface a one-line redirect (do NOT offer `CronCreate` or `/loop`):
 
-| Threads | Recommended | Rationale |
-|---------|-------------|-----------|
-| ≥3 active | **(a) Recurring `CronCreate` poll** — set-and-forget, fires even when REPL is idle between user messages | Too many threads to track manually |
-| 1-2 active | **(b) `/loop 5m /status`** — dynamic, tied to this session, dies on session exit | Lightweight; self-paced |
-| 0 active | **(c) Passive** — user pings the PM thread when PRs need attention | Nothing to monitor |
+> "You have {N} active cloud threads. Once PRs start opening, run `/pr-monitor-and-manage` to auto-dispatch fixes and merges across the fleet with per-PR state tracking."
 
-Only offer option (c) proactively when there are zero active threads. If the user explicitly requests passive mode at any count, honor it.
+For 0–2 active threads, emit no polling offer — proceed with the assignments table and status only.
 
-**In the same message that proposes the option, state the cancel command.** The user should never have to spelunk to escape a poll:
+### 2.3: Passive tracking (default)
 
-- Option (a): `CronDelete {jobId}` — emit the job ID as soon as `CronCreate` returns it.
-- Option (b): interrupt the loop (Ctrl+C in CLI, stop in web), or say "stop polling".
-- Option (c): N/A.
+`/pm` tracks orchestration state on demand. When the user asks "status", "what's next?", or similar, Step 3 fetches live GitHub state and updates the assignments table. The user may explicitly say "passive" or "just track state" at any time — honor that.
 
-Template message:
+Update `~/.claude/session-state.json` to reflect passive tracking. Preserve unknown fields and record at least:
 
-> "Detected {N} active cloud threads. Recommend **{option}** — {schedule/command}. To stop: **{cancel command}**. Say 'yes' to start, 'passive' to skip, or pick a different option."
+- `monitoring_active` — true when `/pm` is tracking in-flight work (not a recurring poll)
+- `monitoring_mode`: `passive` for `/pm`-owned monitoring
+- tracked `prs` and `active_agents` where known
 
-### 2.2a: Record selected monitoring state
+**Do not create, modify, or clear `polling_jobs[]` on `/pm`'s behalf.** That field remains valid for other skills (`/pr-monitor-and-manage`, `/babysit-pr`, etc.); leave entries `/pm` did not create intact.
 
-When the user selects an option, update `~/.claude/session-state.json` before the first tick. Preserve unknown fields and record at least:
+If orchestration state is stale after context turnover, recover using `.claude/rules/monitor-mode.md` "PM Monitoring Recovery".
 
-- `monitoring_active`
-- `monitoring_mode` (`loop`, `cron`, or `passive`)
-- `monitoring_command` (default `/status`)
-- `monitoring_interval_minutes` for `/loop`, or `polling_jobs[].cron` for `CronCreate`
-- `monitoring_durable`
-- `monitoring_started_at`, `last_poll_at`, `next_expected_poll_at`
-- tracked `prs`, `active_agents`, and `polling_jobs` where known
+### 2.4: Backwards compatibility
 
-Each later polling turn refreshes the timing watermarks and any changed PR/agent status. If the loop drops, recover using `.claude/rules/monitor-mode.md` "PM Monitoring Recovery".
+Any `/pm`-created `CronCreate` jobs from before this change persist until the 7-day auto-expiry or explicit `CronDelete`. New `/pm` sessions do not create replacement polls.
 
-Mode-switch cleanup requirements:
-- Switching to `passive`: set `monitoring_active=false`, clear `next_expected_poll_at`, run `CronDelete` for each entry in `polling_jobs[]`, then clear `polling_jobs[]` so `session-state.json` stays authoritative.
-- Switching away from `cron`: call `CronDelete` for each live job in `polling_jobs[]`, then remove their IDs from `polling_jobs[]` so `session-state.json` stays authoritative.
-- Switching to `cron`: persist returned job IDs to `polling_jobs[]` immediately; keep `polling_jobs[]` authoritative.
-
-### 2.3: Off-peak minute selection (option a only)
-
-When creating a `CronCreate` job, pick a minute that is NOT 0, 5, 30, or 55 — these are fleet pile-up minutes where every agent's schedule collides on the API. Use `.claude/scripts/off-peak-minute.sh` so the same repo always lands on the same minute (predictability) but different repos spread across the hour (no collision):
-
-```bash
-MINUTE=$(.claude/scripts/off-peak-minute.sh)
-echo "Off-peak minute for $(gh repo view --json nameWithOwner --jq .nameWithOwner): $MINUTE"
-```
-
-The script hashes the current repo's `owner/name` with `cksum`, reduces mod 60, and nudges off the pile-up minutes (0, 5, 30, 55). Pass `--repo <owner/name>` to target a different repo; pass `--every-n-min N` to also emit a cron-friendly step-range (see below).
-
-**CronCreate defaults for `/pm` polling:**
-- `cron`: `"$MINUTE * * * *"` for hourly (most common). For tighter cadence like every 10 min, invoke the script with `--every-n-min 10` — it returns two lines (chosen minute on line 1, range string like `7-59/10` on line 2), and handles the ones-digit reduction + re-nudge so the step range doesn't truncate (cron's `A-59/10` form fires only at :A and :A+10 when `A > 9`, e.g., `47-59/10` silently collapses to :47 and :57). Example: `{ read -r M; read -r RANGE; } < <(.claude/scripts/off-peak-minute.sh --every-n-min 10); CRON="$RANGE * * * *"`.
-- `recurring`: `true` (default).
-- `durable`: `false` — session-only. Only set `durable: true` when the user explicitly asks the poll to survive across sessions.
-- `prompt`: `/status` (or a PM-specific scan command) — the cron fires it in a fresh invocation, so the prompt must be self-contained.
-- Tell the user about the 7-day auto-expiry.
-
-### 2.4: Heartbeat etiquette
-
-Every poll cycle should produce **at most ~3 lines** of status unless action is required. Long silence between cycles is the goal — the user shouldn't feel spammed.
-
-This cadence is independent of the 5-minute user-heartbeat rule in `.claude/rules/monitor-mode.md` (which applies only while actively monitoring subagents). PM polling is a slower tempo — hourly is normal, 5-10 min when PRs are actively merging.
-
-Good heartbeat:
-```
-{time} ET — 3 active PRs: #88 clean, #90 CR reviewing, #92 CI failing. No action needed.
-```
-
-Bad heartbeat (too verbose):
-```
-{time} ET — Polled GitHub. PR #88 has 0 new comments, last review clean, CI green, waiting for merge gate. PR #90 ...
-```
-
-After setup (or if the user picks passive mode), proceed to **Step 3: Orchestration Loop**.
+After setup, proceed to **Step 3: Orchestration Loop**.
 
 ---
 

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -286,7 +286,7 @@ worktree directory at all times.
 
 > **Note on `subagent_type`:** Do NOT set `subagent_type: "phase-a-fixer"` here. The `/subagent` skill's "Phase A" does **initial implementation** of a new issue (no PR exists yet), but `.claude/agents/phase-a-fixer.md` is designed for **fixing existing review findings** on an already-open PR — its workflow references findings, review threads, and push replies that don't apply to green-field implementation. Let this Agent call fall back to the default general-purpose agent; the long custom prompt below carries all the rules the subagent needs.
 
-Record each spawned agent in `session-state.json` under `active_agents` and set `monitoring_active=true`. Also record the monitoring primitive state from `.claude/reference/pm-monitoring-decision.md`: use in-turn Dedicated Monitor Mode immediately, and arm between-turn `/loop` for 1-2 active workers or `CronCreate` for 3+ workers/cross-session durability when the campaign needs polling after the current turn.
+Record each spawned agent in `session-state.json` under `active_agents` and set `monitoring_active=true`. Also record the monitoring primitive state from `.claude/reference/pm-monitoring-decision.md`: use in-turn Dedicated Monitor Mode immediately. For between-turn PR fleet monitoring, point the user at `/pr-monitor-and-manage`; for explicit user "poll every N" on non-PR work, use `/loop` per `scheduling-reliability.md`.
 
 ## Step 8: Enter Monitor Mode
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Retires `/pm`'s Step 2 polling offer (`CronCreate` / `/loop 5m /status`) in favor of a redirect to `/pr-monitor-and-manage` when ≥3 active threads are detected. `/pm` is now a strictly on-demand orchestrator; PR fleet between-message polling is owned by PMM.

Closes #522

## Changes

- **`.claude/skills/pm/SKILL.md`** — Rewrote Step 2: removed options table, off-peak scheduling, heartbeat etiquette, and `polling_jobs[]` mutation. Added `/pr-monitor-and-manage` redirect at ≥3 threads, passive tracking default, and backwards-compat migration note.
- **`.claude/reference/pm-monitoring-decision.md`** — Documented new division: `/pm` never polls; PMM owns PR fleet polling; `/loop` valid for explicit user non-PR polls.
- **`.claude/rules/monitor-mode.md`** — PM Monitoring Recovery no longer restarts `/pm`-created polls.
- **`.claude/rules/scheduling-reliability.md`** — Updated PM Monitoring Primitive section to redirect PR polling to PMM.
- **`.claude/skills/pm-handoff/SKILL.md`** — Removed "re-establish polling on resume"; handoff snapshots other skills' jobs for info only.
- **`.claude/skills/subagent/SKILL.md`** — Aligned cross-reference with new decision doc.
- **`.claude/scripts/off-peak-minute.sh`** — Re-attributed comments away from `/pm` Step 2.3.
- **`.claude/reference/session-state-schema.json`** — Updated example `polling_jobs[]` entry to PMM-owned job.

## Test Plan

- [ ] Fresh `/pm` cold-start with 0 active threads → no polling offer; passive-track behavior only
- [ ] `/pm` cold-start with 2 active threads → no polling offer; just an assignments table + status
- [ ] `/pm` cold-start with 3+ active threads → redirect message naming `/pr-monitor-and-manage`; no `CronCreate`/`/loop` proposal
- [ ] User says "status" to a running `/pm` thread → live GitHub scan runs, table updates, no polling
- [ ] `/pm-handoff` followed by a `/pm resume` in a fresh thread → resumed session picks up assignments but does NOT restart or offer a poll
- [ ] Grep `.claude/` for any residual references to `/pm` setting up polls — should be zero after the sweep
- [ ] `/pr-monitor-and-manage` invocation still works normally — it's the recommended path from `/pm`'s redirect

## Acceptance Criteria

- [x] `.claude/skills/pm/SKILL.md` Step 2 no longer offers `CronCreate` or `/loop 5m /status`
- [x] When active-thread count ≥3, `/pm` surfaces redirect to `/pr-monitor-and-manage`
- [x] Redirect names skill by exact command with one-line description
- [x] Step 3 status-detection behavior unchanged
- [x] Cold-start scan + prompt generation unchanged
- [x] `session-state.json` mode-switch cleanup simplified — `/pm` no longer creates/clears `polling_jobs[]`
- [x] `pm-monitoring-decision.md` updated for new division
- [x] `monitor-mode.md` PM Monitoring Recovery updated
- [x] Rule files grep-swept for stale `/pm` polling references
- [x] `/pm-handoff` updated — no polling re-establishment on resume

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2a18170-e517-4e1b-a9d9-e5fa213ec8b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2a18170-e517-4e1b-a9d9-e5fa213ec8b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Move PR fleet monitoring out of `/pm` and into `/pr-monitor-and-manage`**

### What Changed
- `/pm` no longer offers or restarts recurring polls; when 3 or more active threads are detected, it directs users to `/pr-monitor-and-manage` instead.
- `/pm` now stays on-demand and passive, keeping only current work status without creating, deleting, or re-arming polling jobs.
- Resume and recovery flows no longer tell users to rebuild `/pm` polling; polling jobs are treated as owned by other skills and are recovered through those skills instead.
- The off-peak scheduling helper and related references now point to the skills that still create scheduled jobs.

### Impact
`✅ Fewer duplicate polling jobs`
`✅ Clearer PR fleet monitoring handoff`
`✅ Less confusion after session resume`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
