### PR TITLE
feat(#601): add in-session model guard to chip-launched threads

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -32,6 +32,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `pm-data-patterns.md` — PM skills data patterns and bot filters
 - `pm-monitoring-decision.md` — `/pm` vs `/pr-monitor-and-manage` division of responsibility
 - `pm-handoff-chips-decision.md` — decision record: `/pm-handoff` intentionally does not offer task chips; its portable prompt text is the deliverable (#562)
+- `chip-model-guard-decision.md` — decision record: the chip model-guard preamble rides in both the chip `prompt` and the fallback block, redefining the fallback baseline (#601)
 - `scheduling-failure-modes.md` — recurring poll failure analysis
 - `skill-sync-hooks.md` — skills worktree sync and hook registration narrative
 - `double-loading-fix.md` — decision record for suppressing the duplicate global CLAUDE.md + rules copy via project-local `claudeMdExcludes` (#461)

--- a/.claude/reference/chip-launching.md
+++ b/.claude/reference/chip-launching.md
@@ -1,8 +1,10 @@
 # Chip Launching — One-Click Coding Threads
 
-Canonical mechanics for offering a coding-thread prompt as a **task chip** the user can click to spin off a new session. Shared by `/pm` (Step 3.1) and `/prompt` (Step 6). Skill-specific wiring stays in each SKILL.md; everything below is defined once, here.
+Canonical mechanics for offering a coding-thread prompt as a **task chip** the user can click to spin off a new session. Shared by `/pm` (Step 3.1), `/prompt` (Step 6), and `/start-issue` (Step 7). Skill-specific wiring stays in each SKILL.md; everything below is defined once, here.
 
 **Out of scope (explicit):** `/pm-handoff` does not offer chips and will not — its handoff prompt is a context-turnover artifact whose visible, portable text is the deliverable, and it has no issue number, model line, or lifecycle for these mechanics to key on. Decided in #562; rationale in `pm-handoff-chips-decision.md`.
+
+**Model-guard placement:** the guard defined below rides in both the chip `prompt` and the fallback block — it is part of the baseline, not a chip-only addition. Decided in #601; rationale in `chip-model-guard-decision.md`.
 
 > **NON-NEGOTIABLE — execution boundary.** Offering a chip is NOT launching a thread. Skills NEVER auto-launch: no Agent-tool spawn, no session start, no work begun on the user's behalf. **The user's chip click is the only launch path.** This does not widen any skill's existing explicit-ask exception (e.g. `/pm`'s "go ahead and run those") — it narrows nothing and grants nothing new.
 
@@ -21,7 +23,30 @@ Chip mode is active **only** when the `mcp__ccd_session__spawn_task` tool is pre
 | `tldr` | 1–2 plain-English sentences: what the spawned session will do and why. No file paths, no jargon |
 | `cwd` | Repo root |
 
-**Chips carry no model or effort preset.** The tool has no such parameter and cannot drive the picker. Therefore the recommended model **MUST** appear as a `**Model:** {MODEL} — {REASON}` line inside the `prompt` text itself, so the spawned session sees the recommendation, **and** in the visible short summary, so the user can set the picker before clicking.
+**Chips carry no model or effort preset.** The tool has no such parameter and cannot drive the picker. Therefore the recommended model **MUST** appear as a `**Model:** {MODEL} — {REASON}` line inside the `prompt` text itself, so the spawned session sees the recommendation, **and** in the visible short summary, so the user can set the picker before clicking. The `**Model:**` line is immediately followed by the model-guard preamble below — the two travel together as a unit.
+
+## Model-guard preamble
+
+The recommended model is worthless if nothing checks it at launch time. Every `prompt` payload — chip or fallback — MUST include this preamble immediately after the `**Model:** {MODEL} — {REASON}` line (no blank line in between, matching the existing fence-adjacent placement of the `**Model:**` line itself). Reproduce it **verbatim** — do not reword it per skill, the same way `safety.md`'s `SAFETY:`/`MINDSET:` blocks are copied into subagent prompts unchanged:
+
+```text
+MODEL GUARD: Your very first action — before any repo reads, file edits, or
+other tool calls — is to compare the model you are actually running as
+against the recommendation on the **Model:** line above.
+- Match: state "Running on {MODEL} as recommended." (one line) and proceed
+  immediately — no further prompts.
+- Mismatch, in EITHER direction (under- or over-powered): STOP. Do no other
+  work. Report, in one message, the model you are actually running as and the
+  model recommended above, then wait. Resume only on an explicit user reply
+  (e.g. "continue anyway"), proceeding on the current model — switching
+  models and relaunching is the recommended path instead.
+This is a best-effort self-report: no runtime API exists to introspect the
+active model, so the check relies on the model naming itself accurately.
+```
+
+**Placement rule:** for every emitter, the `**Model:**` line is the first line of the `prompt` payload and this preamble is the content that immediately follows it — see each skill's Step for how its own template maps onto this shape.
+
+**Why prompt-level, not tooling-level:** there is no `spawn_task` model/effort parameter and no runtime mechanism for a thread to introspect its own active model — model identity is always asserted by the caller, never read back. The guard is therefore a best-effort self-report, not a hard technical guarantee. Full trade-off: `chip-model-guard-decision.md`.
 
 ## Short-summary transcript format (chip mode)
 
@@ -57,8 +82,8 @@ Withdraw a tracked chip via `mcp__ccd_session__dismiss_task` (pass the recorded 
 
 ## Print-on-demand replay
 
-In chip mode, "print the full prompt for #N" (or any equivalent ask) re-emits that issue's **complete block verbatim**, in the same fenced form fallback mode would have printed. The chip's prompt is the source of truth — the printed block and the chip must match. The chip stays offered; printing is not dismissing.
+In chip mode, "print the full prompt for #N" (or any equivalent ask) re-emits that issue's **complete block verbatim**, in the same fenced form fallback mode would have printed — including the model-guard preamble. The chip's prompt is the source of truth — the printed block and the chip must match. The chip stays offered; printing is not dismissing.
 
 ## Fallback mode
 
-When chip mode is unavailable, output is **byte-for-byte identical to pre-chip behavior**: full fenced blocks, every existing fence and label contract preserved (`/prompt`'s mandatory `~~~` outer fence and first-line `**Model:**` label especially). Fallback is the baseline, not a degraded variant — a CLI thread should be unable to tell this feature exists.
+When chip mode is unavailable, output is **byte-identical to the chip `prompt`**: full fenced blocks, every existing fence and label contract preserved (`/prompt`'s mandatory `~~~` outer fence and first-line `**Model:**` label especially), model-guard preamble included. This redefines the pre-#601 baseline of "byte-for-byte identical to pre-chip behavior" — the guard is a universal addition, not a chip-only one, so fallback output gained it rather than the chip `prompt` and fallback block diverging. See `chip-model-guard-decision.md` for the full trade-off. Fallback remains the *baseline* representation, not a degraded variant — a CLI thread simply receives the same content a chip-mode session would.

--- a/.claude/reference/chip-model-guard-decision.md
+++ b/.claude/reference/chip-model-guard-decision.md
@@ -1,0 +1,37 @@
+# Model-Guard Placement Decision (#601)
+
+## Decision
+
+**The model guard rides in both the chip `prompt` and the fallback block.** Every chip-launched or pasted coding thread carries a mandatory model-guard preamble, positioned immediately after the `**Model:** {MODEL} — {REASON}` line, defined once in `chip-launching.md` and inherited by reference — not restated — in `/pm` (Step 3.1), `/prompt` (Step 6), and `/start-issue` (Step 7).
+
+This redefines the fallback baseline. Before #601, `chip-launching.md` guaranteed fallback output was **byte-for-byte identical to pre-chip behavior** — a CLI thread could not tell the chip feature existed. That guarantee is retired. The new guarantee is **byte-identical to the chip `prompt`**: whatever a chip carries, the fallback block carries too, guard included. Print-on-demand replay stays pinned to the chip's actual `prompt` content, so replay, chip, and fallback block never diverge.
+
+Policy: a hard stop on **any** mismatch, in either direction (over- or under-powered), with a single-line override. An explicit user reply (e.g. "continue anyway") proceeds on the current model; switching models and relaunching is the recommended path. A matching model — or a post-override continuation — proceeds with at most one status line and no further friction.
+
+## Rationale
+
+Two invariants existed before this ticket and a new preamble can preserve at most one of them:
+
+- **(A) Chip `prompt` == fallback block.** The chip's `prompt` payload has always been defined as identical to what the fallback block would print inside its fence (`chip-launching.md`'s invocation table, since #555).
+- **(B) Fallback block == pre-chip output.** Fallback mode was defined to be indistinguishable from the tool's behavior before chips existed at all.
+
+Adding a guard that only some threads receive forces a choice: put it in the chip `prompt` only (preserves B, breaks A — the chip and the printed block diverge) or put it in both (preserves A, breaks B — fallback output is no longer what it was before chips shipped).
+
+**The strongest "guard chip-only" argument, and why it loses:** a CLI/headless paste flow already has a manual checkpoint the chip flow lacks — the user opens the new thread themselves, so they can set the model before pasting. By that logic the guard is solving a chip-specific problem and doesn't belong in the fallback path at all. This argument loses because the checkpoint it describes is a *default*, not an enforced one — nothing stops a user from pasting a Heavy-tier block into an already-open Sonnet 5 thread, which is exactly the failure mode the guard exists to catch. More decisively, invariant (A) is architecturally load-bearing: AC5 of #601 pins print-on-demand replay to the chip's actual `prompt`, and `chip-launching.md` already treats "chip `prompt` byte-identical to fallback block" as the base contract three skills consume by reference. Fracturing that into "chip has X, fallback has X-minus-the-guard" would mean two representations per issue instead of one, undermining the single-sourced design #555 established. Between fracturing an architectural invariant and revising a behavioral guarantee that was never a design goal in itself (it was a byproduct of chips being purely additive), revising the guarantee is the smaller, more defensible cut. The guard is also universally beneficial in the fallback path, not merely tolerated there — it catches the same wrong-model paste mistake a CLI user can make.
+
+**Model self-detection is best-effort.** There is no runtime mechanism for a thread to introspect its own active model — model identity is always asserted by the caller (the picker, the harness), never read back by the model itself. The guard therefore relies on the launched thread's own self-report of which model it believes it is running as, compared textually against the `**Model:** {MODEL}` line. This is a known limitation, not an oversight: if `spawn_task` later gains a model/effort parameter (the ticket's own "root cause is upstream" note), the guard becomes a pure safety net for the residual paste-flow case rather than the only defense, and this whole convention can simplify.
+
+## Explicitly Rejected
+
+- **Guard in chip `prompt` only** (mirroring how `/start-issue`'s `**Model:**` line was chip-only before this ticket) — rejected: breaks invariant (A), forces print-on-demand replay to pick between two non-identical artifacts, and leaves the fallback/paste path exposed to the same wrong-model mistake the guard exists to catch.
+- **Deferring the guard until `spawn_task` gains a model parameter** — rejected: blocks a cheap, prompt-only mitigation on an upstream capability with no committed timeline; the ticket explicitly wants a self-enforcing preamble now, with the future parameter treated as a simplification, not a prerequisite.
+- **Surfacing the model in the chip's `title` or `tldr`** (declined at ticket capture) — rejected: those fields are scanned pre-click, not enforced; a title mention doesn't stop a click on the wrong picker state the way a first-action stop inside the thread does.
+- **A separate paste-block fallback reserved for tier-critical (Fable 5 / Heavy) work** (declined at ticket capture) — rejected: adds a second fallback shape to maintain for a subset of issues when one guard, applied uniformly, already covers the tier-critical case at hard-stop severity.
+
+## References
+
+- Issue [#601](https://github.com/auerbachb/claude-code-config/issues/601) — this decision
+- `chip-launching.md` — canonical chip mechanics; defines the model-guard preamble this decision authorizes
+- `.claude/skills/pm/SKILL.md` Step 3.1, `.claude/skills/prompt/SKILL.md` Step 6, `.claude/skills/start-issue/SKILL.md` Step 7 — the three chip emitters that inherit the guard by reference
+- `pm-handoff-chips-decision.md` — the house style this record follows (`## Decision` / `## Rationale` / `## Explicitly Rejected` / `## References`)
+- Issue [#547](https://github.com/auerbachb/claude-code-config/issues/547) (closed) — model fleet reconciliation across selection surfaces, the related prior work this ticket builds on

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -437,17 +437,20 @@ For each selected issue, generate a self-contained prompt. The prompt content be
 **First, check chip availability** per `.claude/reference/chip-launching.md`, then branch:
 
 - **Chip mode** (`mcp__ccd_session__spawn_task` present): call `spawn_task` once per selected issue with `title` / `prompt` / `tldr` / `cwd`, where `prompt` is the full self-contained prompt below, unchanged. Print **only** the short summary per issue (issue, title, `**Model:**` line, one-line rationale) — see the reference for the exact format. Record each returned `task_id` in the Active Work table (3.2) and set that issue's status to `Chip offered`.
-- **Fallback mode** (tool absent): emit the full prompt blocks for every selected issue exactly as before — same fences, same content.
+- **Fallback mode** (tool absent): emit the full prompt blocks for every selected issue — same fences, same content, model-guard preamble included. `chip-launching.md` redefines the fallback baseline as byte-identical to the chip `prompt` (guard included), not pre-chip output — see `chip-model-guard-decision.md`.
 
 **Spawn outcomes are tracked per issue.** A failed `spawn_task` falls back for **that issue alone** — print its full block and leave it at `Prompt generated`. Issues whose spawns succeeded keep their chip, their `task_id`, and their `Chip offered` status; never re-print their block as well, or the same issue is offered twice. Every selected issue ends with exactly one of: a chip, or a printed block.
 
-Chips carry no model preset, so the `**Model:**` line must appear both in the visible summary and inside the chip's prompt text. Get the model recommendation from `/prompt`'s tier classification when it ran; otherwise infer it from the issue's signals using the same Heavy/Standard/Light mapping.
+Chips carry no model preset, so the `**Model:**` line must appear both in the visible summary and inside the chip's prompt text. Get the model recommendation from `/prompt`'s tier classification when it ran; otherwise infer it from the issue's signals using the same Heavy/Standard/Light mapping. Immediately after the `**Model:**` line, the prompt also carries the mandatory model-guard preamble defined in `chip-launching.md` — insert it verbatim, never reworded.
 
-If the user asks to "print the full prompt for #N" while in chip mode, re-emit that issue's complete block verbatim — the chip stays offered.
+If the user asks to "print the full prompt for #N" while in chip mode, re-emit that issue's complete block verbatim, guard included — the chip stays offered.
 
 Each prompt must include:
 
 ```
+**Model:** {MODEL} — {REASON}
+{Model-guard preamble — insert verbatim from `chip-launching.md` "Model-guard preamble", immediately after this line, no blank line between}
+
 You are a coding agent working on {repo URL}.
 
 ## Task

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -24,6 +24,8 @@ Separately from Fast mode: for Light-tier work, **Haiku 4.5** is a valid cheaper
 
 **Per-block model label (mandatory):** The first content inside each tilde-fenced block (immediately after the opening `~~~`) MUST be a single line: `**Model:** {MODEL} — {REASON}` where `{MODEL}` is the model string for **that issue's** `issue_tier` (from Step 5 — not the batch tier), and `{REASON}` is a concise task-type phrase of **at most 10 words** derived from that issue's signals (dominant drivers such as rules/CLAUDE.md, orchestration, file count, AC count, skills, dependencies, or scope keywords). The label must be **inside** the tilde fence so a pasted block is self-explanatory without surrounding prose. In chip mode the same line MUST open the chip's `prompt` text **and** appear in the visible short summary — chips cannot preset the model picker, so the user needs it before clicking and the spawned session needs it after.
 
+**Model-guard preamble (mandatory):** Immediately after the `**Model:**` line — no blank line between — insert the model-guard preamble defined in `.claude/reference/chip-launching.md` "Model-guard preamble," verbatim, never reworded. It applies in both delivery modes: the launched thread's first action is to compare its actual running model against the `**Model:**` line and stop on any mismatch. See `chip-model-guard-decision.md` for why the guard rides in both the chip `prompt` and the fallback block.
+
 ## Step 0: Parse Arguments and Detect Context
 
 Parse `$ARGUMENTS` as space-separated issue references. Strip `#` prefixes to get bare issue numbers.
@@ -204,7 +206,7 @@ Produce the following output in Markdown. Use the gathered data to fill in each 
 Check chip availability per `.claude/reference/chip-launching.md`, then branch. The **prompt content is identical either way** — only delivery differs:
 
 - **Chip mode** (`mcp__ccd_session__spawn_task` present): for each thread-prompt issue (after Step 5.5 partitioning), call `spawn_task` with `title` / `prompt` / `tldr` / `cwd`, where `prompt` is exactly the content that would sit **inside** that issue's `~~~` fences in fallback mode — the fence delimiters themselves are not part of the prompt. Everything between them, starting with the `**Model:**` line, is. Print only the short summary per issue — issue, title, `**Model:**` line, one-line rationale. The user clicks to launch; never launch for them.
-- **Fallback mode** (tool absent): print today's `~~~`-fenced blocks for every thread-prompt issue, unchanged — **copy-paste-ready**, each independently pasteable into a new thread. Byte-for-byte identical to pre-chip output.
+- **Fallback mode** (tool absent): print today's `~~~`-fenced blocks for every thread-prompt issue — **copy-paste-ready**, each independently pasteable into a new thread. Byte-identical to the chip `prompt` (model-guard preamble included) — see `chip-model-guard-decision.md` for why this is no longer byte-for-byte identical to pre-chip output.
 
 **Spawn outcomes are tracked per issue.** A failed `spawn_task` falls back for **that issue alone** — print its full block and note the fallback once for the batch (per `chip-launching.md`); the rest of the batch keeps its chips. Do not print a block for an issue whose chip spawned successfully. Every thread-prompt issue ends with exactly one of: a chip, or a printed block.
 
@@ -275,6 +277,7 @@ Then, for each issue, output a self-contained prompt block. Use tilde fences (`~
 
 ~~~
 **Model:** Opus 4.8 — skill change with many acceptance checks
+{Model-guard preamble — insert verbatim from `chip-launching.md` "Model-guard preamble", immediately after this line, no blank line between}
 ### Issue #{NUMBER}: {TITLE}
 
 **Acceptance Criteria:**
@@ -355,9 +358,10 @@ This task is done when:
 - **All PM-detected issues are subagent-eligible:** Output only the Subagent Candidates section. No tier recommendation or prompt blocks needed.
 - **All PM-detected issues are thread-prompt-eligible:** Output normally — skip the Subagent Candidates section entirely. This is the same as the explicit-args path.
 - **`/subagent` skill not yet available:** The Subagent Candidates section outputs a `/subagent` command suggestion regardless of whether the skill exists. If the user runs it and the skill is missing, they will get a clear error. The `/prompt` skill does not gate on `/subagent` availability.
-- **Chip tool unavailable (CLI, headless, older client):** Fallback mode — output is identical to pre-chip behavior. Do not mention chips.
+- **Chip tool unavailable (CLI, headless, older client):** Fallback mode — output is byte-identical to the chip `prompt`, model-guard preamble included (see `chip-model-guard-decision.md`). Do not mention chips.
 - **Spawn fails mid-batch:** Fall back to a printed block for that issue only; the rest of the batch keeps its chips. Do not retry the failed spawn.
-- **User asks for the full prompt in chip mode:** Re-emit that issue's complete tilde-fenced block verbatim; leave the chip in place.
+- **User asks for the full prompt in chip mode:** Re-emit that issue's complete tilde-fenced block verbatim, guard included; leave the chip in place.
+- **Launched thread's running model mismatches its `**Model:**` line:** The guard rules live in `chip-launching.md`, not here — the launched thread stops on any mismatch as its first action and waits for the user, per the model-guard preamble. `/prompt` only has to ensure the preamble is present in every block; it does not itself detect or resolve mismatches.
 
 ## Usage Examples
 
@@ -395,6 +399,7 @@ The prompt block that follows:
 
 ~~~
 **Model:** Opus 4.8 — skill file with multiple acceptance criteria
+{model-guard preamble — see "Model-guard preamble" above, verbatim, omitted here for brevity}
 ### Issue #110: {Title}
 
 **Acceptance Criteria:**

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -195,7 +195,7 @@ This creates **one canonical planning document** the coding agent can work from.
 
 ### Fallback mode output
 
-Print a compact summary to the user. Per `chip-launching.md`, this block is now **byte-identical to the chip `prompt`** (model-guard preamble included) rather than byte-for-byte identical to pre-chip behavior — see `chip-model-guard-decision.md` for the trade-off. One consequence: the `**Model:**` line, previously a chip-only addition here, is now baked into the base block below so the guard has a recommendation to compare against in fallback mode too:
+Print a compact summary to the user. Per `chip-launching.md`, the content **inside** this block (not the fence delimiters themselves) is now **byte-identical to the chip `prompt`** (model-guard preamble included) rather than byte-for-byte identical to pre-chip behavior — see `chip-model-guard-decision.md` for the trade-off. One consequence: the `**Model:**` line, previously a chip-only addition here, is now baked into the base block below, so the guard has a recommendation to compare against in fallback mode too:
 
 ```
 **Model:** {MODEL} — {REASON}
@@ -225,7 +225,7 @@ Ready to code. Start with step 1 of the plan above. Run the dual-CLI local revie
 | Param | Value |
 |-------|-------|
 | `title` | Verb-first, ≤60 chars, includes the issue number — built from `ISSUE_NUMBER` + `TITLE` (e.g. `Fix #42 stale worktree warning`) |
-| `prompt` | The complete self-contained coding-thread prompt: the fallback block above, reproduced **verbatim** — Model line and model-guard preamble included. No further additions are made for chip mode; the block above is already the full chip payload |
+| `prompt` | The complete self-contained coding-thread prompt: the **content inside** the fallback fence above (not the fence delimiters themselves), reproduced **verbatim** — Model line and model-guard preamble included. No further additions are made for chip mode; the block content above is already the full chip payload |
 | `tldr` | 1–2 plain-English sentences from `TITLE` / the merged plan: what the session will do and why. No file paths, no jargon |
 | `cwd` | `WORKTREE_PATH` — the worktree created in Step 6 |
 

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -195,9 +195,12 @@ This creates **one canonical planning document** the coding agent can work from.
 
 ### Fallback mode output
 
-Print a compact summary to the user. This block is the pre-chip baseline — emit it **byte-for-byte identical** to what `/start-issue` printed before chips existed (same heading, fields, plan/AC sections, and closing "Ready to code…" line), so a CLI or headless thread cannot tell this feature exists:
+Print a compact summary to the user. Per `chip-launching.md`, this block is now **byte-identical to the chip `prompt`** (model-guard preamble included) rather than byte-for-byte identical to pre-chip behavior — see `chip-model-guard-decision.md` for the trade-off. One consequence: the `**Model:**` line, previously a chip-only addition here, is now baked into the base block below so the guard has a recommendation to compare against in fallback mode too:
 
 ```
+**Model:** {MODEL} — {REASON}
+{Model-guard preamble — insert verbatim from `chip-launching.md` "Model-guard preamble", immediately after this line, no blank line between}
+
 ## Ready to code — Issue #{N}
 
 **Title:** {TITLE}
@@ -222,19 +225,19 @@ Ready to code. Start with step 1 of the plan above. Run the dual-CLI local revie
 | Param | Value |
 |-------|-------|
 | `title` | Verb-first, ≤60 chars, includes the issue number — built from `ISSUE_NUMBER` + `TITLE` (e.g. `Fix #42 stale worktree warning`) |
-| `prompt` | The complete self-contained coding-thread prompt: the `**Model:**` line, then a blank line, then the **content** of the fallback block above reproduced verbatim (the fence delimiters are not part of the prompt; everything between them is). The Model line is the only addition — the block's own text is never reworded to suit the chip |
+| `prompt` | The complete self-contained coding-thread prompt: the fallback block above, reproduced **verbatim** — Model line and model-guard preamble included. No further additions are made for chip mode; the block above is already the full chip payload |
 | `tldr` | 1–2 plain-English sentences from `TITLE` / the merged plan: what the session will do and why. No file paths, no jargon |
 | `cwd` | `WORKTREE_PATH` — the worktree created in Step 6 |
 
 > **`cwd` deliberately differs from `/pm` and `/prompt`,** which pass the repo root. By Step 7, `/start-issue` has already created an issue-specific worktree, so the launched thread must start *there* — repo root would land it in the wrong checkout, on the wrong branch. This is an intentional divergence, not an inconsistency with the shared contract.
 
-**Chips carry no model preset,** so the `**Model:** {MODEL} — {REASON}` line MUST appear both at the top of the chip's `prompt` text (so the spawned session sees it) and in the visible short summary (so the user can set the picker before clicking).
+**The `**Model:** {MODEL} — {REASON}` line and its guard live in the base block, not as a chip-only addition** — chips cannot preset the model picker, so both a fallback-mode reader and a chip-mode spawned session need the recommendation and the guard in the text itself. The visible short summary in chip mode still repeats just the `**Model:**` line (not the guard) so the user can set the picker before clicking.
 
-**Record the returned `task_id` immediately,** before any dependent step — an unrecorded chip cannot be withdrawn. `/start-issue` has no Active Work table, so track it **session-locally**, keyed by issue number, and say so in the summary; the chip stays dismissable for this session only. If the issue already has a live chip recorded in this session, skip the spawn rather than offering it twice. `dismiss_task` hygiene and print-on-demand replay ("print the full prompt for #N" re-emits that chip's `prompt` verbatim — Model line and block — in the fenced form fallback would have printed; the chip stays offered) follow the reference — do not restate its rules here.
+**Record the returned `task_id` immediately,** before any dependent step — an unrecorded chip cannot be withdrawn. `/start-issue` has no Active Work table, so track it **session-locally**, keyed by issue number, and say so in the summary; the chip stays dismissable for this session only. If the issue already has a live chip recorded in this session, skip the spawn rather than offering it twice. `dismiss_task` hygiene and print-on-demand replay ("print the full prompt for #N" re-emits that chip's `prompt` verbatim — Model line, guard preamble, and block — in the fenced form fallback would have printed; the chip stays offered) follow the reference — do not restate its rules here.
 
 ### Model recommendation
 
-Chips need a `{MODEL}` and a `{REASON}`. Use this lightweight, role-based rule over the canonical roster (**Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5** — see `.claude/rules/subagent-orchestration.md` "Model Selection"):
+Every handoff — chip or fallback — needs a `{MODEL}` and a `{REASON}`. Use this lightweight, role-based rule over the canonical roster (**Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5** — see `.claude/rules/subagent-orchestration.md` "Model Selection"):
 
 - **Default: Sonnet 5** — ordinary single-issue coding work.
 - **Step up to Opus 4.8** when the issue touches rules, `CLAUDE.md`, skills, or orchestration — instruction-adherence work where literal-following models misfire.
@@ -253,6 +256,7 @@ Stop after delivering the handoff. Do NOT start coding automatically — the use
 - **New issue description matches an existing open issue** (e.g. duplicate title): the skill will still create a new issue. It does not dedupe — that is the user's responsibility.
 - **Empty argument:** stop and ask the user for input.
 - **`gh` not authenticated or repo lookup fails:** stop and report the underlying `gh` error to the user.
+- **Launched thread's running model mismatches its `**Model:**` line:** guard rules live in `chip-launching.md`, not here — the launched thread stops on any mismatch as its first action and waits for the user, per the model-guard preamble. `/start-issue` only has to ensure the preamble is present in the block; it does not itself detect or resolve mismatches.
 
 ## Usage examples
 


### PR DESCRIPTION
## **User description**
## Summary

Chip-launched threads currently start on whatever model the app last used — the `**Model:** {MODEL} — {REASON}` recommendation carried in the chip's `prompt` is purely informational, and nothing checks it at launch time. This adds a mandatory **model-guard preamble** to the shared chip contract: as its very first action, a launched thread compares the model it's actually running on against the recommendation and hard-stops on any mismatch, waiting for the user to relaunch on the right model or explicitly reply "continue anyway."

## What changed

- **`.claude/reference/chip-launching.md`** — new canonical "Model-guard preamble" section (verbatim `MODEL GUARD:` block, positioned immediately after the `**Model:**` line in every `prompt` payload); "Fallback mode" and "Print-on-demand replay" sections redefined so the guard rides in both the chip `prompt` and the fallback block.
- **`.claude/reference/chip-model-guard-decision.md`** (new) — decision record (mirrors `pm-handoff-chips-decision.md`'s house style) resolving the open placement question in favor of guard-in-both, and documenting why that breaks the old "fallback byte-for-byte identical to pre-chip behavior" guarantee in favor of a new "fallback byte-identical to the chip `prompt`" guarantee.
- **`.claude/reference/README.md`** — indexed the new decision record.
- **`.claude/skills/pm/SKILL.md`** (Step 3.1), **`.claude/skills/prompt/SKILL.md`** (Step 6), **`.claude/skills/start-issue/SKILL.md`** (Step 7) — each now inherits the guard by reference (no restated guard text), with byte-identical wording reconciled to the new baseline. `/start-issue`'s `**Model:**` line, previously a chip-only addition, is now baked into its base fallback block alongside the guard (a necessary consequence of "guard in both" — the guard needs a `**Model:**` line to compare against in fallback mode too).

## Why guard-in-both (not chip-only)

Two pre-existing invariants can't both survive: (A) chip `prompt` == fallback block, and (B) fallback block == pre-chip output. Guard-in-both preserves (A) — which AC5 and print-on-demand replay depend on — at the cost of (B). Full rationale, including the strongest counterargument and why it loses, is in `chip-model-guard-decision.md`.

Closes #601

## Test plan

- [x] `chip-launching.md` defines the mandatory model-guard preamble as part of the chip `prompt` contract: first action = compare running model vs. `**Model:**` line, hard stop on any mismatch, report running vs. recommended, wait for the user.
- [x] Override semantics specified: explicit "continue anyway" proceeds on current model; switch + relaunch is the recommended path.
- [x] Matching model (or post-override) proceeds with at most one status line.
- [x] All three chip emitters (`/pm` Step 3.1, `/prompt` Step 6, `/start-issue` Step 7) inherit the guard via the shared reference — verified no per-skill restatement of the `MODEL GUARD:` text (placeholder references only).
- [x] Chip↔fallback-block relationship explicitly resolved and documented in `chip-launching.md`; print-on-demand replay pinned to the chip's actual `prompt` content (guard included).

## Note on local review

Both local review CLIs were unavailable this session: **CodeRabbit** hit its rate limit twice in a row (`errorType: rate_limit`, recoverable but repeated) and **CodeAnt** hung indefinitely on this batch past the documented 2-minute bound (known `codeant` 0.5.1 quirk) and was killed. Per `cr-local-review.md`'s fallback rule, this PR went through a self-review instead of a clean CLI pass.

## Note on GitHub review

- **CodeAnt** approved cleanly on the initial commit (`c8d94ca`) and re-approved after the fix commit (`bbc3560`).
- **CodeRabbit** found one valid finding on `c8d94ca` (ambiguous "fallback block reproduced verbatim" wording — could be read as including the fence delimiters themselves, breaking the "Model line is first" placement rule). Fixed, replied, and resolved in `bbc3560`. CodeRabbit's re-review of `bbc3560` then hit the same shared rate limit that affected the local CLI (`CodeRabbit` commit status: `failure` / "Review rate limited") — this is a known local/GitHub shared-quota interaction, not a new issue.
- **BugBot** ("Cursor Bugbot") reported "couldn't run - usage limit reached" — a documented failure mode, not a clean pass.
- Per the CR → BugBot → Greptile escalation chain, **Greptile** was triggered and came back clean: Confidence Score 5/5, "This looks safe to merge," no inline findings.
- `mergeStateStatus` shows `UNSTABLE` solely due to the abandoned, non-required `CodeRabbit` commit status above — `CodeRabbit` is not in this repo's required status checks (only `rule-lint` is), and `mergeable` is `MERGEABLE`. This is not expected to self-resolve while intentionally staying on the sticky Greptile path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized task prompt delivery across supported workflows.
  * Added a model-guard notice to generated prompts, including fallback output.
  * Ensured fallback prompts match chip-launched prompts exactly.
  * Clarified behavior when the selected model does not match the running model.
  * Documented chip availability, prompt re-display, and issue-specific fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add a mandatory model check to launched coding threads**

### What Changed
- Launched threads now start by checking that they are running on the model named in the `**Model:**` line; if it does not match, they stop and wait for the user to relaunch or continue anyway.
- The model recommendation and guard now appear in both chip-launched prompts and fallback printed prompts, so the same text is delivered in either mode.
- The shared chip guidance and related skill instructions were updated to reflect the new prompt shape and to clarify that replaying a full prompt includes the guard text.

### Impact
`✅ Fewer wrong-model coding sessions`
`✅ Clearer launch-time model warnings`
`✅ Consistent prompts in chip and fallback mode`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
