### PR TITLE
docs(#591): document 6 missing slash commands + add skill-catalog lint guard

### DIFF
--- a/.github/scripts/skill-catalog-lint.sh
+++ b/.github/scripts/skill-catalog-lint.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Lint the README slash-command catalog against .claude/skills/.
+#
+# Validates:
+#   1. The Slash Commands table in README.md matches the actual set of
+#      .claude/skills/*/ directories (no drift in either direction).
+#   2. No duplicate command rows (a dupe would inflate the count while
+#      leaving a command undocumented).
+#   3. Every skill directory actually contains a SKILL.md.
+#   4. The hardcoded command counts in README prose match the row count.
+#
+# Companion to rule-lint.sh, which enforces the same index-alignment
+# invariant for .claude/rules/*.md against the CLAUDE.md rule index.
+# Paths are repo-root-relative, so run it from the repo root.
+#
+# Output uses GitHub Actions annotations (::error::) so issues surface
+# directly on PR checks. Exits 1 on any error condition.
+
+set -euo pipefail
+shopt -s nullglob
+
+README="README.md"
+SKILLS_DIR=".claude/skills"
+
+errors=0
+
+usage() {
+  cat <<'EOF'
+Usage: .github/scripts/skill-catalog-lint.sh
+
+  Verifies the README Slash Commands table stays in sync with .claude/skills/.
+  No options. Run from the repo root. Exits 1 on any error.
+EOF
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "::error::Unknown argument: $1"
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ ! -f "$README" ]]; then
+  echo "::error file=${README}::README.md not found at repo root"
+  exit 1
+fi
+
+if [[ ! -d "$SKILLS_DIR" ]]; then
+  echo "::error::${SKILLS_DIR} directory not found"
+  exit 1
+fi
+
+# --- 1. Catalog alignment check ------------------------------------------
+# Table rows look like:
+#   | `/pm` | PM | Active PM orchestrator — ... |
+# Anchoring on '^| `/' scopes the match to command rows, so inline `/foo`
+# references in prose or other tables aren't misread as catalog entries.
+# `|| true` keeps a no-match grep (exit 1) from killing the script under
+# `set -euo pipefail`; the empty case is handled by the comm logic below.
+documented_all=$(grep -oE '^\| `/[a-z0-9-]+`' "$README" \
+  | sed 's/^| `\///; s/`$//' \
+  | sort || true)
+documented=$(printf '%s\n' "$documented_all" | sort -u)
+
+actual=$(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; \
+  | sort -u)
+
+undocumented=$(comm -23 <(printf '%s\n' "$actual") <(printf '%s\n' "$documented") || true)
+phantom=$(comm -13 <(printf '%s\n' "$actual") <(printf '%s\n' "$documented") || true)
+
+if [[ -n "$undocumented" ]]; then
+  while IFS= read -r s; do
+    [[ -z "$s" ]] && continue
+    echo "::error file=${README}::Skill '${s}' exists in ${SKILLS_DIR}/ but has no row in the README Slash Commands table"
+    errors=$((errors + 1))
+  done <<< "$undocumented"
+fi
+
+if [[ -n "$phantom" ]]; then
+  while IFS= read -r s; do
+    [[ -z "$s" ]] && continue
+    echo "::error file=${README}::README documents '/${s}' but no such skill exists in ${SKILLS_DIR}/"
+    errors=$((errors + 1))
+  done <<< "$phantom"
+fi
+
+# --- 2. Duplicate row check ----------------------------------------------
+row_count=$(printf '%s\n' "$documented_all" | grep -c . || true)
+unique_count=$(printf '%s\n' "$documented" | grep -c . || true)
+
+if (( row_count != unique_count )); then
+  printf '%s\n' "$documented_all" | uniq -d | while IFS= read -r dupe; do
+    [[ -z "$dupe" ]] && continue
+    echo "::error file=${README}::Command '/${dupe}' has more than one row in the Slash Commands table"
+  done
+  errors=$((errors + row_count - unique_count))
+fi
+
+# --- 3. SKILL.md presence ------------------------------------------------
+# Keeps "directory count" and "documented command count" the same number, so
+# `ls -d .claude/skills/*/ | wc -l` stays a valid cross-check of the table.
+while IFS= read -r s; do
+  [[ -z "$s" ]] && continue
+  if [[ ! -f "${SKILLS_DIR}/${s}/SKILL.md" ]]; then
+    echo "::error::${SKILLS_DIR}/${s}/ has no SKILL.md — either add one or remove the directory"
+    errors=$((errors + 1))
+  fi
+done <<< "$actual"
+
+if (( errors == 0 )); then
+  echo "Skill catalog alignment: OK (${unique_count} commands)"
+fi
+
+# --- 4. Hardcoded count check --------------------------------------------
+# Each anchor must appear exactly once. Zero matches (someone reworded the
+# prose) or several (an ambiguous target) is an error, not a pass — otherwise
+# a future edit would silently disable this check instead of failing loudly.
+check_count_anchor() {
+  local label="$1" regex="$2" matches found
+  matches=$(grep -oE "$regex" "$README" || true)
+  local n
+  n=$(printf '%s\n' "$matches" | grep -c . || true)
+
+  if (( n == 0 )); then
+    echo "::error file=${README}::Could not find the ${label} count claim (expected prose matching /${regex}/). If the wording changed, update skill-catalog-lint.sh to match."
+    errors=$((errors + 1))
+    return
+  fi
+  if (( n > 1 )); then
+    echo "::error file=${README}::The ${label} count claim matched ${n} times (expected exactly 1) — the anchor is ambiguous. Reword README or tighten skill-catalog-lint.sh."
+    errors=$((errors + 1))
+    return
+  fi
+
+  found=$(printf '%s\n' "$matches" | grep -oE '[0-9]+')
+  # 10# forces base-10: a leading zero would otherwise be read as octal and
+  # abort the script on an invalid digit (same guard rule-lint.sh uses).
+  if (( 10#$found != unique_count )); then
+    echo "::error file=${README}::The ${label} count says ${found} but the table has ${unique_count} commands"
+    errors=$((errors + 1))
+  fi
+}
+
+check_count_anchor "'What You Get' bullet" '[0-9]+ slash commands'
+check_count_anchor "'Slash Commands' intro" 'All [0-9]+ commands are invoked'
+
+if (( errors > 0 )); then
+  echo "skill-catalog-lint: ${errors} error(s) found"
+  exit 1
+fi
+
+echo "skill-catalog-lint: OK"

--- a/.github/scripts/skill-catalog-lint.sh
+++ b/.github/scripts/skill-catalog-lint.sh
@@ -61,11 +61,19 @@ fi
 # --- 1. Catalog alignment check ------------------------------------------
 # Table rows look like:
 #   | `/pm` | PM | Active PM orchestrator — ... |
-# Anchoring on '^| `/' scopes the match to command rows, so inline `/foo`
-# references in prose or other tables aren't misread as catalog entries.
+# Scoped to the '## Slash Commands' section (up to the next '## ' header) so
+# a command-shaped row in an unrelated table elsewhere in the README isn't
+# misread as a catalog entry.
 # `|| true` keeps a no-match grep (exit 1) from killing the script under
 # `set -euo pipefail`; the empty case is handled by the comm logic below.
-documented_all=$(grep -oE '^\| `/[a-z0-9-]+`' "$README" \
+catalog_section=$(awk '
+  /^## Slash Commands/ { in_section=1; next }
+  in_section && /^## / { exit }
+  in_section { print }
+' "$README")
+
+documented_all=$(printf '%s\n' "$catalog_section" \
+  | grep -oE '^\| `/[a-z0-9-]+`' \
   | sed 's/^| `\///; s/`$//' \
   | sort || true)
 documented=$(printf '%s\n' "$documented_all" | sort -u)

--- a/.github/scripts/skill-catalog-lint.sh
+++ b/.github/scripts/skill-catalog-lint.sh
@@ -123,10 +123,6 @@ while IFS= read -r s; do
   fi
 done <<< "$actual"
 
-if (( errors == 0 )); then
-  echo "Skill catalog alignment: OK (${unique_count} commands)"
-fi
-
 # --- 4. Hardcoded count check --------------------------------------------
 # Each anchor must appear exactly once. Zero matches (someone reworded the
 # prose) or several (an ambiguous target) is an error, not a pass — otherwise
@@ -165,4 +161,4 @@ if (( errors > 0 )); then
   exit 1
 fi
 
-echo "skill-catalog-lint: OK"
+echo "skill-catalog-lint: OK (${unique_count} commands)"

--- a/.github/scripts/tests/skill-catalog-lint.test.sh
+++ b/.github/scripts/tests/skill-catalog-lint.test.sh
@@ -74,6 +74,19 @@ expect() {
 
 noop() { :; }
 
+# Inserts a command-shaped row ("| `/decoy` | ... |") before the
+# '## Slash Commands' header, simulating an unrelated table elsewhere in the
+# README that happens to start a row the same way a catalog row does.
+insert_decoy_row_before_catalog() {
+  local tmp
+  tmp=$(mktemp)
+  awk '
+    { print }
+    /^# Fixture/ && !done { print "\n| `/decoy` | Fake | Should be ignored |"; done=1 }
+  ' README.md > "$tmp"
+  mv "$tmp" README.md
+}
+
 # --- passing case ---------------------------------------------------------
 expect "well-formed catalog passes" 0 'skill-catalog-lint: OK' noop
 
@@ -97,6 +110,11 @@ expect "duplicate row fails" 1 \
 expect "skill dir without SKILL.md fails" 1 \
   'gamma/ has no SKILL.md' \
   bash -c 'mkdir -p .claude/skills/gamma && printf "%s\n" "| \`/gamma\` | PM | No skill file |" >> README.md'
+
+# --- section-scoping regression (CodeAnt finding on PR #594) ---------------
+expect "row outside Slash Commands section is ignored" 0 \
+  'skill-catalog-lint: OK' \
+  insert_decoy_row_before_catalog
 
 # --- count-anchor failures ------------------------------------------------
 expect "stale 'slash commands' count fails" 1 \

--- a/.github/scripts/tests/skill-catalog-lint.test.sh
+++ b/.github/scripts/tests/skill-catalog-lint.test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Unit tests for skill-catalog-lint.sh (issue #591)
+#
+# The lint reads repo-root-relative paths, so each case builds a throwaway
+# fixture tree and runs the script with that tree as cwd.
+#
+# Every failure mode gets an explicit case: a guard asserted only on
+# well-formed input would pass without proving it catches anything.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LINT="${REPO_ROOT}/.github/scripts/skill-catalog-lint.sh"
+
+TMP_ROOT=$(mktemp -d -t skill-catalog-lint.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+case_num=0
+
+# Build a well-formed fixture: 2 skills, 2 matching rows, both counts = 2.
+make_fixture() {
+  local dir="$1"
+  mkdir -p "$dir/.claude/skills/alpha" "$dir/.claude/skills/beta"
+  echo "alpha" > "$dir/.claude/skills/alpha/SKILL.md"
+  echo "beta" > "$dir/.claude/skills/beta/SKILL.md"
+  cat > "$dir/README.md" <<'EOF'
+# Fixture
+
+- **Manage your project** — 2 slash commands for testing.
+
+## Slash Commands
+
+All 2 commands are invoked as `/command` in a Claude Code session.
+
+| Command | Category | Description |
+|---------|----------|-------------|
+| `/alpha` | PM | First |
+| `/beta` | Workflow | Second |
+EOF
+}
+
+# expect <name> <expected-exit> <expected-output-regex> <mutator...>
+# Builds a fresh fixture, applies the mutator, then asserts BOTH the exit
+# status and that the output matches the regex. Asserting the message too
+# is what stops a case from passing on an unrelated error (a typo or a
+# syntax break also exits non-zero, and would otherwise look like a pass).
+expect() {
+  local name="$1" want="$2" want_re="$3"; shift 3
+  case_num=$((case_num + 1))
+  local dir="${TMP_ROOT}/case${case_num}"
+  make_fixture "$dir"
+  ( cd "$dir" && "$@" )
+
+  local out got
+  out=$(cd "$dir" && bash "$LINT" 2>&1) && got=0 || got=$?
+
+  if (( got != want )); then
+    echo "FAIL — ${name}: expected exit ${want}, got ${got}"
+    echo "$out" | sed 's/^/       /'
+    failures=$((failures + 1))
+    return
+  fi
+
+  if ! grep -qE "$want_re" <<< "$out"; then
+    echo "FAIL — ${name}: exit ${got} as expected, but output did not match /${want_re}/"
+    echo "$out" | sed 's/^/       /'
+    failures=$((failures + 1))
+    return
+  fi
+
+  echo "ok   — ${name}"
+}
+
+noop() { :; }
+
+# --- passing case ---------------------------------------------------------
+expect "well-formed catalog passes" 0 'skill-catalog-lint: OK' noop
+
+# --- alignment failures ---------------------------------------------------
+# Each mutator isolates one failure mode: the added skill gets a SKILL.md so
+# only the missing-row error fires, and the phantom case deletes a directory
+# (rather than adding a row) so the row count still matches both anchors.
+expect "skill dir with no README row fails" 1 \
+  "Skill 'gamma' exists in .* but has no row" \
+  bash -c 'mkdir -p .claude/skills/gamma && echo gamma > .claude/skills/gamma/SKILL.md'
+
+expect "README row with no skill dir fails" 1 \
+  "README documents '/beta' but no such skill exists" \
+  rm -rf .claude/skills/beta
+
+# --- structural failures --------------------------------------------------
+expect "duplicate row fails" 1 \
+  "Command '/alpha' has more than one row" \
+  bash -c 'printf "%s\n" "| \`/alpha\` | PM | Dupe |" >> README.md'
+
+expect "skill dir without SKILL.md fails" 1 \
+  'gamma/ has no SKILL.md' \
+  bash -c 'mkdir -p .claude/skills/gamma && printf "%s\n" "| \`/gamma\` | PM | No skill file |" >> README.md'
+
+# --- count-anchor failures ------------------------------------------------
+expect "stale 'slash commands' count fails" 1 \
+  "count says 9 but the table has 2" \
+  sed -i.bak 's/2 slash commands/9 slash commands/' README.md
+
+expect "stale 'All N commands' count fails" 1 \
+  "count says 9 but the table has 2" \
+  sed -i.bak 's/All 2 commands/All 9 commands/' README.md
+
+expect "missing 'slash commands' anchor fails" 1 \
+  'Could not find.*count claim' \
+  sed -i.bak '/slash commands/d' README.md
+
+expect "missing 'All N commands' anchor fails" 1 \
+  'Could not find.*count claim' \
+  sed -i.bak '/All 2 commands are invoked/d' README.md
+
+expect "ambiguous duplicated anchor fails" 1 \
+  'matched 2 times.*anchor is ambiguous' \
+  bash -c 'printf "%s\n" "All 2 commands are invoked again." >> README.md'
+
+# --- CLI contract ---------------------------------------------------------
+case_num=$((case_num + 1))
+help_dir="${TMP_ROOT}/case${case_num}"
+make_fixture "$help_dir"
+if (cd "$help_dir" && bash "$LINT" --help >/dev/null 2>&1); then
+  echo "ok   — --help exits 0"
+else
+  echo "FAIL — --help should exit 0"
+  failures=$((failures + 1))
+fi
+
+got=0
+(cd "$help_dir" && bash "$LINT" --bogus >/dev/null 2>&1) || got=$?
+if (( got == 2 )); then
+  echo "ok   — unknown arg exits 2"
+else
+  echo "FAIL — unknown arg: expected exit 2, got ${got}"
+  failures=$((failures + 1))
+fi
+
+# --- real repo ------------------------------------------------------------
+if (cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1); then
+  echo "ok   — real repo catalog is in sync"
+else
+  echo "FAIL — lint does not pass against the real repo"
+  (cd "$REPO_ROOT" && bash "$LINT" 2>&1 | sed 's/^/       /') || true
+  failures=$((failures + 1))
+fi
+
+if (( failures > 0 )); then
+  echo "skill-catalog-lint.test: ${failures} failure(s)"
+  exit 1
+fi
+
+echo "OK: skill-catalog-lint tests passed (${case_num} fixtures)"

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -53,6 +53,9 @@ jobs:
       - name: escalate-review.sh BugBot failure detection unit test (issue #552)
         run: bash .claude/scripts/tests/escalate-review.test.sh
 
+      - name: skill-catalog-lint unit tests (issue #591)
+        run: bash .github/scripts/tests/skill-catalog-lint.test.sh
+
       - name: skill-usage-merge unit test (issue #572)
         run: bash .claude/scripts/tests/skill-usage-merge.test.sh
 

--- a/.github/workflows/rule-lint.yml
+++ b/.github/workflows/rule-lint.yml
@@ -1,4 +1,4 @@
-name: Rule Index & Word Count Lint
+name: Rule Index, Skill Catalog & Word Count Lint
 
 on:
   workflow_dispatch: {}
@@ -8,6 +8,9 @@ permissions:
   contents: read
 
 jobs:
+  # The job id is the required status-check name on main. Do not rename it or
+  # add a `name:` — either would silently drop the check from branch protection.
+  # New doc lints belong here as steps so they inherit that gate (issue #591).
   rule-lint:
     runs-on: ubuntu-latest
     steps:
@@ -18,3 +21,6 @@ jobs:
 
       - name: Run rule-lint
         run: bash .github/scripts/rule-lint.sh
+
+      - name: Run skill-catalog-lint
+        run: bash .github/scripts/skill-catalog-lint.sh

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ ls -la ~/.claude/skills/       # each skill -> ~/.claude/skills-worktree/.claude
 
 ## Slash Commands
 
-The 21 core commands below are invoked as `/command` in a Claude Code session. All commands are defined as skill files in `.claude/skills/` and symlinked globally; operational companions (`/babysit-pr`, `/pr-monitor-and-manage`, `/merge-conflict`, and their stop/wake helpers) live there too but are not cataloged individually.
+All 27 commands are invoked as `/command` in a Claude Code session. They are defined as skill files in `.claude/skills/` and symlinked globally.
 
 | Command | Category | Description |
 |---------|----------|-------------|
@@ -143,12 +143,18 @@ The 21 core commands below are invoked as `/command` in a Claude Code session. A
 | `/issue-maker` | Planning | Capture-only thread mode — drafts and opens well-structured issues, reflects before writing, no implementation |
 | `/fixpr` | Review | Single-pass PR cleanup — fixes review findings and CI failures, replies to findings, resolves threads |
 | `/monitor` | Review | Audit all open PRs for engagement from the 4 AI reviewers (CodeRabbit/CodeAnt/BugBot/Graphite); render a gap matrix and post missing triggers after confirmation |
+| `/babysit-pr` | Review | Watch one PR on a recurring loop and auto-dispatch `/fixpr` or `/wrap` until it merges or hard-blocks |
+| `/babysit-pr-stop` | Review | Clean-cancel companion to `/babysit-pr` — stops the watcher for one PR |
+| `/pr-monitor-and-manage` | Review | PR fleet manager — rediscover open PRs each tick and drive the per-PR decision tree until the fleet is clean |
+| `/pr-monitor-and-manage-stop` | Review | Clean-cancel companion to `/pr-monitor-and-manage` — tears down the fleet loop and its state |
+| `/pr-monitor-and-manage-wake` | Review | Resume companion to `/pr-monitor-and-manage` — wakes a paused fleet loop and re-arms it |
 | `/pr-review-help` | Review | Executive PR review — multi-PR parallel strategic analysis |
 | `/open-code-review` | Review | Run Alibaba's self-hosted `ocr` CLI as a manual/advisory reviewer (not in the merge gate) |
 | `/recap` | Workflow | Functional summary of a single PR or issue — nested bullets or table |
 | `/standup` | Workflow | Daily standup summary (single contributor) |
 | `/status` | Workflow | Dashboard of open PRs with review state |
 | `/go-on` | Workflow | Resume an interrupted review workflow |
+| `/merge-conflict` | Workflow | Classify merge/rebase conflicts against `main`, auto-resolve safe hunks, report complex ones (also dispatched from `/fixpr`) |
 | `/merge` | Workflow | Squash merge with merge gate + AC verification |
 | `/admin-merge` | Workflow | Print a user-runnable bypass command to merge a solo-owner PR blocked by `enforce_admins` (Claude never modifies branch protection) |
 | `/wrap` | Workflow | End-of-session: verify, squash merge, aggressively reset root `main`, detect follow-ups, extract lessons |


### PR DESCRIPTION
## **User description**
Closes #591

## What this changes

The README's Slash Commands table had drifted from `.claude/skills/`: **27 documented rows vs 33 skill directories**. Six user-facing skills had never appeared in the catalog, and two prose sentences hardcoded the stale count `27`.

This PR closes the gap **and** adds the guard that stops it reopening.

### 1. The six missing commands are now documented

| Command | Category |
|---------|----------|
| `/babysit-pr` | Review |
| `/babysit-pr-stop` | Review |
| `/pr-monitor-and-manage` | Review |
| `/pr-monitor-and-manage-stop` | Review |
| `/pr-monitor-and-manage-wake` | Review |
| `/merge-conflict` | Workflow |

Both hardcoded counts now read `27` (main removed six unrelated skills while this PR was in flight, per issue #582; the row-to-directory invariant still holds at the new number).

### 2. Why separate rows, not grouped companions

Issue #591 weighed folding the `-stop`/`-wake` companions into their parent's row. **Rejected:** it would permanently break the 1:1 row-to-directory relationship and force a hardcoded "except N companions" fudge factor into any guard — the same class of drift that caused this bug. Each companion instead names its parent in its description cell, which keeps the grouping benefit at zero cost to the invariant.

"Document them as internal" was also rejected as factually wrong: five carry `triggers:` + `argument-hint:` frontmatter, and `merge-conflict` is documented as directly runnable after a conflicted `git merge`/`git rebase` (it is *also* dispatched from `/fixpr` — dual-use, still user-facing).

### 3. The root-cause fix

`.github/scripts/skill-catalog-lint.sh` enforces the invariant, modeled on `rule-lint.sh` — which already guards the structurally identical `.claude/rules/` index, and which is why *that* table has never drifted. It checks:

- every `.claude/skills/*/` has a README row, and every row has a directory (both directions reported separately);
- no duplicate rows (a dupe would let the arithmetic pass while the table lies);
- every skill directory has a `SKILL.md`, keeping "directory count" and "command count" provably the same number;
- both hardcoded counts equal the row count — and each count anchor must match **exactly once**, so a future reword fails loudly instead of silently disabling the check.

### 4. CI wiring — and one constraint worth knowing

`rule-lint` is the **only** required status check on `main`. A new workflow would not be required and could go red without blocking a merge, so the lint runs as a **step inside the existing `rule-lint` job**. The job id is untouched (no `name:` override added), so the required-check name is unchanged — there's now a comment on the job saying so, since renaming it would silently drop the gate from branch protection.

## Verification highlights

The guard was validated by **negative control**, not just a green run: against the pre-fix README it fails and names all six drifted skills. The test suite was then **mutation-tested** — disabling the count check fails exactly the two count cases, disabling the alignment check fails exactly the missing-row case. Each failure case asserts the *specific* error message, so a case can't pass on an unrelated error.

## Note for #583

Issue #583 (fold `/prioritize` into `/pm`) is in flight and will remove a row. With this guard in place it will get a CI failure naming exactly what to update — that is the guard working, not a conflict.

## Local review — both CLIs unavailable, self-review used

Per `cr-local-review.md`, **a clean self-review does not satisfy the merge gate** — flagging that explicitly rather than implying local review passed. The GitHub-side reviewers are doing the real gating here.

- **CodeRabbit CLI:** dropped — returned `rate_limit` (21-minute wait, Pro tier). Not waited out deliberately: the CLI and GitHub reviews share one adaptive quota, so burning it locally would starve the GitHub merge gate, which is the one that counts.
- **CodeAnt CLI:** dropped — hung with **zero output for 240s** (known 0.5.1 silent-hang failure mode), killed at the 2-minute bound per `cr-local-review.md`.

What was verified locally instead: `bash -n` syntax on both new scripts, the pre-existing `rule-lint` still passing, the full 13-assertion test suite, the negative control, and mutation testing of the suite. `shellcheck` is not installed locally and is not a CI gate.

## Test plan

- [x] All six skills have their own row in the README Slash Commands table
- [x] Each companion row's description names its parent command
- [x] Both hardcoded counts (README ~L34, ~L130) read `27` and match the row count (count shifted from 33 to 27 after main's unrelated six-skill removal, issue #582, landed under this PR during rebase)
- [x] `grep -c '^| `/' README.md` equals `ls -d .claude/skills/*/ | wc -l` (27 == 27)
- [x] Lint fails when a skill directory has no README row
- [x] Lint fails when a README row has no skill directory
- [x] Lint fails when either hardcoded count disagrees with the row count
- [x] Lint fails when a count anchor is missing or ambiguous
- [x] Lint fails on a duplicate row and on a skill directory without `SKILL.md`
- [x] `bash .github/scripts/tests/skill-catalog-lint.test.sh` passes (14 assertions — added a regression test for a CodeAnt-flagged section-scoping fix during merge cleanup)
- [x] Negative control: lint fails against the pre-fix README and names all six skills
- [x] Lint runs inside the existing `rule-lint` job and the required-check name `rule-lint` is unchanged
- [x] Pre-existing `rule-lint` still passes
- [x] Both local review CLIs unavailable this session (CR rate-limited, CodeAnt silent-hang) — drops documented above; self-review does not satisfy the merge gate


___

## **CodeAnt-AI Description**
**Document the full slash-command catalog and add a guard to keep it in sync**

### What Changed
- Adds the missing slash commands to the README catalog and updates the command count to 27
- Clarifies that all listed commands come from `.claude/skills/`, including the new review and workflow companions
- Adds a lint check that fails if the README catalog drifts from the skill directories, has duplicate rows, misses `SKILL.md` files, or has stale command counts
- Adds automated tests for the lint check and runs it in CI

### Impact
`✅ Fewer missing slash commands in the README`
`✅ Fewer catalog drift regressions`
`✅ Clearer command list for users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
