### PR TITLE
fix(#575): classify CR's auto-generated walkthrough comment as an acknowledgment

### DIFF
--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -362,8 +362,19 @@ CONVO=$(run_gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per
 #      3. BugBot BUGBOT_REVIEW zero-issue check MUST precede the generic "issues? found"
 #         finding pattern — otherwise the finding pattern swallows BugBot clean summaries.
 #      4. Finding patterns (severity/badges/phrases/suggestions) come next.
-#      5. Weak-ack fallback (lgtm variants) last, so it can't hide a real finding.
-#      6. Default is finding — under-classifying is the failure mode this skill prevents.
+#      5. Weak-ack fallback (lgtm variants) next, so it can't hide a real finding.
+#      6. CR walkthrough/summary marker ("<!-- ... summarize by coderabbit.ai -->") is the LAST
+#         override, immediately above the default — deliberately NOT in the tier-1 group above (#575).
+#         This is a different trigger from #557's rate-limit/usage-limit family: the walkthrough is
+#         the boilerplate CR posts on nearly every PR, and it matched no branch at all, so it fell
+#         through to default → finding and produced phantom findings.
+#         Its late placement is load-bearing: the walkthrough can carry "actionable comments posted: N"
+#         (N > 0) and severity keywords for the findings it is summarizing. Hoisting this branch up
+#         with the other overrides would mask those real findings — a false clean on the review gate,
+#         which is strictly worse than the phantom-finding noise it fixes. Every finding pattern must
+#         be evaluated first and win. Ordering alone supplies that guard, so no AND-not guard (of the
+#         BugBot zero-issue kind) is needed here.
+#      7. Default is finding — under-classifying is the failure mode this skill prevents.
 # ----------------------------------------------------------------------
 NEW_SINCE="null"
 if [[ -n "$SINCE" ]]; then
@@ -392,6 +403,7 @@ if [[ -n "$SINCE" ]]; then
       elif test("Prompt for AI Agent"; "i") then {class: "finding", reason: "CR fix prompt"}
       elif test("```suggestion"; "m") then {class: "finding", reason: "suggestion block"}
       elif test("\\b(lgtm|looks good|approved|confirmed|resolved)\\b"; "i") then {class: "acknowledgment", reason: "lgtm variant"}
+      elif test("<!--\\s*This is an auto-generated comment:\\s*summarize by coderabbit\\.ai\\s*-->"; "i") then {class: "acknowledgment", reason: "CR walkthrough summary"}
       else {class: "finding", reason: "default — no pattern matched"}
       end;
     def enrich($since; $tsfield):

--- a/.claude/scripts/tests/pr-state-classify.test.sh
+++ b/.claude/scripts/tests/pr-state-classify.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Unit test for the `classify` jq function inside `pr-state.sh --since`
-# (issues #535, #557).
+# (issues #535, #557, #575).
 #
 # Verifies that comment bodies observed misclassified in the wild are now correctly
 # classified as acknowledgments, and that existing patterns are not regressed:
@@ -8,6 +8,12 @@
 #     BugBot zero-issue summary, CR error stub.
 #   - #557: two bodies on auerbachb/claude-code-config PR #554 (Jul 16 2026) — CR
 #     Fair-Usage rate-limit notice, BugBot usage-limit notice.
+#   - #575: CR's auto-generated walkthrough/summary comment (PR #568) — plus two
+#     masking guards (Bug6a/Bug6b) pinning the override's load-bearing LATE position.
+#     Those guards are not vacuous: they pass pre-fix only because everything defaults
+#     to `finding`. Their real job is to fail against a WRONG fix. Verified by hoisting
+#     the override into the tier-1 group, which flips both to acknowledgment — the exact
+#     false-clean the placement prevents. Re-run that control if you touch the ordering.
 #
 # Strategy: extract the classify function definition via sed from pr-state.sh and
 # exercise it in isolation with jq -n. This tests the actual production code rather
@@ -366,6 +372,113 @@ class="${result%%|*}"
   || fail "Edge: finding discussing usage/spend limits — got $class"
 
 # ---------------------------------------------------------------------------
+# Bug 6: CodeRabbit auto-generated walkthrough / summary comment (issue #575)
+#
+# The boilerplate CR posts on nearly every PR. It matched NO branch, so it fell
+# through to default → finding and produced phantom findings during /wrap Phase 1
+# on PRs where CR had posted zero reviews and zero inline comments.
+# Was: default → finding; Should be: CR walkthrough summary → acknowledgment
+#
+# Fixture note (why this is not the verbatim live body of comment 4994462241):
+# CR edits its walkthrough comment IN PLACE. Since #575 was filed, that comment has
+# had a rate-limit notice merged into the same body, so it now classifies as
+# acknowledgment via #557's "rate limit notice" override — i.e. it would pass this
+# test even with the walkthrough override deleted, asserting nothing. The body below
+# is the walkthrough WITHOUT the rate-limit block: the normal, uncovered case that
+# CR posts whenever it is not throttled. Bug6c pins the observed composite separately.
+# ---------------------------------------------------------------------------
+BODY='<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
+<!-- review_stack_entry_start -->
+
+[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auerbachb/claude-code-config/pull/568)
+
+<!-- review_stack_entry_end -->
+
+## Walkthrough
+
+The start-issue skill now offers a handoff chip.
+
+<details>
+<summary>📒 Files selected for processing (1)</summary>
+
+* `.claude/skills/start-issue/SKILL.md`
+
+</details>
+
+<sub>Comment `@coderabbitai help` to get the list of available commands.</sub>'
+result=$(classify_body "$BODY")
+class="${result%%|*}"; reason="${result##*|}"
+if [[ "$class" == "acknowledgment" && "$reason" == "CR walkthrough summary" ]]; then
+  pass "Bug6: CR walkthrough/summary comment → acknowledgment"
+else
+  fail "Bug6: CR walkthrough/summary — expected acknowledgment/CR walkthrough summary, got $class/$reason"
+fi
+
+# ---------------------------------------------------------------------------
+# Bug6a: MASKING GUARD — walkthrough marker + non-zero actionable count stays a finding.
+#
+# This is the reason the #575 override sits immediately above the default fallback
+# instead of joining the tier-1 overrides. CR's walkthrough carries the actionable
+# count for the findings it summarizes; an early marker override would classify this
+# as an acknowledgment and drop the findings out of finding_count — a false clean on
+# the review gate, strictly worse than the phantom-finding noise #575 fixes.
+# Verified to FAIL if the override is hoisted above the finding branches.
+# ---------------------------------------------------------------------------
+BODY='<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
+
+## Walkthrough
+
+Actionable comments posted: 3
+
+<details>
+<summary>📒 Files selected for processing (1)</summary>
+
+* `.claude/scripts/pr-state.sh`
+
+</details>'
+result=$(classify_body "$BODY")
+class="${result%%|*}"
+[[ "$class" == "finding" ]] && pass "Bug6a: walkthrough marker + 'Actionable comments posted: 3' → finding (real findings not masked)" \
+  || fail "Bug6a: walkthrough marker + actionable count — expected finding, got $class"
+
+# ---------------------------------------------------------------------------
+# Bug6b: MASKING GUARD — walkthrough marker + severity keyword stays a finding.
+# Same rationale as Bug6a, via the severity-keyword branch rather than the count.
+# ---------------------------------------------------------------------------
+BODY='<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
+
+## Walkthrough
+
+Summary of changes, including one nitpick raised against the retry loop.'
+result=$(classify_body "$BODY")
+class="${result%%|*}"
+[[ "$class" == "finding" ]] && pass "Bug6b: walkthrough marker + severity keyword 'nitpick' → finding (real findings not masked)" \
+  || fail "Bug6b: walkthrough marker + severity keyword — expected finding, got $class"
+
+# ---------------------------------------------------------------------------
+# Bug6c: the as-observed composite — walkthrough marker AND a rate-limit notice in
+# one body (comment 4994462241 on PR #568, after CR edited it in place).
+# Satisfied by EITHER the #557 rate-limit override or the #575 walkthrough override;
+# asserting only the class keeps it robust to which one fires first. Kept so the
+# real-world body stays covered without becoming a vacuous proxy for Bug6.
+# ---------------------------------------------------------------------------
+BODY='<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
+<!-- review_stack_entry_start -->
+<!-- review_stack_entry_end -->
+<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->
+
+> [!WARNING]
+> ## Review limit reached
+>
+> **Next review available in:** **16 minutes**
+
+<!-- end of auto-generated comment: rate limited by coderabbit.ai -->'
+result=$(classify_body "$BODY")
+class="${result%%|*}"
+[[ "$class" == "acknowledgment" ]] && pass "Bug6c: walkthrough marker + rate-limit notice composite → acknowledgment" \
+  || fail "Bug6c: walkthrough + rate-limit composite — expected acknowledgment, got $class"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""
@@ -373,4 +486,4 @@ echo "Results: $PASS passed, $FAIL failed"
 if [[ "$FAIL" -gt 0 ]]; then
   exit 1
 fi
-echo "OK: pr-state.sh classify — all fixtures and regressions passed (issues #535, #557)"
+echo "OK: pr-state.sh classify — all fixtures and regressions passed (issues #535, #557, #575)"

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -808,7 +808,11 @@ jq -r '
    - Fix markers: a fenced ```` ```suggestion ```` block, or a `Prompt for AI Agent` heading
 3. **Weak-ack fallbacks** (only if no finding matched):
    - LGTM variants: `lgtm`, `looks good`, `approved`, `confirmed`, `resolved`
-4. **Default** (no pattern matched) → `finding`. The safer default — under-classifying here is the failure mode this whole skill exists to prevent.
+4. **CR walkthrough/summary override** (the LAST override, checked immediately before the default):
+   - Marker `<!-- This is an auto-generated comment: summarize by coderabbit.ai -->` → `acknowledgment` (CR's walkthrough boilerplate, posted on nearly every PR; it matched no rule at all and fell through to `default → finding`, producing phantom findings on PRs where CR posted zero reviews — #575).
+   - **Its late position is load-bearing — do not hoist it into the tier-1 override group.** The walkthrough can carry `actionable comments posted: N` (N>0) and severity keywords for the findings it summarizes, so an early override would classify a real-finding summary as an acknowledgment and drop it from `finding_count` — a false clean on the review gate, strictly worse than the phantom-finding noise it fixes. Every finding pattern in tier 2 must be evaluated first and win. Ordering alone supplies that guard, so no AND-not guard (of the `BUGBOT_REVIEW` kind) is needed. Guarded by `Bug6a`/`Bug6b` in `pr-state-classify.test.sh`.
+   - Distinct trigger from #557's rate-limit/usage-limit family in tier 1. Note CR edits this comment in place and may merge a rate-limit notice into the same body, in which case the tier-1 rate-limit rule matches it first — both yield `acknowledgment`.
+5. **Default** (no pattern matched) → `finding`. The safer default — under-classifying here is the failure mode this whole skill exists to prevent.
 
 **If `finding_count > 0`:** findings landed between the Step 4d wait exit and this verify. If `FIXPR_WAIT_ITER < FIXPR_MAX_ITERATIONS`, start the next sweep at Step 0 (a fresh `$RUN_STARTED_AT` re-audits and picks them up). At the outer cap: set `FIXPR_WAIT_FINAL=new-findings-pending`, emit `NEW_FINDINGS` in Step 7, and stop — re-running `/fixpr` resets the iteration budget.
 


### PR DESCRIPTION
## **User description**
## Summary

`classify` in `.claude/scripts/pr-state.sh` labelled CodeRabbit's auto-generated **walkthrough/summary** comment — the boilerplate CR posts on nearly every PR — as a `finding`. It matched no branch at all and fell through to `default → finding`, producing phantom findings during `/wrap` Phase 1 on PRs where CR had posted zero reviews and zero inline comments.

This adds a single acknowledgment override keyed on CR's stable marker:

```
<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
```

Closes #575

## The ordering is the whole point

The override is the **last `elif` before the `else` default** — below every finding branch — and is deliberately **not** in the tier-1 override group with the rate-limit / clean-pass rules.

CR's walkthrough can carry `Actionable comments posted: N` (N>0) and severity keywords for the findings it summarizes. Hoisting the marker override upward would classify a real-finding summary as an acknowledgment and drop it out of `finding_count` — **a false clean on the review gate**, strictly worse than the phantom-finding noise being fixed here. Ordering alone supplies the masking guard, so no AND-not guard (of the `BUGBOT_REVIEW` kind) is needed. `default → finding` is unchanged.

Both my analysis and CodeRabbit's plan independently converged on this shape (Option 1 in the issue).

## Two findings worth flagging to reviewers

**1. AC #1's fixture is a moving target — and would have asserted nothing.**
CR edits its walkthrough comment *in place*. Since #575 was filed, comment `4994462241` has had a rate-limit notice merged into that same body, so on current `main` it **already** classifies as `acknowledgment|rate limit notice` — satisfied incidentally by #565's override, not by anything walkthrough-specific. A fixture pinned to that live body would have gone green via the rate-limit branch and stayed green even with the walkthrough override deleted.

The primary fixture (`Bug6`) is therefore the walkthrough **without** the rate-limit block — the normal case CR posts whenever it is not throttled, which still reproduced `finding|default — no pattern matched`. The observed composite is pinned separately as `Bug6c`.

**2. The masking guards can't fail pre-fix — so I proved them a different way.**
The issue asks that the masking-guard cases genuinely fail before the fix. They can't: pre-fix, *everything* defaults to `finding`, so `Bug6a`/`Bug6b` pass vacuously. Their real job is to fail against a **wrong** fix. I built that negative control — hoisting the override into the tier-1 group — and confirmed both flip to `acknowledgment`, i.e. the exact false-clean the placement prevents:

```
FAIL: Bug6a: walkthrough marker + actionable count — expected finding, got acknowledgment
FAIL: Bug6b: walkthrough marker + severity keyword — expected finding, got acknowledgment
```

Pre-fix, `Bug6` alone fails (`36 passed, 1 failed`); post-fix the suite is `37 passed, 0 failed`. The control is documented in the test header so the next editor re-runs it if they touch the ordering.

## Test plan

- [x] Comment id `4994462241` (CR walkthrough, PR #568) classifies as `acknowledgment`, not `finding`.
- [x] A CR summary body that contains the walkthrough marker **and** `Actionable comments posted: 3` still classifies as `finding` (real findings are not masked).
- [x] A CR summary body containing the marker **and** a severity keyword (e.g. `nitpick`) still classifies as `finding`.
- [x] `default → finding` fallback unchanged; all existing override branches still match their fixtures.
- [x] `.claude/scripts/tests/pr-state-classify.test.sh` covers the walkthrough case plus the two masking-guard cases above.
- [x] The in-file `Branch ordering in classify` header comment in `pr-state.sh` names the new override in code order.
- [x] `.claude/skills/fixpr/SKILL.md` Step 5b rule list documents the new override in the same order as the code.

## Verification

```
$ bash .claude/scripts/tests/pr-state-classify.test.sh
Results: 37 passed, 0 failed
OK: pr-state.sh classify — all fixtures and regressions passed (issues #535, #557, #575)
```

- Local CodeAnt CLI: clean (`issues: []`, `noFiles: false`, `total_changed: 4`, `skipped: []`, `capped: false` — false-clean signals checked, not just exit code).
- #565 was already merged and this branch is cut from that tip (`a88d68f`), so the rebase-onto-#565 note in the issue is satisfied; no conflict.


___

## **CodeAnt-AI Description**
**Treat CodeRabbit’s auto-generated walkthrough comment as an acknowledgment**

### What Changed
- CodeRabbit’s standard walkthrough/summary comment now counts as an acknowledgment instead of a finding, preventing phantom findings when it is the only comment on a PR
- The walkthrough rule is kept at the end of the acknowledgment checks so real findings in the same comment still win
- Added test coverage for the walkthrough comment, plus safeguards that confirm the new rule does not hide real findings
- Updated the PR-state and fix-pr guidance to explain the new rule and why its placement matters

### Impact
`✅ Fewer phantom review findings`
`✅ Cleaner /wrap and /fixpr results`
`✅ Safer handling of CodeRabbit walkthrough comments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

