### PR TITLE
docs(setup): account identity — ask, never assume (per-tool confirmation + storage locations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Review ownership is sticky once a fallback tier takes over:
 
 **Optional:** [Greptile](https://greptile.com) — AI code reviewer used as a fallback when CodeRabbit and BugBot are unavailable. Install the GitHub App and configure via the [Greptile dashboard](https://app.greptile.com).
 
+> **Account identity:** during setup, Claude must explicitly ask which email/account to use for git identity and for each CLI tool it authenticates (GitHub CLI, CodeRabbit, CodeAnt today — the checklist is extensible) — never assume one. See [SETUP.md — Account identity](SETUP.md#account-identity--ask-never-assume) for the checklist and where each credential is stored.
+
 ### Install
 
 > **Using an LLM to set this up?** See **[SETUP.md](SETUP.md)** — it has the same `bash ./setup.sh` command with LLM-friendly context.

--- a/SETUP.md
+++ b/SETUP.md
@@ -16,6 +16,39 @@ The script handles everything: directory creation, symlinks, settings merge, hoo
 
 **Do not manually run the individual steps from README.md.** The `setup.sh` script is the single source of truth for installation. The README documents what each step does for reference, but `setup.sh` is the canonical installer.
 
+## Account identity — ask, never assume
+
+Machine setup wires several accounts together. **Claude must ask the user which email/account to use for each of these — never infer one from the Claude account, shell environment, or hostname.** (Motivating incident: a new-machine setup reused the Claude account email for git identity; GitHub couldn't link the commits, and CodeAnt refused PR reviews keyed to that email.)
+
+### 1. Git commit identity
+
+Ask the user for the email to use in `git config --global user.email`. If their GitHub account has email privacy enabled (GitHub Settings → Emails → "Keep my email addresses private"), recommend the **noreply form**: `<id>+<username>@users.noreply.github.com`.
+
+### 2. Per-tool account confirmation
+
+Before running each tool's auth command, confirm with the user which account (email) holds that tool's subscription — a browser OAuth flow will otherwise silently bind whatever account happens to be signed in:
+
+| Tool | Auth command | Confirm with the user |
+|------|--------------|-----------------------|
+| GitHub CLI (`gh`) | `gh auth login` | the GitHub account that owns your repos |
+| CodeRabbit CLI | `coderabbit auth login` | account holding the CodeRabbit seat |
+| CodeAnt CLI | `codeant login` | account holding the CodeAnt subscription |
+
+The CodeRabbit and CodeAnt **GitHub Apps** must be installed on the personal account or organization that hosts the target repositories. The CLI login account does not need to match the App installation — it needs to hold that vendor's subscription/seat, and `gh auth login` simply needs access to the repos.
+
+**Future tools follow the same pattern:** add a row here and ask before authenticating.
+
+### 3. Where this is stored (inspect any time)
+
+Default locations (may vary with your setup):
+
+| What | Where |
+|------|-------|
+| Git identity | `~/.gitconfig` (or XDG: `~/.config/git/config`) — view with `git config --global user.email` |
+| CodeAnt CLI key | `~/.codeant/config.json` (written by `codeant login`) |
+| CodeRabbit CLI auth | `~/.coderabbit/` — inspect with `coderabbit auth status` |
+| Optional CodeRabbit API key | `CODERABBIT_API_KEY` in your shell init file (e.g. `~/.zshrc`) — never commit or print it |
+
 ## What It Does
 
 > Steps below are the logical workflow — see `setup.sh` for exact step numbering in script output.


### PR DESCRIPTION
## **User description**
Closes #550

## Summary

Adds the **"Account identity — ask, never assume"** section to SETUP.md (motivated by the 2026-07-15 incident where setup inferred git identity from the Claude account email): explicit-ask rule with the GitHub noreply recommendation, a per-tool account-confirmation checklist (GitHub CLI, CodeRabbit, CodeAnt — extensible for future tools), and a storage-locations table (`~/.gitconfig` (+XDG), `~/.codeant/config.json`, `~/.coderabbit/`, shell-init `CODERABBIT_API_KEY`) so the user can inspect what setup configured. README Getting Started gets a pointer.

**This PR is also the live CodeAnt verification:** first PR authored under the corrected noreply identity — watching whether `codeant-ai[bot]` engages without the "no PR Review subscription" nag seen on PRs #542/#544/#545/#546.

## Local review evidence

- **CodeRabbit CLI:** 2 rounds; 4 valid findings fixed (add `gh auth login` to the checklist; correct the GitHub-App-installation claim — Apps bind to the repo-hosting account/org, CLI login account need not match; storage paths as defaults with XDG/shell-init generality; README↔SETUP scope alignment). Round 3 was cut off by an org rate limit (50-min wait, usage-based reviews disabled).
- **CodeAnt CLI: dropped per fallback** — 2× `HTTP error 500` on the 2-file batch, both runs misreporting `issues: []` / exit 0 (same false-clean bug as the batch-timeout case on 2026-07-15; upstream report pending). Zero pre-drop findings to waive.
- **Self-review (both CLIs unavailable):** verified noreply form against the account, all four storage paths on this machine, anchor slug, markdown hygiene, no secrets. Per `cr-local-review.md`, self-review exits the local loop but does not satisfy the merge gate — the GitHub-side review below gates the merge.

## Test plan

- [x] SETUP.md contains the "Account identity — ask, never assume" section with the explicit-ask rule and noreply recommendation
- [x] Per-tool checklist lists GitHub CLI + CodeRabbit + CodeAnt with the future-tools extension note
- [x] Storage-locations table present, paths verified on a real machine (defaults + XDG noted)
- [x] README Getting Started points to the section
- [x] No secrets in the diff; `.claude/rules/` untouched (`rule-lint: OK`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Clarify which account setup should use for git and CLI logins**

### What Changed
- Adds a setup checklist that tells Claude to ask the user which email/account to use instead of guessing from the Claude account, shell, or machine name
- Recommends GitHub’s noreply email format when private email is enabled
- Lists the account to confirm before signing into GitHub CLI, CodeRabbit, and CodeAnt, and explains that future tools should follow the same pattern
- Shows where setup stores each identity or credential so users can review or verify it later
- Adds a README pointer to the new setup guidance

### Impact
`✅ Fewer wrong-account setup mistakes`
`✅ Fewer failed Git commits from mismatched email`
`✅ Easier to check where credentials were saved`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>