### PR TITLE
docs(setup): document CodeRabbit + CodeAnt CLI install & auth

### DIFF
--- a/.claude/reference/codeant-graphite-supplemental.md
+++ b/.claude/reference/codeant-graphite-supplemental.md
@@ -11,3 +11,13 @@ Full detail extracted from `.claude/rules/cr-github-review.md`. Parallel supplem
 **Graphite:** Poll like other bots; not a merge-gate tier until reliable. If silent: check [Graphite app](https://github.com/apps/graphite-app) access, AI review toggle, workspace link, limits; try `@graphite-app re-review` on a test PR.
 
 CodeAnt and Graphite are parallel supplements; the primary chain stays CR → BugBot → Greptile.
+
+## CodeAnt Local CLI
+
+`codeant-cli` (npm) is a separate local/pre-push capability, distinct from the PR-side `codeant-ai[bot]` role above — it does **not** itself satisfy the GitHub merge gate (`cr-merge-gate.md`, `merge-gate-reviewer-paths.md`); treat it as advisory, same as the rest of CodeAnt's supplemental status in this repo.
+
+- Install: `npm install -g codeant-cli` (Node.js/npm required). Auth: `codeant login` (browser OAuth against `app.codeant.ai`); key persisted to `~/.codeant/config.json`.
+- `codeant review` scope flags: `--all` (default), `--uncommitted`, `--staged`, `--committed`, `--base <branch>`, `--base-commit <commit>`.
+- `--fail-on <severity>`: `BLOCKER` / `CRITICAL` / `MAJOR` / `MINOR` / `INFO` (default `CRITICAL`) — sets the exit-code threshold.
+- `--headless`: JSON results on stdout, progress/status on stderr — for agent/CI parsing.
+- An MCP server mode and a Claude Code integration also exist (`docs.codeant.ai/cli/mcp-server`, `docs.codeant.ai/cli/claude-code-integration`) — not wired into this repo's workflow yet.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Review ownership is sticky once a fallback tier takes over:
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `npm install -g @anthropic-ai/claude-code` | The CLI / desktop app itself |
 | [GitHub CLI (`gh`)](https://cli.github.com/) | `brew install gh && gh auth login` | Issue/PR creation, API calls |
 | [CodeRabbit](https://coderabbit.ai) | Install the GitHub App on your repos | AI code review on PRs |
-| [CodeRabbit CLI](https://docs.coderabbit.ai/cli) | `brew install coderabbit` (macOS) or `curl -fsSL https://cli.coderabbit.ai/install.sh \| sh`; auth via `coderabbit auth login` or `$CODERABBIT_API_KEY` | Local pre-push reviews |
+| [CodeRabbit CLI](https://docs.coderabbit.ai/cli) | `brew install coderabbit` (macOS) or `curl -fsSL https://cli.coderabbit.ai/install.sh \| sh`; then `coderabbit auth login` (see [SETUP.md](SETUP.md) for the `$CODERABBIT_API_KEY` non-interactive option) | Local pre-push reviews |
 | CodeAnt | Install the GitHub App on your repos | Supplemental AI code review on PRs |
 | [CodeAnt CLI](https://docs.codeant.ai/cli/setup.md) | `npm install -g codeant-cli` (Node.js required); auth via `codeant login` | Local pre-push reviews |
 | Graphite AI Reviews | Enable in Graphite for your repos | Supplemental AI review/check-run signal on PRs |

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ Review ownership is sticky once a fallback tier takes over:
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `npm install -g @anthropic-ai/claude-code` | The CLI / desktop app itself |
 | [GitHub CLI (`gh`)](https://cli.github.com/) | `brew install gh && gh auth login` | Issue/PR creation, API calls |
 | [CodeRabbit](https://coderabbit.ai) | Install the GitHub App on your repos | AI code review on PRs |
-| [CodeRabbit CLI](https://docs.coderabbit.ai/cli) | `curl -fsSL https://cli.coderabbit.ai/install.sh \| sh` | Local pre-push reviews |
+| [CodeRabbit CLI](https://docs.coderabbit.ai/cli) | `brew install coderabbit` (macOS) or `curl -fsSL https://cli.coderabbit.ai/install.sh \| sh`; auth via `coderabbit auth login` or `$CODERABBIT_API_KEY` | Local pre-push reviews |
 | CodeAnt | Install the GitHub App on your repos | Supplemental AI code review on PRs |
+| [CodeAnt CLI](https://docs.codeant.ai/cli/setup.md) | `npm install -g codeant-cli` (Node.js required); auth via `codeant login` | Local pre-push reviews |
 | Graphite AI Reviews | Enable in Graphite for your repos | Supplemental AI review/check-run signal on PRs |
 | [Graphite CLI](https://graphite.dev/docs/command-line) (`gt`) | `brew install withgraphite/tap/graphite` or `npm install -g @withgraphite/graphite-cli@stable` | Stacked PR workflow; required for the Graphite Claude Code plugins (`graphite`, `graphite-mcp`). MCP integration needs **v1.6.7+**. |
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -39,7 +39,8 @@ The script handles everything: directory creation, symlinks, settings merge, hoo
 
 Optional tools (for the full review workflow):
 - [CodeRabbit](https://coderabbit.ai) — AI code review on PRs
-- [CodeRabbit CLI](https://docs.coderabbit.ai/cli) — local pre-push reviews (`coderabbit review --agent`)
+- [CodeRabbit CLI](https://docs.coderabbit.ai/cli) — local pre-push reviews (`coderabbit review --agent`). Install via `brew install coderabbit` (macOS) or `curl -fsSL https://cli.coderabbit.ai/install.sh | sh` (cross-platform); auth via `coderabbit auth login` (browser OAuth) or the `$CODERABBIT_API_KEY` env var for non-interactive use
+- [CodeAnt CLI](https://docs.codeant.ai/cli/setup.md) — local pre-push reviews, npm/Node.js required. Install via `npm install -g codeant-cli`; auth via `codeant login` (browser OAuth, key stored in `~/.codeant/config.json`)
 - [Graphite CLI](https://graphite.dev/docs/command-line) — stacked PRs; pair with the Graphite Claude Code plugins enabled via `setup.sh` (see [README.md](README.md#getting-started))
 - [Greptile](https://greptile.com) — fallback reviewer when CodeRabbit is rate-limited
 


### PR DESCRIPTION
## **User description**
## Summary

New-machine bootstrap required manual research to get the local-review CLIs working. This closes two docs gaps:

- **SETUP.md** — the CodeRabbit CLI bullet had only a docs link, no install/auth commands. Added `brew install coderabbit` / curl installer + `coderabbit auth login` / `$CODERABBIT_API_KEY`.
- **CodeAnt CLI (`codeant-cli` on npm) was undocumented anywhere.** Added it to SETUP.md, README.md's Prerequisites table (as a new row, distinct from the existing "CodeAnt (GitHub App)" PR-side row), and gave it a full "Local CLI" section in `.claude/reference/codeant-graphite-supplemental.md` covering `codeant review` scope flags, `--fail-on`, `--headless`, and auth/config location — explicitly clarified as advisory/local-only, not a merge-gate tier.

All commands verified live against docs.coderabbit.ai/cli and docs.codeant.ai/cli/{setup,review} (including confirming `coderabbit`/`cr` are documented aliases, and that CodeAnt's MCP-server mode + Claude Code integration exist as separate doc pages). No secrets or key values appear anywhere — only env var names (`$CODERABBIT_API_KEY`) and config paths (`~/.codeant/config.json`).

Docs-only change. No `.claude/rules/*.md` files touched, so no rules-budget ratchet impact.

Closes #539

## Test plan

- [x] SETUP.md documents install + auth for the CodeRabbit CLI (brew + curl variants) and the CodeAnt CLI (npm + Node prerequisite)
- [x] README.md optional-tools/Getting Started section reflects the same commands
- [x] `codeant-graphite-supplemental.md` documents the CodeAnt CLI (review scopes, `--fail-on`, `--headless`, auth/config location)
- [x] All commands verified against official vendor docs (docs.coderabbit.ai/cli, docs.codeant.ai/cli/setup.md, docs.codeant.ai/cli/review)
- [x] No secrets/keys appear in any doc — reference env var names and config paths only
- [x] `rule-lint.sh` passes (no rules-budget regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Document local setup for CodeRabbit and CodeAnt review tools**

### What Changed
- Added install and sign-in steps for the CodeRabbit CLI in setup docs and the README, including the browser login flow and the non-interactive API key option
- Added the CodeAnt CLI to setup docs, the README, and the supplemental reference, with install and login steps for local pre-push reviews
- Clarified how to use CodeAnt review modes, exit severity thresholds, and headless output for automation, and noted related local features that are not part of this repo’s workflow

### Impact
`✅ Faster first-time setup for local review tools`
`✅ Fewer blocked pre-push reviews`
`✅ Clearer CLI setup instructions for new machines`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
