### PR TITLE
fix(scripts): bash-3.2 compatibility in dismiss-stale-bot-changes.sh

### DIFF
--- a/.claude/scripts/dismiss-stale-bot-changes.sh
+++ b/.claude/scripts/dismiss-stale-bot-changes.sh
@@ -92,7 +92,11 @@ if [[ -z "$REVIEWS_JSON" ]] || ! echo "$REVIEWS_JSON" | jq -e . >/dev/null 2>&1;
   exit 4
 fi
 
-mapfile -t DISMISS_IDS < <(
+# Read loop, not mapfile — macOS ships bash 3.2, which has no mapfile/readarray.
+DISMISS_IDS=()
+while IFS= read -r rid; do
+  [[ -n "$rid" ]] && DISMISS_IDS+=("$rid")
+done < <(
   echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" --argjson allow "$ALLOWLIST_JSON" '
     [.[]?
       | select(.state == "CHANGES_REQUESTED")
@@ -111,10 +115,8 @@ DISMISSED_IDS=()
 DISMISS_FAILURE_IDS=()
 MESSAGE="Superseded by fixes on ${HEAD_SHA}"
 
-for rid in "${DISMISS_IDS[@]}"; do
-  if [[ -z "$rid" ]]; then
-    continue
-  fi
+# ${arr[@]+...} guard: bash 3.2 treats "${arr[@]}" on an empty array as unbound under set -u.
+for rid in ${DISMISS_IDS[@]+"${DISMISS_IDS[@]}"}; do
   # Idempotent: duplicate dismiss may fail — refetch to confirm DISMISSED.
   if gh api -X PUT \
     "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews/$rid/dismissals" \


### PR DESCRIPTION
## **User description**
## Summary

`.claude/scripts/dismiss-stale-bot-changes.sh` failed on macOS's default `/bin/bash` 3.2:

- line 95: `mapfile: command not found` (bash 4+ builtin)
- follow-on `DISMISS_IDS[@]: unbound variable` under `set -u` — also a latent standalone bug, since bash 3.2 treats `"${arr[@]}"` on an *empty* array as unbound even when the array was populated correctly

Observed Thu Jul 2 2026 running `/fixpr` on auerbachb/inventory PR #2 (exit 1). Harmless there (no CHANGES_REQUESTED reviews), but on a PR with stale bot reviews the dismissal step would silently fail and leave `reviewDecision` blocked.

**Fix:** replace `mapfile -t` with a `while IFS= read -r` loop (empty lines filtered at append time) and guard the for-loop expansion with `${DISMISS_IDS[@]+"${DISMISS_IDS[@]}"}`. Length-guarded expansions elsewhere in the script are already 3.2-safe and unchanged. Matches the existing convention in `pr-state.sh` and `verify-exit-report-block.sh`, which document the same constraint.

**Audit:** repo-wide grep for `mapfile|readarray` across `.claude/scripts/` and `.claude/hooks/` — this was the only occurrence.

Closes #533

## Test plan

- [x] No `mapfile`/`readarray` remains in `dismiss-stale-bot-changes.sh` (repo-wide grep of `.claude/scripts/` and `.claude/hooks/` confirms no other usage)
- [x] `/bin/bash -n` passes on the script
- [x] Under `/bin/bash` 3.2 with stubbed `gh`, empty dismissal list → exit 0, "no stale bot CHANGES_REQUESTED" message, no unbound-variable errors
- [x] Under `/bin/bash` 3.2 with stubbed `gh`, two stale bot reviews (plus a human CHANGES_REQUESTED and a current-HEAD bot review as controls) → exactly the two stale bot review IDs dismissed and appended to the handoff file; controls untouched
- [x] shellcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix stale bot review dismissal on macOS Bash 3.2**

### What Changed
- The script now works on macOS's default Bash 3.2 instead of failing on `mapfile` and stopping stale-review cleanup.
- Empty review lists are handled safely, so the script no longer hits an unbound-variable error when there is nothing to dismiss.
- Only matching bot reviews on older commits are still dismissed; other reviews are left untouched.

### Impact
`✅ Fewer stale review blocks`
`✅ Works on default macOS shells`
`✅ Clearer bot review cleanup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
