### PR TITLE
fix(#589): ac-checkboxes.sh --tick/--all-pass broken by GitHub projectCards deprecation

### DIFF
--- a/.claude/scripts/ac-checkboxes.sh
+++ b/.claude/scripts/ac-checkboxes.sh
@@ -4,8 +4,12 @@
 # Parse Markdown checkboxes from the PR body's `## Test plan` section (case-
 # insensitive match; also accepts `## Test Plan` and `## Acceptance Criteria`),
 # then either emit them as JSON or flip `- [ ]` to `- [x]` via
-# `gh pr edit --body-file` (using --body-file, not --body, preserves the body's
-# exact whitespace and trailing-newline profile).
+# `gh api repos/{owner}/{repo}/pulls/{N} -X PATCH -F body=@file` (using a file
+# argument, not an inline string, preserves the body's exact whitespace and
+# trailing-newline profile). The REST endpoint is used instead of
+# `gh pr edit --body-file` because gh's edit command pre-fetches the PR via a
+# GraphQL query that still selects the deprecated `projectCards` field, which
+# GitHub now rejects — see issue #589.
 #
 # Implements the AC-verification contract from .claude/rules/cr-merge-gate.md
 # Step 2. Call sites: /merge, /wrap, /go-on, /subagent, phase-c-merger.
@@ -46,11 +50,11 @@
 #   2  Usage error (or internal script error — e.g., python parse failure,
 #      missing prerequisite)
 #   3  PR not found (or closed/merged — `gh pr view` failed)
-#   4  `gh pr edit --body-file` failed (only reachable from --tick/--all-pass)
+#   4  `gh api ... -X PATCH` failed (only reachable from --tick/--all-pass)
 #
 # Notes:
-#   - `gh pr edit --body-file` replaces the entire body; this script fetches
-#     first, mutates in memory, and writes back via --body-file to preserve
+#   - The PATCH call replaces the entire body; this script fetches first,
+#     mutates in memory, and writes back via a file argument to preserve
 #     all non-Test-Plan content verbatim (trailing newlines included).
 #   - --tick and --all-pass are no-ops (exit 0) when nothing needs ticking.
 #   - For --tick with no matches, exit is 0 and a note is printed to stderr.
@@ -407,10 +411,13 @@ case "$RESULT" in
   updated)
     BODY_PATH=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["body_path"])' "$PY_OUT")
     TICKED=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); t=d["ticked"]; n=d["items"]; print(f"ticked {len(t)} of {n} items: {t}")' "$PY_OUT")
-    # gh pr edit --body-file reads the full body verbatim (preserves newlines).
+    # Use the REST endpoint (not `gh pr edit`) to update the body: gh's edit
+    # command pre-fetches the PR via a GraphQL query that still selects the
+    # deprecated `projectCards` field, which GitHub now rejects (issue #589).
+    # `-F body=@file` reads the full body verbatim (preserves newlines).
     EDIT_ERR_FILE="$TMPDIR_AC/edit-stderr"
-    if ! gh pr edit "$PR_NUMBER" --body-file "$BODY_PATH" >/dev/null 2>"$EDIT_ERR_FILE"; then
-      echo "ERROR: gh pr edit failed for PR #$PR_NUMBER:" >&2
+    if ! gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER" -X PATCH -F body=@"$BODY_PATH" >/dev/null 2>"$EDIT_ERR_FILE"; then
+      echo "ERROR: gh api PATCH failed for PR #$PR_NUMBER:" >&2
       cat "$EDIT_ERR_FILE" >&2
       exit 4
     fi


### PR DESCRIPTION
## **User description**
## Summary
- `.claude/scripts/ac-checkboxes.sh`'s write path (`--tick`/`--all-pass`) shelled out to `gh pr edit --body-file`, which GitHub now rejects because `gh`'s edit command pre-fetches the PR via a GraphQL query that still selects the deprecated `projectCards` field.
- Replaced the write path with `gh api "repos/{owner}/{repo}/pulls/{N}" -X PATCH -F body=@file`, which doesn't touch `projectCards`.
- `--extract` (read-only) was unaffected and is unchanged. Exit-code contract (`0/1/2/3/4`) is preserved — exit `4` is now `gh api PATCH` failure instead of `gh pr edit` failure.

Closes #589

## Test plan
- [x] On an open PR with unchecked Test-plan boxes, run `--all-pass`; verify exit 0 and boxes flipped on GitHub
- [x] Run `--tick` with a subset; verify only those indexes flip
- [x] Verify `--extract` round-trips (`checked` values match the rendered PR body)
- [x] No remaining `gh pr edit --body` call in the write path


___

## **CodeAnt-AI Description**
Fix checkbox updates on PR test plans when GitHub blocks the old edit flow

### What Changed
- Updating checked items in a PR’s Test Plan now uses GitHub’s direct PR update path, so `--tick` and `--all-pass` work again
- The script keeps preserving the PR body’s existing spacing and line breaks when it writes changes back
- Read-only extraction stays the same, and the exit codes for success, no test plan, and update failure are unchanged

### Impact
`✅ Restored Test Plan checkbox updates`
`✅ Fewer PR automation failures`
`✅ Preserved PR body formatting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
