### PR TITLE
feat(#537): prefix GitHub #N refs with type in agent output

### DIFF
--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -144,7 +144,7 @@ jq -r '.[] | "  session-candidate: #\(.number) (phase=\(.phase // "?"), needs=\(
 When inference picked from multiple candidates, append the override hint on its own line (one line; annotate each other PR with its session `needs`/`phase`):
 
 ```text
-Also tracking: #458 (bugbot_review_poll), #445 (cr_confirmation_pass)
+Also tracking: PR #458 (bugbot_review_poll), PR #445 (cr_confirmation_pass)
 ```
 
 ### Step 0c: Pre-flight — draft→ready + four-reviewer trigger (issue #493)

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -186,7 +186,7 @@ PR    | Draft | Title                          | CodeRabbit | CodeAnt | BugBot |
 
 Below the table, summarize:
 - **Fully covered:** PRs with all four ✅.
-- **Gaps:** one line per PR listing the missing reviewers, e.g. `#476 — missing: CodeAnt, Graphite`.
+- **Gaps:** one line per PR listing the missing reviewers, e.g. `PR #476 — missing: CodeAnt, Graphite`.
 - If every PR is fully covered, say so and skip Steps 4–5.
 
 ---

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -889,9 +889,9 @@ Reason:   <user-stop>
 Fleet:    <final status table>
 Pre-flight: <per-PR draft→ready + reviewers triggered this session, from each PR's PREFLIGHT_SUMMARY; "clean" where no-op>
 Actions:  <rebases / phase-a-fixer subagents / /wrap dispatched this session, per PR — include Subagent outcomes>
-Merged:   <PR #s successfully merged this session via /wrap — e.g. "#1599, #1601"; "none" if none>
+Merged:   <PR #s successfully merged this session via /wrap — e.g. "PR #1599, PR #1601"; "none" if none>
 Subagents: <per-PR spawn/complete/failed summary from active_agents audit>
-Blocked:  <PR # + reason for each HARD_BLOCK entry reported this session — e.g. "#123 human CHANGES_REQUESTED by @alice">
+Blocked:  <PR # + reason for each HARD_BLOCK entry reported this session — e.g. "PR #123 human CHANGES_REQUESTED by @alice">
 ```
 
 Hard-blocked PRs are reported here for visibility; the fleet may auto-pause afterward when idle.

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -132,7 +132,7 @@ fi   # 0 single, 1 multiple, 2 none, 3/4 error
 
 ```text
 [INFERRED] PR #462 from thread context
-Also tracking: #458   ← only when other candidates exist
+Also tracking: PR #458   ← only when other candidates exist
 ```
 
 Use a `<source>` of `explicit argument`, `thread context`, or `session-state` as applicable. After emitting the line, pause briefly to let the user interrupt if the inferred PR is wrong — this is the only abort point, since `/wrap` runs end-to-end without confirmation prompts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Best-effort: lead the first user message with `[#N]` (or `[#339, #341]`) so tab 
 
 Whenever referencing a GitHub number in human-facing prose, you **must** prefix it with its type: `PR #1234` or `Issue #1234`. Example: "Blocked on PR #1930: Issue #1931, Issue #1934" — not "Blocked on #1930: #1931, #1934".
 
-**Exceptions:** bare `#N` stays correct for GitHub closing keywords (`Closes #123`, `Fixes #456`), commit messages/code, and bulk list shorthand for 5+ same-type items (`PRs #1234, #1235, #1236`). Markdown link text must still include the type: `[PR #1234](url)`, not `[#1234](url)`.
+**Exceptions:** bare `#N` stays correct for GitHub closing keywords (`Closes #123`, `Fixes #456`), commit messages/code, bulk list shorthand for 5+ same-type items (`PRs #1234, #1235, #1236`), and the thread-title `[#N]` prefix above. Markdown link text must still include the type: `[PR #1234](url)`, not `[#1234](url)`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Best-effort: lead the first user message with `[#N]` (or `[#339, #341]`) so tab 
 
 Whenever referencing a GitHub number in human-facing prose, you **must** prefix it with its type: `PR #1234` or `Issue #1234`. Example: "Blocked on PR #1930: Issue #1931, Issue #1934" — not "Blocked on #1930: #1931, #1934".
 
-**Exceptions (bare `#N` stays correct):** GitHub closing keywords (`Closes #123`, `Fixes #456`); commit messages and code; bulk list shorthand for 5+ same-type items (`PRs #1234, #1235, #1236`); markdown link text, which keeps the type (`[PR #1234](url)`).
+**Exceptions:** bare `#N` stays correct for GitHub closing keywords (`Closes #123`, `Fixes #456`), commit messages/code, and bulk list shorthand for 5+ same-type items (`PRs #1234, #1235, #1236`). Markdown link text must still include the type: `[PR #1234](url)`, not `[#1234](url)`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,12 @@ After context compaction, your FIRST action is to reconstruct monitoring state (
 
 Best-effort: lead the first user message with `[#N]` (or `[#339, #341]`) so tab titles may pick up issue numbers.
 
+## GitHub reference prefix
+
+Whenever referencing a GitHub number in human-facing prose, you **must** prefix it with its type: `PR #1234` or `Issue #1234`. Example: "Blocked on PR #1930: Issue #1931, Issue #1934" — not "Blocked on #1930: #1931, #1934".
+
+**Exceptions (bare `#N` stays correct):** GitHub closing keywords (`Closes #123`, `Fixes #456`); commit messages and code; bulk list shorthand for 5+ same-type items (`PRs #1234, #1235, #1236`); markdown link text, which keeps the type (`[PR #1234](url)`).
+
 ---
 
 ## AUTONOMOUS WORKFLOW EXECUTION — DO NOT ASK PERMISSION


### PR DESCRIPTION
## Summary

- Adds a new **must**-worded "GitHub reference prefix" subsection to `CLAUDE.md`, immediately after the existing `[#issue]` thread-title subsection — the only other `#N`-formatting rule in the file.
- Requires human-facing prose to prefix GitHub numbers with their type (`PR #1234` / `Issue #1234`), with the four exceptions called out explicitly: closing keywords, commit messages/code, bulk list shorthand (5+ same-type items), and markdown link text.
- Aligns the small number of literal SKILL.md example-output blocks that showed bare `#N` so documented examples don't contradict the new rule (`wrap`, `fixpr`, `pr-monitor-and-manage`, `monitor`).

## Grep sweep evidence

`grep -rn '#[0-9]\{3,\}' .claude/skills/*/SKILL.md` (89 matches total). Breakdown:

**Updated (in-scope example-output lines, 4 total):**
- `.claude/skills/wrap/SKILL.md:135` — `Also tracking: #458` → `Also tracking: PR #458`
- `.claude/skills/fixpr/SKILL.md:147` — `Also tracking: #458 (...), #445 (...)` → `Also tracking: PR #458 (...), PR #445 (...)`
- `.claude/skills/pr-monitor-and-manage/SKILL.md:892,894` — exit-report template `e.g.` strings: `"#1599, #1601"` → `"PR #1599, PR #1601"`; `"#123 human CHANGES_REQUESTED..."` → `"PR #123 human CHANGES_REQUESTED..."`
- `.claude/skills/monitor/SKILL.md:189` — gap summary example: `` `#476 — missing: ...` `` → `` `PR #476 — missing: ...` ``

**Intentionally left unchanged (remaining ~85 matches):**
- Prose/design-rationale citations of internal ticket numbers, e.g. `(issue #454)`, `(issue #452)` — these are references to *this repo's own development history* in skill documentation, not GitHub numbers surfaced to an end user in agent output.
- Bash comments (e.g. `# ... (#493)`), argument-hint/usage strings (`pr-review-help`, `issue-maker`, `prompt`), and `gh issue view N` / `/fixpr #458` command syntax — out of scope per the convention (prose-only rule).
- The `monitor/SKILL.md` gap-matrix **table** (`#481`, `#479`, `#476` under an explicit `PR` column header) — left as-is; the column header already disambiguates the type unambiguously, so adding a redundant `PR` prefix inside each cell would read oddly next to the header.
- Examples already correct, e.g. `recap/SKILL.md` (`PR #452`, `Issue #457`) and `fixpr/SKILL.md:139-141` (`[INFERRED] PR #462 ...`).

## Test plan

- [x] Read the updated `CLAUDE.md` — the new subsection is discoverable near the existing `[#issue]` thread-title rule; the example is scannable in under 30 seconds
- [x] Rule worded as **must**, not "prefer"
- [x] All four exceptions listed explicitly in the same subsection (closing keywords, commit messages/code, bulk list shorthand, markdown links)
- [x] Addition is under 100 words (verified: 80 words for the new subsection body, after both Greptile P2 wording fixes)
- [x] `.github/scripts/rule-lint.sh` passes (10,967 words, well under the 12,000 soft limit and 12,232 ratchet cap)
- [x] Grep sweep note included in this PR body, distinguishing updated example lines from intentionally-unchanged prose citations
- [x] No per-skill SKILL.md *rule* edits were required — only literal example-output blocks were updated to match

Closes #537


