### PR TITLE
feat(#572): durable skill-usage telemetry — merge primitive + weekly skill-telemetry branch snapshot

### DIFF
--- a/.claude/hooks/skill-usage-snapshot-hook.sh
+++ b/.claude/hooks/skill-usage-snapshot-hook.sh
@@ -50,10 +50,12 @@ fi
 
 # Due: background the real push. The snapshot script owns the lock and the
 # authoritative under-lock throttle re-check, so concurrent Stop hooks from
-# parallel sessions collapse to a single push.
+# parallel sessions collapse to a single push. Pass the SANITIZED interval —
+# the child would otherwise inherit the original invalid env value and exit
+# on a usage error every Stop, and pushes would never succeed.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SNAPSHOT="$HOOK_DIR/../scripts/skill-usage-snapshot.sh"
 [ -f "$SNAPSHOT" ] || exit 0
-nohup bash "$SNAPSHOT" --push --quiet >/dev/null 2>&1 &
+SNAPSHOT_INTERVAL_DAYS="$INTERVAL_DAYS" nohup bash "$SNAPSHOT" --push --quiet >/dev/null 2>&1 &
 
 exit 0

--- a/.claude/hooks/skill-usage-snapshot-hook.sh
+++ b/.claude/hooks/skill-usage-snapshot-hook.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# skill-usage-snapshot-hook.sh — Stop hook: keep the skill-telemetry snapshot
+# fresh (issue #572).
+#
+# Contract mirrors skill-usage-tracker.sh: consume stdin, always emit an empty
+# JSON object, always exit 0 — this hook must never block or fail a session.
+#
+# The throttle pre-check here is deliberately cheap (bash + sed + date; no
+# python, no jq, NO network) because Stop fires after every agent response.
+# When a push is due, the real work — locking, authoritative throttle
+# re-check, gh api calls — is backgrounded via skill-usage-snapshot.sh
+# --push --quiet, so the hook returns immediately either way. State only
+# advances on a confirmed push, so weeks offline simply retry on later Stops.
+
+set -uo pipefail
+
+# Consume stdin per the hook contract (content unused).
+cat >/dev/null
+
+# Always emit empty JSON and never fail — this hook is non-blocking.
+trap 'echo "{}"; exit 0' EXIT
+
+STATE_FILE="$HOME/.claude/skill-usage-snapshot-state.json"
+
+INTERVAL_DAYS="${SNAPSHOT_INTERVAL_DAYS:-7}"
+case "$INTERVAL_DAYS" in
+  ''|*[!0-9]*) INTERVAL_DAYS=7 ;;
+esac
+# 0 is numeric but would make every Stop spawn a push attempt — clamp to >=1
+# (matches the snapshot script, which rejects <1 outright).
+[ "$INTERVAL_DAYS" -ge 1 ] || INTERVAL_DAYS=7
+INTERVAL_SECS=$(( INTERVAL_DAYS * 86400 ))
+
+# NOTE: no lock-dir short-circuit here on purpose. The snapshot script owns
+# all lock handling — in-flight locks make it exit instantly, stale locks
+# (crashed pusher) are stolen atomically. An early `[ -d lock ] && exit`
+# in the hook would turn one crashed push into permanently disabled pushes.
+
+# Throttle pre-check: parse last_push_epoch out of the state JSON with sed;
+# missing/garbled state means "due" (first push ever).
+LAST=0
+if [ -f "$STATE_FILE" ]; then
+  LAST=$(sed -n 's/.*"last_push_epoch"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$STATE_FILE" 2>/dev/null | head -1)
+  LAST=${LAST:-0}
+fi
+NOW=$(date +%s)
+if (( NOW - LAST < INTERVAL_SECS )); then
+  exit 0
+fi
+
+# Due: background the real push. The snapshot script owns the lock and the
+# authoritative under-lock throttle re-check, so concurrent Stop hooks from
+# parallel sessions collapse to a single push.
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SNAPSHOT="$HOOK_DIR/../scripts/skill-usage-snapshot.sh"
+[ -f "$SNAPSHOT" ] || exit 0
+nohup bash "$SNAPSHOT" --push --quiet >/dev/null 2>&1 &
+
+exit 0

--- a/.claude/reference/skill-usage-durability.md
+++ b/.claude/reference/skill-usage-durability.md
@@ -1,0 +1,72 @@
+# Skill-Usage Telemetry Durability (issue #572)
+
+How the skill-usage record survives machine moves, OS reinstalls, and
+`~/.claude` cleanups.
+
+## Storage model
+
+| Layer | Where | Written by | Role |
+|-------|-------|-----------|------|
+| Live log | `~/.claude/skill-usage.log` | `skill-usage-tracker.sh` (PostToolUse hook) | Append-only source of truth: `ISO8601Z \t skill_name \t session_id` |
+| Live CSV | `~/.claude/skill-usage.csv` | same hook | Aggregated counts (`skill_name,start_date,use_count,last_used`) |
+| Durable snapshot | `skill-telemetry` branch, files `skill-usage.log`, `skill-usage.csv`, `manifest.json` at branch root | `skill-usage-snapshot.sh --push` | Machine-independent copy, refreshed ≤ weekly |
+| Seed CSV | `.claude/skill-usage.csv` on `main` | PRs | Bootstrap-only template for first run — NOT the snapshot |
+
+The `skill-usage-snapshot-hook.sh` Stop hook backgrounds `--push --quiet`
+when ≥7 days (`SNAPSHOT_INTERVAL_DAYS`) have passed since the last confirmed
+push. Pushes go through the GitHub contents API (`gh api`) — no local
+checkout, no commits to `main`, no PR noise. When nothing changed, no commit
+is created but the throttle still advances. Offline attempts are silent
+no-ops that retry on a later Stop. `stale-cleanup.sh` lists `skill-telemetry`
+in `PROTECTED_BRANCHES` so idle weeks never make the branch prunable.
+
+Check state anytime: `bash .claude/scripts/skill-usage-snapshot.sh --status`
+
+## Recovery how-to
+
+**Machine move (old machine still alive):** copy the old machine's
+`~/.claude/skill-usage.log` and `~/.claude/skill-usage.csv` over
+(AirDrop/scp), then on the new machine:
+
+```bash
+bash .claude/scripts/skill-usage-merge.sh --log <old.log> --csv <old.csv>
+bash .claude/scripts/skill-usage-report.sh     # verify the full window
+bash .claude/scripts/skill-usage-snapshot.sh --push --force   # make it durable now
+```
+
+Default `--csv-counts sum` is correct here: the two machines' histories are
+disjoint. Live files are backed up to `*.bak.<UTC-ts>` before any write.
+
+**Fresh machine / lost `~/.claude` (old machine gone):**
+
+```bash
+bash .claude/scripts/skill-usage-snapshot.sh --restore
+```
+
+Fetches the snapshot and merges with `--csv-counts recompute`
+(`use_count = max(each CSV's count, merged-log count)`) — idempotent and
+safe when local files partially survive; on a truly fresh machine it
+degrades to a copy. You lose at most the invocations since the last push
+(≤ 7 days).
+
+## Fallback baseline (old files declared unrecoverable)
+
+If raw files from the pre-switch machine never arrive, encode a baseline
+into the live CSV instead (documented as **approximate**): per-skill rows
+with `start_date` 2026-05-01, counts and `last_used` from the best available
+snapshot table. Known sources, freshest first:
+
+1. `~/Downloads/skill-usage-report-2026-07-16.md` — rendered on the old
+   MacBook on 2026-07-16 (145 invocations through Jul 16).
+2. Issue #431's 2026-06-26 comment table — 106 invocations through Jun 26.
+
+Limitations, by design: a CSV baseline cannot back-date the log-derived
+"tracking since" line in `skill-usage-report.sh` (that needs real log
+lines), and recompute-mode restores preserve baseline counts via the `max`
+rule but never regenerate the underlying events.
+
+## Related
+
+- `skill-usage-merge.sh --help` / `skill-usage-snapshot.sh --help` — full
+  semantics, locking, and edge cases
+- Issues #416 (tracking), #431 (first audit), #572 (durability)

--- a/.claude/scripts/skill-usage-merge.sh
+++ b/.claude/scripts/skill-usage-merge.sh
@@ -52,8 +52,11 @@
 # SAFETY:
 #   - Live files are backed up to <file>.bak.<UTC-ts> (a .N suffix is added
 #     rather than ever overwriting an existing backup) before any write.
-#   - All mutations run under the same fcntl-flock sidecar lock the tracker
-#     uses (~/.claude/skill-usage.csv.lock), then atomic tmp + os.replace.
+#   - Live-file READS and all mutations run under the same fcntl-flock
+#     sidecar lock the tracker uses (~/.claude/skill-usage.csv.lock) — the
+#     lock is taken before reading so a tracker CSV increment cannot land
+#     between read and write and be overwritten. Writes are atomic
+#     (tmp + os.replace). Dry-run is read-only and lock-free.
 #   - KNOWN RACE: the tracker's log append (>>) is NOT under that lock, so a
 #     merge that rewrites the log can lose a log line appended in the same
 #     millisecond. Merges are rare and manual — run them when no active
@@ -254,6 +257,26 @@ def backup(path):
     return dest
 
 
+# ---- lock BEFORE reading live files ------------------------------------------
+# The tracker mutates the CSV under this same lock. Reading live files before
+# acquiring it would let a tracker increment land between read and write and
+# be overwritten by stale merged data. Dry-run stays lock-free: it is
+# read-only, so the worst case is a report computed from a mid-update
+# snapshot — nothing is written.
+lock_path = live_csv + ".lock"
+lock_fd = None
+try:
+    import fcntl
+except ImportError:
+    fcntl = None  # mirrors the tracker: proceed unlocked on such platforms
+
+if not dry_run and fcntl is not None:
+    try:
+        lock_fd = open(lock_path, "w")
+        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+    except OSError:
+        fail("could not acquire %s — is another merge or tracker write stuck?" % lock_path)
+
 # ---- compute merged log -----------------------------------------------------
 live_lines = read_lines(live_log)
 other_lines = read_lines(other_log) if merge_log else []
@@ -366,21 +389,7 @@ if dry_run:
     print("dry-run: no files written, no backups taken")
     sys.exit(0)
 
-# ---- write under the tracker's lock ------------------------------------------
-lock_path = live_csv + ".lock"
-lock_fd = None
-try:
-    import fcntl
-except ImportError:
-    fcntl = None  # mirrors the tracker: proceed unlocked on such platforms
-
-if fcntl is not None:
-    try:
-        lock_fd = open(lock_path, "w")
-        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
-    except OSError:
-        fail("could not acquire %s — is another merge or tracker write stuck?" % lock_path)
-
+# ---- write (still under the lock acquired before the reads) -------------------
 try:
     backups = []
     for p in ([live_log] if merge_log else []) + ([live_csv] if merge_csv else []):

--- a/.claude/scripts/skill-usage-merge.sh
+++ b/.claude/scripts/skill-usage-merge.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+# skill-usage-merge.sh — Merge another copy of the skill-usage telemetry into
+# the live files (~/.claude/skill-usage.log + ~/.claude/skill-usage.csv).
+#
+# PURPOSE (issue #572):
+#   The telemetry written by skill-usage-tracker.sh lives only on the machine
+#   that wrote it. This script is the merge primitive for both recovery paths:
+#     - Machine move: merge the OLD machine's raw files into the new machine's
+#       live files (disjoint histories — default --csv-counts sum).
+#     - Snapshot restore: merge the skill-telemetry branch snapshot back into
+#       the live files (overlapping histories — --csv-counts recompute, used
+#       by skill-usage-snapshot.sh --restore; idempotent).
+#
+# USAGE:
+#   skill-usage-merge.sh [--log <other.log>] [--csv <other.csv>]
+#                        [--csv-counts sum|recompute] [--dry-run]
+#   skill-usage-merge.sh --help
+#
+#   At least one of --log / --csv is required.
+#
+# SEMANTICS:
+#   Log  — line-level union of live + other, exact-line dedupe, chronological
+#          order (lines start with an ISO8601Z timestamp, so a plain lexical
+#          sort IS chronological; same-timestamp lines tie-break on the rest
+#          of the line, deterministically). Malformed non-empty lines are
+#          preserved — union means never dropping data. Known limit of the
+#          AC-specified dedupe: two REAL events from the same session, same
+#          skill, and same second produce identical lines and collapse to
+#          one — indistinguishable from a cross-copy duplicate by design.
+#   CSV  — row union keyed on skill_name (header preserved; duplicate rows
+#          for one skill are folded with the same rules):
+#            use_count : sum        (default — correct for disjoint machine
+#                                    histories, per issue #572 AC)
+#                        recompute  (max of each CSV's own count and the
+#                                    merged-log line count — safe under
+#                                    overlap, hence idempotent; the restore
+#                                    path always uses this. max, not
+#                                    log-only, so a CSV-only baseline such
+#                                    as the #431 fallback — counts with no
+#                                    log lines behind them — survives a
+#                                    restore instead of being zeroed)
+#            last_used : max — a real date beats "never". Recompute also
+#                        considers the merged log's last entry (UTC date).
+#            start_date: min. Recompute also considers a skill's first log
+#                        appearance (UTC date) — this is what lets a fresh
+#                        machine reconstruct rows for skills the seed CSV
+#                        never listed.
+#   Dates: the tracker stamps last_used with the ET calendar date; log-derived
+#          dates (recompute mode) use the UTC date of the log timestamp. The
+#          two can differ by one day near midnight — acceptable for telemetry.
+#
+# SAFETY:
+#   - Live files are backed up to <file>.bak.<UTC-ts> (a .N suffix is added
+#     rather than ever overwriting an existing backup) before any write.
+#   - All mutations run under the same fcntl-flock sidecar lock the tracker
+#     uses (~/.claude/skill-usage.csv.lock), then atomic tmp + os.replace.
+#   - KNOWN RACE: the tracker's log append (>>) is NOT under that lock, so a
+#     merge that rewrites the log can lose a log line appended in the same
+#     millisecond. Merges are rare and manual — run them when no active
+#     session is mid-Skill-invocation.
+#
+# EXIT STATUS:
+#   0  merge complete (or --dry-run report printed)
+#   2  usage error
+#   3  environment error (missing input file, no python3)
+#   4  merge failure (lock unavailable, write failed)
+
+set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
+
+print_help() {
+  awk 'NR == 1 { next } /^$/ { exit } { sub(/^# ?/, ""); print }' "$0"
+}
+
+usage_error() {
+  echo "skill-usage-merge.sh: $1" >&2
+  echo "Run with --help for usage." >&2
+  exit 2
+}
+
+OTHER_LOG=""
+OTHER_CSV=""
+CSV_COUNTS="sum"
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    --log)
+      [[ $# -ge 2 ]] || usage_error "--log requires a path"
+      OTHER_LOG="$2"
+      shift 2
+      ;;
+    --csv)
+      [[ $# -ge 2 ]] || usage_error "--csv requires a path"
+      OTHER_CSV="$2"
+      shift 2
+      ;;
+    --csv-counts)
+      [[ $# -ge 2 ]] || usage_error "--csv-counts requires sum or recompute"
+      CSV_COUNTS="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    *)
+      usage_error "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$OTHER_LOG" && -z "$OTHER_CSV" ]]; then
+  usage_error "nothing to merge — pass --log and/or --csv"
+fi
+if [[ "$CSV_COUNTS" != "sum" && "$CSV_COUNTS" != "recompute" ]]; then
+  usage_error "--csv-counts must be sum or recompute (got: $CSV_COUNTS)"
+fi
+if [[ -n "$OTHER_LOG" && ! -f "$OTHER_LOG" ]]; then
+  echo "error: --log file not found: $OTHER_LOG" >&2
+  exit 3
+fi
+if [[ -n "$OTHER_CSV" && ! -f "$OTHER_CSV" ]]; then
+  echo "error: --csv file not found: $OTHER_CSV" >&2
+  exit 3
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 not found" >&2
+  exit 3
+fi
+
+LIVE_LOG="$HOME/.claude/skill-usage.log"
+LIVE_CSV="$HOME/.claude/skill-usage.csv"
+mkdir -p "$HOME/.claude"
+
+# Python core mirrors skill-usage-tracker.sh: fcntl flock on the CSV sidecar
+# lock, atomic tmp + os.replace writes. Python 3.9-compatible (macOS CLT).
+python3 - "$LIVE_LOG" "$LIVE_CSV" "$OTHER_LOG" "$OTHER_CSV" "$CSV_COUNTS" "$DRY_RUN" <<'PY'
+import csv
+import os
+import shutil
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+live_log, live_csv, other_log, other_csv, csv_counts, dry_run_s = sys.argv[1:7]
+dry_run = dry_run_s == "1"
+merge_log = bool(other_log)
+merge_csv = bool(other_csv)
+
+HEADER = ["skill_name", "start_date", "use_count", "last_used"]
+
+
+def fail(msg):
+    print("error: %s" % msg, file=sys.stderr)
+    sys.exit(4)
+
+
+def read_lines(path):
+    """Non-empty lines of a log file, or [] when the file is absent."""
+    if not path or not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        return [ln.rstrip("\n") for ln in fh if ln.strip()]
+
+
+def read_csv_rows(path):
+    """(header, rows) of a CSV, or (None, []) when absent/empty."""
+    if not path or not os.path.exists(path):
+        return None, []
+    with open(path, "r", newline="", encoding="utf-8", errors="replace") as fh:
+        rows = list(csv.reader(fh))
+    if not rows:
+        return None, []
+    return rows[0], rows[1:]
+
+
+def parse_date(s):
+    """YYYY-MM-DD -> date, else None ('never', blank, malformed)."""
+    try:
+        return datetime.strptime((s or "").strip(), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def parse_count(s):
+    try:
+        return int(s)
+    except (TypeError, ValueError):
+        return 0
+
+
+def log_utc_date(ts_raw):
+    """ISO8601 log timestamp -> UTC date, else None."""
+    ts = (ts_raw or "").strip()
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).date()
+
+
+def atomic_write_text(path, text):
+    dir_ = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(prefix=".skill-usage-merge.", dir=dir_)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_csv(path, header, data):
+    dir_ = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(prefix=".skill-usage-merge.", dir=dir_)
+    try:
+        with os.fdopen(fd, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(header)
+            w.writerows(data)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def backup(path):
+    """Copy path to path.bak.<UTC-ts>[.N]; never overwrite a prior backup."""
+    if not os.path.exists(path):
+        return None
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    dest = "%s.bak.%s" % (path, stamp)
+    n = 0
+    while os.path.exists(dest):
+        n += 1
+        dest = "%s.bak.%s.%d" % (path, stamp, n)
+    shutil.copy2(path, dest)
+    return dest
+
+
+# ---- compute merged log -----------------------------------------------------
+live_lines = read_lines(live_log)
+other_lines = read_lines(other_log) if merge_log else []
+if merge_log:
+    union = set(live_lines) | set(other_lines)
+    # Lines start with an ISO8601Z timestamp, so sorting whole lines is
+    # chronological; the rest of the line is a deterministic tie-break.
+    merged_lines = sorted(union)
+    dupes = len(live_lines) + len(other_lines) - len(merged_lines)
+else:
+    merged_lines = live_lines
+    dupes = 0
+
+# ---- compute merged CSV -----------------------------------------------------
+merged_header = None
+merged_rows = []
+csv_changes = []
+if merge_csv:
+    live_header, live_rows = read_csv_rows(live_csv)
+    other_header, other_rows = read_csv_rows(other_csv)
+    merged_header = live_header or other_header or HEADER
+
+    # Fold rows keyed on skill_name; duplicates within one file fold by the
+    # same sum/max/min rules so the result is deterministic.
+    order = []          # first-seen order: live rows, then other-only rows
+    merged = {}         # skill -> {count, last_used(date|None), start(date|None)}
+
+    def fold(rows, source):
+        for row in rows:
+            if len(row) < 4 or not row[0].strip():
+                continue  # malformed CSV row — nothing usable to merge
+            skill = row[0].strip()
+            cnt = parse_count(row[2])
+            last = parse_date(row[3])
+            start = parse_date(row[1])
+            if skill not in merged:
+                merged[skill] = {"count": 0, "last": None, "start": None,
+                                 "live_count": 0, "other_count": 0}
+                order.append(skill)
+            m = merged[skill]
+            m["count"] += cnt
+            m[source + "_count"] += cnt
+            if last is not None and (m["last"] is None or last > m["last"]):
+                m["last"] = last
+            if start is not None and (m["start"] is None or start < m["start"]):
+                m["start"] = start
+
+    fold(live_rows, "live")
+    fold(other_rows, "other")
+
+    if csv_counts == "recompute":
+        # use_count = max(live CSV count, other CSV count, merged-log count).
+        # Each event is counted at most once regardless of history overlap
+        # (idempotent), and a CSV-only baseline with no log lines behind it
+        # (e.g. the #431 fallback, or increments whose unlocked log append
+        # failed) is preserved instead of being zeroed by the log count.
+        log_counts = {}
+        log_first = {}
+        log_last = {}
+        for ln in merged_lines:
+            parts = ln.split("\t")
+            if len(parts) < 2 or not parts[1].strip():
+                continue
+            skill = parts[1].strip()
+            log_counts[skill] = log_counts.get(skill, 0) + 1
+            d = log_utc_date(parts[0])
+            if d is not None:
+                if skill not in log_first or d < log_first[skill]:
+                    log_first[skill] = d
+                if skill not in log_last or d > log_last[skill]:
+                    log_last[skill] = d
+        for skill in log_counts:
+            if skill not in merged:
+                merged[skill] = {"count": 0, "last": None, "start": None,
+                                 "live_count": 0, "other_count": 0}
+                order.append(skill)
+        for skill, m in merged.items():
+            m["count"] = max(m["live_count"], m["other_count"],
+                             log_counts.get(skill, 0))
+            log_last_d = log_last.get(skill)
+            if log_last_d is not None and (m["last"] is None or log_last_d > m["last"]):
+                m["last"] = log_last_d
+            if skill in log_first and (m["start"] is None or log_first[skill] < m["start"]):
+                m["start"] = log_first[skill]
+
+    for skill in order:
+        m = merged[skill]
+        start_s = m["start"].isoformat() if m["start"] else "never"
+        last_s = m["last"].isoformat() if m["last"] else "never"
+        merged_rows.append([skill, start_s, str(m["count"]), last_s])
+        if csv_counts == "sum":
+            detail = "%d + %d -> %d" % (m["live_count"], m["other_count"], m["count"])
+        else:
+            detail = "max(csv %d, csv %d, log) -> %d" % (
+                m["live_count"], m["other_count"], m["count"])
+        csv_changes.append("  %-28s use_count %s, last_used %s, start_date %s"
+                           % (skill, detail, last_s, start_s))
+
+# ---- report -----------------------------------------------------------------
+if merge_log:
+    print("log: %d live + %d other -> %d merged (%d duplicate line(s) removed)"
+          % (len(live_lines), len(other_lines), len(merged_lines), dupes))
+if merge_csv:
+    print("csv: %d skill row(s) after merge (--csv-counts %s)"
+          % (len(merged_rows), csv_counts))
+    for line in csv_changes:
+        print(line)
+
+if dry_run:
+    print("dry-run: no files written, no backups taken")
+    sys.exit(0)
+
+# ---- write under the tracker's lock ------------------------------------------
+lock_path = live_csv + ".lock"
+lock_fd = None
+try:
+    import fcntl
+except ImportError:
+    fcntl = None  # mirrors the tracker: proceed unlocked on such platforms
+
+if fcntl is not None:
+    try:
+        lock_fd = open(lock_path, "w")
+        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+    except OSError:
+        fail("could not acquire %s — is another merge or tracker write stuck?" % lock_path)
+
+try:
+    backups = []
+    for p in ([live_log] if merge_log else []) + ([live_csv] if merge_csv else []):
+        b = backup(p)
+        if b:
+            backups.append(b)
+    for b in backups:
+        print("backup: %s" % b)
+
+    if merge_log:
+        atomic_write_text(live_log,
+                          ("\n".join(merged_lines) + "\n") if merged_lines else "")
+        print("wrote: %s (%d line(s))" % (live_log, len(merged_lines)))
+    if merge_csv:
+        atomic_write_csv(live_csv, merged_header, merged_rows)
+        print("wrote: %s (%d row(s))" % (live_csv, len(merged_rows)))
+finally:
+    if lock_fd is not None:
+        try:
+            lock_fd.close()
+        except OSError:
+            pass
+PY

--- a/.claude/scripts/skill-usage-snapshot.sh
+++ b/.claude/scripts/skill-usage-snapshot.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+# skill-usage-snapshot.sh — Keep a machine-independent snapshot of the skill
+# telemetry (~/.claude/skill-usage.log + .csv) on the repo's dedicated
+# `skill-telemetry` branch, and restore from it on a fresh machine.
+#
+# STORAGE MODEL (issue #572):
+#   Live files stay in ~/.claude/ (written by skill-usage-tracker.sh). This
+#   script pushes copies of them — plus a manifest.json — to the branch root
+#   of `skill-telemetry` via the GitHub contents API (gh api; no local
+#   checkout, no worktree, no commits to main). The Stop hook
+#   skill-usage-snapshot-hook.sh backgrounds `--push --quiet` at most once
+#   per SNAPSHOT_INTERVAL_DAYS, so no single laptop is ever the only copy.
+#
+# USAGE:
+#   skill-usage-snapshot.sh --push [--force] [--quiet]
+#   skill-usage-snapshot.sh --restore [--from <dir>]
+#   skill-usage-snapshot.sh --status
+#   skill-usage-snapshot.sh --help
+#
+#   --push     Snapshot the live files to the skill-telemetry branch.
+#              Throttled to once per SNAPSHOT_INTERVAL_DAYS (default 7) via
+#              ~/.claude/skill-usage-snapshot-state.json; --force bypasses
+#              the throttle. State advances only on a confirmed push (or on
+#              a verified no-change), so an offline attempt simply retries
+#              on a later Stop. --quiet swallows all output AND all errors
+#              (exit 0) — the background-hook contract.
+#   --restore  Fetch the snapshot files and merge them into the live files
+#              via skill-usage-merge.sh --csv-counts recompute (idempotent,
+#              overlap-safe; on a fresh machine it degrades to a copy).
+#              --from <dir> skips the fetch and restores from an already-
+#              downloaded directory (testing / manual escape hatch).
+#   --status   Show last push time, throttle state, and local vs remote
+#              line counts (remote is best-effort).
+#
+# CONCURRENCY: a mkdir lock (~/.claude/skill-usage-snapshot.lock) serializes
+#   pushes across concurrent sessions; a lock older than 15 minutes is
+#   presumed stale (crashed pusher) and stolen. macOS ships no flock(1), so
+#   mkdir is the portable atomic primitive here.
+#
+# NO-CHANGE PUSHES: file blobs are compared via `git hash-object` against the
+#   branch's blob SHAs; when nothing changed, no commit is created and the
+#   throttle state still advances (an idle week produces zero branch noise).
+#
+# TESTING OVERRIDES (env): SKILL_TELEMETRY_BRANCH (default skill-telemetry),
+#   SNAPSHOT_INTERVAL_DAYS (default 7).
+#
+# EXIT STATUS:
+#   0  success, throttled no-op, or --quiet swallowing a failure
+#   2  usage error
+#   3  environment error (no git/gh/python3, cannot resolve repo)
+#   4  push/restore failure (without --quiet)
+
+set -uo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
+
+print_help() {
+  awk 'NR == 1 { next } /^$/ { exit } { sub(/^# ?/, ""); print }' "$0"
+}
+
+usage_error() {
+  echo "skill-usage-snapshot.sh: $1" >&2
+  echo "Run with --help for usage." >&2
+  exit 2
+}
+
+MODE=""
+FORCE=0
+QUIET=0
+FROM_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) print_help; exit 0 ;;
+    --push|--restore|--status)
+      [[ -n "$MODE" ]] && usage_error "--push/--restore/--status are mutually exclusive"
+      MODE="${1#--}"
+      shift
+      ;;
+    --force) FORCE=1; shift ;;
+    --quiet) QUIET=1; shift ;;
+    --from)
+      [[ $# -ge 2 ]] || usage_error "--from requires a directory"
+      FROM_DIR="$2"
+      shift 2
+      ;;
+    *) usage_error "unknown argument: $1" ;;
+  esac
+done
+
+[[ -z "$MODE" ]] && usage_error "one of --push / --restore / --status is required"
+[[ "$FORCE" == 1 && "$MODE" != "push" ]] && usage_error "--force only applies to --push"
+[[ -n "$FROM_DIR" && "$MODE" != "restore" ]] && usage_error "--from only applies to --restore"
+
+say() { [[ "$QUIET" == 1 ]] || echo "$@"; }
+warn() { [[ "$QUIET" == 1 ]] || echo "$@" >&2; }
+# Failure exit honoring the --quiet background contract (swallow, exit 0).
+die_soft() {
+  warn "skill-usage-snapshot: $1"
+  [[ "$QUIET" == 1 ]] && exit 0
+  exit 4
+}
+
+BRANCH="${SKILL_TELEMETRY_BRANCH:-skill-telemetry}"
+INTERVAL_DAYS="${SNAPSHOT_INTERVAL_DAYS:-7}"
+if ! [[ "$INTERVAL_DAYS" =~ ^[0-9]+$ ]] || (( INTERVAL_DAYS < 1 )); then
+  usage_error "SNAPSHOT_INTERVAL_DAYS must be a positive integer (got: $INTERVAL_DAYS)"
+fi
+INTERVAL_SECS=$(( INTERVAL_DAYS * 86400 ))
+
+LIVE_LOG="$HOME/.claude/skill-usage.log"
+LIVE_CSV="$HOME/.claude/skill-usage.csv"
+STATE_FILE="$HOME/.claude/skill-usage-snapshot-state.json"
+LOCK_DIR="$HOME/.claude/skill-usage-snapshot.lock"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Cleanup state is global: traps fire in top-level context after functions
+# have returned, so function-locals would be gone by then.
+STAGING=""
+FETCH_DIR=""
+HOLDING_LOCK=0
+cleanup() {
+  [[ -n "$STAGING" ]] && rm -rf "$STAGING"
+  [[ -n "$FETCH_DIR" ]] && rm -rf "$FETCH_DIR"
+  (( HOLDING_LOCK == 1 )) && rmdir "$LOCK_DIR" 2>/dev/null
+  return 0
+}
+trap cleanup EXIT
+
+for tool in git gh python3; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    [[ "$QUIET" == 1 ]] && exit 0
+    echo "error: $tool not found" >&2
+    exit 3
+  fi
+done
+
+# Resolve owner/repo from the checkout containing this script — works no
+# matter what cwd the (possibly backgrounded) caller had.
+resolve_repo() {
+  local url
+  url="$(git -C "$SCRIPT_DIR" remote get-url origin 2>/dev/null)" || return 1
+  url="${url%.git}"
+  case "$url" in
+    git@*:*) printf '%s\n' "${url#*:}" ;;
+    http://*|https://*|ssh://*)
+      url="${url#*://}"          # host/owner/repo (drop scheme)
+      url="${url#*@}"            # drop user@ if present
+      printf '%s\n' "${url#*/}"  # drop host
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+OWNER_REPO="$(resolve_repo)" || true
+if [[ -z "${OWNER_REPO:-}" || "$OWNER_REPO" != */* ]]; then
+  [[ "$QUIET" == 1 ]] && exit 0
+  echo "error: cannot resolve owner/repo from $SCRIPT_DIR's origin remote" >&2
+  exit 3
+fi
+
+now_epoch() { date +%s; }
+now_utc() { date -u +%FT%TZ; }
+
+state_get_epoch() {
+  # Best-effort read of last_push_epoch; 0 when missing/garbled.
+  [[ -f "$STATE_FILE" ]] || { echo 0; return; }
+  local v
+  v="$(sed -n 's/.*"last_push_epoch"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$STATE_FILE" | head -1)"
+  echo "${v:-0}"
+}
+
+write_state() {
+  # write_state <result> <log_lines> <csv_rows>
+  local tmp
+  tmp="$(mktemp "$STATE_FILE.XXXXXX")" || return 1
+  printf '{\n  "schema_version": 1,\n  "last_push_epoch": %s,\n  "last_push_at": "%s",\n  "last_result": "%s",\n  "branch": "%s",\n  "repo": "%s",\n  "hostname": "%s",\n  "log_lines": %s,\n  "csv_rows": %s\n}\n' \
+    "$(now_epoch)" "$(now_utc)" "$1" "$BRANCH" "$OWNER_REPO" "$(hostname -s 2>/dev/null || echo unknown)" "$2" "$3" > "$tmp" \
+    && mv "$tmp" "$STATE_FILE"
+}
+
+count_lines() {
+  if [[ -f "$1" ]]; then wc -l < "$1" | tr -d ' '; else echo 0; fi
+}
+
+count_csv_rows() {
+  # Data rows only — the header line is not a skill row.
+  local n
+  n="$(count_lines "$1")"
+  if (( n > 0 )); then echo $(( n - 1 )); else echo 0; fi
+}
+
+# gh api wrapper. Exit codes: 0 success (body on stdout), 44 HTTP 404
+# (missing object — actionable), 1 anything else (offline, auth, 5xx —
+# skip this cycle). Exit codes survive command substitution, unlike
+# variables set inside the $() subshell.
+gh_api() {
+  local err out rc
+  err="$(mktemp)" || return 1
+  if out="$(gh api "$@" 2>"$err")"; then
+    rm -f "$err"
+    printf '%s\n' "$out"
+    return 0
+  fi
+  rc=1
+  grep -q "HTTP 404" "$err" && rc=44
+  rm -f "$err"
+  return "$rc"
+}
+
+ensure_branch() {
+  local rc default_branch base_sha
+  gh_api "repos/$OWNER_REPO/git/ref/heads/$BRANCH" >/dev/null
+  rc=$?
+  (( rc == 0 )) && return 0
+  (( rc == 44 )) || return 1   # network/auth trouble — not ours to fix
+  default_branch="$(gh_api "repos/$OWNER_REPO" --jq .default_branch)" || return 1
+  [[ -n "$default_branch" ]] || default_branch="main"
+  base_sha="$(gh_api "repos/$OWNER_REPO/git/ref/heads/$default_branch" --jq .object.sha)" || return 1
+  say "creating branch $BRANCH from $default_branch @ ${base_sha:0:7}"
+  gh_api -X POST "repos/$OWNER_REPO/git/refs" \
+    -f ref="refs/heads/$BRANCH" -f sha="$base_sha" >/dev/null
+}
+
+remote_blob_sha() {
+  # remote_blob_sha <path> — prints the blob SHA, or "" when the file does
+  # not exist on the branch (404). Returns 1 only on non-404 failure.
+  local sha rc
+  sha="$(gh_api "repos/$OWNER_REPO/contents/$1?ref=$BRANCH" --jq .sha)"
+  rc=$?
+  if (( rc == 0 )); then
+    printf '%s\n' "$sha"
+    return 0
+  fi
+  if (( rc == 44 )); then
+    echo ""
+    return 0
+  fi
+  return 1
+}
+
+put_file() {
+  # put_file <local-file> <repo-path> <message> <remote-sha-or-empty>
+  local local_file="$1" repo_path="$2" message="$3" remote_sha="$4"
+  # JSON body built in python: no shell argv limits as the log grows, and
+  # base64 handled without BSD/GNU flag differences.
+  python3 - "$local_file" "$message" "$BRANCH" "$remote_sha" <<'PY' | gh_api -X PUT "repos/$OWNER_REPO/contents/$repo_path" --input - >/dev/null || return 1
+import base64, json, sys
+path, message, branch, sha = sys.argv[1:5]
+with open(path, "rb") as fh:
+    content = base64.b64encode(fh.read()).decode("ascii")
+body = {"message": message, "content": content, "branch": branch}
+if sha:
+    body["sha"] = sha
+print(json.dumps(body))
+PY
+  say "pushed: $repo_path"
+}
+
+# sync_file <staged-file> <repo-path> <message>
+# Pushes the staged file unless the branch already has identical content.
+# Verdict lands in SYNC_RESULT (changed|unchanged) — a global, not stdout,
+# so put_file's progress output is not swallowed by command substitution.
+# Returns 1 on failure. Must be called from the main shell, not a subshell.
+SYNC_RESULT=""
+sync_file() {
+  local staged="$1" repo_path="$2" message="$3" remote_sha local_sha
+  SYNC_RESULT=""
+  remote_sha="$(remote_blob_sha "$repo_path")" || return 1
+  local_sha="$(git hash-object "$staged" 2>/dev/null)" || local_sha=""
+  if [[ -n "$local_sha" && "$local_sha" == "$remote_sha" ]]; then
+    say "unchanged: $repo_path"
+    SYNC_RESULT="unchanged"
+    return 0
+  fi
+  put_file "$staged" "$repo_path" "$message" "$remote_sha" || return 1
+  SYNC_RESULT="changed"
+}
+
+do_push() {
+  # Cheap throttle check (authoritative re-check happens under the lock).
+  local last now
+  last="$(state_get_epoch)"
+  now="$(now_epoch)"
+  if (( FORCE == 0 )) && (( now - last < INTERVAL_SECS )); then
+    say "throttled: last push $(( (now - last) / 86400 ))d ago (< ${INTERVAL_DAYS}d); use --force to override"
+    return 0
+  fi
+
+  if [[ ! -f "$LIVE_LOG" && ! -f "$LIVE_CSV" ]]; then
+    say "nothing to push: no live telemetry files yet"
+    return 0
+  fi
+
+  # Serialize concurrent pushers; steal locks older than 15 minutes. The
+  # steal renames the stale dir first — mv is atomic, so exactly one
+  # contender wins it and a freshly re-created lock can never be removed
+  # by a racing second stealer.
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    if [[ -n "$(find "$LOCK_DIR" -maxdepth 0 -mmin +15 2>/dev/null)" ]]; then
+      if mv "$LOCK_DIR" "$LOCK_DIR.stale.$$" 2>/dev/null; then
+        rmdir "$LOCK_DIR.stale.$$" 2>/dev/null || true
+        if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+          say "another push holds the lock"
+          return 0
+        fi
+      else
+        say "another push is stealing the lock"
+        return 0
+      fi
+    else
+      say "another push is in flight"
+      return 0
+    fi
+  fi
+  HOLDING_LOCK=1
+
+  # Re-check throttle under the lock (a concurrent pusher may have just won).
+  last="$(state_get_epoch)"
+  now="$(now_epoch)"
+  if (( FORCE == 0 )) && (( now - last < INTERVAL_SECS )); then
+    say "throttled: a concurrent push just completed"
+    return 0
+  fi
+
+  # Copy to a staging dir so all three PUTs describe one moment in time. The
+  # tracker's log append (>>) is unlocked — a torn final line here is
+  # possible but self-heals on the next push.
+  STAGING="$(mktemp -d)" || die_soft "mktemp failed"
+  local log_lines=0 csv_rows=0
+  if [[ -f "$LIVE_LOG" ]]; then
+    cp "$LIVE_LOG" "$STAGING/skill-usage.log" || die_soft "cp log failed"
+    log_lines="$(count_lines "$STAGING/skill-usage.log")"
+  fi
+  if [[ -f "$LIVE_CSV" ]]; then
+    cp "$LIVE_CSV" "$STAGING/skill-usage.csv" || die_soft "cp csv failed"
+    csv_rows="$(count_csv_rows "$STAGING/skill-usage.csv")"
+  fi
+
+  ensure_branch || die_soft "cannot reach GitHub (offline?) — will retry on a later Stop"
+
+  local stamp msg pushed_any=0
+  stamp="$(now_utc)"
+  msg="telemetry: snapshot $stamp from $(hostname -s 2>/dev/null || echo unknown) [skip ci]"
+
+  if [[ -f "$STAGING/skill-usage.log" ]]; then
+    sync_file "$STAGING/skill-usage.log" "skill-usage.log" "$msg" \
+      || die_soft "push of skill-usage.log failed"
+    [[ "$SYNC_RESULT" == "changed" ]] && pushed_any=1
+  fi
+  if [[ -f "$STAGING/skill-usage.csv" ]]; then
+    sync_file "$STAGING/skill-usage.csv" "skill-usage.csv" "$msg" \
+      || die_soft "push of skill-usage.csv failed"
+    [[ "$SYNC_RESULT" == "changed" ]] && pushed_any=1
+  fi
+
+  if (( pushed_any == 1 )); then
+    printf '{\n  "schema_version": 1,\n  "pushed_at": "%s",\n  "hostname": "%s",\n  "log_lines": %s,\n  "csv_rows": %s\n}\n' \
+      "$stamp" "$(hostname -s 2>/dev/null || echo unknown)" "$log_lines" "$csv_rows" > "$STAGING/manifest.json"
+    local msha
+    msha="$(remote_blob_sha "manifest.json")" || die_soft "contents lookup failed"
+    put_file "$STAGING/manifest.json" "manifest.json" "$msg" "$msha" \
+      || die_soft "push of manifest.json failed"
+    write_state "pushed" "$log_lines" "$csv_rows" || die_soft "state write failed"
+    say "snapshot pushed to $OWNER_REPO@$BRANCH ($log_lines log line(s), $csv_rows csv row(s))"
+  else
+    # Verified no-change: advance the throttle without creating a commit.
+    write_state "unchanged" "$log_lines" "$csv_rows" || die_soft "state write failed"
+    say "snapshot already current on $OWNER_REPO@$BRANCH — no commit created"
+  fi
+}
+
+fetch_file() {
+  # fetch_file <repo-path> <dest> — raw media type avoids base64 handling.
+  # Exit: 0 fetched, 44 file not on the branch (404 — legitimately skippable),
+  # 1 anything else (offline/auth/5xx — the caller must ABORT, not treat the
+  # file as absent, or a transient failure silently restores partial state).
+  local err rc
+  err="$(mktemp)" || return 1
+  if gh api -H "Accept: application/vnd.github.raw" \
+      "repos/$OWNER_REPO/contents/$1?ref=$BRANCH" > "$2" 2>"$err"; then
+    rm -f "$err"
+    return 0
+  fi
+  rc=1
+  grep -q "HTTP 404" "$err" && rc=44
+  rm -f "$err"
+  rm -f "$2"   # gh writes the JSON error body to stdout — never keep it
+  return "$rc"
+}
+
+do_restore() {
+  local src="$FROM_DIR" rc
+  if [[ -n "$src" ]]; then
+    if [[ ! -d "$src" ]]; then
+      echo "error: --from dir not found: $src" >&2
+      exit 3
+    fi
+  else
+    FETCH_DIR="$(mktemp -d)" || die_soft "mktemp failed"
+    src="$FETCH_DIR"
+    say "fetching snapshot from $OWNER_REPO@$BRANCH ..."
+    fetch_file "skill-usage.log" "$src/skill-usage.log"
+    rc=$?
+    (( rc == 1 )) && die_soft "fetch of skill-usage.log failed (offline?) — aborting restore"
+    fetch_file "skill-usage.csv" "$src/skill-usage.csv"
+    rc=$?
+    (( rc == 1 )) && die_soft "fetch of skill-usage.csv failed (offline?) — aborting restore"
+  fi
+
+  local args=()
+  [[ -s "$src/skill-usage.log" ]] && args+=(--log "$src/skill-usage.log")
+  [[ -s "$src/skill-usage.csv" ]] && args+=(--csv "$src/skill-usage.csv")
+  if (( ${#args[@]} == 0 )); then
+    die_soft "no snapshot files found on $OWNER_REPO@$BRANCH — nothing to restore"
+  fi
+  bash "$SCRIPT_DIR/skill-usage-merge.sh" "${args[@]}" --csv-counts recompute \
+    || die_soft "merge step failed"
+  say "restore complete — run skill-usage-report.sh to verify the window"
+}
+
+do_status() {
+  echo "repo:   $OWNER_REPO"
+  echo "branch: $BRANCH"
+  echo "interval: ${INTERVAL_DAYS}d"
+  if [[ -f "$STATE_FILE" ]]; then
+    echo "state ($STATE_FILE):"
+    sed 's/^/  /' "$STATE_FILE"
+    local last now due
+    last="$(state_get_epoch)"
+    now="$(now_epoch)"
+    due=$(( last + INTERVAL_SECS ))
+    if (( now >= due )); then
+      echo "next push: due now (on next Stop hook)"
+    else
+      echo "next push: in $(( (due - now) / 86400 ))d $(( ((due - now) % 86400) / 3600 ))h"
+    fi
+  else
+    echo "state: none — no push has succeeded yet (first due Stop hook will push)"
+  fi
+  echo "local:  $(count_lines "$LIVE_LOG") log line(s), $(count_csv_rows "$LIVE_CSV") csv row(s)"
+  local manifest
+  if manifest="$(gh api -H "Accept: application/vnd.github.raw" \
+      "repos/$OWNER_REPO/contents/manifest.json?ref=$BRANCH" 2>/dev/null)"; then
+    echo "remote manifest:"
+    printf '%s\n' "$manifest" | sed 's/^/  /'
+  else
+    echo "remote manifest: unavailable (no snapshot yet, or offline)"
+  fi
+}
+
+case "$MODE" in
+  push) do_push ;;
+  restore) do_restore ;;
+  status) do_status ;;
+esac

--- a/.claude/scripts/stale-cleanup.sh
+++ b/.claude/scripts/stale-cleanup.sh
@@ -150,7 +150,16 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 4
 fi
 
-PROTECTED_BRANCHES=("main" "master" "develop")
+# skill-telemetry is the data-only usage-snapshot branch (issue #572). It is
+# updated at most weekly and must survive long gaps — a laptop that dies after
+# weeks offline is exactly the window the snapshot exists for — so it must
+# never age into the remote-stale prune set. The default name stays protected
+# even when SKILL_TELEMETRY_BRANCH points snapshots at an override branch;
+# the override (when set) is protected additionally.
+PROTECTED_BRANCHES=("main" "master" "develop" "skill-telemetry")
+if [[ -n "${SKILL_TELEMETRY_BRANCH:-}" ]]; then
+  PROTECTED_BRANCHES+=("$SKILL_TELEMETRY_BRANCH")
+fi
 is_protected() {
   local b="$1"
   for p in "${PROTECTED_BRANCHES[@]}"; do

--- a/.claude/scripts/tests/skill-usage-merge.test.sh
+++ b/.claude/scripts/tests/skill-usage-merge.test.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# skill-usage-merge.test.sh — unit tests for skill-usage-merge.sh (issue #572)
+#
+# Covers the merge semantics the issue's AC pins down:
+#   - log: line-level union, exact-line dedupe, chronological order
+#   - csv (sum): use_count summed, last_used = max (real date beats "never"),
+#     start_date = min
+#   - csv (recompute): idempotent under full overlap; preserves CSV-only
+#     baseline counts (no log lines behind them); adds rows for log-only skills
+#   - fresh machine (no live files) degrades to a copy
+#   - --dry-run writes nothing; real runs back up live files first
+#   - usage/environment error exits
+#
+# Runs hermetically inside a temp HOME. No network, no git, no gh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MERGE="$SCRIPT_DIR/../skill-usage-merge.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+
+ok() {
+  PASS=$((PASS + 1))
+  echo "  ok: $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: $1" >&2
+}
+
+assert_eq() {
+  # assert_eq <label> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then
+    ok "$1"
+  else
+    fail "$1 — expected [$2], got [$3]"
+  fi
+}
+
+csv_field() {
+  # csv_field <file> <skill> <1-based-field>
+  # tr strips the \r that csv.writer row endings (CRLF, same as the tracker
+  # writes) leave on the final field.
+  awk -F, -v s="$2" -v f="$3" '$1 == s { print $f }' "$1" | tr -d '\r'
+}
+
+fresh_home() {
+  rm -rf "$WORK/home"
+  mkdir -p "$WORK/home/.claude"
+}
+
+# ---- fixtures ---------------------------------------------------------------
+mkdir -p "$WORK/other"
+# "other" machine: May–June history, one line shared with live.
+printf '2026-05-01T18:02:00Z\twrap\told-1\n2026-05-02T00:00:00Z\tprompt\told-2\n2026-06-01T00:00:00Z\twrap\tshared\n' \
+  > "$WORK/other/skill-usage.log"
+printf 'skill_name,start_date,use_count,last_used\nwrap,2026-05-01,2,2026-06-01\nprompt,2026-05-01,1,2026-05-02\nlessons,2026-03-01,0,never\n' \
+  > "$WORK/other/skill-usage.csv"
+
+seed_live() {
+  # live machine: July history + the shared line; later start_date, one
+  # skill (lessons) known only as never-used.
+  printf '2026-07-10T01:00:00Z\twrap\tnew-1\n2026-07-12T02:00:00Z\tfixpr\tnew-2\n2026-06-01T00:00:00Z\twrap\tshared\n' \
+    > "$WORK/home/.claude/skill-usage.log"
+  printf 'skill_name,start_date,use_count,last_used\nwrap,2026-04-10,2,2026-07-10\nfixpr,2026-04-10,1,2026-07-12\nlessons,2026-04-10,0,never\n' \
+    > "$WORK/home/.claude/skill-usage.csv"
+}
+
+# ---- 1. sum-mode disjoint merge (the machine-move path) ----------------------
+echo "test: sum-mode merge"
+fresh_home
+seed_live
+HOME="$WORK/home" bash "$MERGE" --log "$WORK/other/skill-usage.log" \
+  --csv "$WORK/other/skill-usage.csv" > "$WORK/out1.txt"
+
+LOG="$WORK/home/.claude/skill-usage.log"
+CSV="$WORK/home/.claude/skill-usage.csv"
+
+assert_eq "log union deduped (3+3 with 1 shared -> 5)" "5" "$(wc -l < "$LOG" | tr -d ' ')"
+assert_eq "log chronological" "$(sort "$LOG")" "$(cat "$LOG")"
+assert_eq "first line is the old machine's May 1 entry" \
+  "2026-05-01T18:02:00Z" "$(head -1 "$LOG" | cut -f1)"
+assert_eq "use_count summed (wrap 2+2)" "4" "$(csv_field "$CSV" wrap 3)"
+assert_eq "use_count summed (fixpr 1+0)" "1" "$(csv_field "$CSV" fixpr 3)"
+assert_eq "last_used = max (wrap)" "2026-07-10" "$(csv_field "$CSV" wrap 4)"
+assert_eq "last_used never+never stays never (lessons)" "never" "$(csv_field "$CSV" lessons 4)"
+assert_eq "start_date = min (wrap)" "2026-04-10" "$(csv_field "$CSV" wrap 2)"
+assert_eq "start_date = min (lessons, other older)" "2026-03-01" "$(csv_field "$CSV" lessons 2)"
+assert_eq "other-only skill row added (prompt)" "1" "$(csv_field "$CSV" prompt 3)"
+BACKUPS="$(find "$WORK/home/.claude" -name 'skill-usage.log.bak.*' | wc -l | tr -d ' ')"
+assert_eq "log backup created" "1" "$BACKUPS"
+
+# ---- 2. recompute idempotency + baseline preservation -----------------------
+echo "test: recompute (restore path)"
+fresh_home
+# Live CSV carries a baseline count (37) far above the log's 1 line for wrap —
+# e.g. the #431 fallback baseline. Restore must never zero it.
+printf '2026-07-16T02:00:00Z\twrap\ts1\n' > "$WORK/home/.claude/skill-usage.log"
+printf 'skill_name,start_date,use_count,last_used\nwrap,2026-05-01,37,2026-07-16\nprompt,2026-05-01,25,2026-06-26\n' \
+  > "$WORK/home/.claude/skill-usage.csv"
+cp "$WORK/home/.claude/skill-usage.log" "$WORK/snap.log"
+cp "$WORK/home/.claude/skill-usage.csv" "$WORK/snap.csv"
+# Snapshot also carries a log-only skill the CSVs have never seen.
+printf '2026-07-01T00:00:00Z\tstatus\ts2\n' >> "$WORK/snap.log"
+
+HOME="$WORK/home" bash "$MERGE" --log "$WORK/snap.log" --csv "$WORK/snap.csv" \
+  --csv-counts recompute > /dev/null
+CSV="$WORK/home/.claude/skill-usage.csv"
+assert_eq "baseline count preserved (wrap 37 > log 1)" "37" "$(csv_field "$CSV" wrap 3)"
+assert_eq "baseline count preserved (prompt 25, 0 log lines)" "25" "$(csv_field "$CSV" prompt 3)"
+assert_eq "log-only skill gains a row (status)" "1" "$(csv_field "$CSV" status 3)"
+assert_eq "log-only skill dates from log (status)" "2026-07-01" "$(csv_field "$CSV" status 4)"
+
+cp "$CSV" "$WORK/pass1.csv"
+cp "$WORK/home/.claude/skill-usage.log" "$WORK/pass1.log"
+HOME="$WORK/home" bash "$MERGE" --log "$WORK/snap.log" --csv "$WORK/snap.csv" \
+  --csv-counts recompute > /dev/null
+if diff -q "$WORK/pass1.csv" "$CSV" > /dev/null \
+   && diff -q "$WORK/pass1.log" "$WORK/home/.claude/skill-usage.log" > /dev/null; then
+  ok "recompute is idempotent"
+else
+  fail "recompute is idempotent — second pass changed files"
+fi
+
+# ---- 3. fresh machine degrades to a copy ------------------------------------
+echo "test: fresh machine restore"
+fresh_home
+HOME="$WORK/home" bash "$MERGE" --log "$WORK/snap.log" --csv "$WORK/snap.csv" \
+  --csv-counts recompute > /dev/null
+assert_eq "fresh log equals snapshot (sorted)" \
+  "$(sort "$WORK/snap.log")" "$(cat "$WORK/home/.claude/skill-usage.log")"
+assert_eq "fresh csv has snapshot counts (wrap)" "37" \
+  "$(csv_field "$WORK/home/.claude/skill-usage.csv" wrap 3)"
+
+# ---- 4. dry-run writes nothing ------------------------------------------------
+echo "test: dry-run"
+fresh_home
+seed_live
+BEFORE_LOG="$(cat "$WORK/home/.claude/skill-usage.log")"
+BEFORE_CSV="$(cat "$WORK/home/.claude/skill-usage.csv")"
+HOME="$WORK/home" bash "$MERGE" --log "$WORK/other/skill-usage.log" \
+  --csv "$WORK/other/skill-usage.csv" --dry-run > "$WORK/dry.txt"
+assert_eq "dry-run left log untouched" "$BEFORE_LOG" "$(cat "$WORK/home/.claude/skill-usage.log")"
+assert_eq "dry-run left csv untouched" "$BEFORE_CSV" "$(cat "$WORK/home/.claude/skill-usage.csv")"
+BACKUPS="$(find "$WORK/home/.claude" -name '*.bak.*' | wc -l | tr -d ' ')"
+assert_eq "dry-run made no backups" "0" "$BACKUPS"
+if grep -q "dry-run: no files written" "$WORK/dry.txt"; then
+  ok "dry-run announces itself"
+else
+  fail "dry-run announces itself"
+fi
+
+# ---- 5. error exits ------------------------------------------------------------
+echo "test: error handling"
+set +e
+HOME="$WORK/home" bash "$MERGE" > /dev/null 2>&1
+assert_eq "no args -> usage exit 2" "2" "$?"
+HOME="$WORK/home" bash "$MERGE" --log "$WORK/does-not-exist.log" > /dev/null 2>&1
+assert_eq "missing input file -> env exit 3" "3" "$?"
+HOME="$WORK/home" bash "$MERGE" --log "$WORK/snap.log" --csv-counts bogus > /dev/null 2>&1
+assert_eq "bad --csv-counts -> usage exit 2" "2" "$?"
+set -e
+
+# ---- summary ---------------------------------------------------------------
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -53,6 +53,9 @@ jobs:
       - name: escalate-review.sh BugBot failure detection unit test (issue #552)
         run: bash .claude/scripts/tests/escalate-review.test.sh
 
+      - name: skill-usage-merge unit test (issue #572)
+        run: bash .claude/scripts/tests/skill-usage-merge.test.sh
+
   # macOS system python3 is 3.9.6 (Xcode CLT) while ubuntu-latest ships 3.10+,
   # so a hook that crashes on 3.9 (e.g. eagerly-evaluated PEP 604 unions,
   # issue #560) passes the job above yet fails open locally. Pin 3.9 here.

--- a/global-settings.json
+++ b/global-settings.json
@@ -48,6 +48,11 @@
             "type": "command",
             "command": "/path/to/claude-code-config/.claude/hooks/dirty-main-warn.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/skill-usage-snapshot-hook.sh",
+            "timeout": 10
           }
         ]
       }

--- a/setup-skills-worktree.sh
+++ b/setup-skills-worktree.sh
@@ -220,6 +220,7 @@ HOOKS_MANIFEST=(
   $'Stop\t\tsilence-detector-ack.sh\t5'
   $'Stop\t\ttrust-flag-repair.sh\t10'
   $'Stop\t\tdirty-main-warn.sh\t10'
+  $'Stop\t\tskill-usage-snapshot-hook.sh\t10'
   $'PostToolUse\t\tsession-start-sync.sh\t30'
   $'PostToolUse\tBash\tpost-merge-pull.sh\t15'
   $'PostToolUse\tBash\tpolling-backoff-warn.sh\t5'


### PR DESCRIPTION
## **User description**
Part of #572

## Summary

Makes skill-usage telemetry durable across machine moves. The May–June history stranded on the old MacBook proved the failure mode: `~/.claude/skill-usage.log` / `.csv` live only on the machine that wrote them.

Two parts; this PR ships Part 2 (durability) **plus** the Part 1 merge tooling. The actual Part 1 merge is one command the moment the old machine's raw files land (they had not arrived as of Jul 16 — only the old machine's rendered report reached `~/Downloads`), which is why this PR is `Part of` rather than `Closes`.

### New

- **`.claude/scripts/skill-usage-merge.sh`** — backup-first merge primitive. Log: line-level union, exact-line dedupe, chronological. CSV: `use_count` summed (default; disjoint machine histories) or `max(csv, log)` recompute (restore path — idempotent, overlap-safe, preserves CSV-only baselines like the #431 fallback). `last_used` = max, `start_date` = min. Runs under the tracker's own flock; atomic writes; `--dry-run`.
- **`.claude/scripts/skill-usage-snapshot.sh`** — `--push` (≥7-day throttle, contents-API PUTs of `skill-usage.log`, `skill-usage.csv`, `manifest.json` to the data-only **`skill-telemetry`** branch — no local checkout, no commits to `main`; blob-sha comparison makes no-change pushes commit-free; offline = silent retry-later; atomic `mv`-based stale-lock steal), `--restore` (fetch + recompute merge; fresh machine degrades to copy), `--status`.
- **`.claude/hooks/skill-usage-snapshot-hook.sh`** — Stop hook: consume stdin, cheap bash+sed throttle pre-check (no python/jq/network), backgrounds the push when due, always emits `{}` / exit 0.
- **`.claude/reference/skill-usage-durability.md`** — storage model, recovery how-tos, fallback-baseline procedure.
- **`.claude/scripts/tests/skill-usage-merge.test.sh`** — 25 assertions; wired into `hook-scripts.yml`.

### Changed

- `global-settings.json` + `setup-skills-worktree.sh` Step 6 manifest — register the Stop hook (kept in sync; setup.sh Step 7 verifies).
- `.claude/scripts/stale-cleanup.sh` — `skill-telemetry` added to `PROTECTED_BRANCHES` (an idle branch older than STALE_DAYS was previously prunable — exactly the dead-laptop window the snapshot exists to survive).

### Proven live (this thread)

- First `--push --force` created `skill-telemetry` from `main` and pushed all three files; `--status` reads the remote manifest back.
- Immediate re-push: `unchanged` ×2, **no commit created**, throttle advanced; plain `--push` throttles.
- Simulated total loss (empty `$HOME`): `--restore` rebuilt both files; `skill-usage-report.sh` covers the full local window.

## Test plan

- [x] `bash .claude/scripts/tests/skill-usage-merge.test.sh` passes (25/25): log union/dedupe/chronological; CSV sum/max/min semantics; recompute idempotent under full overlap; CSV-only baseline preserved; fresh-machine copy; dry-run writes nothing; backups created; usage/env error exits
- [x] Stop hook emits `{}` and exit 0 on every path (due, not-due, garbled state, `SNAPSHOT_INTERVAL_DAYS=0` clamp) and never blocks a session
- [x] Hook registered identically in `global-settings.json` and the `setup-skills-worktree.sh` Step 6 manifest
- [x] `skill-telemetry` branch exists with `skill-usage.log`, `skill-usage.csv`, `manifest.json`; no-change `--push --force` creates no new commit
- [x] `--restore` on a scratch `$HOME` reproduces the live window in `skill-usage-report.sh`
- [x] `stale-cleanup.sh` skips `skill-telemetry` as protected
- [x] CI (hook-scripts) green, including the new test step

## Review notes

- **CodeRabbit CLI dropped for this session** per the two-errors policy (`cr-local-review.md`): rate-limited at 1:55 PM and again at 2:06 PM ET, zero findings emitted before dropping. CodeAnt CLI is the surviving local gate (clean pass required); GitHub-side review runs normally on this PR.
- CodeAnt local rounds found 6 findings across 2 rounds (zero-day throttle clamp, hardcoded default branch, env-override branch protection, hook lock-check that could permanently disable pushes after a crash, non-atomic stale-lock steal, same-second dedupe caveat) — 5 fixed, 1 documented as the AC-specified dedupe semantic.

## Post-merge

1. Run `bash setup-skills-worktree.sh` once on the live machine (idempotent) to register the Stop hook.
2. When the old MacBook's raw files arrive: `bash .claude/scripts/skill-usage-merge.sh --log <old.log> --csv <old.csv>` → verify with `skill-usage-report.sh` (tracking since ~2026-05-01) → `bash .claude/scripts/skill-usage-snapshot.sh --push --force`. Then close #572.
3. If the old files are declared unrecoverable, encode the fallback baseline instead — freshest source is `~/Downloads/skill-usage-report-2026-07-16.md` (145 invocations through Jul 16, rendered on the old machine), else #431's Jun 26 table; procedure in `.claude/reference/skill-usage-durability.md`.


___

## **CodeAnt-AI Description**
**Keep skill-usage telemetry safe across machine moves and long offline periods**

### What Changed
- Adds a background snapshot that saves skill-usage telemetry to a dedicated `skill-telemetry` branch, so the data survives laptop replacement, reinstalls, and `~/.claude` cleanup.
- Lets a fresh machine restore the snapshot and merge it into local telemetry, while preserving existing counts and adding any missing skill rows.
- Adds a manual merge command for combining telemetry from another machine, with backups and dry-run support before any files are changed.
- Schedules the snapshot hook in Stop events, protects the telemetry branch from cleanup, and adds documentation and tests for the new behavior.

### Impact
`✅ Skill-usage data survives device changes`
`✅ Fewer lost telemetry records after offline periods`
`✅ Safer recovery after reinstall or cleanup` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

