### PR TITLE
fix(#549): worktree guard blocks on target path's checkout, not session cwd

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # Worktree guard — PreToolUse hook
-# Blocks Write/Edit/NotebookEdit when the current branch of the claude-code-config
-# repo is `main`. Enforces the "ALWAYS USE A WORKTREE" rule mechanically.
+# Blocks Write/Edit/NotebookEdit when the TARGET FILE resolves into a
+# claude-code-config checkout whose current branch is `main`. Enforces the
+# "ALWAYS USE A WORKTREE" rule mechanically without blocking writes that land
+# outside the repo (session scratchpad, ~/.claude memory, other repos) when
+# the session cwd happens to be on main — see issue #549.
 #
 # Hook contract (PreToolUse):
 #   stdin  — JSON with {tool_name, tool_input, cwd, ...}
@@ -17,23 +20,73 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 0
 fi
 
-# Parse cwd and tool_name from the hook input JSON via stdin (safe for any content)
+# Parse tool_name, cwd, and the tool's target path from the hook input JSON.
+# Output protocol: four newline-separated fields — tool, cwd, anchor, target.
+#   anchor — nearest EXISTING ancestor directory of the resolved target; git
+#            queries run there (Write targets and their parent dirs may not
+#            exist yet). Empty when no target path could be parsed — bash then
+#            falls back to the legacy cwd-based check so malformed tool_input
+#            cannot bypass the guard.
+#   target — resolved absolute target path, used in the deny message only.
 PARSED=$(printf '%s' "$INPUT" | python3 -c '
-import json, sys
+import json, os, sys
+
+def clean(s):
+    return (s or "").replace("\n", " ").replace("\r", " ")
+
+def emit(tool="", cwd="", anchor="", target=""):
+    print(clean(tool))
+    print(clean(cwd))
+    # A newline inside a real directory name would corrupt the line protocol;
+    # treat such a path as unparseable (legacy fallback) instead of mis-parsing.
+    print(anchor if anchor == clean(anchor) else "")
+    print(clean(target))
+
+def as_str(v):
+    # Coerce non-string metadata to "" instead of crashing the helper —
+    # a crash here would empty PARSED and fail the guard open.
+    return v if isinstance(v, str) else ""
+
 try:
     d = json.loads(sys.stdin.read() or "{}")
 except Exception:
-    print("|")
-    sys.exit(0)
-cwd = (d.get("cwd") or "").replace("\n", " ").replace("\r", " ")
-tool = (d.get("tool_name") or "").replace("\n", " ").replace("\r", " ")
-print(f"{cwd}|{tool}")
+    d = None
+if not isinstance(d, dict):
+    d = {}
+
+cwd = as_str(d.get("cwd"))
+tool = as_str(d.get("tool_name"))
+ti = d.get("tool_input") or d.get("toolInput") or {}
+if not isinstance(ti, dict):
+    ti = {}
+target = as_str(ti.get("file_path")) or as_str(ti.get("notebook_path"))
+
+anchor = ""
+resolved = ""
+if target:
+    if os.path.isabs(target):
+        p = target
+    else:
+        p = os.path.join(cwd, target) if cwd else ""
+    if p:
+        # realpath: normalize + resolve symlinks; safe for non-existent paths
+        resolved = os.path.realpath(p)
+        probe = resolved
+        while probe and not os.path.isdir(probe):
+            parent = os.path.dirname(probe)
+            if parent == probe:
+                break
+            probe = parent
+        if os.path.isdir(probe):
+            anchor = probe
+
+emit(tool, cwd, anchor, resolved)
 ' 2>/dev/null)
 
-CWD="${PARSED%|*}"
-TOOL_NAME="${PARSED##*|}"
-
-[ -z "$CWD" ] && exit 0
+TOOL_NAME=$(printf '%s\n' "$PARSED" | sed -n '1p')
+CWD=$(printf '%s\n' "$PARSED" | sed -n '2p')
+ANCHOR=$(printf '%s\n' "$PARSED" | sed -n '3p')
+TARGET=$(printf '%s\n' "$PARSED" | sed -n '4p')
 
 # Defense-in-depth: also filter here in case the matcher in global-settings.json
 # is ever widened or the script is invoked directly during testing.
@@ -42,36 +95,47 @@ case "$TOOL_NAME" in
   *) exit 0 ;;
 esac
 
-TOPLEVEL=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+# No parseable target path: fall back to the legacy cwd-based check.
+if [ -z "$ANCHOR" ]; then
+  ANCHOR="$CWD"
+fi
+[ -z "$ANCHOR" ] && exit 0
+
+TOPLEVEL=$(git -C "$ANCHOR" rev-parse --show-toplevel 2>/dev/null || true)
 [ -z "$TOPLEVEL" ] && exit 0
 
 # Scope enforcement to the claude-code-config repo only. The hook is registered
-# globally in ~/.claude/settings.json, but we only want to block writes on main
-# for this specific repo. Match the repo's canonical directory name as a full
-# path component:
+# globally in ~/.claude/settings.json, but we only want to block writes into
+# main for this specific repo. Match the repo's canonical directory name as a
+# full path component:
 #   - Excludes forks like /foo/claude-code-config-fork/bar (requires literal
 #     /claude-code-config trailing segment or /claude-code-config/ prefix segment)
 #   - Excludes clones under alternate names (e.g., ~/my-config) — intentional
 #     trade-off: the guard only protects the canonical directory name
+#   - Linked worktrees under .claude/worktrees/ still match the pattern, but
+#     their own checked-out branch (not main's) is what gets evaluated below.
 case "$TOPLEVEL" in
   */claude-code-config|*/claude-code-config/*) ;;
   *) exit 0 ;;
 esac
 
-BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null || true)
+BRANCH=$(git -C "$ANCHOR" branch --show-current 2>/dev/null || true)
 
 if [ "$BRANCH" = "main" ]; then
   # If this python3 invocation fails for any reason (transient crash, etc.),
   # the hook exits 0 with empty stdout — the framework treats that as "allow"
   # (fail-open). The inline script is trivially simple so this is unlikely.
-  python3 -c '
-import json
+  TARGET_DISPLAY="$TARGET" python3 -c '
+import json, os
+target = os.environ.get("TARGET_DISPLAY") or ""
+suffix = " (target: %s)" % target if target else ""
 print(json.dumps({
     "hookSpecificOutput": {
         "hookEventName": "PreToolUse",
         "permissionDecision": "deny",
         "permissionDecisionReason": (
-            "BLOCKED: Cannot write files on main branch in claude-code-config. "
+            "BLOCKED: Cannot write files on main branch in claude-code-config"
+            + suffix + ". "
             "Use EnterWorktree to create a worktree first. "
             "See CLAUDE.md \"ALWAYS USE A WORKTREE\" section."
         ),

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -30,6 +30,9 @@ jobs:
       - name: config-protection unit tests
         run: python3 -m unittest tests.test_config_protection -v
 
+      - name: worktree-guard unit tests (issue #549)
+        run: python3 -m unittest tests.test_worktree_guard -v
+
       - name: pr-preflight unit test (issue #493)
         run: bash .claude/scripts/tests/pr-preflight.test.sh
 

--- a/tests/test_worktree_guard.py
+++ b/tests/test_worktree_guard.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Unit tests for .claude/hooks/worktree-guard.sh (issue #549).
+
+The guard must evaluate the TARGET file's checkout — not the session cwd —
+so writes outside the repo (session scratchpad, ~/.claude memory) are never
+blocked, while writes into a claude-code-config `main` checkout are denied
+regardless of where the session cwd sits.
+"""
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+HOOK_PATH = REPO_ROOT / ".claude" / "hooks" / "worktree-guard.sh"
+
+
+def run_hook(stdin_text: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def hook_decision(payload: dict) -> str:
+    """Return 'deny' or 'allow' for a hook-input payload.
+
+    Empty stdout means the hook made no decision, which the framework
+    treats as allow.
+    """
+    proc = run_hook(json.dumps(payload))
+    out = proc.stdout.strip()
+    if not out:
+        return "allow"
+    data = json.loads(out)
+    return data["hookSpecificOutput"]["permissionDecision"]
+
+
+def deny_reason(payload: dict) -> str:
+    proc = run_hook(json.dumps(payload))
+    data = json.loads(proc.stdout.strip())
+    return data["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def write_payload(cwd, file_path, tool: str = "Write") -> dict:
+    return {
+        "tool_name": tool,
+        "cwd": str(cwd),
+        "tool_input": {"file_path": str(file_path)},
+    }
+
+
+class WorktreeGuardTests(unittest.TestCase):
+    """Fixture layout (all under one temp dir, physical paths):
+
+    base/
+      claude-code-config/            git repo on `main` (one commit)
+        .claude/worktrees/wt/        linked worktree on `issue-test`
+      feature/claude-code-config/    git repo on `issue-x` (never main)
+      other-config/                  git repo on `main`, non-matching name
+      outside/scratchpad/            plain directory, no repo
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.base = pathlib.Path(tempfile.mkdtemp()).resolve()
+
+        cls.repo = cls.base / "claude-code-config"
+        cls._init_repo(cls.repo, branch="main")
+
+        cls.worktree = cls.repo / ".claude" / "worktrees" / "wt"
+        cls.worktree.parent.mkdir(parents=True)
+        cls._git(cls.repo, "worktree", "add", str(cls.worktree), "-b", "issue-test")
+
+        cls.feature_repo = cls.base / "feature" / "claude-code-config"
+        cls._init_repo(cls.feature_repo, branch="issue-x")
+
+        cls.other_repo = cls.base / "other-config"
+        cls._init_repo(cls.other_repo, branch="main")
+
+        cls.outside = cls.base / "outside" / "scratchpad"
+        cls.outside.mkdir(parents=True)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(cls.base, ignore_errors=True)
+
+    @staticmethod
+    def _git(cwd: pathlib.Path, *args: str) -> None:
+        subprocess.run(
+            [
+                "git",
+                "-c", "user.email=test@example.com",
+                "-c", "user.name=Test",
+                *args,
+            ],
+            cwd=str(cwd),
+            check=True,
+            capture_output=True,
+        )
+
+    @classmethod
+    def _init_repo(cls, path: pathlib.Path, branch: str) -> None:
+        path.mkdir(parents=True)
+        cls._git(path, "init", "-q", "-b", branch)
+        (path / "README.md").write_text("fixture\n", encoding="utf-8")
+        cls._git(path, "add", "README.md")
+        cls._git(path, "commit", "-q", "-m", "init")
+
+    # --- The issue #549 regressions: targets OUTSIDE the repo must pass ---
+
+    def test_allows_target_outside_repo_when_cwd_on_main(self) -> None:
+        payload = write_payload(self.repo, self.outside / "notes.md")
+        self.assertEqual(hook_decision(payload), "allow")
+
+    def test_allows_target_in_nonexistent_dirs_outside_repo(self) -> None:
+        # Mirrors the ~/.claude/projects/<slug>/memory/ case: deep path whose
+        # directories do not exist yet — the ancestor walk must land outside
+        # any repo and allow.
+        target = self.base / "home" / ".claude" / "projects" / "x" / "memory" / "m.md"
+        payload = write_payload(self.repo, target)
+        self.assertEqual(hook_decision(payload), "allow")
+
+    # --- Writes into the main checkout still deny ---
+
+    def test_denies_absolute_target_inside_main_checkout(self) -> None:
+        payload = write_payload(self.repo, self.repo / "newfile.md")
+        self.assertEqual(hook_decision(payload), "deny")
+        reason = deny_reason(payload)
+        self.assertIn("BLOCKED", reason)
+        self.assertIn(str(self.repo / "newfile.md"), reason)
+
+    def test_denies_relative_target_resolving_inside_main_checkout(self) -> None:
+        payload = write_payload(self.repo, "sub/newfile.md")
+        self.assertEqual(hook_decision(payload), "deny")
+
+    def test_denies_target_under_nonexistent_dirs_inside_main_checkout(self) -> None:
+        payload = write_payload(self.repo, self.repo / "a" / "b" / "c" / "new.md")
+        self.assertEqual(hook_decision(payload), "deny")
+
+    def test_denies_edit_tool_inside_main_checkout(self) -> None:
+        payload = write_payload(self.repo, self.repo / "README.md", tool="Edit")
+        self.assertEqual(hook_decision(payload), "deny")
+
+    def test_denies_symlink_resolving_into_main_checkout(self) -> None:
+        link = self.outside / "link.md"
+        if not link.is_symlink():
+            os.symlink(self.repo / "README.md", link)
+        payload = write_payload(self.outside, link)
+        self.assertEqual(hook_decision(payload), "deny")
+
+    def test_denies_camelcase_tool_input_inside_main_checkout(self) -> None:
+        payload = {
+            "tool_name": "Write",
+            "cwd": str(self.outside),
+            "toolInput": {"file_path": str(self.repo / "newfile.md")},
+        }
+        self.assertEqual(hook_decision(payload), "deny")
+
+    # --- The target's checkout governs, not the cwd's ---
+
+    def test_allows_target_in_feature_worktree_when_cwd_on_main(self) -> None:
+        payload = write_payload(self.repo, self.worktree / "wip.md")
+        self.assertEqual(hook_decision(payload), "allow")
+
+    def test_denies_target_in_main_checkout_when_cwd_in_worktree(self) -> None:
+        payload = write_payload(self.worktree, self.repo / "drift.md")
+        self.assertEqual(hook_decision(payload), "deny")
+
+    def test_allows_repo_checked_out_on_feature_branch(self) -> None:
+        payload = write_payload(self.feature_repo, self.feature_repo / "f.md")
+        self.assertEqual(hook_decision(payload), "allow")
+
+    def test_allows_differently_named_repo_on_main(self) -> None:
+        payload = write_payload(self.other_repo, self.other_repo / "f.md")
+        self.assertEqual(hook_decision(payload), "allow")
+
+    # --- NotebookEdit uses notebook_path ---
+
+    def test_notebook_edit_denies_inside_main_checkout(self) -> None:
+        payload = {
+            "tool_name": "NotebookEdit",
+            "cwd": str(self.outside),
+            "tool_input": {"notebook_path": str(self.repo / "nb.ipynb")},
+        }
+        self.assertEqual(hook_decision(payload), "deny")
+
+    def test_notebook_edit_allows_outside_repo(self) -> None:
+        payload = {
+            "tool_name": "NotebookEdit",
+            "cwd": str(self.repo),
+            "tool_input": {"notebook_path": str(self.outside / "nb.ipynb")},
+        }
+        self.assertEqual(hook_decision(payload), "allow")
+
+    # --- Guard rails: tool filter, legacy fallback, fail-open ---
+
+    def test_ignores_non_write_tools(self) -> None:
+        payload = write_payload(self.repo, self.repo / "newfile.md", tool="Bash")
+        self.assertEqual(hook_decision(payload), "allow")
+
+    def test_missing_file_path_falls_back_to_cwd_deny(self) -> None:
+        payload = {"tool_name": "Write", "cwd": str(self.repo), "tool_input": {}}
+        self.assertEqual(hook_decision(payload), "deny")
+
+    def test_missing_file_path_with_outside_cwd_allows(self) -> None:
+        payload = {"tool_name": "Write", "cwd": str(self.outside), "tool_input": {}}
+        self.assertEqual(hook_decision(payload), "allow")
+
+    def test_non_dict_tool_input_falls_back_to_cwd_deny(self) -> None:
+        payload = {"tool_name": "Write", "cwd": str(self.repo), "tool_input": "junk"}
+        self.assertEqual(hook_decision(payload), "deny")
+
+    def test_non_string_tool_name_allows_without_crash(self) -> None:
+        payload = {
+            "tool_name": 123,
+            "cwd": str(self.repo),
+            "tool_input": {"file_path": str(self.repo / "x.md")},
+        }
+        self.assertEqual(hook_decision(payload), "allow")
+
+    def test_non_string_file_path_falls_back_to_cwd_deny(self) -> None:
+        payload = {"tool_name": "Write", "cwd": str(self.repo), "tool_input": {"file_path": 123}}
+        self.assertEqual(hook_decision(payload), "deny")
+
+    def test_non_string_cwd_with_absolute_target_denies(self) -> None:
+        # Regression (CodeAnt local finding): a non-string cwd used to crash
+        # the helper and fail the guard open even for main-checkout targets.
+        payload = {
+            "tool_name": "Write",
+            "cwd": 123,
+            "tool_input": {"file_path": str(self.repo / "x.md")},
+        }
+        self.assertEqual(hook_decision(payload), "deny")
+
+    def test_json_array_stdin_fails_open(self) -> None:
+        proc = run_hook("[1, 2, 3]")
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(proc.stdout.strip(), "")
+
+    def test_malformed_json_fails_open(self) -> None:
+        proc = run_hook("this is not json")
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(proc.stdout.strip(), "")
+
+    def test_empty_stdin_fails_open(self) -> None:
+        proc = run_hook("")
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(proc.stdout.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## **User description**
## Summary

The PreToolUse worktree guard (`.claude/hooks/worktree-guard.sh`) denied Write/Edit/NotebookEdit whenever the **session cwd** sat on a claude-code-config `main` checkout — even when the target file was outside the repository (session scratchpad, `~/.claude/projects/*/memory`), forcing Bash-heredoc fallbacks that bypass the guard entirely (observed twice on 2026-07-15/16).

The hook now resolves the **tool's target path** and evaluates *that* checkout's branch:

- `tool_input.file_path` / `notebook_path` (plus camelCase `toolInput`), relative paths joined to cwd, `os.path.realpath` symlink/normalization, ancestor-walk to the nearest existing directory for not-yet-created paths
- Target outside any repo → **allow** (the #549 false positives)
- Target in a linked worktree on a feature branch → **allow** even from a main cwd
- Target inside a `main` checkout → **deny** regardless of cwd (strengthens the old cwd-only behavior; deny message now names the offending target)
- No parseable target → legacy cwd-based decision (fail-conservative); malformed JSON / missing python3 → fail open (unchanged)
- Hardened against non-string payload metadata crashing the helper into fail-open (CodeAnt local finding)

Name-scoping to `*/claude-code-config` path components is unchanged. Adds `tests/test_worktree_guard.py` (24 cases) wired into the `hook-tests` CI job.

Closes #549

## Test plan

- [x] Write/Edit to paths outside the repo (scratchpad, `~/.claude/projects/*/memory`) are allowed regardless of session cwd/branch
- [x] Write/Edit targeting files inside a claude-code-config `main` checkout are denied, including relative paths and new files in not-yet-existing directories
- [x] Write/Edit targeting files inside a linked worktree on a feature branch are allowed
- [x] Repos not matching the claude-code-config name scoping are never blocked
- [x] Missing target path falls back to the legacy cwd-based check
- [x] Unit tests in `tests/test_worktree_guard.py` run in the `hook-tests` CI job and pass
- [x] Symlinks outside the repo resolving into the main checkout are denied
- [x] Non-string payload metadata (tool_name/cwd/file_path) cannot crash the guard into fail-open

## Local review

- CodeAnt CLI: clean pass on the final diff (3/3 files reviewed, 0 findings); an earlier pass found the non-string fail-open hardening issue, fixed above
- CodeRabbit CLI: **dropped for this session** — Pro-tier rate limit (~51 min wait) at review time, zero findings emitted before bailing; per `cr-local-review.md` timeout & fallback, the surviving CLI (CodeAnt) gated. GitHub-side review chain still applies
- `python3 -m unittest tests.test_worktree_guard -v`: 24/24 pass locally (Python 3.9.6); smoke-tested the exact #549 regression payloads against the real repo paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop blocking writes outside the repo when the session is on main**

### What Changed
- The worktree guard now checks the file being written, not just the current session folder, so saves outside the repo are no longer blocked just because the session started on `main`
- Writes inside a `main` checkout are still denied, and the warning now names the target file that triggered the block
- Notebook edits are handled the same way as file writes, including relative paths, new paths, symlinks, and nested folders that do not exist yet
- The guard now keeps working when tool input is incomplete or oddly shaped, and its checks are covered by new unit tests in CI

### Impact
`✅ Fewer false blocks on scratchpad and memory files`
`✅ Safer writes inside the main checkout`
`✅ Clearer worktree guard warnings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

