### PR TITLE
fix(#606): distinguish missing vs. unreadable pm-config.md in /pm-handoff

### DIFF
--- a/.claude/skills/pm-handoff/SKILL.md
+++ b/.claude/skills/pm-handoff/SKILL.md
@@ -12,14 +12,35 @@ Parse `$ARGUMENTS`:
 
 ## Step 1: Detect mode (bootstrap vs. standard)
 
-Probe for the config file via the shared parser — rc=2 means missing:
+Probe for the config file via the shared parser. `pm-config-get.sh` returns
+rc=2 for two distinct conditions it does not itself distinguish — "file
+missing" and "file exists but unreadable" (see its EXIT STATUS contract) —
+so disambiguate here with a plain existence check before dispatching.
+Skipping this check means a permissions glitch or transient filesystem issue
+on an *existing* config would be silently overwritten by Step 2's bootstrap.
 
 ```bash
+CONFIG_FILE=".claude/pm-config.md"
 .claude/scripts/pm-config-get.sh --list >/dev/null 2>&1
 CONFIG_RC=$?
+
+if [[ "$CONFIG_RC" -eq 0 || "$CONFIG_RC" -eq 1 ]]; then
+  MODE="CONFIG_EXISTS"
+elif [[ "$CONFIG_RC" -eq 2 && ! -e "$CONFIG_FILE" ]]; then
+  MODE="BOOTSTRAP"
+else
+  MODE="UNREADABLE"
+fi
 ```
 
-- If `CONFIG_RC == 2` (**BOOTSTRAP**): proceed to Step 2 (create config from repo scan)
+`CONFIG_RC` 0 or 1 both mean the file was read successfully (1 just means
+zero sections or an empty section body — see the script's EXIT STATUS
+contract), so both map to `CONFIG_EXISTS`. Anything else — rc=2 with the
+file present, a usage error (rc=3), or any other unexpected exit code — maps
+to `UNREADABLE` rather than being silently treated as a healthy config.
+
+- If `MODE == BOOTSTRAP` (file genuinely absent): proceed to Step 2 (create config from repo scan)
+- If `MODE == UNREADABLE` (file exists but `pm-config-get.sh` returned an error for it, or returned an exit code outside the documented contract): **STOP.** Tell the user: "`.claude/pm-config.md` exists but could not be read — check file permissions and encoding before continuing." Do NOT proceed to Step 2 — bootstrapping here would silently overwrite the existing file's content, including any user-customized Role/OKRs/Team/Notes sections and any non-canonical sections.
 - Otherwise (**CONFIG_EXISTS**): skip to Step 3 (read existing config)
 
 ## Step 2: Bootstrap — create pm-config.md from repo discovery
@@ -112,7 +133,7 @@ You manage the backlog, track progress, write GitHub issues, and generate prompt
 
 Tell the user the config was bootstrapped and they should review/customize the Role, OKRs, Team, and Notes sections.
 
-**Non-canonical sections (e.g. `Complexity triggers`).** Step 1's dispatch to this bootstrap on `CONFIG_RC == 2` (pre-existing behavior, unchanged by this note) fires for both a missing file and an unreadable one — whether an unreadable-but-existing file should instead be treated as an error rather than silently rebuilt is a Step 1 design question, out of scope here. What matters for section preservation: whichever way Step 1 got here, this bootstrap has no parseable prior sections to work from, so there is nothing to preserve in this path. If this path is ever extended to regenerate over an existing, successfully-parsed config (rather than only creating a fresh one), it must apply the identical rule `pm-update` uses in its Step 6: Infrastructure and Architecture are always emitted (regenerated unconditionally); the other six canonical sections (Role, OKRs, Workflow Rules, Dependency Rules, Team, Notes) are emitted only if they were actually present in the original config — never fabricate an empty one; and any other section name is re-inserted verbatim, anchored immediately after the nearest canonical section that preceded it in the original file (or at the top if none did). Never silently drop a section absent from the canonical list — see `pm-update/SKILL.md` Step 6 for the full algorithm and worked example.
+**Non-canonical sections (e.g. `Complexity triggers`).** Step 1 now only dispatches here (`MODE == BOOTSTRAP`) when the config file is genuinely absent — an existing-but-unreadable file instead stops with an error (`MODE == UNREADABLE`, see #606) rather than reaching this bootstrap. So this path never has parseable prior sections to work from, and there is nothing to preserve here. If this path is ever extended to regenerate over an existing, successfully-parsed config (rather than only creating a fresh one), it must apply the identical rule `pm-update` uses in its Step 6: Infrastructure and Architecture are always emitted (regenerated unconditionally); the other six canonical sections (Role, OKRs, Workflow Rules, Dependency Rules, Team, Notes) are emitted only if they were actually present in the original config — never fabricate an empty one; and any other section name is re-inserted verbatim, anchored immediately after the nearest canonical section that preceded it in the original file (or at the top if none did). Never silently drop a section absent from the canonical list — see `pm-update/SKILL.md` Step 6 for the full algorithm and worked example.
 
 ## Step 3: Read existing config
 


### PR DESCRIPTION
## **User description**
Closes #606

## Summary

`pm-handoff/SKILL.md` Step 1's dispatch treated `pm-config-get.sh`'s exit code 2 as always meaning "no config file," so an existing-but-unreadable `.claude/pm-config.md` (permissions glitch, transient FS issue, race) would be silently overwritten by Step 2's bootstrap — destroying any user-customized Role/OKRs/Team/Notes sections and non-canonical sections (e.g. `Complexity triggers`, see #362/#597/#600).

## Changes

- `pm-handoff/SKILL.md` Step 1 now runs a plain `-e` existence check alongside `CONFIG_RC` to distinguish:
  - `CONFIG_RC` 0 or 1 → `CONFIG_EXISTS` (file read successfully; 1 just means zero/empty sections)
  - `CONFIG_RC` 2 **and nothing exists at that path** → `BOOTSTRAP` (genuinely absent — unchanged behavior)
  - Everything else (rc=2 with the path present, a usage error, or any other unexpected exit code) → `UNREADABLE` — **STOP** and surface an error to the user instead of silently bootstrapping over it
- Tightened the Step 1 prose to match `pm-config-get.sh`'s actual EXIT STATUS contract (rc=2 is a file-existence/readability check only, not a content-parse check — that's rc=1's territory).
- Used `-e` rather than `-f` for the existence check so a non-regular-file entry at that path (e.g. a directory) isn't misclassified as "missing" and bootstrapped over.

## Local review

- **CodeAnt CLI:** clean pass after two rounds of fixes (see commit history — findings were: unexpected exit codes silently misrouted to `CONFIG_EXISTS`; prose overstating rc=2 as covering "unparseable" content; `-f` vs `-e` file-type edge case).
- **CodeRabbit CLI:** hit an account-level rate limit twice (10-12 min cooldown reported both times) and was dropped for this session per `cr-local-review.md`'s timeout/fallback rule. No CodeRabbit findings were available to fix. GitHub-side CodeRabbit review will still run per the standard PR flow.

## Test plan

- [x] `pm-handoff/SKILL.md` Step 1 distinguishes "file absent" from "file exists but unreadable" before dispatching to bootstrap.
- [x] When the file exists but is unreadable/unparseable, the skill stops and surfaces a clear error to the user instead of silently regenerating `pm-config.md`.
- [x] When the file is genuinely absent, behavior is unchanged (dispatches to Step 2 bootstrap as before).
- [x] No regression to the existing "file exists and is readable" (CONFIG_EXISTS) path.


___

## **CodeAnt-AI Description**
**Stop overwriting an existing config file when it cannot be read**

### What Changed
- `/pm-handoff` now checks whether `.claude/pm-config.md` actually exists before deciding to create a new one
- If the file exists but cannot be read, the flow now stops and shows an error instead of replacing it with a new config
- Unexpected return values from the config check are also treated as errors, so they no longer fall through as if the config were valid

### Impact
`✅ Fewer lost pm-config settings`
`✅ Safer handoff setup after permission or filesystem issues`
`✅ Clearer errors when config files cannot be read`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
