### PR TITLE
feat(#571): skill-first reflex rule — agents proactively surface and use existing skills

### DIFF
--- a/.claude/rules/skill-first.md
+++ b/.claude/rules/skill-first.md
@@ -1,0 +1,21 @@
+# Skill-First Reflex
+
+> **Always:** Before hand-rolling any multi-step task, scan the in-context skill catalog for a match. Invoke matched skills via the Skill tool — never reimplement one from memory (only Skill-tool calls reach the usage log).
+> **Ask first:** Borderline matches — one line ("this looks like /go-on — run it?"), then follow the user's answer.
+> **Never:** Mention skills when nothing matches (precision over recall). Auto-invoke an authorization-carrying skill (`/merge`, `/wrap`, `/pr-monitor-and-manage`) unless the user explicitly asked for that outcome.
+
+## Confidence ladder
+
+| Match | Behavior |
+|-------|----------|
+| Clear — the request is a skill's core job | Invoke via the Skill tool immediately |
+| Borderline — overlaps, fit uncertain | One-line suggestion; proceed per the answer, no long detour |
+| None | No skill mention at all |
+
+"Clear" means the skill's description names the requested task (e.g. "summarize what this PR changed" → `/recap`; "what should I work on next?" → `/pm` or `/prioritize`).
+
+## Why
+
+Skills encode hard-won process. Hand-rolling does the work worse and skips `~/.claude/skill-usage.log`, undercounting live skills and poisoning prune audits (issue #431) and durable telemetry (issue #572).
+
+Scope: parent-agent sessions. Subagents run from narrow agent definitions — extending the reflex to them is a follow-up (see issue #571 Notes).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ Detailed workflow rules are split into topic-specific files in `.claude/rules/`:
 | `repo-bootstrap.md` | Repo bootstrap |
 | `trust-dialog-fix.md` | Trust flags |
 | `skill-symlinks.md` | Skill symlinks |
+| `skill-first.md` | Proactive skill matching |
 
 These files auto-load for the parent agent session. **Subagents do NOT auto-load these files.** See `subagent-orchestration.md` for how to pass rules to subagents.
 


### PR DESCRIPTION
## **User description**
## Summary

Closes #571.

Implements the approved mechanism (always-loaded rule, not a hook) that makes "is there a skill for this?" part of default behavior:

- **New `.claude/rules/skill-first.md`** (213 words) — the confidence ladder: clear match → invoke via the Skill tool immediately; borderline → one-line suggestion, no long detour; no match → total silence (precision over recall).
- **Skill-tool mandate** — matched skills must be invoked via the Skill tool, never reimplemented from memory, so `.claude/hooks/skill-usage-tracker.sh` telemetry (`~/.claude/skill-usage.log`) stays honest for the October audit (issue #573) and durable telemetry (issue #572).
- **Authorization guard** — `/merge`, `/wrap`, `/pr-monitor-and-manage` are never auto-invoked on a fuzzy match; direct invocation only when the user explicitly asked for that outcome.
- **CLAUDE.md** — `| skill-first.md | Proactive skill matching |` row added to the Rule Files table (rule-lint enforces table↔directory alignment).

Rejected alternatives (rationale in the issue body): `UserPromptSubmit` fuzzy-match hook (a worse matcher in front of a better one, false-positive noise, per-skill trigger-phrase maintenance) and periodic catalog reminders (noise). Subagent nudges are out of scope (issue #571 Notes — follow-up).

## Rules budget

`rule-lint.sh`: **OK** — index alignment 17 files; corpus **11,703 words** (was 11,483, net +220), under the 12,000 soft limit and the 12,232 ratchet cap (`.budget-soft-cap` untouched).

## Demos (AC 5)

**Vehicle disclosure:** pre-merge, a branch-only rule cannot load into a genuinely fresh interactive thread (fresh threads open on `main`'s corpus), and no host CLI exists for headless runs (the desktop app bundles only a Linux-ARM VM binary; no CLI credentials on the host — verified). Demos therefore ran as **fresh subagent contexts**: each auto-loads the 16-rule corpus + CLAUDE.md + the live skill catalog + the Skill tool natively, and received `skill-first.md` verbatim via the documented manual rule-injection fallback (`subagent-orchestration.md`), framed identically to its sibling rules, followed by **one bare prompt**. The control (Demo C) received the **identical preamble**, making it a true precision test. Model: `sonnet` (fleet workhorse tier).

| Demo | Bare prompt | Result |
|------|-------------|--------|
| A | "summarize what PR #570 actually changed" | Invoked `Skill(recap)`; output was a functional recap of PR #570 ("taught `/wrap` to distinguish 'no coding to wrap' from a failed PR lookup…") |
| B | "what should I work on next?" | Invoked `Skill(pm)`; output was a full PM-style ranked backlog with recommendation |
| C (control) | "difference between `git worktree` and `git clone`?" | Direct answer; **zero skill mentions**; no usage-log line |

Usage-log evidence (tracker hook fired on the Skill-tool calls):

```
2026-07-16T17:46:35Z	recap	ef7a3b04-5111-4045-8a3b-58cef1a2f466
2026-07-16T17:47:20Z	pm	ef7a3b04-5111-4045-8a3b-58cef1a2f466
```

Post-merge, the rule auto-loads from `main` into every fresh interactive thread via the existing `~/.claude/rules` → skills-worktree symlink; a real fresh-thread spot-check is a natural post-merge follow-up.

## Local review

- **CodeAnt CLI (0.5.1):** clean — `--uncommitted --headless` reviewed exactly the 2 changed files (`total_changed: 2`, `skipped: []`, `capped: false`), `issues: []`. (An earlier `--all` run diffed a stale base and swept in 12 unrelated main-side files; discarded and re-run scoped.)
- **CodeRabbit CLI (0.6.5):** dropped for this session per `cr-local-review.md` Timeout & fallback — two consecutive `rate_limit` errors (shared adaptive quota; 9-min then 11-min waits), zero findings emitted before failure, one retry used. GitHub-side CodeRabbit review still gates this PR normally.

## Test plan

- [x] `skill-first.md` exists in `.claude/rules/` and `rule-lint.sh` passes (index alignment + corpus ≤ caps)
- [x] Clear-match demo: bare "summarize what PR #570 actually changed" → `/recap` used or suggested (Demo A above)
- [x] Clear-match demo: bare "what should I work on next?" → `/pm` or `/prioritize` used or suggested (Demo B above)
- [x] Control demo: a prompt no skill covers → no skill suggestion appears (Demo C above)
- [x] Demo invocations appear in `~/.claude/skill-usage.log` (lines quoted above)
- [x] Rule text mandates Skill-tool invocation (telemetry) and guards authorization-carrying skills from auto-invocation


___

## **CodeAnt-AI Description**
**Teach the agent to spot and use matching skills first**

### What Changed
- The agent now checks for a matching skill before taking on a multi-step task itself
- When a skill clearly fits, it is used right away instead of being rebuilt from scratch
- When a match is uncertain, the agent gives a one-line suggestion and waits for the user's choice
- If no skill fits, the agent stays silent about skills
- Tasks that can take action on the user's behalf, like merge or wrap-up commands, are only auto-used when the user explicitly asks for that outcome
- The new rule is listed in the main rules index so it is part of the default workflow

### Impact
`✅ Faster skill use for common tasks`
`✅ Fewer unnecessary detours when a skill fits`
`✅ Safer handling of merge and wrap-up actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

