### PR TITLE
feat(rules): dual-CLI local review — CodeAnt alongside CodeRabbit

### DIFF
--- a/.claude/rules/cr-local-review.md
+++ b/.claude/rules/cr-local-review.md
@@ -1,44 +1,46 @@
-## Local CodeRabbit Review Loop (Primary)
+## Local Review Loop — CodeRabbit + CodeAnt CLIs (Primary)
 
-> **Always:** Run local CR review before push; verify findings; exit after one clean pass.
+> **Always:** Run both local CLI reviews (CodeRabbit + CodeAnt) before push; verify findings; exit after one clean pass on each available CLI (Timeout & fallback below governs dropping one).
 > **Ask first:** Never — review, fix, push, PR creation are automatic.
-> **Never:** Push before local review; treat local review as the merge gate.
+> **Never:** Push before local review; treat local review as the merge gate; skip a healthy CLI because the other came back clean.
 
 Primary review workflow — catches issues before PR noise/quota; does not replace the GitHub merge gate.
 
 ### Anti–rate-limit pre-flight (local-first)
 
-**~8 reviews/hour** (hidden cap, tier-dependent). **Batch locally:** `coderabbit review --agent` → fix all → re-run until clean → **one commit, one push**. `/fixpr` matches: all threads + CI, **one** commit/push; cap + session tracking: `cr-github-review.md` and `cr-review-hourly.sh`.
+**~8 CR reviews/hour** (hidden cap, tier-dependent). **Batch locally:** run the Fix loop below to a clean pass, then **one commit, one push**. `/fixpr` matches: all threads + CI, **one** commit/push; cap + session tracking: `cr-github-review.md` and `cr-review-hourly.sh`.
 
 ### Prerequisites
 
-- CLI installed/authenticated (`coderabbit --version`); `.coderabbit.yaml` if the repo uses CR.
-- `CODERABBIT_API_KEY` may live in shell config — never print or commit.
+- CodeRabbit CLI installed/authenticated (`coderabbit --version`); `.coderabbit.yaml` if the repo uses CR. `CODERABBIT_API_KEY` may live in shell config — never print or commit.
+- CodeAnt CLI installed/authenticated (`codeant --version`); `codeant login` stores the key in `~/.codeant/config.json` — never print or commit it.
 
 ### When/how to run
 
 After implementation, before push. Optional mid-development. Run from repo root:
 
 - `coderabbit review --agent` — all changes (`--agent` emits structured NDJSON findings, optimized for agent parsing)
-- `--type uncommitted` / `--type committed` — scope to working dir or last commit
+- `codeant review --all --headless` — all changes, committed + uncommitted (`--headless` emits clean JSON for agents)
+- Scoping: CR `--type uncommitted` / `--type committed`; CodeAnt `--uncommitted` / `--committed`
+- If base-branch detection fails (fresh clone, no remote), pass `--base <branch>` — both CLIs support it
 
 ### Fix loop
-1. Run `coderabbit review --agent` to review changes
-2. Parse the findings — verify each against the actual code before fixing
+1. Run both CLIs on the change set
+2. Union the findings — verify each against the actual code before fixing
 3. Fix **all valid findings**
-4. Run `coderabbit review --agent` again
-5. Repeat until CR returns no findings
+4. Run both CLIs again
+5. Repeat until **each available CLI** returns no findings
 
 ### Never Suppress Linter Errors (NON-NEGOTIABLE)
 
 Never add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or equivalent just to pass CI. Read the lint/type errors and fix the code, even in a file you did not modify. Suppression is allowed only when the linter is provably wrong and the comment explains why.
 
 ### Timeout & fallback
-- If `coderabbit review` hangs for more than **2 minutes** or errors out, skip it and run a **self-review** instead (see self-review fallback rules).
-- Do not retry more than once. If CR CLI fails twice, it's down — move on with self-review.
+- Per CLI: hangs for more than **2 minutes** or errors out twice → drop that CLI for the session and note it in the PR body. Preserve any findings it already emitted — the remaining CLI gates only after those are resolved or explicitly waived in the PR body. Do not retry a failed CLI more than once.
+- If both CLIs are down, run a **self-review** instead (see self-review fallback rules).
 
 ### Exit criteria
-- **One clean local review** with no findings (or one clean self-review if CR CLI is unavailable)
+- **One clean pass on both CLIs** (or on the surviving CLI + PR-body note; one clean self-review if both are unavailable)
 - Once clean, commit all changes and push the branch
 - **This transition is automatic.** After a clean pass, IMMEDIATELY commit and push — do not ask "should I push now?" or "ready to create a PR?"
 

--- a/.claude/rules/cr-local-review.md
+++ b/.claude/rules/cr-local-review.md
@@ -1,4 +1,4 @@
-## Local Review Loop — CodeRabbit + CodeAnt CLIs (Primary)
+# Local Review Loop — CodeRabbit + CodeAnt CLIs (Primary)
 
 > **Always:** Run both local CLI reviews (CodeRabbit + CodeAnt) before push; verify findings; exit after one clean pass on each available CLI (Timeout & fallback below governs dropping one).
 > **Ask first:** Never — review, fix, push, PR creation are automatic.
@@ -25,6 +25,7 @@ After implementation, before push. Optional mid-development. Run from repo root:
 - If base-branch detection fails (fresh clone, no remote), pass `--base <branch>` — both CLIs support it
 
 ### Fix loop
+
 1. Run both CLIs on the change set
 2. Union the findings — verify each against the actual code before fixing
 3. Fix **all valid findings**
@@ -36,10 +37,12 @@ After implementation, before push. Optional mid-development. Run from repo root:
 Never add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or equivalent just to pass CI. Read the lint/type errors and fix the code, even in a file you did not modify. Suppression is allowed only when the linter is provably wrong and the comment explains why.
 
 ### Timeout & fallback
+
 - Per CLI: hangs for more than **2 minutes** or errors out twice → drop that CLI for the session and note it in the PR body. Preserve any findings it already emitted — the remaining CLI gates only after those are resolved or explicitly waived in the PR body. Do not retry a failed CLI more than once.
 - If both CLIs are down, run a **self-review** instead (see self-review fallback rules).
 
 ### Exit criteria
+
 - **One clean pass on both CLIs** (or on the surviving CLI + PR-body note; one clean self-review if both are unavailable)
 - Once clean, commit all changes and push the branch
 - **This transition is automatic.** After a clean pass, IMMEDIATELY commit and push — do not ask "should I push now?" or "ready to create a PR?"

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -14,7 +14,7 @@ Bounded-convergence cleanup of the current branch's PR (issue #454 added the pos
 
 CodeRabbit caps **~8 GitHub PR reviews per hour** per account; **each push** consumes one. **Multi-round PRs** exhaust that budget fast if you fix-and-push repeatedly.
 
-**Coalesce locally first:** Before opening `/fixpr` on minor iterations, run **`coderabbit review --agent`** per `cr-local-review.md` on uncommitted changes when feasible — catch issues **before** they cost a GitHub review.
+**Coalesce locally first:** Before opening `/fixpr` on minor iterations, run the dual-CLI local review (**`coderabbit review --agent`** + **`codeant review --uncommitted --headless`**) per `cr-local-review.md` on uncommitted changes when feasible — catch issues **before** they cost a GitHub review.
 
 **Coalesce inside `/fixpr`:** Steps 1–3 intentionally gather **every** unresolved finding + every failing CI check, then fix **all** actionable items and **`git push` once**. Never push once per finding. One `/fixpr` cycle should produce **at most one** consume-side CR review per completed push (tracked below).
 

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -354,7 +354,7 @@ Fix/implement issue #{N}: {title}
 3. Check issue comments only to detect any plan content not yet merged into the body — if found, merge it first
 4. Implement the changes
 5. Run the local dual-CLI review per `cr-local-review.md` (`coderabbit review --agent` + `codeant review --all --headless`) — fix all findings
-6. One clean pass on both CLIs, then commit and push
+6. One clean pass on each available CLI (dropped-CLI and outage fallbacks per `cr-local-review.md`), then commit and push
 7. Create a PR with `Closes #{N}` in the body
 8. Include a Test Plan section with checkboxes for acceptance criteria
 9. Enter the review polling loop and fix any findings

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -353,8 +353,8 @@ Fix/implement issue #{N}: {title}
 2. Read the issue body — this is the canonical implementation plan (includes merged CodeRabbit recommendations when available)
 3. Check issue comments only to detect any plan content not yet merged into the body — if found, merge it first
 4. Implement the changes
-5. Run local CodeRabbit review (`coderabbit review --agent`) — fix all findings
-6. One clean pass, then commit and push
+5. Run the local dual-CLI review per `cr-local-review.md` (`coderabbit review --agent` + `codeant review --all --headless`) — fix all findings
+6. One clean pass on both CLIs, then commit and push
 7. Create a PR with `Closes #{N}` in the body
 8. Include a Test Plan section with checkboxes for acceptance criteria
 9. Enter the review polling loop and fix any findings

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -292,7 +292,7 @@ These are mandatory verification points. The executing agent MUST follow these:
 {Include relevant checkpoints based on the task type:}
 
 **If the task involves pushing code and creating a PR:**
-- [ ] After coding: Run `coderabbit review --agent` and `codeant review --all --headless` — one clean pass on each required before pushing
+- [ ] After coding: Run `coderabbit review --agent` and `codeant review --all --headless` — one clean pass on each available CLI required before pushing (fallbacks per `cr-local-review.md`)
 - [ ] After pushing: Enter GitHub review polling loop immediately — do NOT ask permission
 - [ ] After CR/Greptile posts findings: Fix all valid findings in ONE commit, push once, reply to every thread
 

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -292,7 +292,7 @@ These are mandatory verification points. The executing agent MUST follow these:
 {Include relevant checkpoints based on the task type:}
 
 **If the task involves pushing code and creating a PR:**
-- [ ] After coding: Run `coderabbit review --agent` — one clean pass required before pushing
+- [ ] After coding: Run `coderabbit review --agent` and `codeant review --all --headless` — one clean pass on each required before pushing
 - [ ] After pushing: Enter GitHub review polling loop immediately — do NOT ask permission
 - [ ] After CR/Greptile posts findings: Fix all valid findings in ONE commit, push once, reply to every thread
 

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -203,7 +203,7 @@ Print a compact summary to the user:
 {unchecked checkbox items from the issue body}
 
 ---
-Ready to code. Start with step 1 of the plan above. Run local CR review (`coderabbit review --agent`) before pushing.
+Ready to code. Start with step 1 of the plan above. Run the dual-CLI local review per `cr-local-review.md`, fix all valid findings, and rerun until the required clean gate is reached before pushing.
 ```
 
 Stop after printing the summary. Do NOT start coding automatically — the user may want to review the plan first.

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -235,8 +235,8 @@ worktree directory at all times.
 4. Run the local dual-CLI review per `cr-local-review.md`: `coderabbit review --agent` AND `codeant review --all --headless`
    - Union the findings; fix all valid findings.
    - Run all available CLIs again. Repeat until each remaining CLI has one clean pass.
-   - If a CLI hangs >2 minutes or errors twice, drop it for the session, gate on the remaining one, and note the drop in the PR body.
-   - If both are down, do one self-review instead and note it in the PR body — self-review never counts as a clean review gate.
+   - If a CLI hangs >2 minutes or errors twice, drop it for the session, resolve or explicitly waive its pre-drop findings in the PR body, gate on the remaining one, and note the drop.
+   - If both are down, do one self-review and note it in the PR body — it exits the local loop but never satisfies the GitHub merge gate.
 5. Commit all changes in ONE commit.
 6. Push the branch.
 7. Create the PR via `gh pr create` with:

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -232,10 +232,11 @@ worktree directory at all times.
 1. You are already in a worktree — verify with `git branch --show-current`.
 2. Read the issue body above — this is your implementation plan.
 3. Implement the changes.
-4. Run local CodeRabbit review: `coderabbit review --agent`
-   - Fix all valid findings.
-   - Run again. Repeat until one clean pass with no findings.
-   - If coderabbit CLI hangs >2 minutes or errors twice, do a self-review instead.
+4. Run the local dual-CLI review per `cr-local-review.md`: `coderabbit review --agent` AND `codeant review --all --headless`
+   - Union the findings; fix all valid findings.
+   - Run all available CLIs again. Repeat until each remaining CLI has one clean pass.
+   - If a CLI hangs >2 minutes or errors twice, drop it for the session, gate on the remaining one, and note the drop in the PR body.
+   - If both are down, do one self-review instead and note it in the PR body — self-review never counts as a clean review gate.
 5. Commit all changes in ONE commit.
 6. Push the branch.
 7. Create the PR via `gh pr create` with:


### PR DESCRIPTION
Closes #540

## Summary

Generalizes the local pre-push review loop from CodeRabbit-only to **both** review CLIs, so Claude gets CodeRabbit's and CodeAnt's bug-catching before any PR opens:

- **`.claude/rules/cr-local-review.md`** (canonical): retitled; both CLIs required before push (`coderabbit review --agent` + `codeant review --all --headless`); union-verify-fix loop until each *available* CLI has one clean pass; per-CLI drop rule (>2 min hang or 2 errors → drop for session, preserve its already-emitted findings for resolution-or-waiver in the PR body, gate on the survivor); both down → self-review (never a clean gate); CodeAnt prerequisites/auth (`codeant login`, key in `~/.codeant/config.json`, never print/commit); `--base <branch>` note for failed base detection.
- **Five skill inline mentions** updated to defer to the canonical loop: `fixpr` (coalesce-locally), `pm` (worker steps 5–6), `subagent` (Phase A step 4 incl. fallback), `start-issue` (ready-to-code footer), `prompt` (protocol checkpoint).

## Local review evidence (dogfooded this loop)

- **CodeRabbit:** 4 rounds on this diff (Pro org binding). 5 valid findings from rounds 1–3 fixed: pre-flight/fix-loop dedup; Always/Never vs fallback contradiction; "both"→"each available CLI" drop semantics (rules + subagent). Round 4's 3 findings dismissed with reasons below.
- **CodeAnt:** dropped per the new fallback rule — 2× `UND_ERR_HEADERS_TIMEOUT` on the 6-file batch (`codeant` 0.5.1); it emitted **zero findings before the drop, so nothing is pending waiver**. Upstream bug to report: failed files appear in `reviewed_files` with `error: null` and exit 0 (silent false-clean). Single-file review works (verified in an isolated smoke repo).

### Dismissed round-4 findings (waiver reasons)

1. *Raise the 2-min CLI timeout*: pre-existing repo convention made symmetric here; "hang" = no output, not total runtime; repo-wide timeout policy is out of scope for #540.
2. *Remove "~8 CR reviews/hour"*: constant is documented in `cr-github-review.md`, `.claude/reference/cr-rate-limits.md`, and `fixpr`; single-file change would create cross-file drift. Wording already hedges "hidden cap, tier-dependent."
3. *Both-CLIs-down should block commit/push/PR with `OUTCOME: exhaustion`*: inverts repo design — local review is explicitly not the merge gate (GitHub reviewer chain is), and `exhaustion` is reserved for token exhaustion (parent auto-respawn protocol; misuse would loop-respawn Phase A while CLIs are down).

## Test plan

- [x] `cr-local-review.md` documents the dual-CLI fix loop: both commands, union-verify-fix, exit = one clean pass per available CLI, per-CLI fallback with finding preservation, one commit/push after clean
- [x] All five skill files reference the dual-CLI local review instead of CR-only (grep shows no CR-only `coderabbit review --agent` mentions without CodeAnt)
- [x] Rules corpus within committed budget cap (`rule-lint.sh`: OK, 10,883 ≤ 12,232; CI `rule-lint` check green)
- [x] No secrets/keys in the diff (env-var/config-path names only)
- [x] Commands verified against `codeant` 0.5.1 `--help` and CodeRabbit CLI docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dual-tool local code review workflow.
  * Reviews now combine findings from both available analysis tools and require clean results before pushing changes.
  * Added fallback handling for unavailable or repeatedly failing review tools.
* **Documentation**
  * Updated development workflow guidance across issue, prompt, PM, fix, and subagent processes.
  * Clarified review retry, authentication, timeout, and completion requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->