### PR TITLE
fix(#590): replace HEAD committer-date proxy with the timeline force-push event

### DIFF
--- a/.claude/scripts/pr-preflight.sh
+++ b/.claude/scripts/pr-preflight.sh
@@ -14,9 +14,11 @@
 #        coderabbitai[bot], cursor[bot], graphite-app[bot], decide whether that
 #        reviewer is engaged ON THE CURRENT HEAD SHA (issue #576). Scans all 3
 #        PR endpoints (pulls/reviews, pulls/comments, issues/comments,
-#        per_page=100) plus the HEAD commit's check-runs. A reviewer counts as
-#        engaged only when it has a HEAD-fresh artifact, or we already posted
-#        its trigger for this HEAD. Otherwise the trigger comment is posted.
+#        per_page=100) plus the HEAD commit's check-runs and, for the
+#        SHA-less issue-comment path only, the PR timeline (issue #590). A
+#        reviewer counts as engaged only when it has a HEAD-fresh artifact,
+#        or we already posted its trigger for this HEAD. Otherwise the
+#        trigger comment is posted.
 #        Greptile is intentionally NOT triggered (stays manual per greptile.md).
 #        Before posting `@coderabbitai full review`, gate on
 #        cr-review-hourly.sh (--check global budget + read-only --peek-explicit
@@ -44,30 +46,57 @@
 #     • a review (pulls/reviews) with .commit_id == HEAD
 #     • an inline comment (pulls/comments) with .commit_id == HEAD
 #     • a check-run on the HEAD commit whose .app.slug maps to that reviewer
-#     • an issue comment (issues/comments) created at/after the HEAD commit's
-#       committer date — issue comments carry NO SHA, so a timestamp comparison
-#       is the only signal available for them
+#     • an issue comment (issues/comments) created at/after the HEAD-freshness
+#       anchor — issue comments carry NO SHA, so a timestamp comparison is the
+#       only signal available for them. The anchor prefers the PR timeline's
+#       head_ref_force_pushed/head_ref_pushed event timestamp (GitHub's own
+#       clock, stamped when the ref actually moved) and falls back to the HEAD
+#       commit's committer date when no such event exists or the timeline call
+#       fails (issue #590; see LIMITATION and DEGRADATION below).
 #
 #   Trigger-comment idempotency is scoped the same way: a trigger posted before
 #   the current HEAD existed is stale and does not suppress a fresh trigger.
 #
-#   LIMITATION (SHA-less issue comments): the HEAD committer date is a proxy for
-#   "when HEAD appeared". A rebase stamps the committer date at rebase time,
-#   which can precede the push by minutes; a bot comment about the OLD sha that
-#   lands in that window is misread as fresh. The window is narrow and the
-#   failure mode is benign — a skipped re-trigger, i.e. the pre-#576 behavior.
-#   Closing it would need the timeline's head_ref_force_pushed event (another
-#   paginated call per check).
+#   LIMITATION (SHA-less issue comments, narrowed by #590): the committer-date
+#   proxy had two gaps — a rebase stamps the committer date at REBASE time,
+#   which can precede the push by minutes, so a stale-sha comment landing in
+#   that window read as fresh; and the committer date is the LOCAL git clock,
+#   which can disagree with GitHub's clock by seconds in either direction
+#   (observed live on PR #586: an APPROVED review timestamped ~29s before its
+#   own reviewed commit's committer date). The timeline's
+#   head_ref_force_pushed/head_ref_pushed event — GitHub's own clock, stamped
+#   after the ref actually moved — closes both gaps when it exists. What
+#   remains: a PR whose HEAD has never been rebased/force-pushed has no such
+#   event, so its SHA-less issue-comment freshness still falls back to the
+#   HEAD committer date and inherits that proxy's narrower clock-skew exposure
+#   (no rebase means no rebase-window gap, just ordinary clock disagreement).
+#   Same failure mode as before, same benign direction — a skipped re-trigger,
+#   never a false one.
 #
 # DEGRADATION (deliberately asymmetric — fail toward silence, never toward
 # spamming four bots every tick)
-#   • HEAD committer date unavailable → SHA-less issue comments count as present
-#     (pre-#576 behavior), surfaced as a warning.
-#   • HEAD committer date in the FUTURE (skewed clock on whoever committed) →
-#     same path. Otherwise every real comment looks older than HEAD, i.e. every
-#     reviewer stale, spending a CodeRabbit slot for nothing.
+#   • Timeline fetch fails, or returns no head_ref_force_pushed/head_ref_pushed
+#     event → falls back to the HEAD commit's committer date (unchanged #576
+#     proxy). A fetch failure is surfaced as a warning; no matching event is
+#     the common, expected case for a PR that has never been rebased and is
+#     silent (it is not an error).
+#   • HEAD committer date unavailable (fallback path only) → SHA-less issue
+#     comments count as present (pre-#576 behavior), surfaced as a warning.
+#   • HEAD committer date in the FUTURE (fallback path only; skewed clock on
+#     whoever committed) → same path. Otherwise every real comment looks older
+#     than HEAD, i.e. every reviewer stale, spending a CodeRabbit slot for
+#     nothing.
 #   • check-runs fetch fails → that one signal is skipped; reviews and inline
 #     comments still decide.
+#
+# API COST (issue #590)
+#   One additional paginated call — repos/{owner}/{repo}/issues/{N}/timeline —
+#   per pre-flight run, on top of the existing 5 (PR view, 3 endpoint scans,
+#   commit, check-runs). Measured locally against a real (small) PR's timeline
+#   on this repo: ~0.7s wall-clock for the call alone. Pre-flight runs once per
+#   PR per tick in /babysit-pr and /pr-monitor-and-manage, so this is one extra
+#   sub-second `gh api` round-trip per PR per tick — not re-measured against a
+#   large/long-lived PR's full timeline history, which would paginate further.
 #
 # USAGE
 #   pr-preflight.sh <pr_number> [--json] [--dry-run]
@@ -271,8 +300,9 @@ CURRENT_USER="$(gh api user --jq .login 2>/dev/null || echo "")"
 # fields needed to decide freshness against HEAD.
 ARTIFACTS_TMP="$(mktemp)"   # login US commit_id US created_at US collapsed_body
 SLUGS_TMP="$(mktemp)"       # app.slug of each check-run on the HEAD commit
+TIMELINE_TMP="$(mktemp)"    # created_at of each head_ref_force_pushed/head_ref_pushed event
 GH_ERR="$(mktemp)"
-trap 'rm -f "$PR_VIEW_ERR" "$ARTIFACTS_TMP" "$SLUGS_TMP" "$GH_ERR" 2>/dev/null' EXIT
+trap 'rm -f "$PR_VIEW_ERR" "$ARTIFACTS_TMP" "$SLUGS_TMP" "$TIMELINE_TMP" "$GH_ERR" 2>/dev/null' EXIT
 
 # SHA field: prefer .original_commit_id, fall back to .commit_id.
 #
@@ -319,29 +349,53 @@ for endpoint in \
   fi
 done
 
-# HEAD committer date — the only freshness signal for SHA-less issue comments.
-# Failure is NON-fatal and degrades to pre-#576 behavior (see DEGRADATION).
-HEAD_DATE=""
+# HEAD freshness anchor for SHA-less issue comments (issue #590). Preferred
+# source: the PR timeline's head_ref_force_pushed/head_ref_pushed event —
+# GitHub's own clock, stamped when the ref actually moved. Falls back to the
+# HEAD commit's committer date (the original #576 proxy, logic unchanged
+# below) when no such event exists or the timeline call fails. Either stage
+# failing is NON-fatal (see DEGRADATION).
+TIMELINE_JQ='.[]? | select(.event=="head_ref_force_pushed" or .event=="head_ref_pushed") | (.created_at // empty)'
+HEAD_PUSH_DATE=""
 if [[ -n "$HEAD_SHA" ]]; then
-  HEAD_DATE="$(gh api "repos/{owner}/{repo}/commits/$HEAD_SHA" \
-                 --jq '.commit.committer.date // ""' 2>/dev/null || echo "")"
+  if gh api --paginate "repos/{owner}/{repo}/issues/$PR/timeline?per_page=100" \
+       --jq "$TIMELINE_JQ" >"$TIMELINE_TMP" 2>"$GH_ERR"; then
+    # Latest event wins when a PR was rebased more than once. ISO-8601 UTC
+    # timestamps sort lexicographically (same rationale as at_or_after_head).
+    HEAD_PUSH_DATE="$(LC_ALL=C sort "$TIMELINE_TMP" | tail -1)"
+  else
+    surface "WARNING: could not read PR timeline for #$PR — falling back to HEAD commit committer date: $(cat "$GH_ERR")"
+  fi
 fi
-# A future-dated HEAD commit (skewed clock on whoever rebased — committer date
-# comes from that machine's clock) would make every real comment look older than
-# HEAD, i.e. every reviewer stale. The per-SHA dedupe bounds that to one trigger
-# per SHA rather than a per-tick storm, but it still spends a CodeRabbit slot for
-# nothing. Treat it as an unreadable date and take the same degradation path.
-# The false-positive direction (a *local* clock running behind GitHub's) merely
-# degrades to "present" — the safe side, consistent with the rule above.
-if [[ -z "$HEAD_DATE" ]]; then
-  surface "WARNING: could not read HEAD commit date for ${HEAD_SHA:0:7} — treating SHA-less issue comments as engaged (pre-#576 behavior); a stale reviewer may not be re-triggered this run"
+
+if [[ -n "$HEAD_PUSH_DATE" ]]; then
+  HEAD_DATE="$HEAD_PUSH_DATE"
 else
-  # `[` is a regular builtin, so an assignment prefix is legal here — unlike the
-  # `[[` keyword (see at_or_after_head).
-  NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  if LC_ALL=C [ "$HEAD_DATE" \> "$NOW_UTC" ]; then
-    surface "WARNING: HEAD commit date ($HEAD_DATE) is in the future — ignoring it (clock skew on the machine that committed?); treating SHA-less issue comments as engaged this run"
-    HEAD_DATE=""
+  # HEAD committer date — the fallback freshness signal for SHA-less issue
+  # comments. Failure is NON-fatal and degrades to pre-#576 behavior (see
+  # DEGRADATION).
+  HEAD_DATE=""
+  if [[ -n "$HEAD_SHA" ]]; then
+    HEAD_DATE="$(gh api "repos/{owner}/{repo}/commits/$HEAD_SHA" \
+                   --jq '.commit.committer.date // ""' 2>/dev/null || echo "")"
+  fi
+  # A future-dated HEAD commit (skewed clock on whoever rebased — committer date
+  # comes from that machine's clock) would make every real comment look older than
+  # HEAD, i.e. every reviewer stale. The per-SHA dedupe bounds that to one trigger
+  # per SHA rather than a per-tick storm, but it still spends a CodeRabbit slot for
+  # nothing. Treat it as an unreadable date and take the same degradation path.
+  # The false-positive direction (a *local* clock running behind GitHub's) merely
+  # degrades to "present" — the safe side, consistent with the rule above.
+  if [[ -z "$HEAD_DATE" ]]; then
+    surface "WARNING: could not read HEAD commit date for ${HEAD_SHA:0:7} — treating SHA-less issue comments as engaged (pre-#576 behavior); a stale reviewer may not be re-triggered this run"
+  else
+    # `[` is a regular builtin, so an assignment prefix is legal here — unlike the
+    # `[[` keyword (see at_or_after_head).
+    NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    if LC_ALL=C [ "$HEAD_DATE" \> "$NOW_UTC" ]; then
+      surface "WARNING: HEAD commit date ($HEAD_DATE) is in the future — ignoring it (clock skew on the machine that committed?); treating SHA-less issue comments as engaged this run"
+      HEAD_DATE=""
+    fi
   fi
 fi
 

--- a/.claude/scripts/tests/pr-preflight.test.sh
+++ b/.claude/scripts/tests/pr-preflight.test.sh
@@ -85,6 +85,8 @@ case "$sub" in
                                    [[ "$GH_CHECK_RUNS_RC" != 0 ]] && exit "$GH_CHECK_RUNS_RC" ;;
       *"/commits/"*)               fixture="${FIX_COMMIT:-}"; : "${GH_COMMIT_RC:=0}"
                                    [[ "$GH_COMMIT_RC" != 0 ]] && exit "$GH_COMMIT_RC" ;;
+      *"/issues/"*"/timeline"*)    fixture="${FIX_TIMELINE:-}"; : "${GH_TIMELINE_RC:=0}"
+                                   [[ "$GH_TIMELINE_RC" != 0 ]] && exit "$GH_TIMELINE_RC" ;;
       *"/pulls/"*"/reviews"*)  fixture="$FIX_REVIEWS" ;;
       *"/pulls/"*"/comments"*) fixture="$FIX_PULL_COMMENTS" ;;
       *"/issues/"*"/comments"*) fixture="$FIX_ISSUE_COMMENTS" ;;
@@ -184,6 +186,7 @@ write_pull_comments() { printf '%s' "$1" > "$TMP/pull_comments.json"; export FIX
 write_issue_comments() { printf '%s' "$1" > "$TMP/issue_comments.json"; export FIX_ISSUE_COMMENTS="$TMP/issue_comments.json"; }
 write_check_runs() { printf '%s' "$1" > "$TMP/check_runs.json"; export FIX_CHECK_RUNS="$TMP/check_runs.json"; }
 write_commit() { printf '%s' "$1" > "$TMP/commit.json"; export FIX_COMMIT="$TMP/commit.json"; }
+write_timeline() { printf '%s' "$1" > "$TMP/timeline.json"; export FIX_TIMELINE="$TMP/timeline.json"; }
 
 # Default view/commit/check-runs for the common case: ready PR, HEAD_SHA, known
 # HEAD date, no bot check-runs. Scenarios override as needed.
@@ -191,6 +194,10 @@ view_ready() { write_view "{\"isDraft\":false,\"author\":{\"login\":\"me\"},\"st
 view_draft() { write_view "{\"isDraft\":true,\"author\":{\"login\":\"$1\"},\"state\":\"OPEN\",\"headRefOid\":\"$HEAD_SHA\"}"; }
 commit_ok()  { write_commit "{\"commit\":{\"committer\":{\"date\":\"$HEAD_DATE\"}}}"; }
 no_checks()  { write_check_runs '{"check_runs":[]}'; }
+# No head_ref_force_pushed/head_ref_pushed event — the common case (PR never
+# rebased). Forces every scenario that doesn't opt in to a custom timeline
+# fixture to exercise the committer-date fallback, unchanged from #576.
+no_timeline() { write_timeline '[]'; unset GH_TIMELINE_RC; }
 
 run_json() {
   export GH_ACTIONS_LOG="$TMP/actions.log"
@@ -212,8 +219,8 @@ export PREFLIGHT_SESSION_STATE_SH="$TMP/no-such-session-state.sh"
 enable_state_dedupe()  { export PREFLIGHT_SESSION_STATE_SH="$STATE_STUB"; reset_state; }
 disable_state_dedupe() { export PREFLIGHT_SESSION_STATE_SH="$TMP/no-such-session-state.sh"; }
 
-# Every scenario starts from a known-good commit/check-runs baseline.
-commit_ok; no_checks
+# Every scenario starts from a known-good commit/check-runs/timeline baseline.
+commit_ok; no_checks; no_timeline
 
 ############################################################################
 echo "== Scenario 1: draft + author is me + all 4 reviewers absent =="
@@ -609,6 +616,77 @@ check_eq "the post is graphite" "1" "$(actions | grep -cF '@graphite-app re-revi
 check_eq "map REPLACED — holds graphite only, no carry-over" "graphite" \
   "$(jq -r '[.prs["493"].preflight_triggered | to_entries[] | select(.value == true) | .key] | sort | join(",")' "$STATE_JSON")"
 disable_state_dedupe
+
+############################################################################
+# Issue #590 — timeline-based freshness anchor for SHA-less issue comments,
+# replacing the committer-date-only proxy.
+############################################################################
+
+echo "== Scenario 20: REBASE WINDOW — comment on the OLD sha lands between rebase and push =="
+# The committer date is stamped at REBASE time (earliest), a bot comment about
+# the pre-rebase sha lands next, and the actual force-push (GitHub's clock, via
+# the timeline event) happens last. Under the old committer-date-only proxy the
+# comment (after the committer date) read as fresh; the timeline anchor (after
+# the comment) correctly reads it as stale, so the reviewer is re-triggered.
+REBASE_TIME="$(iso_from_now -3700)"
+COMMENT_ON_OLD_SHA="$(iso_from_now -3500)"
+PUSH_TIME_A="$(iso_from_now -3400)"
+view_ready
+write_commit "{\"commit\":{\"committer\":{\"date\":\"$REBASE_TIME\"}}}"
+write_timeline "[{\"event\":\"head_ref_force_pushed\",\"created_at\":\"$PUSH_TIME_A\",\"commit_id\":\"$HEAD_SHA\"}]"
+no_checks
+write_reviews "[{\"user\":{\"login\":\"codeant-ai[bot]\"},\"commit_id\":\"$HEAD_SHA\",\"submitted_at\":\"$PUSH_TIME_A\",\"body\":\"r\"},{\"user\":{\"login\":\"coderabbitai[bot]\"},\"commit_id\":\"$HEAD_SHA\",\"submitted_at\":\"$PUSH_TIME_A\",\"body\":\"r\"}]"
+write_pull_comments "[{\"user\":{\"login\":\"cursor[bot]\"},\"commit_id\":\"$HEAD_SHA\",\"created_at\":\"$PUSH_TIME_A\",\"body\":\"c\"}]"
+write_issue_comments "[{\"user\":{\"login\":\"graphite-app[bot]\"},\"created_at\":\"$COMMENT_ON_OLD_SHA\",\"body\":\"finding on the pre-rebase commit\"}]"
+OUT=$(run_json 493); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "rebase-window comment judged stale — graphite re-triggered" "triggered" "$(jq -r '.reviewers.graphite.status' <<<"$OUT")"
+check_eq "codeant already-present via HEAD review (unaffected)" "already-present" "$(jq -r '.reviewers.codeant.status' <<<"$OUT")"
+check_eq "coderabbit already-present via HEAD review (unaffected)" "already-present" "$(jq -r '.reviewers.coderabbit.status' <<<"$OUT")"
+check_eq "cursor already-present via HEAD comment (unaffected)" "already-present" "$(jq -r '.reviewers.cursor.status' <<<"$OUT")"
+check_eq "only graphite re-triggered" "1" "$(actions | grep -c '^COMMENT')"
+check_eq "the trigger is graphite" "1" "$(actions | grep -cF '@graphite-app re-review')"
+check_eq "clean=false" "false" "$(jq -r '.clean' <<<"$OUT")"
+no_timeline; commit_ok; no_checks
+
+echo "== Scenario 21: CLOCK SKEW — fresh comment precedes the committer date but follows the push event =="
+# Mirrors the live PR #586 observation: the committer date (local git clock)
+# can read LATER than the timeline's push event (GitHub's clock) even though
+# the push happened after the commit in real time. A bot comment posted right
+# after the real push can therefore carry a timestamp before the committer
+# date. The old committer-date-only proxy misread it as stale (wasting a
+# rate-limited CodeRabbit slot); the timeline anchor correctly reads it as
+# fresh.
+COMMITTER_DATE_SKEWED="$(iso_from_now -3600)"
+PUSH_TIME_B="$(iso_from_now -3660)"
+COMMENT_AFTER_PUSH="$(iso_from_now -3650)"
+view_ready
+write_commit "{\"commit\":{\"committer\":{\"date\":\"$COMMITTER_DATE_SKEWED\"}}}"
+write_timeline "[{\"event\":\"head_ref_force_pushed\",\"created_at\":\"$PUSH_TIME_B\",\"commit_id\":\"$HEAD_SHA\"}]"
+no_checks
+write_reviews "[{\"user\":{\"login\":\"codeant-ai[bot]\"},\"commit_id\":\"$HEAD_SHA\",\"submitted_at\":\"$PUSH_TIME_B\",\"body\":\"r\"},{\"user\":{\"login\":\"cursor[bot]\"},\"commit_id\":\"$HEAD_SHA\",\"submitted_at\":\"$PUSH_TIME_B\",\"body\":\"c\"},{\"user\":{\"login\":\"graphite-app[bot]\"},\"commit_id\":\"$HEAD_SHA\",\"submitted_at\":\"$PUSH_TIME_B\",\"body\":\"g\"}]"
+write_pull_comments "$EMPTY"
+write_issue_comments "[{\"user\":{\"login\":\"coderabbitai[bot]\"},\"created_at\":\"$COMMENT_AFTER_PUSH\",\"body\":\"fresh finding, GitHub clock slightly behind the committer's\"}]"
+OUT=$(run_json 493); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "clock-skew comment judged fresh — coderabbit stays already-present" "already-present" "$(jq -r '.reviewers.coderabbit.status' <<<"$OUT")"
+check_eq "codeant already-present via HEAD review (unaffected)" "already-present" "$(jq -r '.reviewers.codeant.status' <<<"$OUT")"
+check_eq "cursor already-present via HEAD review (unaffected)" "already-present" "$(jq -r '.reviewers.cursor.status' <<<"$OUT")"
+check_eq "graphite already-present via HEAD review (unaffected)" "already-present" "$(jq -r '.reviewers.graphite.status' <<<"$OUT")"
+check_eq "no CR trigger posted (budget not spent)" "0" "$(actions | grep -cF '@coderabbitai full review')"
+check_eq "fully clean — no comments posted at all" "0" "$(actions | grep -c '^COMMENT')"
+check_eq "clean=true" "true" "$(jq -r '.clean' <<<"$OUT")"
+no_timeline; commit_ok; no_checks
+
+echo "== Scenario 22: timeline fetch fails → falls back to committer date, no trigger storm =="
+view_ready; commit_ok; no_checks
+write_reviews "$EMPTY"; write_pull_comments "$EMPTY"
+write_issue_comments "[{\"user\":{\"login\":\"graphite-app[bot]\"},\"created_at\":\"$AFTER_HEAD\",\"body\":\"g\"},{\"user\":{\"login\":\"codeant-ai[bot]\"},\"created_at\":\"$AFTER_HEAD\",\"body\":\"x\"},{\"user\":{\"login\":\"cursor[bot]\"},\"created_at\":\"$AFTER_HEAD\",\"body\":\"y\"},{\"user\":{\"login\":\"coderabbitai[bot]\"},\"created_at\":\"$AFTER_HEAD\",\"body\":\"z\"}]"
+OUT=$(GH_TIMELINE_RC=1 run_json 493); RC=$?
+check_eq "exit 0 (timeline fetch failure is not an error)" 0 "$RC"
+check_eq "falls back to committer date — no trigger storm" "0" "$(actions | grep -c '^COMMENT')"
+check_eq "clean=true" "true" "$(jq -r '.clean' <<<"$OUT")"
+no_timeline
 
 echo
 echo "== summary: $PASS passed, $FAIL failed =="


### PR DESCRIPTION
## **User description**
## Summary

`pr-preflight.sh` judges whether each of the four AI reviewers (CodeAnt, CodeRabbit, Cursor, Graphite) has engaged with the current PR HEAD SHA. Three of the four freshness signals are exact-SHA (reviews, inline comments, check-runs). The fourth — SHA-less issue comments — relied on a proxy: comparing the comment's `created_at` against the HEAD commit's **committer date**. That proxy had two gaps:

1. **Rebase window.** `git rebase` stamps the committer date at rebase time, which can precede the actual push by minutes. A bot comment about the OLD sha landing in that window read as fresh, so a genuinely stale reviewer was not re-triggered (a narrower recurrence of #576).
2. **Clock skew.** The committer date comes from the local git clock, which can disagree with GitHub's clock by seconds in either direction — observed live on PR #586, where a CodeAnt `APPROVED` review was timestamped ~29s *before* its own reviewed commit's committer date. A fresh bot comment could carry a timestamp earlier than the committer date and be misread as stale, wasting a rate-limited CodeRabbit trigger slot.

Freshness for SHA-less issue comments now prefers the PR timeline's `head_ref_force_pushed`/`head_ref_pushed` event timestamp — GitHub's own clock, stamped after the ref actually moved. This closes both gaps at once (the event is after the rebase, and on GitHub's clock). It falls back to the HEAD committer date, unchanged, when no such event exists (a PR that's never been rebased) or the timeline call fails; committer-date unavailability/future-dating still degrades to "present" exactly as before — fail toward silence, never toward spamming four bots a tick.

Cost: one additional paginated call (`issues/{N}/timeline`) per pre-flight run, on top of the existing 5. Measured ~0.7s wall-clock on a real PR's timeline in this repo. `pr-preflight.sh` runs once per PR per tick in `/babysit-pr` and `/pr-monitor-and-manage`.

Closes #590

## Test plan

- [x] `pr-preflight.test.sh` passes (127 → 146 assertions)
- [x] New scenario: comment timestamped between rebase and push against the old SHA → reviewer re-triggered (rebase window) — Scenario 20
- [x] New scenario: fresh comment timestamped before the committer date but after the push event → reviewer stays `already-present` (clock skew) — Scenario 21
- [x] New scenario: timeline fetch fails → falls back to committer date, no trigger storm — Scenario 22
- [x] Existing degradation scenarios (18, 18b, 18c) still pass unchanged
- [x] Mutation-verified: reverting to the committer-date comparison fails the two new scenarios (manually verified — forced `HEAD_PUSH_DATE` empty, confirmed Scenarios 20/21 fail, then restored)
- [x] SHA-less issue-comment freshness judged against the timeline's `head_ref_force_pushed`/`head_ref_pushed` timestamp rather than the HEAD committer date
- [x] Rebase-window case correctly judged stale and re-triggered
- [x] Clock-skew case correctly judged fresh and not re-triggered
- [x] Timeline fetch failure degrades to committer date; committer-date failure/future-dating degrades to "present" (unchanged contract)
- [x] CodeRabbit ≤2/PR/hour cap still gates every CR trigger — untouched by this change
- [x] Greptile never triggered; another user's draft never flipped; `--dry-run` stays side-effect-free (unchanged code paths, verified by existing scenarios 7/8)
- [x] Idempotent: repeated runs on an already-fresh SHA remain `actions: 0, clean: true` (Scenario 13, unchanged)
- [x] `LIMITATION` block in `pr-preflight.sh`'s header updated to reflect the new behavior and narrowed residual gap
- [x] Added API cost measured and noted in the header (`API COST` section)

## Notes on local review

CodeRabbit CLI hit a rate limit (49-minute cooldown) and CodeAnt CLI hung past its 2-minute timeout budget with no findings emitted. Both dropped for this session per `cr-local-review.md`; self-reviewed the diff instead. GitHub-side CR/CodeAnt/BugBot/Graphite review will run as usual on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Use the PR timeline to judge whether bot issue comments are still fresh**

### What Changed
- SHA-less issue comments now use the PR’s push timeline event as the main freshness signal, so stale bot comments after a rebase are recognized and reviewers are re-triggered when needed
- If the timeline can’t be read, the check falls back to the commit date and keeps the same safe behavior as before
- Added coverage for rebase-window freshness, clock-skew cases, and timeline read failures

### Impact
`✅ Fewer missed re-triggers after rebases`
`✅ Clearer handling of bot comments when clocks differ`
`✅ Fewer unnecessary reviewer pings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
