### PR TITLE
fix(#596): refine /pm ranking logic — dependency-map freshness, in-flight-PR source, tier precedence

### DIFF
--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -166,8 +166,8 @@ gh pr list --state merged --limit 20 --json number,title,mergedAt,author,body
 # Open issues — the backlog
 gh issue list --state open --json number,title,labels,assignees,createdAt,updatedAt --limit 500
 
-# Open PRs — detect in-flight work
-gh pr list --state open --json number,title,headRefName,author,updatedAt,additions,deletions
+# Open PRs — detect in-flight work (body is required to scan for Fixes/Closes #N)
+gh pr list --state open --json number,title,headRefName,author,updatedAt,additions,deletions,body
 
 # User-scoped views (only if $GH_USER is set from Step 0)
 if [ -n "$GH_USER" ]; then
@@ -208,7 +208,7 @@ Extract from each:
 - Dependency references, from the body **and** comments:
   - Blocked direction: `blocked by #N`, `depends on #N`, `prerequisite for #N`, `after #N`
   - Unblocking direction: `unblocks #N`, `enables #N`, `required by #N`, `before #N`
-  - In-flight signal: `Fixes #N`, `Closes #N` (a PR may already exist)
+- In-flight signal: cross-reference against the open-PR list already fetched in 1B.2 (now includes `body`) — a PR body containing a GitHub closing keyword (`close`/`closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`, case-insensitive) for this issue's number means a PR is already underway; match both local (`#N`) and cross-repo (`owner/repo#N`) reference forms. GitHub's closing keywords live in PR bodies, not in the issue's own text, so this signal is never collected from the issue body or comments — same source Section 3.3's progress detection reuses.
 - Complexity signals: number of acceptance criteria, files mentioned, architectural scope
 - Current assignee — who, if anyone, is already on it
 
@@ -224,6 +224,8 @@ Sort candidates into four tiers — **Critical**, **High**, **Medium**, **Low**.
 - **Low** — tangential, or serves a different goal entirely.
 
 **With no stated goal (the default)**, the priority signals in (1) below set the tier instead. Either way, (2)-(6) then apply to every candidate.
+
+**Precedence:** the initial tier always comes from goal-alignment (if a goal is stated) or priority-signals (1) otherwise. Leverage (2) and OKR (3) never set the tier on their own — they only modify it afterward, and only upward: leverage via an explicit tier-jump, OKR via the one-tier boost or tie-break rules in (3), never a downgrade. Momentum (4), cost-benefit (5), and exclusions (6) don't touch the tier at all — they refine ordering and the candidate pool within whatever tier (2)-(3) leave it in.
 
 1. **Priority signals:**
    - Labels: `P0`/`critical` > `P1`/`bug` > `P2`/`enhancement` > unlabeled
@@ -247,7 +249,7 @@ Sort candidates into four tiers — **Critical**, **High**, **Medium**, **Low**.
 5. **Cost-benefit (tie-break within a tier):** at equal alignment, the smaller issue wins. Read effort from `complexity:quick|light|medium|heavy` labels when present, otherwise from scope signals in the body (count of acceptance criteria, files mentioned, architectural reach).
 
 6. **Exclusions:**
-   - Skip issues that already have an open PR (someone is working on it — `Fixes #N` / `Closes #N` in an open PR body means in flight)
+   - Skip issues that already have an open PR (per the in-flight signal cross-referenced in 1B.3 — a closing keyword in an open PR body means in flight)
    - Skip issues assigned to someone else (unless stale > 14 days)
    - Skip issues labeled `blocked`, `on-hold`, `wontfix`, `duplicate`
 
@@ -510,7 +512,7 @@ Also accept user input: "thread for #42 is done", "PR #88 merged", "#55 is block
 When one or more threads finish (PRs merged, issues closed):
 
 1. **Dismiss the chips of finished issues, then remove their rows.** Order matters: a row carries its chip's `task_id`, and once the row is gone the chip can no longer be withdrawn. So for every completed issue still at `Chip offered`, `dismiss_task` first — its work is done, the offer is dead — and only then drop it from the assignments table.
-2. Re-scan open issues (reuse 1B.2-1B.4b logic but lighter — only re-read bodies for new/changed issues). **Re-score the whole retained candidate set, not just the changed issues:** tiers depend on the dependency map, so a closed or merged issue can change an *unchanged* issue's tier — #42 loses its leverage boost the moment the issues it unblocked are done. Refresh the map with what closed, then re-run 1B.4/1B.4b across every remaining candidate. Re-reading bodies is the expensive part and stays incremental; re-scoring is cheap and must be total.
+2. Re-scan open issues (reuse 1B.2-1B.4b logic but lighter — only re-read bodies **and comments** for issues whose `updatedAt` moved since the last scan's baseline, or that have no recorded baseline yet (first seen this pass — always gets a full read, same as a changed issue); track/update that baseline per issue as you go). **`updatedAt` bumps on a new comment just like a body edit**, so a dependency reference added in a comment on an otherwise-untouched issue (e.g. "blocked by #99") is still caught on the next pass — re-reading is scoped by *any* change, not just body/title edits, which is what keeps this from being a real completeness gap. **Re-score the whole retained candidate set, not just the changed issues:** tiers depend on the dependency map, so a closed or merged issue can change an *unchanged* issue's tier — #42 loses its leverage boost the moment the issues it unblocked are done. Refresh the map with what closed **and** what changed, then re-run 1B.4/1B.4b across every remaining candidate. Re-reading bodies and comments stays scoped to issues whose `updatedAt` moved or that are new — that's the expensive part and it stays incremental; re-scoring the dependency map and tiers is cheap and must be total.
 3. Suggest 1-3 new issues to fill the pipeline
 4. Generate prompts for the user's selected issues (Step 3.1 — chip or fallback)
 5. **Dismiss superseded and re-planned chips.** Beyond the finished issues handled in step 1, withdraw a `Chip offered` chip only when its offer is genuinely dead:


### PR DESCRIPTION
## **User description**
## Summary

Follow-up from PR #595 (issue #583) — CodeRabbit flagged 3 "major" design-refinement findings during that PR's rebase, filed as issue #596 since #595 was already approved/CI-green. This PR fixes all three in `.claude/skills/pm/SKILL.md`:

1. **3.4 dependency-map freshness** — the incremental re-scan now tracks a per-issue `updatedAt` baseline instead of a vague "new/changed" check. Since GitHub bumps `updatedAt` on a new comment just like a body edit, a dependency reference dropped in a comment on an otherwise-untouched issue (e.g. "blocked by #99") is now caught on the next pass. First-seen issues with no recorded baseline always get a full read too (closes a gap CodeAnt's local review caught on the first fix pass).

2. **1B.3 in-flight-PR signal source** — was instructing a scan of the issue's own body/comments for `Fixes #N`/`Closes #N`, which never fires since GitHub's closing keywords live in PR bodies, not issue text. Now cross-references the open-PR list already fetched in 1B.2 (extended to fetch `body`), matching the source 1B.4's exclusion logic and Section 3.3 already use correctly. Also broadened to recognize all GitHub-recognized closing keywords (`close`/`fix`/`resolve` and inflections, case-insensitive) plus cross-repo `owner/repo#N` references, not just the two literal forms (CodeRabbit local-review finding).

3. **Tier-precedence ambiguity** — added one explicit sentence in 1B.4: the initial tier always comes from goal-alignment (if a goal is stated) or priority-signals otherwise; leverage and OKR can only raise the tier afterward (never lower it), following their existing sub-case rules; momentum/cost-benefit/exclusions don't touch the tier at all.

## Local review note

CodeRabbit CLI delivered one valid finding on an early pass (fixed — see point 2 above), then hit a rate limit (49-min wait) on the verification re-run. Per `cr-local-review.md`'s timeout/fallback rule, it was dropped for the session; CodeAnt CLI came back clean (0 issues) on the final pass. GitHub review polling (CodeRabbit/BugBot/etc.) will still run against this PR.

Closes #596

## Test plan

- [x] 1B.3/1B.4 in-flight-PR detection is verified to work against real PR data (not issue comment text)
- [x] 3.4's dependency-map refresh behavior (comments-on-unchanged-issues) is either fixed or explicitly documented as a known limitation
- [x] Tier-precedence rule (goal/priority-signal → leverage/OKR modifiers) is stated unambiguously in one place

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Refine issue ranking rules for open work and comment-based updates**

### What Changed
- Open PR checks now look at PR body text, so issues are marked as in progress when a linked PR uses GitHub closing words like “fixes” or “closes,” including cross-repo links.
- Re-scans now pick up dependency notes added in comments as well as body edits, and first-seen issues always get a full read.
- Tier assignment rules now state a clear order: goal alignment or priority signals set the starting tier, and later checks can only raise it, not lower it.

### Impact
`✅ Fewer duplicate issues`
`✅ Fewer missed in-progress PRs`
`✅ More accurate issue ranking after new comments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>