### PR TITLE
ci(#566): pin GitHub Actions to full commit SHAs + persist-credentials hardening

### DIFF
--- a/.claude/scripts/repo-bootstrap.sh
+++ b/.claude/scripts/repo-bootstrap.sh
@@ -132,7 +132,7 @@ jobs:
     if: "!endsWith(github.event.issue.user.login, '[bot]')"
     steps:
       - name: Comment @coderabbitai plan
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/cr-plan-on-issue.yml
+++ b/.github/workflows/cr-plan-on-issue.yml
@@ -13,7 +13,7 @@ jobs:
     if: "!endsWith(github.event.issue.user.login, '[bot]')"
     steps:
       - name: Comment @coderabbitai plan
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/cursor-review-pr-comment.yml
+++ b/.github/workflows/cursor-review-pr-comment.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment @cursor review
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Configure git (worktree tests)
         run: |
@@ -58,12 +60,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.9'
 

--- a/.github/workflows/rule-lint.yml
+++ b/.github/workflows/rule-lint.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Run rule-lint
         run: bash .github/scripts/rule-lint.sh


### PR DESCRIPTION
## **User description**
Closes #566

## Summary

Mechanical supply-chain hardening of every GitHub Actions reference in the repo, as proposed in Issue #566 (originally flagged by CodeRabbit's local CLI during Issue #560 work and deferred there as repo-wide scope):

1. **All 7 `uses:` references pinned to full 40-char commit SHAs** with a trailing `# vX.Y.Z` comment noting the tracked release — 6 in `.github/workflows/`, plus the embedded installer template in `.claude/scripts/repo-bootstrap.sh` (kept byte-identical to `cr-plan-on-issue.yml` so bootstrapped repos receive the pinned version).
2. **`persist-credentials: false` on the two checkout steps that lacked it** (`hook-scripts.yml` `hook-tests`, `rule-lint.yml`). The `hook-tests-py39` checkout already set it (PR #564). No workflow pushes; the two `github-script` workflows have no checkout.
3. **New `.github/dependabot.yml`** (`github-actions` ecosystem, weekly) so SHA pins receive automated bump PRs instead of rotting. Known gap, by design: Dependabot does not scan the shell-heredoc template copy in `repo-bootstrap.sh`.

## Pins (resolved + re-verified upstream at commit time)

| Action | Pinned SHA | Release |
|--------|-----------|---------|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 (current `v4`) |
| `actions/setup-python` | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.0 (current `v5`) |
| `actions/github-script` | `f28e40c7f34bde8b3046d885e986cb6290c5673b` | v7.1.0 (current `v7`) |

Each floating tag currently resolves to the same commit as the pinned release, so workflows run **bit-identical action code to before this PR** — zero behavior change.

Verification evidence (pre-commit hard gate; each `gh api repos/actions/<repo>/commits/<tag> --jq .sha` compared against the pin):

```
OK checkout v4.3.1
OK setup-python v5.6.0
OK github-script v7.1.0
OK no floating tags
checkouts=3 persists=3
OK persist-credentials coverage
OK heredoc identical
OK bash -n
OK bootstrap --check
OK yaml
```

## Test plan

- [x] Every `uses:` in `.github/workflows/` is a full 40-char commit SHA with a `# vX.Y.Z` comment (`grep -rnE 'uses:.*@v[0-9]' .github/workflows/` returns nothing)
- [x] Each pinned SHA matches its upstream release tag (`gh api repos/actions/<repo>/commits/<tag> --jq .sha` — evidence above)
- [x] All 3 `actions/checkout` steps set `persist-credentials: false`
- [x] `.github/dependabot.yml` exists and covers the `github-actions` ecosystem
- [x] `repo-bootstrap.sh` heredoc template remains byte-identical to `cr-plan-on-issue.yml` (`bash -n` + `--check` still pass)
- [x] No functional change: pinned SHAs equal today's floating-tag targets
- [x] CI green on this PR (`hook-scripts`, `rule-lint` — both run the pinned actions themselves)

## Local review

- **CodeAnt CLI:** clean pass — `issues: []`, all 6 changed files present in `reviewed_files`, `noFiles: false`, `capped: false`.
- **CodeRabbit CLI:** dropped for this round — the local run hit the org rate limit (8-minute backoff) after emitting zero findings. Local CLI and GitHub reviews draw from one shared adaptive quota, so rather than burn another round locally, CodeRabbit reviews this PR through the standard GitHub merge gate.


___

## **CodeAnt-AI Description**
**Lock down GitHub Actions references and prevent checkout credentials from being reused**

### What Changed
- Replaced floating GitHub Actions versions with fixed release commits in workflows and the repo bootstrap template
- Turned off saved checkout credentials in the jobs that do not need to push changes
- Added Dependabot updates for GitHub Actions so pinned versions can be refreshed automatically

### Impact
`✅ Fewer supply-chain surprises in CI`
`✅ Lower chance of accidental git pushes from workflow runs`
`✅ Automated updates for pinned Actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated repository workflows to use fixed, verified action versions for more consistent and reliable execution.
  * Preserved existing workflow behavior, including pull request comments, repository checks, and hook testing.
  * Added weekly monitoring for GitHub Actions updates to help keep automation dependencies current.
  * Maintained Python 3.9 testing and existing credential-handling settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
