### PR TITLE
docs(#417): verification-evidence-patterns reference

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -32,6 +32,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `skill-sync-hooks.md` — skills worktree sync and hook registration narrative
 - `double-loading-fix.md` — decision record for suppressing the duplicate global CLAUDE.md + rules copy via project-local `claudeMdExcludes` (#461)
 - `skill-authoring-patterns.md` — authoring *judgment* for skills/rules (description-as-trigger, match-form-to-failure, bulletproofing); complements CONTRIBUTING.md mechanics
+- `verification-evidence-patterns.md` — claim→evidence checklist for AC, exit reports, and merge claims; complements phase protocols (#417 harvest from superpowers)
 
 ### Living trackers (updated each cycle — not point-in-time)
 

--- a/.claude/reference/verification-evidence-patterns.md
+++ b/.claude/reference/verification-evidence-patterns.md
@@ -42,12 +42,12 @@ Skip a step = the claim is unsupported.
 | Local CR clean | `coderabbit review --agent` → zero findings on current diff | Earlier clean run before new edits |
 | Rule budget OK | `{ cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } \| wc -w` within budget; `rule-lint.sh` pass | "Looks short" |
 | Hook tests pass | `for f in .claude/hooks/tests/*.test.sh; do bash "$f"; done` + `python3 -m unittest discover -s tests -p 'test_*.py'` | Single test file only |
-| CI green on PR SHA | `bash .claude/scripts/ci-status.sh <PR>` or `merge-gate.sh` JSON `ci_clean: true` on current HEAD | Last run before push |
+| CI green on PR SHA | `bash .claude/scripts/ci-status.sh <PR>` or `merge-gate.sh` JSON with `ci_status.failing == 0` and `ci_status.in_progress == 0` on current HEAD | Last run before push |
 | Review gate met | `bash .claude/scripts/merge-gate.sh <PR>` exit 0 + quoted verdict JSON (omit `--reviewer` — auto-detects cr/bugbot/greptile path) | Stale APPROVED on old SHA |
 | AC checkboxes honest | `ac-checkboxes.sh --extract` matches reality; only `--tick` after verification | Ticking from intent |
 | Phase A/B complete | Exit report block per `exit-report-format.md` with command output | "Fixed the findings" |
 | PR merge-ready | `merge-gate.sh` exit 0 **and** zero unresolved threads **and** CI clean on HEAD | Local review only |
-| Skill conventions OK | `bash .claude/scripts/skill-conventions-audit.sh` exit 0 (or documented warnings) | Eyeballing frontmatter |
+| Skill conventions OK | `bash .claude/scripts/skill-conventions-audit.sh` exit 0 when the script is present on the branch (issue #417); else `rule-lint.sh` + frontmatter spot-check | Eyeballing frontmatter |
 
 ## Red flags — stop and verify
 

--- a/.claude/reference/verification-evidence-patterns.md
+++ b/.claude/reference/verification-evidence-patterns.md
@@ -41,9 +41,9 @@ Skip a step = the claim is unsupported.
 |-------|---------------------------|----------------|
 | Local CR clean | `coderabbit review --agent` → zero findings on current diff | Earlier clean run before new edits |
 | Rule budget OK | `{ cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } \| wc -w` within budget; `rule-lint.sh` pass | "Looks short" |
-| Hook tests pass | `bash .claude/hooks/tests/*.test.sh` + `python3 -m unittest discover -s tests -p 'test_*.py'` | Single test file only |
+| Hook tests pass | `for f in .claude/hooks/tests/*.test.sh; do bash "$f"; done` + `python3 -m unittest discover -s tests -p 'test_*.py'` | Single test file only |
 | CI green on PR SHA | `bash .claude/scripts/ci-status.sh <PR>` or `merge-gate.sh` JSON `ci_clean: true` on current HEAD | Last run before push |
-| Review gate met | `bash .claude/scripts/merge-gate.sh <PR> --reviewer cr` exit 0 + quoted verdict JSON | Stale APPROVED on old SHA |
+| Review gate met | `bash .claude/scripts/merge-gate.sh <PR>` exit 0 + quoted verdict JSON (omit `--reviewer` — auto-detects cr/bugbot/greptile path) | Stale APPROVED on old SHA |
 | AC checkboxes honest | `ac-checkboxes.sh --extract` matches reality; only `--tick` after verification | Ticking from intent |
 | Phase A/B complete | Exit report block per `exit-report-format.md` with command output | "Fixed the findings" |
 | PR merge-ready | `merge-gate.sh` exit 0 **and** zero unresolved threads **and** CI clean on HEAD | Local review only |

--- a/.claude/reference/verification-evidence-patterns.md
+++ b/.claude/reference/verification-evidence-patterns.md
@@ -1,0 +1,86 @@
+# Verification Evidence Patterns
+
+On-demand reference for **evidence-before-claims** discipline in this repo's
+workflow. Phase A/B/C exit reports and `/check-acceptance-criteria` already
+require proof; this document distills the *judgment* — which command proves
+which claim — adapted from [obra/superpowers
+`verification-before-completion`](https://github.com/obra/superpowers/tree/main/skills/verification-before-completion)
+(harvested via issue #417).
+
+The superpowers plugin skill remains the runtime source for generic
+verification discipline. Read this when writing exit reports, ticking AC
+checkboxes, or claiming merge readiness in *this* repo.
+
+Not auto-loaded.
+
+## Iron law (repo-specific)
+
+```
+NO COMPLETION / MERGE / AC CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE IN THIS MESSAGE
+```
+
+If you have not run the proving command in the current turn, you cannot claim the
+outcome — even if a prior turn passed, a subagent reported success, or CI
+"should" be green after a push.
+
+## Gate function
+
+Before any status claim (`done`, `passing`, `clean`, `merge-ready`, `AC met`):
+
+1. **Identify** — what command or script output proves this claim in *our* stack?
+2. **Run** — execute the full command fresh (not a partial grep, not memory).
+3. **Read** — exit code + full relevant output (counts, SHAs, verdict lines).
+4. **Verify** — does output actually support the claim?
+5. **Claim with evidence** — quote the decisive lines or JSON fields.
+
+Skip a step = the claim is unsupported.
+
+## Claim → evidence map (our workflow)
+
+| Claim | Proving command / artifact | Not sufficient |
+|-------|---------------------------|----------------|
+| Local CR clean | `coderabbit review --agent` → zero findings on current diff | Earlier clean run before new edits |
+| Rule budget OK | `{ cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } \| wc -w` within budget; `rule-lint.sh` pass | "Looks short" |
+| Hook tests pass | `bash .claude/hooks/tests/*.test.sh` + `python3 -m unittest discover -s tests -p 'test_*.py'` | Single test file only |
+| CI green on PR SHA | `bash .claude/scripts/ci-status.sh <PR>` or `merge-gate.sh` JSON `ci_clean: true` on current HEAD | Last run before push |
+| Review gate met | `bash .claude/scripts/merge-gate.sh <PR> --reviewer cr` exit 0 + quoted verdict JSON | Stale APPROVED on old SHA |
+| AC checkboxes honest | `ac-checkboxes.sh --extract` matches reality; only `--tick` after verification | Ticking from intent |
+| Phase A/B complete | Exit report block per `exit-report-format.md` with command output | "Fixed the findings" |
+| PR merge-ready | `merge-gate.sh` exit 0 **and** zero unresolved threads **and** CI clean on HEAD | Local review only |
+| Skill conventions OK | `bash .claude/scripts/skill-conventions-audit.sh` exit 0 (or documented warnings) | Eyeballing frontmatter |
+
+## Red flags — stop and verify
+
+- "Should pass now", "probably clean", "looks good"
+- Satisfaction words before running proof ("Done!", "All set!", "Merge-ready!")
+- Trusting subagent "success" without VCS diff or test output
+- Partial checks (linter only when tests are the claim)
+- Quoting CI/CR from a SHA that is not current HEAD after your last push
+- Ticking Test plan checkboxes before running the listed verification
+
+## Rationalization table
+
+| Excuse | Reality |
+|--------|---------|
+| "CR was clean earlier" | Re-run on current diff |
+| "Subagent said tests pass" | Run the test command yourself |
+| "Linter is clean" | Linter ≠ tests ≠ merge gate |
+| "Just this once" | No exceptions — exit reports are audit trail |
+| "Different wording so rule doesn't apply" | Spirit over letter |
+| "User wants it merged" | Gate first, merge second |
+
+## Where this applies in our skills
+
+- **`/check-acceptance-criteria`** — each AC item needs mapped evidence before `--tick`
+- **`/wrap`, `/merge`, `/go-on`** — `merge-gate.sh` + thread/CI proof on HEAD
+- **`/fixpr`** — zero failing checks means `ci-status` output, not assumption
+- **Phase A/B/C exit reports** — include command output snippets per `exit-report-format.md`
+- **CONTRIBUTING PRs** — Test plan checkboxes are claims; verify before checking
+
+## Related
+
+- `.claude/reference/exit-report-format.md` — structured proof blocks
+- `.claude/rules/cr-local-review.md` — local CR loop
+- `.claude/rules/cr-merge-gate.md` — GitHub merge gate
+- `.claude/skills/check-acceptance-criteria/SKILL.md` — AC verification skill
+- superpowers plugin `verification-before-completion` — generic discipline skill

--- a/.claude/rules/phase-protocols.md
+++ b/.claude/rules/phase-protocols.md
@@ -6,7 +6,7 @@
 
 ## Structured Exit Report (MANDATORY — all phases)
 
-Every subagent MUST print an `EXIT_REPORT` block as its **final output**. Required fields and valid `OUTCOME` values live in `.claude/reference/exit-report-format.md`.
+Every subagent MUST print an `EXIT_REPORT` block as its **final output**. Required fields and valid `OUTCOME` values live in `.claude/reference/exit-report-format.md`. Claims in the report (tests pass, CI clean, etc.) require fresh command evidence — see `.claude/reference/verification-evidence-patterns.md`.
 
 Rules: one colon-separated field per line, no extra whitespace, and on exhaustion print `OUTCOME: exhaustion` before the hard token limit.
 

--- a/.claude/skills/check-acceptance-criteria/SKILL.md
+++ b/.claude/skills/check-acceptance-criteria/SKILL.md
@@ -6,6 +6,8 @@ argument-hint: "[PR number, default: current branch's PR]"
 
 Verify acceptance criteria for PR $ARGUMENTS (or the current branch's PR if no argument given).
 
+Before ticking any checkbox, map each AC item to proving evidence per `.claude/reference/verification-evidence-patterns.md` — no claims without fresh command output.
+
 ## Steps
 
 ### Step 1: Identify the PR


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Harvests the evidence-before-claims discipline from [obra/superpowers](https://github.com/obra/superpowers) (`verification-before-completion` @ `f268f7c`) as a **repo-specific reference doc** — not a duplicate of the plugin skill.

`verification-evidence-patterns.md` maps common completion claims to our proving commands (`coderabbit review`, `merge-gate.sh`, `ci-status.sh`, `ac-checkboxes.sh`, rule-lint, hook tests) and links from `phase-protocols.md` and `/check-acceptance-criteria`.

Refs #417 (does not close).

## Source & adaptation

| Source | What we took | What we changed |
|--------|--------------|-----------------|
| superpowers `verification-before-completion` | Iron law, gate function, rationalization table | Repo-specific claim→evidence map; on-demand reference (not auto-loaded skill) |

## Test plan

- [x] Linked from `.claude/reference/README.md`
- [x] Pointer added to `phase-protocols.md` and `check-acceptance-criteria` skill
- [x] Rule word-count budget verified (minimal rule delta)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cffda88-9ff0-41b8-bf4c-a6d22d4b3b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cffda88-9ff0-41b8-bf4c-a6d22d4b3b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add a repo guide for verifying claims before marking work complete**

### What Changed
- Added a reference page that maps common claims like “tests pass,” “CI is green,” and “merge-ready” to the commands or output needed to prove them
- Linked this guide from the main reference list, acceptance-criteria checks, and phase exit rules
- Updated the acceptance-criteria and exit-report guidance to require fresh evidence before ticking items or stating completion

### Impact
`✅ Fewer unchecked completion claims`
`✅ Clearer acceptance-criteria verification`
`✅ More reliable merge-readiness checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
