### PR TITLE
fix(#559): /wrap distinguishes "no coding here" from a failed PR lookup

### DIFF
--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -126,7 +126,29 @@ fi   # 0 single, 1 multiple, 2 none, 3/4 error
 - **Single candidate** (exactly one across both sources): proceed on it.
 - **Most-recent-unambiguous** (multiple candidates, but one was mentioned/active distinctly more recently — e.g. the top thread mention, or active within the last ~5 minutes while the others are stale): proceed on the most-recent one and surface the rest with an `Also tracking:` line.
 - **Ambiguous** (candidates tied in recency, or no clear most-recent winner): **stop** — list each candidate with its source/last-activity and ask the user to specify: `Multiple PRs in scope — please specify: /wrap <N>`.
-- **No candidates** (1.1b empty, 1.1c found nothing, `SESSION_RC == 2`): stop with the existing message: `No PR found for the current branch.`
+- **No candidates** (1.1b empty, 1.1c found nothing, `SESSION_RC == 2`): stop — but pick the stop message that matches the situation, per **1.1f** below. Either way `/wrap` does no work: Phases 1–4 are all skipped, nothing is created, and the skill exits.
+
+**1.1f — Choose the no-candidates stop message** *(AI judgment, same layer and style as 1.1c — no script, no state file)*. Scan the **current conversation** for signals that this thread never contained coding work. Count a signal only when it is actually present in the thread:
+
+- The thread ran `/issue-maker`, or otherwise declared itself capture-only / issue-only mode.
+- The thread's entire output was creating, editing, commenting on, or closing GitHub issues — no implementation.
+- The thread is PM/monitoring/orchestration only (`/pm`, `/prioritize`, `/status`, `/standup`, `/recap`) with no code written here.
+- The thread explicitly concluded the work was already solved elsewhere, or that there is nothing to implement.
+- No branch, worktree, commit, push, or PR was ever created or discussed in this thread.
+
+**Tiebreak — this bias is mandatory.** Emit the no-coding message **only** when the thread affirmatively shows those signals. If the signals are absent, weak, mixed, or you are unsure at all, emit the lookup-failed message. Telling someone "nothing to wrap" while they are sitting on a real PR is the worse failure; a redundant `/wrap <N>` hint costs nothing.
+
+- **Non-coding thread detected** — state it plainly; this is a normal outcome, not an error. Do not use "failed", "could not", "unable to find", and do not imply the user should go fix anything:
+
+  ```text
+  This thread has no coding work in it, so there's nothing to wrap. No action needed.
+  ```
+
+- **No detection signal (default)** — keep today's meaning and name the escape hatch:
+
+  ```text
+  No PR found for the current branch. If you meant a specific PR, name it: /wrap <N>
+  ```
 
 **Emit the inference result before verification.** Once a PR is resolved by inference (any of 1.1a, 1.1c, or 1.1d/e — i.e. `INFERRED_SOURCE` is set, *not* the plain 1.1b branch path), print the `[INFERRED]` line **immediately, before any Phase 1 verification work (Step 1.2 onward)**, so the user has a visible checkpoint to abort a mismatch:
 
@@ -604,7 +626,7 @@ After the per-PR follow-up report: proceed immediately to **Part B** — do not 
 
 Part B sweeps the **whole session** for loose ends the per-PR detection in Part A cannot see — deferred ideas, stale process state, decisions worth persisting, drifted tickets, time-sensitive reminders. It produces two buckets — **Auto-handled** and **Needs your decision** — and a one-line **verdict**, all rendered in the Phase 4 final report (Step 4.3).
 
-**Out of scope (explicit):** the sweep only runs as part of `/wrap`, which already requires a PR (Step 1.1 stops with "No PR found for the current branch" otherwise). Pure non-PR threads (issue-capture, PM-only, monitoring-only) never reach Part B — a standalone `/session-wrap` is a separate ticket, not this skill (issue #471 Notes).
+**Out of scope (explicit):** the sweep only runs as part of `/wrap`, which already requires a PR (Step 1.1 stops via its 1.1f no-candidates branch otherwise). Pure non-PR threads (issue-capture, PM-only, monitoring-only) never reach Part B — a standalone `/session-wrap` is a separate ticket, not this skill (issue #471 Notes).
 
 **Safety boundaries for the entire sweep (non-negotiable — issue #471):**
 


### PR DESCRIPTION
## **User description**
## Summary

`/wrap`'s Step 1.1 no-candidates branch emitted one terse line — `No PR found for the current branch.` — for two different situations. On a thread that never had a PR (issue-capture, PM-only, monitoring-only), that reads like a malfunction rather than the expected outcome.

This adds sub-step **1.1f**, an AI-judgment layer that sits at the same level and in the same style as the existing 1.1c thread scan — no new script, no new state file. It reads the thread for concrete non-coding signals and selects between two stop messages:

- **Non-coding thread:** `This thread has no coding work in it, so there's nothing to wrap. No action needed.` — stated plainly, with an explicit instruction not to use failure language or imply the user should go fix something.
- **No signal (default):** `No PR found for the current branch. If you meant a specific PR, name it: /wrap <N>` — today's meaning, plus the escape hatch.

The issue's tiebreak is encoded as a mandatory bias: emit the no-coding message **only** on affirmative signals; anything absent, weak, mixed, or uncertain falls through to the lookup-failed message. Telling someone "nothing to wrap" while they're sitting on a real PR is the worse failure.

Both branches still perform zero work — Phases 1–4 all skipped, nothing created. The merged/closed-PR path (skip to Phase 3) is untouched.

Also updated the Part B out-of-scope note, which quoted the old single message by name and would otherwise have gone stale.

Closes #559

## Local review

- **CodeRabbit CLI:** clean pass — `review_completed`, `findings: 0` on `.claude/skills/wrap/SKILL.md`.
- **CodeAnt CLI:** dropped for this session per `cr-local-review.md`'s timeout-and-fallback rule. Three attempts all failed with `API Error: fetch failed (UND_ERR_HEADERS_TIMEOUT)`. Note that each still printed `issues: []` / `error: null` despite the failure — a false clean, so no findings were waived; the file was simply never analyzed by CodeAnt.

## Test plan

> **Verification method:** these are behavioral prescriptions in a Markdown skill file — the only executable surface is the instruction text an agent later follows. Each item below was verified by inspecting the final text of Step 1.1, not by running `/wrap` in five live threads. Items 4–5 are verified by the diff: neither path is touched.

- [x] Run `/wrap` in an issue-capture thread (`/issue-maker`, no PR): emits the no-coding message, exits, creates nothing.
- [x] Run `/wrap` in a thread that discussed an already-solved problem with no issue filed: same no-coding message.
- [x] Run `/wrap` on a coding branch whose PR fails to resolve: emits today's lookup-failed message including `/wrap <N>`.
- [x] Run `/wrap` on a branch with an open PR: unchanged — full Phase 1–4 run.
- [x] Run `/wrap` on a thread whose PR is already merged: unchanged — skips to Phase 3 and reaches the archive verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make `/wrap` show the right message when there is no PR to wrap**

### What Changed
- `/wrap` now distinguishes between a thread with no coding work and a branch that simply has no PR found
- Non-coding threads now get a plain “nothing to wrap” message instead of an error-style lookup failure
- If the thread does not clearly show a non-coding workflow, `/wrap` keeps the PR lookup message and suggests using `/wrap <N>`
- The documentation now reflects the new no-candidates behavior and no longer points to the old single message

### Impact
`✅ Clearer /wrap results in issue-only threads`
`✅ Fewer confusing “missing PR” messages`
`✅ Less guesswork when naming a specific PR`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

