### PR TITLE
docs(#562): record decision that /pm-handoff does not offer chips

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -31,6 +31,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `phase-decomposition.md` — phase split reference material
 - `pm-data-patterns.md` — PM skills data patterns and bot filters
 - `pm-monitoring-decision.md` — `/pm` vs `/pr-monitor-and-manage` division of responsibility
+- `pm-handoff-chips-decision.md` — decision record: `/pm-handoff` intentionally does not offer task chips; its portable prompt text is the deliverable (#562)
 - `scheduling-failure-modes.md` — recurring poll failure analysis
 - `skill-sync-hooks.md` — skills worktree sync and hook registration narrative
 - `double-loading-fix.md` — decision record for suppressing the duplicate global CLAUDE.md + rules copy via project-local `claudeMdExcludes` (#461)

--- a/.claude/reference/chip-launching.md
+++ b/.claude/reference/chip-launching.md
@@ -2,6 +2,8 @@
 
 Canonical mechanics for offering a coding-thread prompt as a **task chip** the user can click to spin off a new session. Shared by `/pm` (Step 3.1) and `/prompt` (Step 6). Skill-specific wiring stays in each SKILL.md; everything below is defined once, here.
 
+**Out of scope (explicit):** `/pm-handoff` does not offer chips and will not — its handoff prompt is a context-turnover artifact whose visible, portable text is the deliverable, and it has no issue number, model line, or lifecycle for these mechanics to key on. Decided in #562; rationale in `pm-handoff-chips-decision.md`.
+
 > **NON-NEGOTIABLE — execution boundary.** Offering a chip is NOT launching a thread. Skills NEVER auto-launch: no Agent-tool spawn, no session start, no work begun on the user's behalf. **The user's chip click is the only launch path.** This does not widen any skill's existing explicit-ask exception (e.g. `/pm`'s "go ahead and run those") — it narrows nothing and grants nothing new.
 
 ## Availability detection

--- a/.claude/reference/pm-handoff-chips-decision.md
+++ b/.claude/reference/pm-handoff-chips-decision.md
@@ -1,0 +1,37 @@
+# `/pm-handoff` Chips Decision (#562, follow-up from #548 / PR #555)
+
+## Decision
+
+**`/pm-handoff` does not offer task chips, and will not.** Its output stays what it is today: the complete handoff prompt printed to stdout, optionally copied to the clipboard via the `copy` argument. No `spawn_task` / `dismiss_task` wiring, no chip-mode branch, no availability detection.
+
+PR #555 wired chips into `/pm` (Step 3.1) and `/prompt` (Step 6). Issue #548 deferred `/pm-handoff` by explicit scope decision rather than on the merits; this record settles it on the merits so it stays decided.
+
+## Rationale
+
+**Chip mechanics are keyed to an issue; a handoff has no issue.** Every mechanic in `chip-launching.md` assumes a per-issue coding thread:
+
+- `title` must include the issue number.
+- `prompt` must carry a `**Model:** {MODEL} — {REASON}` line, because chips cannot drive the model picker. A handoff prompt has no model recommendation to carry.
+- Chip state is tracked *keyed by issue number*, and the "already offered — skip it on re-run" dedupe is per-issue.
+- All three `dismiss_task` triggers — gained an open PR, superseded by a later batch, re-planned scope — are issue-lifecycle events.
+
+A handoff prompt has no issue number, no model recommendation, and no lifecycle those triggers can observe. Supporting this would mean **inventing non-issue chip semantics**, which #562's own scope explicitly rules out ("no new chip semantics"). The port is not mechanical; it is a redesign of the chip contract.
+
+**The portable text is the deliverable, not friction.** `/pm-handoff` exists for context-window turnover: it emits a self-contained prompt the user pastes into a deliberately fresh PM thread. The skill's own docs target "a new Claude Code session (**web or CLI**)", and it ships a `copy` argument that pipes the prompt to `pbcopy`. Both are the design conceding that getting the visible, portable full text into the user's hands *is* the point. Chips are client-local: one cannot cross to the web app, to another machine, or into a later moment the user chooses. Wrapping the handoff in a chip would hide exactly the text the user invoked the skill to obtain.
+
+**The strongest "yes" argument, and why it loses.** `spawn_task` genuinely does start a fresh session seeded with a given prompt — which is, narrowly, what turnover wants. But that case holds only for "turnover, in this same client, right now." It still hides the artifact, still cannot reach the web app or a second machine, and still requires the non-issue semantics above. It trades the skill's whole purpose for one keystroke in its narrowest use case.
+
+**Context, not work:** chip `task_id` state is conversation-memory-only and is not captured by any file `/pm-handoff` reads (`session-state.json`, `~/.claude/handoffs/pr-*-handoff.json`, `MEMORY.md`). So no chip-continuity requirement pulls toward "yes" either — there is nothing about live chips a handoff is currently failing to carry across.
+
+## Explicitly Rejected (considered and declined)
+
+- **Mechanical port per `chip-launching.md`** (availability detection, `spawn_task` with `title`/`prompt`/`tldr`/`cwd`, short-summary transcript, `task_id` tracking, `dismiss_task` hygiene, byte-identical fallback, print-on-demand replay) — rejected: chip semantics are per-issue coding-thread launches, so a handoff fits none of the required fields or dismiss triggers, and wrapping the prompt hides the portable text that is the artifact's whole purpose.
+- **A handoff-specific chip variant** (chips without issue numbers, model lines, or lifecycle-based dismissal) — rejected: that is new chip semantics, explicitly out of scope for #562, and it would fork the single-source contract that PR #555 deliberately centralized.
+
+## References
+
+- Issue [#548](https://github.com/auerbachb/claude-code-config/issues/548) — original chip work; deferred `/pm-handoff` by scope decision
+- PR [#555](https://github.com/auerbachb/claude-code-config/pull/555) — wired chips into `/pm` and `/prompt`
+- Issue [#562](https://github.com/auerbachb/claude-code-config/issues/562) — this decision
+- `chip-launching.md` — canonical chip mechanics (the contract this decision declines to extend)
+- `.claude/skills/pm-handoff/SKILL.md` — the skill whose behavior is intentionally unchanged


### PR DESCRIPTION
## **User description**
## Verdict: No — `/pm-handoff` will not offer chips

This is a design-decision ticket, and the deliverable is the verdict. Issue #548 deferred this by scope decision; PR #555 wired chips into `/pm` and `/prompt` only. This PR settles `/pm-handoff` **on the merits** so it stays decided.

**Documentation-only. `/pm-handoff` runtime behavior is unchanged** — no `spawn_task`/`dismiss_task` wiring, `SKILL.md` and `ARCHITECTURE.md` untouched.

### Why "no"

I took the "yes" case seriously — `spawn_task` really does start a fresh session seeded with a prompt, which is narrowly what context turnover wants. It loses on mechanics, not just philosophy:

- **Every mechanic in `chip-launching.md` is keyed to an issue.** `title` must include the issue number; `prompt` must carry a `**Model:**` line (chips can't drive the picker); state is tracked per issue number with per-issue "already offered" dedupe; and all three `dismiss_task` triggers (gained an open PR, superseded, re-planned) are issue-lifecycle events. A handoff has no issue, no model recommendation, and no lifecycle those triggers can observe — so a port would require **inventing non-issue chip semantics**, which this issue's scope explicitly forbids.
- **Chips are client-local.** `/pm-handoff` targets "a new Claude Code session (web or CLI)". A chip can't cross to the web app, another machine, or a later moment — and choosing where turnover lands is the user's call.
- **The skill already concedes the point.** Its `copy`/`pbcopy` argument exists because the portable, visible text *is* the deliverable. A chip would hide exactly the text the user invoked the skill to obtain.

Supporting context (not work): chip `task_id` state is conversation-memory-only and isn't captured by any file `/pm-handoff` reads, so no chip-continuity requirement pulls toward "yes" either.

### Changes

- **New** `.claude/reference/pm-handoff-chips-decision.md` — the decision record (Decision / Rationale / Explicitly Rejected / References), matching the shape of `pm-monitoring-decision.md`.
- `.claude/reference/chip-launching.md` — bolded inline `**Out of scope (explicit):**` note near the "Shared by `/pm` … `/prompt`" line. No new chip semantics.
- `.claude/reference/README.md` — index pointer under **Workflow decomposition and PM helpers** (where `pm-monitoring-decision.md` and `double-loading-fix.md` live), not "Audits and research" — that's where this repo keeps decision records.

## Test plan

- [x] Verdict explicitly decided with stated reasoning — not assumed
- [x] `pm-handoff-chips-decision.md` records verdict, rationale, explicitly-rejected option, and references (#548, PR #555, `chip-launching.md`)
- [x] `chip-launching.md` carries the cross-reference note in the repo's bolded inline scope-note style, adding no new chip semantics
- [x] `.claude/reference/README.md` indexes the decision doc under the PM-helpers/decision-record grouping
- [x] `rule-lint.sh` passes with no budget regression (reference docs aren't auto-loaded)
- [x] `/pm-handoff` runtime behavior unchanged — no `spawn_task`/`dismiss_task` wiring; `SKILL.md` / `ARCHITECTURE.md` untouched
- [x] Both local review CLIs pass clean (verified against false-clean: real `reviewed_files`, `noFiles: false`)

Closes #562


___

## **CodeAnt-AI Description**
Record that `/pm-handoff` will not offer task chips

### What Changed
- Added a decision record stating that `/pm-handoff` keeps printing the full handoff prompt and can still copy it to the clipboard
- Clarified that chips remain out of scope for `/pm-handoff` because the handoff prompt has no issue number, model line, or issue-based lifecycle to attach them to
- Marked `/pm-handoff` as intentionally excluded from the shared chip rules so the guidance stays consistent across docs

### Impact
`✅ Clearer `/pm-handoff` behavior`
`✅ Fewer wrong expectations about task chips`
`✅ Easier to tell which skills can offer chips`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

