### PR TITLE
feat(#561): offer /start-issue handoff as a one-click chip

### DIFF
--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -222,7 +222,7 @@ Ready to code. Start with step 1 of the plan above. Run the dual-CLI local revie
 | Param | Value |
 |-------|-------|
 | `title` | Verb-first, ≤60 chars, includes the issue number — built from `ISSUE_NUMBER` + `TITLE` (e.g. `Fix #42 stale worktree warning`) |
-| `prompt` | The complete self-contained coding-thread prompt — byte-identical to the **content** of the fallback block above (the fence delimiters are not part of the prompt; everything between them is), with the `**Model:**` line at the top |
+| `prompt` | The complete self-contained coding-thread prompt: the `**Model:**` line, then a blank line, then the **content** of the fallback block above reproduced verbatim (the fence delimiters are not part of the prompt; everything between them is). The Model line is the only addition — the block's own text is never reworded to suit the chip |
 | `tldr` | 1–2 plain-English sentences from `TITLE` / the merged plan: what the session will do and why. No file paths, no jargon |
 | `cwd` | `WORKTREE_PATH` — the worktree created in Step 6 |
 
@@ -230,7 +230,7 @@ Ready to code. Start with step 1 of the plan above. Run the dual-CLI local revie
 
 **Chips carry no model preset,** so the `**Model:** {MODEL} — {REASON}` line MUST appear both at the top of the chip's `prompt` text (so the spawned session sees it) and in the visible short summary (so the user can set the picker before clicking).
 
-**Record the returned `task_id` immediately,** before any dependent step — an unrecorded chip cannot be withdrawn. `/start-issue` has no Active Work table, so track it **session-locally**, keyed by issue number, and say so in the summary; the chip stays dismissable for this session only. If the issue already has a live chip recorded in this session, skip the spawn rather than offering it twice. `dismiss_task` hygiene and print-on-demand replay ("print the full prompt for #N" re-emits the complete block verbatim; the chip stays offered) follow the reference — do not restate its rules here.
+**Record the returned `task_id` immediately,** before any dependent step — an unrecorded chip cannot be withdrawn. `/start-issue` has no Active Work table, so track it **session-locally**, keyed by issue number, and say so in the summary; the chip stays dismissable for this session only. If the issue already has a live chip recorded in this session, skip the spawn rather than offering it twice. `dismiss_task` hygiene and print-on-demand replay ("print the full prompt for #N" re-emits that chip's `prompt` verbatim — Model line and block — in the fenced form fallback would have printed; the chip stays offered) follow the reference — do not restate its rules here.
 
 ### Model recommendation
 

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -184,9 +184,18 @@ This creates **one canonical planning document** the coding agent can work from.
    If `pull` fails (diverged history), stop and report to the user — do not force-pull. If `checkout main` fails (uncommitted changes in the root repo), stop and report — do not stash or discard changes.
 5. **Verify:** confirm the worktree directory exists and the branch is checked out before proceeding.
 
-## Step 7: Output ready-to-code summary
+## Step 7: Deliver the ready-to-code handoff
 
-Print a compact summary to the user:
+**First, check chip availability** per `.claude/reference/chip-launching.md`, then branch. The handoff content is the same in both delivery modes — only how it reaches the user differs:
+
+- **Chip mode** (`mcp__ccd_session__spawn_task` present): call `spawn_task` once for this issue with `title` / `prompt` / `tldr` / `cwd` (shape under "Chip construction" below). Print **only** the short summary — issue, title, `**Model:**` line, one-line rationale — in the reference's exact format. Do **not** also print the fallback block, or the same work is offered twice.
+- **Fallback mode** (tool absent): print the summary block below, unchanged.
+
+**A failed `spawn_task` is treated as unavailable** (per the reference): print the full fallback block instead. Do not retry the spawn. The handoff always ends with exactly one of: a chip, or a printed block — never neither.
+
+### Fallback mode output
+
+Print a compact summary to the user. This block is the pre-chip baseline — emit it **byte-for-byte identical** to what `/start-issue` printed before chips existed (same heading, fields, plan/AC sections, and closing "Ready to code…" line), so a CLI or headless thread cannot tell this feature exists:
 
 ```
 ## Ready to code — Issue #{N}
@@ -206,7 +215,35 @@ Print a compact summary to the user:
 Ready to code. Start with step 1 of the plan above. Run the dual-CLI local review per `cr-local-review.md`, fix all valid findings, and rerun until the required clean gate is reached before pushing.
 ```
 
-Stop after printing the summary. Do NOT start coding automatically — the user may want to review the plan first.
+### Chip construction (chip mode)
+
+`.claude/reference/chip-launching.md` is authoritative for chip semantics — this table only maps the skill's existing variables onto its params:
+
+| Param | Value |
+|-------|-------|
+| `title` | Verb-first, ≤60 chars, includes the issue number — built from `ISSUE_NUMBER` + `TITLE` (e.g. `Fix #42 stale worktree warning`) |
+| `prompt` | The complete self-contained coding-thread prompt — byte-identical to the **content** of the fallback block above (the fence delimiters are not part of the prompt; everything between them is), with the `**Model:**` line at the top |
+| `tldr` | 1–2 plain-English sentences from `TITLE` / the merged plan: what the session will do and why. No file paths, no jargon |
+| `cwd` | `WORKTREE_PATH` — the worktree created in Step 6 |
+
+> **`cwd` deliberately differs from `/pm` and `/prompt`,** which pass the repo root. By Step 7, `/start-issue` has already created an issue-specific worktree, so the launched thread must start *there* — repo root would land it in the wrong checkout, on the wrong branch. This is an intentional divergence, not an inconsistency with the shared contract.
+
+**Chips carry no model preset,** so the `**Model:** {MODEL} — {REASON}` line MUST appear both at the top of the chip's `prompt` text (so the spawned session sees it) and in the visible short summary (so the user can set the picker before clicking).
+
+**Record the returned `task_id` immediately,** before any dependent step — an unrecorded chip cannot be withdrawn. `/start-issue` has no Active Work table, so track it **session-locally**, keyed by issue number, and say so in the summary; the chip stays dismissable for this session only. If the issue already has a live chip recorded in this session, skip the spawn rather than offering it twice. `dismiss_task` hygiene and print-on-demand replay ("print the full prompt for #N" re-emits the complete block verbatim; the chip stays offered) follow the reference — do not restate its rules here.
+
+### Model recommendation
+
+Chips need a `{MODEL}` and a `{REASON}`. Use this lightweight, role-based rule over the canonical roster (**Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5** — see `.claude/rules/subagent-orchestration.md` "Model Selection"):
+
+- **Default: Sonnet 5** — ordinary single-issue coding work.
+- **Step up to Opus 4.8** when the issue touches rules, `CLAUDE.md`, skills, or orchestration — instruction-adherence work where literal-following models misfire.
+
+`{REASON}` is a short phrase naming the dominant driver (e.g. `rules + skill wiring`, `single-file code change`). Do **NOT** replicate `/prompt`'s Heavy/Standard/Light multi-signal pipeline — `/start-issue` is single-issue and has no model concept beyond this rule. When `/prompt` already produced a recommendation for the issue, prefer it.
+
+### Execution boundary
+
+Stop after delivering the handoff. Do NOT start coding automatically — the user may want to review the plan first. **Offering a chip is not launching a thread:** `spawn_task` only puts a chip in front of the user, and their click is the only launch path. Never click for them, and never do the coding thread's work yourself — via the Agent tool or otherwise — in place of a chip they haven't clicked.
 
 ## Edge cases
 


### PR DESCRIPTION
## **User description**
## Summary

`/start-issue` ended by printing a ready-to-code summary the user had to act on manually. Step 7 is now a **delivery** step that branches on chip availability per `.claude/reference/chip-launching.md` — the same contract `/pm` and `/prompt` already use. Chip mode offers the handoff as one clickable chip; fallback mode prints exactly what it printed before.

Only `.claude/skills/start-issue/SKILL.md` changes. `chip-launching.md` stays authoritative and untouched — the skill references its rules rather than restating them.

**Notable decisions:**

- **`cwd` = `WORKTREE_PATH`, not repo root.** This deliberately diverges from `/pm` and `/prompt`. By Step 7 `/start-issue` has already built an issue-specific worktree, so the launched thread must start there; repo root would land it on the wrong branch. The skill states the rationale inline so it doesn't read as an inconsistency.
- **Lightweight model rule.** Default Sonnet 5, step up to Opus 4.8 for rules / `CLAUDE.md` / skills / orchestration work. `/prompt`'s Heavy/Standard/Light pipeline is explicitly *not* replicated — `/start-issue` is single-issue and had no model concept before this.
- **Session-local `task_id`.** `/start-issue` has no Active Work table, so the chip handle lives in session state; no persistent table introduced.
- **Chip `prompt` composition.** The prompt is the `**Model:**` line + the fallback block's content verbatim. CodeAnt caught the first draft demanding the prompt be simultaneously byte-identical to the block *and* carry an extra line — impossible, since (unlike `/prompt`) this skill's block has no Model line of its own.

## Review notes

**CodeRabbit CLI was skipped — rate-limited** (`Rate limit exceeded`, 17 min wait) at review time. Per `cr-local-review.md` the CLI was dropped for the session rather than burning the shared adaptive quota that CodeRabbit's *GitHub* review needs to satisfy the merge gate. **CodeAnt CLI ran to a clean pass** (one finding, fixed in `e8a523f`, verified clean on re-run with healthy `meta`). CodeRabbit's GitHub review still gates this PR normally.

## Test plan

- [x] Step 7 opens by checking chip availability per `.claude/reference/chip-launching.md`, then branches into chip / fallback mode, matching `/pm` Step 3.1 and `/prompt` Step 6 phrasing.
- [x] Chip mode emits exactly one `spawn_task` with `title` / `prompt` / `tldr` / `cwd` populated from the skill's existing variables.
- [x] `cwd` is `WORKTREE_PATH` (not repo root), with the deliberate divergence from `/pm` and `/prompt` noted inline.
- [x] On a successful spawn the transcript shows only the reference's short-summary form — no prompt block, no context dump, no AC list.
- [x] A `**Model:** {MODEL} — {REASON}` line appears both inside the chip's `prompt` and in the visible short summary.
- [x] The model rule is lightweight and role-based (default Sonnet 5; Opus 4.8 for rules/`CLAUDE.md`/skills/orchestration), names only the canonical roster, and does not replicate `/prompt`'s pipeline.
- [x] A failed `spawn_task` degrades to printing the full block; the handoff never ends with neither chip nor block.
- [x] Fallback output is byte-for-byte identical to today's Step 7 (verified by diffing the fenced block against `origin/main` — 521 bytes, identical).
- [x] The execution boundary is preserved and stated: "do NOT start coding automatically" retained, plus offering a chip is not launching — the click is the only launch path.
- [x] The returned `task_id` is tracked session-locally so the chip stays dismissable; no persistent table added.
- [x] No chip semantics duplicated into the skill; `chip-launching.md` referenced, not restated.
- [x] `.claude/reference/chip-launching.md` is unmodified by this PR.

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Offer /start-issue handoff as a chip when available, with the same fallback text as before**

### What Changed
- `/start-issue` now checks whether chip launching is available and, when it is, presents the handoff as one clickable chip instead of printing the full block
- If chip launching is not available or the chip cannot be created, it falls back to the exact same printed summary users saw before
- The handoff now always ends with one clear path: either a chip or the printed block, and it avoids showing both
- The chip is tied to the issue’s worktree so the launched thread starts in the right place

### Impact
`✅ One-click issue handoff`
`✅ No duplicate handoff prompts`
`✅ Fewer wrong-branch starts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

