### PR TITLE
feat(#548): launch coding threads via one-click chips from /pm and /prompt

### DIFF
--- a/.claude/reference/chip-launching.md
+++ b/.claude/reference/chip-launching.md
@@ -35,7 +35,9 @@ Nothing else. No prompt block, no context dump, no acceptance criteria. The whol
 
 ## Chip state tracking
 
-Record the `task_id` returned by each successful `spawn_task`, keyed by issue number, so the chip can be withdrawn later. Track it wherever the skill already tracks that issue's state (e.g. `/pm`'s Active Work table). A chip whose `task_id` was not recorded cannot be dismissed.
+Record the `task_id` returned by each successful `spawn_task`, keyed by issue number, **immediately** — before any dependent step. Track it wherever the skill already tracks that issue's state (`/pm`'s Active Work table is the canonical home; `/prompt` writes there in a PM thread, and keeps session state otherwise). A chip whose `task_id` was not recorded cannot be dismissed — it is a live offer with no handle, so recording is not bookkeeping, it is the thing that makes withdrawal possible at all.
+
+An issue with a live recorded chip is **already offered**: skip it when re-running, rather than spawning a second chip for the same work.
 
 ## Stale-chip hygiene — `dismiss_task`
 
@@ -45,7 +47,11 @@ Withdraw a tracked chip via `mcp__ccd_session__dismiss_task` (pass the recorded 
 2. **Superseded** — a later batch replaced the suggestion.
 3. **Re-planned** — the issue's plan or scope changed, so the chip's prompt is stale. Spawn the replacement chip *first*, then dismiss the old one.
 
-**Fail-closed:** only clear tracked chip state after `dismiss_task` returns success. If the user already clicked or dismissed the chip, the tool says so and nothing changes — that is a normal outcome, not an error. Do not retry.
+**Fail-closed:** only clear tracked chip state once the dismiss outcome is known. Distinguish the two non-error outcomes from a real failure:
+
+- **Dismissed** — the chip is withdrawn. Clear the tracked state.
+- **Already clicked or already dismissed** — the tool says so and nothing changes. The offer is gone either way, so the goal is met: treat it as a successful no-op, clear the state, and do not retry.
+- **Genuine failure** — the chip is still live. Keep the `task_id` tracked; the chip is still withdrawable, and dropping the handle would strand it.
 
 ## Print-on-demand replay
 

--- a/.claude/reference/chip-launching.md
+++ b/.claude/reference/chip-launching.md
@@ -1,0 +1,56 @@
+# Chip Launching — One-Click Coding Threads
+
+Canonical mechanics for offering a coding-thread prompt as a **task chip** the user can click to spin off a new session. Shared by `/pm` (Step 3.1) and `/prompt` (Step 6). Skill-specific wiring stays in each SKILL.md; everything below is defined once, here.
+
+> **NON-NEGOTIABLE — execution boundary.** Offering a chip is NOT launching a thread. Skills NEVER auto-launch: no Agent-tool spawn, no session start, no work begun on the user's behalf. **The user's chip click is the only launch path.** This does not widen any skill's existing explicit-ask exception (e.g. `/pm`'s "go ahead and run those") — it narrows nothing and grants nothing new.
+
+## Availability detection
+
+Chip mode is active **only** when the `mcp__ccd_session__spawn_task` tool is present in the session. Otherwise (CLI, headless, older client) the skill is in **fallback mode**.
+
+**Any `spawn_task` failure is treated as "unavailable"** — emit that issue's full fallback block instead. Failures are per-emission: one issue's failed spawn does not force the rest of the batch into fallback, but every issue must end up with either a chip or a full block. Never leave an issue with neither. Degrade quietly and note the fallback once; do not retry the same spawn.
+
+## `spawn_task` invocation shape
+
+| Param | Value |
+|-------|-------|
+| `title` | ≤60 chars, **starts with a verb**, includes the issue number — e.g. `Fix #42 stale worktree warning` |
+| `prompt` | The **complete self-contained thread prompt** — byte-identical to what fallback mode would print inside its fence |
+| `tldr` | 1–2 plain-English sentences: what the spawned session will do and why. No file paths, no jargon |
+| `cwd` | Repo root |
+
+**Chips carry no model or effort preset.** The tool has no such parameter and cannot drive the picker. Therefore the recommended model **MUST** appear as a `**Model:** {MODEL} — {REASON}` line inside the `prompt` text itself, so the spawned session sees the recommendation, **and** in the visible short summary, so the user can set the picker before clicking.
+
+## Short-summary transcript format (chip mode)
+
+In chip mode the transcript shows **only** the short summary per issue — the full prompt rides inside the chip:
+
+```text
+- **#42 — {Title}** — chip offered
+  **Model:** {MODEL} — {REASON}
+  {One-line rationale}
+```
+
+Nothing else. No prompt block, no context dump, no acceptance criteria. The whole point of chip mode is that the transcript stays scannable status output rather than a wall of prompt text.
+
+## Chip state tracking
+
+Record the `task_id` returned by each successful `spawn_task`, keyed by issue number, so the chip can be withdrawn later. Track it wherever the skill already tracks that issue's state (e.g. `/pm`'s Active Work table). A chip whose `task_id` was not recorded cannot be dismissed.
+
+## Stale-chip hygiene — `dismiss_task`
+
+Withdraw a tracked chip via `mcp__ccd_session__dismiss_task` (pass the recorded `task_id` and a short `reason`) on any of these three triggers:
+
+1. **Gained an open PR** — someone is already doing the work.
+2. **Superseded** — a later batch replaced the suggestion.
+3. **Re-planned** — the issue's plan or scope changed, so the chip's prompt is stale. Spawn the replacement chip *first*, then dismiss the old one.
+
+**Fail-closed:** only clear tracked chip state after `dismiss_task` returns success. If the user already clicked or dismissed the chip, the tool says so and nothing changes — that is a normal outcome, not an error. Do not retry.
+
+## Print-on-demand replay
+
+In chip mode, "print the full prompt for #N" (or any equivalent ask) re-emits that issue's **complete block verbatim**, in the same fenced form fallback mode would have printed. The chip's prompt is the source of truth — the printed block and the chip must match. The chip stays offered; printing is not dismissing.
+
+## Fallback mode
+
+When chip mode is unavailable, output is **byte-for-byte identical to pre-chip behavior**: full fenced blocks, every existing fence and label contract preserved (`/prompt`'s mandatory `~~~` outer fence and first-line `**Model:**` label especially). Fallback is the baseline, not a degraded variant — a CLI thread should be unable to tell this feature exists.

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -448,7 +448,13 @@ When one or more threads finish (PRs merged, issues closed):
 
    An offered chip that simply isn't in the new batch is **not** superseded — a suggestion the user hasn't acted on yet stays valid and keeps its chip. Only dismiss on an explicit signal.
 
-   Re-planning is spawn-then-dismiss: create the replacement chip first, then dismiss the old one. If the dismiss fails, the issue now has two chips — withdraw the replacement to restore a single offer, and if that also fails, leave both tracked and tell the user which `task_id` is stale rather than silently dropping either. Update the Active Work table only after a dismiss succeeds.
+   Re-planning is spawn-then-dismiss, in this order:
+
+   1. Spawn the replacement chip.
+   2. **Record the replacement's `task_id` immediately** — before touching the old chip. An unrecorded chip cannot be withdrawn, so if the next step fails you would otherwise be left with a live chip you have no handle for.
+   3. Dismiss the old chip, then reconcile the table: replacement row keeps its `task_id`, old row is cleared.
+
+   **Read the dismiss outcome — "gone" is not "failed".** If `dismiss_task` reports the chip was already clicked or already dismissed, the offer is withdrawn or acted on and the goal is met: treat it as a successful no-op, clear the old `task_id`, and move on. Only a genuine failure (the chip is still live and was not withdrawn) needs recovery: withdraw the replacement to restore a single offer, and if that also fails, keep both `task_id`s tracked and tell the user which one is stale rather than silently dropping either. Update the Active Work table only after the outcome is known.
 
 ### 3.5: Handoff awareness
 

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -330,7 +330,20 @@ This is the core PM behavior. Once the user confirms which issues to work on, en
 
 ### 3.1: Generate coding thread prompts
 
-For each selected issue, generate a self-contained prompt that can be pasted into a new Claude Code thread (web or CLI). Each prompt must include:
+For each selected issue, generate a self-contained prompt. The prompt content below is the same in both delivery modes — only how it reaches the user differs.
+
+**First, check chip availability** per `.claude/reference/chip-launching.md`, then branch:
+
+- **Chip mode** (`mcp__ccd_session__spawn_task` present): call `spawn_task` once per selected issue with `title` / `prompt` / `tldr` / `cwd`, where `prompt` is the full self-contained prompt below, unchanged. Print **only** the short summary per issue (issue, title, `**Model:**` line, one-line rationale) — see the reference for the exact format. Record each returned `task_id` in the Active Work table (3.2) and set that issue's status to `Chip offered`.
+- **Fallback mode** (tool absent): emit the full prompt blocks for every selected issue exactly as before — same fences, same content.
+
+**Spawn outcomes are tracked per issue.** A failed `spawn_task` falls back for **that issue alone** — print its full block and leave it at `Prompt generated`. Issues whose spawns succeeded keep their chip, their `task_id`, and their `Chip offered` status; never re-print their block as well, or the same issue is offered twice. Every selected issue ends with exactly one of: a chip, or a printed block.
+
+Chips carry no model preset, so the `**Model:**` line must appear both in the visible summary and inside the chip's prompt text. Get the model recommendation from `/prompt`'s tier classification when it ran; otherwise infer it from the issue's signals using the same Heavy/Standard/Light mapping.
+
+If the user asks to "print the full prompt for #N" while in chip mode, re-emit that issue's complete block verbatim — the chip stays offered.
+
+Each prompt must include:
 
 ```
 You are a coding agent working on {repo URL}.
@@ -365,7 +378,7 @@ Fix/implement issue #{N}: {title}
 - Squash and merge when reviews are clean
 ```
 
-Present all prompts to the user. Do NOT spawn subagents or execute the prompts — present them for the user to paste into coding threads. Only spawn agents if the user explicitly asks (e.g., "go ahead and run those", "spin up agents for those").
+Offer or present every prompt — never execute one. Do NOT spawn subagents or run the prompts: in chip mode the user's click is the only launch path, and in fallback mode the user pastes the block into a thread. Only spawn agents if the user explicitly asks (e.g., "go ahead and run those", "spin up agents for those").
 
 ### 3.2: Track assignments
 
@@ -374,12 +387,23 @@ Maintain a state table in the conversation. Update it as work progresses:
 ```
 ## Active Work
 
-| Issue | Thread | PR | Status | Last Update |
-|-------|--------|----|--------|-------------|
-| #42 | Prompt generated | — | Awaiting thread start | {timestamp} |
-| #38 | Active | PR #88 | In review | {timestamp} |
-| #55 | Active | PR #90 | Merged | {timestamp} |
+| Issue | Thread | Task ID | PR | Status | Last Update |
+|-------|--------|---------|----|--------|-------------|
+| #42 | Chip offered | `task_abc123` | — | Awaiting thread start | {timestamp} |
+| #61 | Prompt generated | — | — | Awaiting thread start | {timestamp} |
+| #38 | Active | — | PR #88 | In review | {timestamp} |
+| #55 | Active | — | PR #90 | Merged | {timestamp} |
 ```
+
+**Thread column values:**
+
+- `Chip offered` — a chip was spawned for this issue and is waiting on a click (chip mode).
+- `Prompt generated` — a full prompt block was printed for the user to paste (fallback mode, or a failed spawn).
+- `Active` — a thread is running for this issue.
+
+**Task ID column:** every `Chip offered` row MUST carry the `task_id` returned by its `spawn_task` call — it is the only handle for dismissing that chip later, and a chip whose `task_id` was not recorded cannot be withdrawn. `Prompt generated` and `Active` rows leave it empty (`—`).
+
+`Chip offered` and `Prompt generated` are the same state from the pipeline's view — offered, not yet started — and both pair with the `Awaiting thread start` status. Both are excluded from re-offering: `/prompt`'s Path B scan treats an offered-but-unstarted chip exactly as it treats `Prompt generated`, so a re-run never double-offers the same issue.
 
 ### 3.3: Progress detection
 
@@ -406,6 +430,7 @@ Cross-reference with the assignments table:
 - Detect PRs that reference tracked issues (search PR body for `Closes #N`, `Fixes #N`)
 - Mark issues as "PR open" or "Merged" accordingly
 - Flag stale threads: if an issue was assigned > 30 minutes ago with no PR, note it
+- **Dismiss stale chips:** any issue sitting at `Chip offered` that now has an open PR is being worked already — withdraw its chip via `dismiss_task` (see `.claude/reference/chip-launching.md`). Reuse the open-PR result already fetched above and the same closing-keyword predicate — no extra API call. Only clear the tracked `task_id` after the dismiss succeeds.
 
 Also accept user input: "thread for #42 is done", "PR #88 merged", "#55 is blocked".
 
@@ -413,10 +438,17 @@ Also accept user input: "thread for #42 is done", "PR #88 merged", "#55 is block
 
 When one or more threads finish (PRs merged, issues closed):
 
-1. Remove completed items from the assignments table
+1. **Dismiss the chips of finished issues, then remove their rows.** Order matters: a row carries its chip's `task_id`, and once the row is gone the chip can no longer be withdrawn. So for every completed issue still at `Chip offered`, `dismiss_task` first — its work is done, the offer is dead — and only then drop it from the assignments table.
 2. Re-scan open issues (reuse 1B.2-1B.4 logic but lighter — only fetch new/changed issues)
 3. Suggest 1-3 new issues to fill the pipeline
-4. Generate prompts for the user's selected issues
+4. Generate prompts for the user's selected issues (Step 3.1 — chip or fallback)
+5. **Dismiss superseded and re-planned chips.** Beyond the finished issues handled in step 1, withdraw a `Chip offered` chip only when its offer is genuinely dead:
+   - **Superseded** — the issue was explicitly replaced by a newer suggestion.
+   - **Re-planned** — the issue's scope or plan changed, so the chip's prompt is stale.
+
+   An offered chip that simply isn't in the new batch is **not** superseded — a suggestion the user hasn't acted on yet stays valid and keeps its chip. Only dismiss on an explicit signal.
+
+   Re-planning is spawn-then-dismiss: create the replacement chip first, then dismiss the old one. If the dismiss fails, the issue now has two chips — withdraw the replacement to restore a single offer, and if that also fails, leave both tracked and tell the user which `task_id` is stale rather than silently dropping either. Update the Active Work table only after a dismiss succeeds.
 
 ### 3.5: Handoff awareness
 
@@ -432,11 +464,13 @@ When the conversation is getting long (many back-and-forth cycles, multiple batc
 
 The PM orchestrator's job is to:
 - Analyze the backlog and recommend what to work on
-- Generate self-contained prompts for coding threads
+- Generate self-contained prompts for coding threads, and offer them as chips when available
 - Track progress across threads
 - Suggest next work when threads finish
 
-The **user** decides when and where to paste the prompts. The user starts the coding threads. The PM tracks and coordinates.
+The **user** decides when and where to start work — by clicking a chip in chip mode, or by pasting a prompt in fallback mode. The user starts the coding threads. The PM tracks and coordinates.
+
+**Offering a chip is not launching a thread.** `spawn_task` puts a chip in front of the user; only their click starts a session. The PM never clicks for them, and never runs a coding thread's work itself — via the Agent tool or otherwise — in place of a chip the user hasn't clicked. This governs coding threads only; the read-only `pm-worker` data-gathering spawns described under "Model selection for spawned subagents" below remain allowed and are unaffected.
 
 **Exception:** If the user explicitly says "go ahead and run those", "spin up agents", or "execute those prompts" — then and only then may you spawn subagents via the Agent tool to execute the coding thread prompts.
 

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -208,6 +208,10 @@ Check chip availability per `.claude/reference/chip-launching.md`, then branch. 
 
 **Spawn outcomes are tracked per issue.** A failed `spawn_task` falls back for **that issue alone** — print its full block and note the fallback once for the batch (per `chip-launching.md`); the rest of the batch keeps its chips. Do not print a block for an issue whose chip spawned successfully. Every thread-prompt issue ends with exactly one of: a chip, or a printed block.
 
+**Record every chip's `task_id`.** After each successful spawn, record the returned `task_id` against its issue and mark that issue `Chip offered` — an unrecorded chip can never be withdrawn, which would break stale-chip hygiene. In a PM thread, write it to `/pm`'s Active Work table (its `Task ID` column is the canonical home). Outside a PM thread, keep it in this thread's state so it stays dismissable within the session, and say so in the summary.
+
+**Skip issues already offered.** Before spawning, check the recorded state (Path B's Active Work scan already excludes `Chip offered` — see Step 0) and skip any issue that already has a live chip. Re-running `/prompt` must not offer the same issue twice. Issues that were never spawned, or whose spawn failed, are still eligible.
+
 Subagent candidates from Step 5.5 never get chips — they run inline via `/subagent`, so that section is unchanged in both modes.
 
 If the user asks to "print the full prompt for #N" while in chip mode, re-emit that issue's complete tilde-fenced block verbatim. The chip stays offered.

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -20,9 +20,9 @@ The picker also exposes **effort levels** (`low`, `medium`, `high`, `xhigh`, `ma
 
 Separately from Fast mode: for Light-tier work, **Haiku 4.5** is a valid cheaper alternative to Sonnet 5; the output notes this on Light-tier recommendations.
 
-**MANDATORY OUTPUT FORMAT:** Every per-issue prompt block MUST open and close with `~~~` tilde fences. NEVER use backtick fences as the outer prompt-block delimiter.
+**MANDATORY OUTPUT FORMAT:** Every per-issue prompt block printed to the transcript MUST open and close with `~~~` tilde fences. NEVER use backtick fences as the outer prompt-block delimiter. This governs fallback mode and print-on-demand replay — the two paths that print a block. In chip mode the prompt rides inside the chip rather than being printed, so it needs no fence; its content is otherwise identical.
 
-**Per-block model label (mandatory):** The first content inside each tilde-fenced block (immediately after the opening `~~~`) MUST be a single line: `**Model:** {MODEL} — {REASON}` where `{MODEL}` is the model string for **that issue's** `issue_tier` (from Step 5 — not the batch tier), and `{REASON}` is a concise task-type phrase of **at most 10 words** derived from that issue's signals (dominant drivers such as rules/CLAUDE.md, orchestration, file count, AC count, skills, dependencies, or scope keywords). The label must be **inside** the tilde fence so a pasted block is self-explanatory without surrounding prose.
+**Per-block model label (mandatory):** The first content inside each tilde-fenced block (immediately after the opening `~~~`) MUST be a single line: `**Model:** {MODEL} — {REASON}` where `{MODEL}` is the model string for **that issue's** `issue_tier` (from Step 5 — not the batch tier), and `{REASON}` is a concise task-type phrase of **at most 10 words** derived from that issue's signals (dominant drivers such as rules/CLAUDE.md, orchestration, file count, AC count, skills, dependencies, or scope keywords). The label must be **inside** the tilde fence so a pasted block is self-explanatory without surrounding prose. In chip mode the same line MUST open the chip's `prompt` text **and** appear in the visible short summary — chips cannot preset the model picker, so the user needs it before clicking and the spawned session needs it after.
 
 ## Step 0: Parse Arguments and Detect Context
 
@@ -55,7 +55,9 @@ If `$ARGUMENTS` is empty, check for PM orchestration context. PM context is dete
    - Listed in the `## Active Work` table with status "Awaiting thread start"
 
    **Then exclude** (AND NOT — remove any issue that matches any of these):
-   - Marked as "Active", "In review", "Merged", or "Prompt generated" in the `## Active Work` table
+   - Marked as "Active", "In review", "Merged", "Prompt generated", or "Chip offered" in the `## Active Work` table
+
+   "Chip offered" means `/pm` already offered that issue as a click-to-launch chip — it is offered-but-unstarted, exactly like "Prompt generated", so excluding it prevents double-offering the same issue.
 
    Example: If `## Suggested Next Issues` lists #42, #55, #61 and the Active Work table shows #42 as "In review", the result is #55 and #61.
 
@@ -195,9 +197,24 @@ If all issues are subagent-eligible, the thread-prompt group is empty — only t
 
 ## Step 6: Generate Output
 
-Produce the following output in Markdown. Use the gathered data to fill in each section. The output should be **copy-paste-ready** — a user can paste each issue's prompt directly into a new Claude Code thread as a single copyable block.
+Produce the following output in Markdown. Use the gathered data to fill in each section.
+
+### Delivery mode
+
+Check chip availability per `.claude/reference/chip-launching.md`, then branch. The **prompt content is identical either way** — only delivery differs:
+
+- **Chip mode** (`mcp__ccd_session__spawn_task` present): for each thread-prompt issue (after Step 5.5 partitioning), call `spawn_task` with `title` / `prompt` / `tldr` / `cwd`, where `prompt` is exactly the content that would sit **inside** that issue's `~~~` fences in fallback mode — the fence delimiters themselves are not part of the prompt. Everything between them, starting with the `**Model:**` line, is. Print only the short summary per issue — issue, title, `**Model:**` line, one-line rationale. The user clicks to launch; never launch for them.
+- **Fallback mode** (tool absent): print today's `~~~`-fenced blocks for every thread-prompt issue, unchanged — **copy-paste-ready**, each independently pasteable into a new thread. Byte-for-byte identical to pre-chip output.
+
+**Spawn outcomes are tracked per issue.** A failed `spawn_task` falls back for **that issue alone** — print its full block and note the fallback once for the batch (per `chip-launching.md`); the rest of the batch keeps its chips. Do not print a block for an issue whose chip spawned successfully. Every thread-prompt issue ends with exactly one of: a chip, or a printed block.
+
+Subagent candidates from Step 5.5 never get chips — they run inline via `/subagent`, so that section is unchanged in both modes.
+
+If the user asks to "print the full prompt for #N" while in chip mode, re-emit that issue's complete tilde-fenced block verbatim. The chip stays offered.
 
 ### Output Structure
+
+Below is the fallback-mode structure. In chip mode, parts 2 and 3 collapse to short summaries and the block content moves inside each chip's `prompt`.
 
 The output has up to three parts:
 
@@ -334,6 +351,9 @@ This task is done when:
 - **All PM-detected issues are subagent-eligible:** Output only the Subagent Candidates section. No tier recommendation or prompt blocks needed.
 - **All PM-detected issues are thread-prompt-eligible:** Output normally — skip the Subagent Candidates section entirely. This is the same as the explicit-args path.
 - **`/subagent` skill not yet available:** The Subagent Candidates section outputs a `/subagent` command suggestion regardless of whether the skill exists. If the user runs it and the skill is missing, they will get a clear error. The `/prompt` skill does not gate on `/subagent` availability.
+- **Chip tool unavailable (CLI, headless, older client):** Fallback mode — output is identical to pre-chip behavior. Do not mention chips.
+- **Spawn fails mid-batch:** Fall back to a printed block for that issue only; the rest of the batch keeps its chips. Do not retry the failed spawn.
+- **User asks for the full prompt in chip mode:** Re-emit that issue's complete tilde-fenced block verbatim; leave the chip in place.
 
 ## Usage Examples
 
@@ -395,5 +415,11 @@ The prompt block that follows:
 ## CR Implementation Plan
 {CR plan verbatim, or "No CodeRabbit implementation plan available."}
 ~~~
+
+In **chip mode**, that same issue produces a chip plus this summary — the block above rides inside the chip instead of being printed:
+
+> - **#110 — {Title}** — chip offered
+>   **Model:** Opus 4.8 — skill file with multiple acceptance criteria
+>   Modifies a skill under `.claude/skills/` with four acceptance criteria.
 
 **Note:** This skill produces a recommendation. The user decides whether to follow the tier suggestion. When in doubt, the skill errs toward the higher tier — it's better to slightly over-resource than to get instruction adherence failures on a complex task.


### PR DESCRIPTION
## **User description**
## What & why

Ending a PM planning pass meant printing a wall of prompt text per issue and copy-pasting each one into a fresh thread. This adds a chip-based launch path: when the session's task-chip tool is available, `/pm` and `/prompt` offer each suggested issue as a one-click chip, and the transcript keeps just a short summary. You still decide what launches — the click is the only launch path.

Closes #548

## Approach

Chip mechanics are defined once in a new `.claude/reference/chip-launching.md` (per CodeRabbit's plan) rather than duplicated across both skills. Reference docs are **not** auto-loaded each turn, so this costs nothing against the rules budget (`rule-lint` confirms the corpus is unchanged at 10,967 words) while keeping the two skills' contracts from drifting.

- **`/pm`** — Step 3.1 branches on chip availability; Step 3.2 gains a `Task ID` column and a `Chip offered` status; Steps 3.3/3.4 dismiss stale chips (open PR, superseded, re-planned); Execution Boundary extended.
- **`/prompt`** — Step 6 branches on availability; the `**Model:**` line appears in both the visible summary and the chip prompt (chips cannot preset the picker); Path B excludes `Chip offered` so a re-run never double-offers.
- **Fallback** — byte-for-byte identical to today when the tool is absent. A CLI thread cannot tell this feature exists.

## Review notes (please read)

- **CodeAnt was dropped for this session** — it failed twice with `API Error: HTTP error 500` while reporting `"issues": []` behind exit code 0 (a known false-clean quirk). It produced no findings, so none were waived.
- **CodeRabbit CLI then hit its rate limit** (46-minute wait) before a final clean pass, so the last round closed with a **self-review**. Per `cr-local-review.md` a self-review does not satisfy the merge gate — the GitHub bots are the real gate here.
- CR's local review found **8 issues across 2 rounds, all fixed**: per-issue spawn-failure semantics (I had contradicted myself — "any failure → fallback mode" vs "that issue only"), a `task_id` lifetime bug (Step 3.4 removed rows before dismissing their chips), an over-broad prohibition that would have banned the read-only `pm-worker` spawns the same file permits, over-eager supersede detection, re-plan rollback, and fence/prompt-boundary precision.

## Test plan

- [x] Desktop session: `/pm` selects 2+ issues → 2+ chips appear; transcript shows short summaries only; clicking a chip opens a session whose first message is the full self-contained prompt
- [x] "print the full prompt for #N" → complete tilde-fenced block emitted
- [x] `/prompt #N #M` → one chip per issue, Model line visible in each summary
- [x] CLI thread (tool absent): output shape identical to current behavior
- [x] Re-run `/pm` after a suggested issue gains an open PR → its chip is dismissed
- [x] No Agent-tool thread spawns occur without an explicit user ask

## Acceptance criteria

- [x] `/pm` Step 3.1 emits one chip per selected issue (title ≤60 chars, verb + issue number; prompt = today's full thread prompt; 1–2 sentence tldr) with short-summary transcript output
- [x] `/prompt` same chip-per-issue behavior; `**Model:**` line in both summary and chip prompt
- [x] Fallback to today's full tilde-fenced blocks when the tool is unavailable or a spawn fails
- [x] "print the full prompt for #N" reproduces the complete block on demand
- [x] Stale chips withdrawn via `dismiss_task` on re-plan / supersede / open PR
- [x] Execution boundary preserved — chip click is the only launch path
- [x] `/pm` Active Work table supports "Chip offered" alongside "Prompt generated"

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add one-click chips for launching coding threads from `/pm` and `/prompt`

### What Changed
- Suggested coding-thread prompts can now be offered as clickable chips instead of always being printed as copy-paste blocks.
- When chips are available, the transcript shows a short summary with the recommended model, while the full prompt moves into the chip itself.
- If chip creation is unavailable or fails for one issue, that issue falls back to the normal printed prompt without affecting the rest.
- Chips are tracked so they can be withdrawn when an issue is already in progress, replaced, or no longer valid.

### Impact
`✅ Faster thread start`
`✅ Less prompt copy-pasting`
`✅ Fewer duplicate issue launches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional one-click coding task chips for selected issues.
  * Displays the recommended model and task summary directly in each chip.
  * Supports reopening the complete prompt for any chip on request.
* **Bug Fixes**
  * Failed chip creation now falls back to the full prompt for that issue without affecting others.
  * Prevents duplicate offers for issues already presented as chips.
* **Documentation**
  * Clarified chip dismissal, stale-offer handling, and execution boundaries.
  * Confirmed that offering a chip never starts work automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->