### PR TITLE
docs(#547): reconcile model fleet across selection surfaces + Fable 5 tier

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -40,7 +40,9 @@ Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the par
 
 Each agent definition declares a default `model` in frontmatter. The parent must also set `model` explicitly at every Agent tool call site per `.claude/rules/subagent-orchestration.md` "Model Selection" — the call-site parameter overrides the frontmatter default and keeps cost decisions visible at every spawn point.
 
-**Current alias resolution (verified 2026-07):** `opus` → Opus 4.8, `sonnet` → Sonnet 5, `haiku` → Haiku 4.5. Frontmatter intentionally uses bare aliases — Claude Code resolves them to the latest non-legacy model of each family, so agent definitions don't need editing when Anthropic ships a new version. If the runtime ever stops resolving bare aliases, switch frontmatter to explicit versioned IDs (e.g., `claude-opus-4-8`, `claude-sonnet-5`) and update this note.
+**Current fleet (verified 2026-07):** Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5.
+
+**Current alias resolution (verified 2026-07):** `opus` → Opus 4.8, `sonnet` → Sonnet 5, `haiku` → Haiku 4.5. Fable 5 has no bare alias — spawning it requires the explicit model ID `claude-fable-5` at the call site. Frontmatter intentionally uses bare aliases — Claude Code resolves them to the latest non-legacy model of each family, so agent definitions don't need editing when Anthropic ships a new version. If the runtime ever stops resolving bare aliases, switch frontmatter to explicit versioned IDs (e.g., `claude-opus-4-8`, `claude-sonnet-5`) and update this note.
 
 **Per-phase rationale:**
 
@@ -51,6 +53,8 @@ Each agent definition declares a default `model` in frontmatter. The parent must
 | `phase-c-merger` | `sonnet` | Lightweight verification plus canonical `/wrap` execution: reads PR body, checks boxes against code, runs `gh`/git commands, and reports blockers. Read-only tool restrictions (no Write/Edit) — the mechanical work does not need Opus-level reasoning. |
 | `pm-worker` | `sonnet` | Data gathering and formatting: issue creation, repo bootstrap checks. Each task follows a well-defined template. |
 | `researcher` | `sonnet` | Read-only exploration and summarization: reads files, runs `gh`/`git` queries, synthesizes findings. No code edits, no fixes — `sonnet` is sufficient for read-and-report work, and the restricted `allowed-tools` frontmatter prevents any write operations regardless of model. |
+
+**Why Fable 5 is not any agent's default:** Fable 5 is the strongest model in the fleet, but no agent defaults to it — the same cost logic that puts `sonnet` on `phase-c-merger` applies in the other direction. Phase spawns run unattended, often several in parallel, and Opus 4.8 already clears the reasoning bar for the heaviest phase (A/B) work; paying roughly double per spawn buys headroom these phases do not need. Fable 5 is reserved for interactive hardest-work step-ups, where a human is watching the spend and can judge the trade. `/prompt`'s tier ladder is where it is actively recommended (see `.claude/skills/prompt/SKILL.md` "Model Lineup & Effort Levels"). Escalating a specific spawn to `claude-fable-5` is a deliberate exception — document why, and do not make it a default.
 
 The global env var `CLAUDE_CODE_SUBAGENT_MODEL=opus` is a legacy safety net for unexpected/undocumented spawns only — **not** a compliant spawn pattern. Compliant calls must still set `model` explicitly at the call site and must not rely on either the frontmatter default or this env var.
 

--- a/.claude/reference/harness-model-audit-2026-06.md
+++ b/.claude/reference/harness-model-audit-2026-06.md
@@ -34,7 +34,7 @@ Issue #49's AC assumed a month of runtime telemetry (CR response times, false-cl
 | 4. Full rule blob in every subagent prompt | **Already replaced** | `.claude/agents/*.md` are self-contained; full-rule injection is now an explicit *fallback* "if `.claude/agents/` is unavailable" (`subagent-orchestration.md`). |
 | 5. Light path for trivial PRs | **Partially present** | `/prompt` Step 5.5 partitions subagent-eligible issues (file_count 0–1, ac_count ≤3) to `/subagent`; the *review* loop is not yet shortened for trivial PRs (see Finding E). |
 
-So #49 is largely **already satisfied by incremental work**, not an open greenfield audit. The two remaining stale assumptions worth acting on are the **32K output-token limit** (Finding C) and **Fable 5 absence from model selection** (Finding A). Everything else is either done or genuinely needs data.
+So #49 is largely **already satisfied by incremental work**, not an open greenfield audit. Two stale assumptions were worth acting on: **Fable 5's absence from model selection** (Finding A), resolved by FU-1 (issue #547, 2026-07-16), and the **32K output-token limit** (Finding C), which remains open pending FU-2's measurement. Everything else is either done or genuinely needs data.
 
 ---
 
@@ -51,6 +51,8 @@ So #49 is largely **already satisfied by incremental work**, not an open greenfi
 These surfaces are also **internally inconsistent about Haiku 4.5 vs Fable 5**: `CLAUDE.md`'s fleet parenthetical lists Fable 5 and omits Haiku 4.5; the selection docs list Haiku 4.5 and omit Fable 5.
 
 **Why audit-only, not fixed inline:** correctly *slotting* Fable 5 into the spawn defaults or the `/prompt` decision tree requires knowing its capability/price positioning (is it a faster/cheaper coding tier? a reasoning peer to Opus? a Haiku replacement?). That is a product fact this audit cannot verify, and guessing risks mis-routing every subagent spawn. Tracked as **FU-1** (reconcile the fleet across all selection surfaces and define Fable 5's tier).
+
+> **Resolved by FU-1** (issue #547, 2026-07-16) — see the FU-1 entry below for the fleet and tier decision this finding was waiting on.
 
 ### Finding B — 2-clean-CR-passes (#49 component 1): already gone *(Already addressed)*
 
@@ -93,8 +95,11 @@ No inline-fixable model-calibration drift in scripts/skills beyond Findings A an
 
 ### FU-1 — Reconcile model fleet across all selection surfaces; define Fable 5's tier *(small; touches CLAUDE.md + rules + skill → Heavy)*
 
+**Status: RESOLVED** (issue #547, 2026-07-16)
+
 - **Problem:** Fable 5 appears in `CLAUDE.md` but in no selection surface; Haiku 4.5 appears in selection surfaces but not the `CLAUDE.md` fleet parenthetical (Finding A).
 - **AC:** All of `CLAUDE.md`, `subagent-orchestration.md`, `agents/README.md`, and `prompt/SKILL.md` list the same fleet (Opus 4.8, Fable 5, Sonnet 4.6, Haiku 4.5); Fable 5 has a documented tier and either a spawn default or an explicit "not used for spawns, and why"; alias-resolution note updated.
+- **Resolution:** All four surfaces now name one fleet — **Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5**. The AC above says "Sonnet 4.6"; that wording was already stale when written and is **superseded by Sonnet 5**, which was the live default on every selection surface by the time FU-1 was picked up. Fable 5 got both halves of the AC's or: an explicit **Heavy-tier step-up rule** in `/prompt` (Opus 4.8 stays the Heavy default; step up only when Heavy is triggered by two or more signals — ~2× cost, hardest long-horizon work), and an explicit **"not a spawn default, and why"** in `subagent-orchestration.md` + `agents/README.md` (unattended phase spawns are cost-sensitive; Opus 4.8 already clears the bar for Phase A/B). Two adjacent errors were fixed in the same pass: `/prompt`'s legacy list named a Sonnet version that never shipped and simultaneously listed "Opus 4.8 (1M context)" as legacy while recommending Opus 4.8 as current; the fast-mode note implied a Haiku pairing that is not offered (Fast mode is Opus-only).
 
 ### FU-2 — Verify current subagent output budget; relax mandatory decomposition if warranted *(spike + rules)*
 
@@ -134,4 +139,4 @@ No inline-fixable model-calibration drift in scripts/skills beyond Findings A an
 | Collect 1 month of baseline data | Not possible without FU-5 (no telemetry pipeline exists); substituted with static evidence (current thresholds + git-history recency + capability plausibility). Gap recorded, not glossed. |
 | Analyze data, identify simplifiable components | Headline-finding table + Findings B–F: components 1, 3, 4 already simplified; component 2 (32K) is the live candidate; component 5 partially done. |
 | Propose specific rule changes | FU-1…FU-4 are concrete, scoped change proposals. |
-| Implement changes + monitor for regressions | Deferred by design — implementation gated on FU-2's measurement and FU-1's product input; this audit intentionally changes no load-bearing rule. |
+| Implement changes + monitor for regressions | Deferred by design — this audit intentionally changed no load-bearing rule. FU-1's product input has since landed (issue #547, 2026-07-16, documentation-only); remaining implementation is still gated on FU-2's measurement. |

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -36,9 +36,9 @@ If agent definitions are unavailable (e.g., repo without `.claude/agents/`):
 | `pm-worker` | `sonnet` |
 | Read-only review agents (e.g., `/pr-review-help`) | `sonnet` |
 
-Aliases currently resolve to: `opus` = Opus 4.8, `sonnet` = Sonnet 5, `haiku` = Haiku 4.5 (resolution notes: `.claude/agents/README.md`).
+Current fleet: **Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5.** Aliases currently resolve to: `opus` = Opus 4.8, `sonnet` = Sonnet 5, `haiku` = Haiku 4.5 (resolution notes: `.claude/agents/README.md`). Fable 5 has no bare alias and is **not a spawn default for any phase** — automated phase spawns run unattended and are cost-sensitive, so Fable 5 is reserved for interactive hardest-work step-ups where a human is watching the spend. `/prompt`'s tier ladder is where Fable 5 is actively recommended.
 
-Rules: set `model` explicitly on every spawn; call-site value overrides frontmatter. `CLAUDE_CODE_SUBAGENT_MODEL=opus` is only a legacy safety net. If a Sonnet-tier agent underperforms, escalate to `opus` and document why.
+Rules: set `model` explicitly on every spawn; call-site value overrides frontmatter. `CLAUDE_CODE_SUBAGENT_MODEL=opus` is only a legacy safety net. If a Sonnet-tier agent underperforms, escalate to `opus` and document why; escalating a spawn to Fable 5 is a deliberate, case-by-case exception — never a new default.
 
 ## Phase Transition Autonomy (Quick Reference)
 

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -12,11 +12,13 @@ Analyze one or more GitHub issues, classify complexity, and produce a copy-paste
 
 ## Model Lineup & Effort Levels (current as of 2026-07)
 
-The Claude Code picker offers: **Sonnet 5** (default), **Opus 4.8**, **Fable 5**, and **Haiku 4.5**. Opus 4.8 (1M context) / Opus 4.7 / Sonnet 4.6 / 4.7 (1M) are Legacy — never recommend them. Opus 4.8 and Sonnet 5 ship with a native 1M context window; there is no separate "(1M context)" picker option. Bare aliases used elsewhere (agent frontmatter, spawn sites) currently resolve as: `opus` → Opus 4.8, `sonnet` → Sonnet 5, `haiku` → Haiku 4.5 (see `.claude/rules/subagent-orchestration.md` "Model Selection" and `.claude/agents/README.md`).
+The current fleet is **Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5** — the same four models named in `CLAUDE.md`, `.claude/rules/subagent-orchestration.md` "Model Selection", and `.claude/agents/README.md`. In the Claude Code picker, **Sonnet 5** is the default. **Opus 4.7 / Opus 4.6** and **Sonnet 4.6 / Sonnet 4.5** are Legacy — never recommend them. Opus 4.8 and Sonnet 5 ship with a native 1M context window; there is no separate "(1M context)" picker option, so an entry like "Opus 4.8 (1M context)" is not a distinct model. Bare aliases used elsewhere (agent frontmatter, spawn sites) currently resolve as: `opus` → Opus 4.8, `sonnet` → Sonnet 5, `haiku` → Haiku 4.5; Fable 5 has no bare alias and must be named explicitly (`claude-fable-5`).
 
-The picker also exposes **effort levels** (`low`, `medium`, `high`, `xhigh`, `max`, plus session-only `ultracode`). This skill keeps its internal Heavy/Standard/Light tier vocabulary and decision tree unchanged, and maps each tier to a recommended effort level in the output: **Heavy → `max`**, **Standard → `high`**, **Light → `low`**. Users may adjust within a tier's range — e.g., a Heavy task that needs multi-agent orchestration can step up to `ultracode`; a borderline Standard task can step up to `xhigh` or step down to `medium`.
+The picker also exposes **effort levels** (`low`, `medium`, `high`, `xhigh`, `max`, plus session-only `ultracode`). This skill keeps its internal Heavy/Standard/Light tier vocabulary and decision tree unchanged, and maps each tier to a recommended effort level in the output: **Heavy → `max`**, **Standard → `high`**, **Light → `low`**. Users may adjust within a tier's range — e.g., a Heavy task that needs multi-agent orchestration can step up to `ultracode`; a borderline Standard task can step up to `xhigh` or step down to `medium`. Model choice has its own step-up: the hardest long-horizon / orchestration work can move from Opus 4.8 up to **Fable 5** (see Heavy, below).
 
-**Fast mode:** the picker has a Fast mode toggle that trades depth for speed. `/prompt` does NOT accept a `--fast` flag and does not factor Fast mode into recommendations — it is a user-toggled picker option. For Light-tier work, **Haiku 4.5** (with or without Fast mode) is a valid cheaper alternative to Sonnet 5; the output notes this on Light-tier recommendations. A `--fast` flag is a possible follow-up, not part of this skill.
+**Fast mode:** the picker has a Fast mode toggle that gives Claude Opus faster output — it does not downgrade to a smaller model. It applies to **Opus 4.8 only** (and deprecated Opus 4.7); it is not offered for Sonnet 5, Haiku 4.5, or Fable 5, so it never pairs with a Light-tier recommendation. `/prompt` does NOT accept a `--fast` flag and does not factor Fast mode into recommendations — it is a user-toggled picker option. A `--fast` flag is a possible follow-up, not part of this skill.
+
+Separately from Fast mode: for Light-tier work, **Haiku 4.5** is a valid cheaper alternative to Sonnet 5; the output notes this on Light-tier recommendations.
 
 **MANDATORY OUTPUT FORMAT:** Every per-issue prompt block MUST open and close with `~~~` tilde fences. NEVER use backtick fences as the outer prompt-block delimiter.
 
@@ -131,7 +133,7 @@ Apply this decision tree. When signals conflict, choose the **higher** tier (con
 
 **Batch handling rule:** First classify each issue independently to produce a per-issue tier (`issue_tier`). Then compute a batch tier from the most complex `issue_tier` in the set. A batch of 3 issues where one is Heavy makes the batch tier Heavy. The batch tier is used for thread-prompt output formatting and checkpoint inheritance, while per-issue decisions (like Step 5.5 subagent partitioning) must use `issue_tier`.
 
-### Heavy — Opus 4.8, effort `max`
+### Heavy — Opus 4.8, effort `max` (step up to Fable 5 for the hardest long-horizon work)
 
 Assign Heavy if ANY of these are true:
 - `touches_rules` is true (rule files are highest-stakes)
@@ -140,6 +142,8 @@ Assign Heavy if ANY of these are true:
 - `is_multi_issue` AND at least one issue has `file_count > 1` or `ac_count > 3` (multiple non-trivial issues)
 - `file_count > 5`
 - `dependency_count > 2`
+
+**Fable 5 step-up (within Heavy).** Opus 4.8 is the Heavy default. Recommend stepping up to **Fable 5** — the strongest model in the fleet, at roughly 2× Opus 4.8's cost — only for the hardest long-horizon work at the top of the Heavy band. Step up when Heavy was triggered AND at least two of: `has_orchestration_keywords`, `touches_rules` or `touches_claude_md`, `file_count > 5`, `dependency_count > 2`. A Heavy issue that trips exactly one trigger (the common case — e.g. a rules-only wording change) stays on Opus 4.8. Phrase it as a step-up, never a replacement: the recommendation line stays `Opus 4.8`, with the Fable 5 option noted alongside it.
 
 ### Standard — Opus 4.8, effort `high`
 
@@ -240,7 +244,7 @@ Rationale: {1-line explanation of why this tier was selected, citing the dominan
 **OUTPUT MUST USE `~~~` FENCES, NOT BACKTICKS.** The opening and closing lines of every per-issue prompt block must be exactly `~~~`.
 
 **Map tier to `{MODEL}` and `{EFFORT}` strings** (same Heavy / Standard / Light mapping for both the batch **Tier Recommendation** line and each per-issue `**Model:**` line — use **batch tier** for Tier Recommendation and **per-issue `issue_tier`** for each block):
-- **Heavy** → `Opus 4.8`, effort `max` (step up to `ultracode` for multi-agent orchestration work)
+- **Heavy** → `Opus 4.8`, effort `max` (step up to `ultracode` for multi-agent orchestration work; append "(or Fable 5 — ~2× cost, for the hardest long-horizon work)" only when the Step 5 Fable 5 step-up rule is met)
 - **Standard** → `Opus 4.8`, effort `high` (step up to `xhigh` for demanding coding work)
 - **Light** → `Sonnet 5`, effort `low` (Haiku 4.5 is a valid cheaper alternative — append "(or Haiku 4.5)" to Light-tier recommendations)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ These files auto-load for the parent agent session. **Subagents do NOT auto-load
 
 ### Rule File Size Guidelines
 
-Rules load every turn. With the current 1M-token fleet (Opus 4.8, Fable 5, Sonnet 5) the corpus is ~1.5% of the window (~$0.015/turn cached on Opus 4.8), so the budget now exists for **instruction adherence and maintainability** — redundant or contradictory rules misfire on literal-following models — not context pressure. Limits apply to CLAUDE.md + `.claude/rules/*.md`:
+Rules load every turn. With the current fleet (Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5) the corpus is ~1.5% of a 1M-token window (~$0.015/turn cached on Opus 4.8), so the budget now exists for **instruction adherence and maintainability** — redundant or contradictory rules misfire on literal-following models — not context pressure. Limits apply to CLAUDE.md + `.claude/rules/*.md`:
 
 - **Soft warning:** 12,000 words.
 - **Ratchet cap:** `.claude/rules/.budget-soft-cap` must equal `max(current_count + 750, 8500)`. `rule-lint.sh` fails when the corpus exceeds this committed cap, independent of soft/hard checks; run `rule-lint.sh --update-cap` only after intentional cuts.


### PR DESCRIPTION
## **User description**
Closes #547

## What this changes

The repo's model guidance lives in four places that had drifted apart, so "which model should this run on?" depended on which file you happened to read. This makes all four tell the same story: **Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5**. Documentation and wording only — **no routing logic changes**. The per-phase spawn-default table and the Agent Inventory default-model column are deliberately untouched.

**Fable 5 now has a real decision, not just a name.** The issue's AC allowed either a tier rule *or* a "not for spawns, and why"; this does both halves, because they answer different questions:
- `/prompt` gets an explicit **Heavy-tier step-up rule** — Opus 4.8 stays the Heavy default, and Fable 5 is recommended only at the top of the Heavy band (Heavy triggered by two or more signals), carrying its ~2× cost framing. A Heavy issue tripping one signal — the common case, like a rules-only wording change — stays on Opus 4.8.
- The orchestration surfaces get an explicit **"not a spawn default, and why"**: unattended phase spawns are cost-sensitive and Opus 4.8 already clears the reasoning bar for Phase A/B. Both point at `/prompt`'s ladder as where Fable 5 is actively recommended.

## Two things fixed beyond the issue's ask

- **`prompt/SKILL.md` listed "Opus 4.8 (1M context)" as *Legacy* in the same sentence that names Opus 4.8 as a current model** — a self-contradiction sitting next to the phantom legacy entry the issue did flag. The "(1M context)" suffix referred to retired separate picker variants; the legacy list now names only real legacy models (Opus 4.7 / 4.6, Sonnet 4.6 / 4.5).
- **`CLAUDE.md`'s "1M-token fleet" phrasing would have become wrong** the moment Haiku 4.5 joined the list — Haiku is 200K, not 1M. The ~1.5% budget figure is now anchored to "a 1M-token window" instead of describing the whole fleet as 1M-token, which keeps the math honest.

Fast mode is described as **Opus-only** (4.8, and deprecated 4.7). Haiku 4.5 remains a valid Light-tier cheaper alternative — that recommendation stands, just decoupled from Fast mode, which never applied to it.

## Local review — both CLIs dropped (per `cr-local-review.md`)

Disclosing this rather than implying a clean dual-CLI gate:

- **CodeRabbit CLI: dropped** — hung past the 2-minute threshold.
- **CodeAnt CLI (0.5.1): dropped** — two `HTTP 500` failures.
- **4 of 5 files did get a genuine CodeAnt clean pass**: `CLAUDE.md`, `subagent-orchestration.md`, `agents/README.md`, `prompt/SKILL.md`. Only `harness-model-audit-2026-06.md` went unreviewed by either CLI; I self-reviewed that diff.

Worth flagging: CodeAnt reproduced its known **false-clean bug** — on the 500s it still returned `issues: []`, `error: null`, exit 0 while its progress output read `[error] Failed to review`. An agent trusting the exit code would have recorded a fake clean gate. A `--committed` invocation also returned `noFiles: true` with exit 0 for the same reason. Local review does not satisfy the merge gate regardless; the GitHub review path is authoritative here.

## Test plan

- [x] `grep -rn "Sonnet 4.7" .claude CLAUDE.md` returns nothing
- [x] `grep -n "Fable 5"` across the four files shows the same fleet + a tier statement in each
- [x] Run `/prompt` on a known Heavy issue: output reflects the documented Fable 5 decision and the corrected fast-mode note
- [x] Corpus word count within the committed ratchet cap
- [x] `.claude/reference/harness-model-audit-2026-06.md` FU-1 marked resolved


___

## **CodeAnt-AI Description**
**Reconcile the model fleet across all selection docs and define when to step up to Fable 5**

### What Changed
- All model guidance now names the same fleet: Fable 5, Opus 4.8, Sonnet 5, and Haiku 4.5.
- Fable 5 is now described as an explicit step-up choice for the hardest long-horizon work, while Opus 4.8 stays the default for Heavy tasks.
- The agent and orchestration docs now say Fable 5 is not a spawn default and must be chosen intentionally, with a clear reason.
- The prompt guide also fixes outdated model references and clarifies that Fast mode applies to Opus only, not Light-tier recommendations.
- The audit note now marks this fleet reconciliation as resolved and records Sonnet 5 as the current model in place of the stale Sonnet 4.6 reference.

### Impact
`✅ Consistent model recommendations across docs`
`✅ Clearer when to use Fable 5`
`✅ Fewer outdated model references`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

