### PR TITLE
fix(#574): parse JSON with printf, not zsh echo, in skill snippets

### DIFF
--- a/.claude/skills/check-acceptance-criteria/SKILL.md
+++ b/.claude/skills/check-acceptance-criteria/SKILL.md
@@ -51,11 +51,13 @@ esac
 
 ### Step 3: Verify each criterion
 
-Filter `$ITEMS` to only the unchecked entries — already-checked items don't need re-verification. `$ITEMS` is guaranteed to be valid JSON after a successful `--extract` (exit 0), so `jq` cannot fail here unless the file was truncated:
+Filter `$ITEMS` to only the unchecked entries — already-checked items don't need re-verification. `$ITEMS` is guaranteed to be valid JSON after a successful `--extract` (exit 0), so `jq` cannot fail here as long as the payload reaches it intact:
 
 ```bash
-UNCHECKED=$(echo "$ITEMS" | jq '[.[] | select(.checked == false)]')
+UNCHECKED=$(printf '%s' "$ITEMS" | jq '[.[] | select(.checked == false)]')
 ```
+
+Pipe with `printf '%s'`, never `echo` — zsh's builtin `echo` interprets escape sequences in criterion text and corrupts the JSON, so `jq` either errors or returns empty, which reads as "all criteria pass" and falsely clears the AC gate (issue #574).
 
 Then, for each object in `$UNCHECKED`:
 

--- a/.claude/skills/go-on/SKILL.md
+++ b/.claude/skills/go-on/SKILL.md
@@ -99,8 +99,10 @@ git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1
 
 ```bash
 PR_JSON=$(gh pr view --json number,title,body,state 2>/dev/null)
-PR_NUM=$(echo "$PR_JSON" | jq -r '.number // empty')
+PR_NUM=$(printf '%s' "$PR_JSON" | jq -r '.number // empty')
 ```
+
+Pipe with `printf '%s'`, never `echo` — zsh's builtin `echo` interprets the escape sequences in the PR body and corrupts the JSON, so `jq` errors and `PR_NUM` comes back empty, which reads as "no PR exists" (issue #574).
 
 - If a PR exists and is open: `[DONE]` — PR #$PR_NUM exists.
 - If no PR exists: `[ACTION]` — Create one.

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -270,8 +270,9 @@ After each action, append to **`WRAP_RECOVERY_AUDIT`** (free-form lines or bulle
    ```bash
    GATE_JSON=$(.claude/scripts/merge-gate.sh "$PR_NUM")
    GATE_EXIT=$?
-   HEAD_NOW=$(echo "$GATE_JSON" | jq -r '.head_sha // empty')
+   HEAD_NOW=$(printf '%s' "$GATE_JSON" | jq -r '.head_sha // empty')
    ```
+   Pipe JSON with `printf '%s'`, never `echo` — zsh's builtin `echo` interprets escape sequences and corrupts the payload, yielding a parse error or an empty `HEAD_NOW` that defeats the no-stale-SHA contract (issue #574).
    - Exit `3` → PR not found / not open → Phase 3 handling as today.
    - Exit `2`/`4` → surface stderr; append to audit; stop (tooling failure).
    - Exit `0` → if Phase 1 had no outstanding findings trigger **or** findings were cleared by recovery, proceed **out** of the loop to Step 2.2. If Phase 1 still shows classified findings but gate passes (rare), prefer one `/fixpr` verification pass before merge — record in audit.
@@ -310,7 +311,7 @@ After each action, append to **`WRAP_RECOVERY_AUDIT`** (free-form lines or bulle
    **Threads-only detection + delegate heartbeat (issue #455 / #479).** Before delegating, classify whether unresolved review threads are the *only* blocker using `merge-gate.sh`'s **structured** signals — not by string-matching the prose. The gate emits `unresolved_thread_count` (the count behind the thread `missing` entry) and adds exactly **one** `missing` entry for the unresolved-thread gate, so "threads only" is `unresolved_thread_count > 0` **and** `missing` has length 1:
 
    ```bash
-   THREADS_ONLY=$(echo "$GATE_JSON" | jq -r '
+   THREADS_ONLY=$(printf '%s' "$GATE_JSON" | jq -r '
      ((.unresolved_thread_count // 0) > 0)
      and (((.missing // []) | length) == 1)')
    TS=$(TZ='America/New_York' date +'%a %b %-d %I:%M %p ET')


### PR DESCRIPTION
## What

Four documented skill snippets parsed JSON by piping a shell variable through `echo` into `jq`. Under zsh (the default shell here) the builtin `echo` interprets escape sequences, corrupting the payload so `jq` errors or silently returns nothing. This swaps each site to `printf '%s' "$VAR" | jq`, which emits the bytes verbatim.

| File | Variable | Consequence of the corruption |
|---|---|---|
| `.claude/skills/wrap/SKILL.md` | `HEAD_NOW` | empty SHA — defeats /wrap's "no stale gate cache" contract |
| `.claude/skills/wrap/SKILL.md` | `THREADS_ONLY` | misroutes the issue #452 recovery decision tree |
| `.claude/skills/check-acceptance-criteria/SKILL.md` | `UNCHECKED` | empty result reads as "all AC pass" — false clean on the AC gate |
| `.claude/skills/go-on/SKILL.md` | `PR_NUM` | empty number reads as "no PR exists" |

Each site keeps its intermediate variable rather than piping the producer straight into `jq`: `$GATE_JSON` feeds both the `HEAD_NOW` read and the later `THREADS_ONLY` classification (re-running `merge-gate.sh` per read would add an API round-trip and could race on HEAD), `$ITEMS` is consumed by the exit-code `case` before the filter, and `$PR_JSON` backs the surrounding open-state prose. Each fix carries a one-line note naming the hazard, so the next author doesn't reintroduce `echo`.

Nothing under `.claude/scripts/` is touched — the producer scripts emit valid JSON and are blameless. This is documentation-only; no runtime code path changes.

## Why it wasn't cosmetic

Two of the four sites reproduce the failure against live data today, not just in theory:

```
$ ITEMS=$(.claude/scripts/ac-checkboxes.sh 568 --extract)   # exit 0, valid JSON, 12 items per python
$ echo "$ITEMS" | jq 'length'
(eval):7: character not in range
jq: parse error: Unfinished string at EOF at line 2, column 0
$ printf '%s' "$ITEMS" | jq 'length'
12

$ PR_JSON=$(gh pr view 570 --json number,title,body,state)
$ echo "$PR_JSON" | jq -r '.number'
jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 92, column 1
$ printf '%s' "$PR_JSON" | jq -r '.number'
570
```

`go-on`'s `PR_NUM` breaks on any PR whose body contains escape sequences — i.e. essentially every real PR. The `wrap` merge-gate sites happen to survive on payloads with no escapes, which is precisely what makes them a latent trap rather than a loud one.

The failure mode is also a misdiagnosis trap: it looks like the producing script emitted malformed JSON, so the instinct is to file a bug against the script.

## Verification

Rather than eyeball the diff, I extracted the **literal snippet text** out of each SKILL.md with `sed` and executed it under a clean `zsh -f` (5.9) against live data — so what ran is exactly what the file now documents:

| Site | Data | Result |
|---|---|---|
| `wrap` `HEAD_NOW` | `merge-gate.sh 570` | `e5481d7ad373d2a00b7a858c924739f51cbcb42d` — matches python's parse |
| `wrap` `THREADS_ONLY` | same gate JSON | `false` — matches python (`unresolved=0`, `missing` len 1) |
| `check-acceptance-criteria` `UNCHECKED` | `ac-checkboxes.sh 568 --extract` | 12 items / 0 unchecked — the issue's repro case, previously a hard parse error |
| `go-on` `PR_NUM` | no-arg `gh pr view` from the issue-559 branch | `570` — previously a hard parse error |

## Test plan

- [x] `.claude/skills/wrap/SKILL.md` parses `HEAD_NOW` and `THREADS_ONLY` without piping a variable through `echo`.
- [x] `.claude/skills/check-acceptance-criteria/SKILL.md` computes `UNCHECKED` without `echo`-piping.
- [x] `.claude/skills/go-on/SKILL.md` parses `PR_NUM` without `echo`-piping.
- [x] `grep -rnE 'echo "\$[A-Z_]+" *\| *jq' .claude/skills .claude/rules` returns no matches.
- [x] No file under `.claude/scripts/` is modified.
- [x] Each changed snippet is verified to still produce the same value under zsh on real data (e.g. `merge-gate.sh` JSON from a live PR).

## Local review

- **CodeRabbit CLI:** clean pass — 0 findings across all 3 changed files (`.claude/skills/{wrap,go-on,check-acceptance-criteria}/SKILL.md`).
- **CodeAnt CLI:** dropped for this session per `cr-local-review.md` (errored twice), with **no findings carried forward** — both runs failed on the service side rather than returning a genuine clean:
  1. First run reviewed a stale pre-rebase base (6 files, including `pr-state.sh` / `fixpr/SKILL.md` that aren't part of this change), reported `1 file have suggestions`, then `API Error: UND_ERR_HEADERS_TIMEOUT` / `[error] Reflector failed` and emitted `issues: []`. Suggestions were dropped by the reflector failure, so that empty array is not a pass.
  2. Re-run post-rebase scoped correctly (`--last-commit`, `total_changed: 3`, the right files), but `API Error: UND_ERR_HEADERS_TIMEOUT` / `[error] Failed to review` hit **all three files** before analysis, then reported `0 files have suggestions`. Also a failure artifact, not a clean.

  (`--all` in between returned `noFiles: true` simply because `--committed` means *unpushed* commits and the branch was already pushed — not a review result.) **CodeAnt's GitHub-side review is unaffected and did approve this HEAD**; the merge gate rests on that, not on the CLI.

## Out of scope

`echo "$URL" | grep -oE '[0-9]+$'` forms in `start-issue` / `issue-maker` / `wrap` (GitHub URLs contain no escape sequences) and `echo "$PROMPT" | pbcopy` in `pm-handoff` — outside this issue's `jq` scope. The `pr-state.sh` walkthrough-classifier issue is tracked separately.

Closes #574
