### PR TITLE
fix(#560): config-protection hook fails open on Python 3.9 — defer annotations + CI 3.9 guard

### DIFF
--- a/.claude/hooks/config-protection.py
+++ b/.claude/hooks/config-protection.py
@@ -11,6 +11,11 @@
 # First-time creation of a protected basename is allowed (bootstrap path).
 # Modifying an existing protected file is blocked (exit 2 + stderr message).
 
+# Must stay importable on Python 3.9 (macOS system python3 is 3.9.6): the
+# __future__ import defers annotation evaluation so the PEP 604 unions below
+# stay legal on 3.9. Never use `X | Y` unions in runtime expressions here.
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -50,3 +50,29 @@ jobs:
 
       - name: escalate-review.sh BugBot failure detection unit test (issue #552)
         run: bash .claude/scripts/tests/escalate-review.test.sh
+
+  # macOS system python3 is 3.9.6 (Xcode CLT) while ubuntu-latest ships 3.10+,
+  # so a hook that crashes on 3.9 (e.g. eagerly-evaluated PEP 604 unions,
+  # issue #560) passes the job above yet fails open locally. Pin 3.9 here.
+  hook-tests-py39:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Python hook unit tests (3.9)
+        run: python3 -m unittest tests.test_env_guard tests.test_config_protection tests.test_worktree_guard tests.test_cr_plan_filter -v
+
+      - name: Hooks import smoke (3.9)
+        run: |
+          set -euo pipefail
+          for f in .claude/hooks/*.py; do
+            python3 -c 'import importlib.util, sys; p = sys.argv[1]; spec = importlib.util.spec_from_file_location("hook_smoke", p); mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); print("import OK:", p)' "$f"
+          done


### PR DESCRIPTION
## **User description**
## Summary

`.claude/hooks/config-protection.py` used PEP 604 union annotations (`str | None`), which evaluate eagerly on Python < 3.10. macOS system `python3` is 3.9.6, so the registered PreToolUse hook crashed at import on every local Write/Edit/Bash call — and since a hook crash exits 1 (non-blocking), the config protection **silently failed open** on this machine, while CI stayed green on ubuntu-latest's newer Python.

- **Fix:** `from __future__ import annotations` (PEP 563) defers all annotation evaluation — the five union sites become legal on 3.9 with zero runtime behavior change (the hook never introspects annotations at runtime). Header now documents the 3.9 floor.
- **Regression guard:** new `hook-tests-py39` CI job pins Python 3.9 (`actions/setup-python`), runs the three Python hook suites, and import-smokes every `.claude/hooks/*.py` so an untested future Python hook can't reintroduce this class of failure.

Closes #560

## Test plan

- [x] `python3 -m unittest tests.test_config_protection -v` passes on macOS system Python 3.9.6
- [x] End-to-end smoke on 3.9 (as the registered hook runs): Write to existing protected config → exit 2 + BLOCKED stderr; benign Write → exit 0; Bash `sed -i` on protected config → exit 2
- [x] All `.claude/hooks/*.py` import cleanly under Python 3.9 (import smoke)
- [x] CI `hook-tests-py39` job passes (3.9 unit suites + hooks import smoke)
- [x] Hook header documents the Python 3.9 compatibility floor

## Local review (cr-local-review.md)

- **CodeRabbit CLI:** 2 passes. Fixed: added `persist-credentials: false` to the new job's checkout step. Dismissed with reasons:
  1. *"Revert hook-tests-py39 / do not modify existing workflow files"* — misapplies `repo-bootstrap.md`, which constrains the bootstrap **script's** auto-provisioning, not PR evolution of CI; `hook-scripts.yml` accretes per-issue steps by design (issues #493, #541, #417 appear in its step names).
  2. *Pin actions to commit SHAs* — all 6 action refs across the repo's 4 workflows use version tags; single-job SHA pins would be inconsistent. Spun off as a follow-up task (repo-wide pinning + checkout hardening).
- **CodeAnt CLI:** clean pass scoped to the two changed files (`--include`). The first unscoped attempt was an API-failure false-clean (`UND_ERR_HEADERS_TIMEOUT` on stderr with `issues: []`, exit 0 — known 0.5.1 bug) and was discarded per the false-clean guard.

## Deployment note

The live registration in `~/.claude/settings.json` points at the **skills-worktree** copy of the hook (pinned to origin/main). Local protection is restored once this merges and the skills-worktree syncs (the session-start hook does that automatically).


___

## **CodeAnt-AI Description**
**Keep the config protection hook working on Python 3.9 and catch regressions in CI**

### What Changed
- The config protection hook now imports cleanly on Python 3.9, preventing it from crashing at startup on macOS system Python.
- A new CI check runs the Python hook tests on Python 3.9 and imports every hook script to catch compatibility breaks before release.
- The hook file now clearly states that it must stay compatible with Python 3.9.

### Impact
`✅ Fewer blocked local tool runs on macOS`
`✅ Safer config protection on Python 3.9`
`✅ Earlier detection of hook import failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

