### PR TITLE
fix(#608): gh pr view --json merged errors on gh CLI without a merged field

### DIFF
--- a/.claude/scripts/admin-merge.sh
+++ b/.claude/scripts/admin-merge.sh
@@ -472,12 +472,21 @@ if [[ "$MODE" == "execute" ]]; then
     exit 7
   fi
 
-  # Post-verify: protection restored + PR merged.
+  # Post-verify: protection restored + PR merged. Retry the merge-state read a
+  # few times — a successful `gh pr merge --admin` does not guarantee an
+  # immediately-consistent read of PR state (read-after-write lag, or a
+  # queued/deferred merge on repos with a merge queue enabled) — before
+  # concluding the merge did not complete.
   FINAL_ENFORCE=$(gh api "repos/$OWNER/$REPO/branches/$BRANCH/protection/enforce_admins" --jq '.enabled' 2>/dev/null || echo "unknown")
-  FINAL_MERGED=$(gh pr view "$PR_NUMBER" --json state --jq '(.state == "MERGED")' 2>/dev/null || echo "unknown")
+  FINAL_MERGED="unknown"
+  for _attempt in 1 2 3; do
+    FINAL_MERGED=$(gh pr view "$PR_NUMBER" --json state --jq '(.state == "MERGED")' 2>/dev/null || echo "unknown")
+    [[ "$FINAL_MERGED" == "true" ]] && break
+    (( _attempt < 3 )) && sleep 2
+  done
   echo "[admin-merge] done: PR merged=$FINAL_MERGED, enforce_admins enabled=$FINAL_ENFORCE"
   if [[ "$FINAL_MERGED" != "true" ]]; then
-    echo "WARNING: PR does not report state=MERGED — the merge may not have completed (e.g. a queued/deferred merge). Verify manually: gh pr view $PR_NUMBER --json state,mergedAt" >&2
+    echo "WARNING: PR does not report state=MERGED after retrying — the merge may not have completed (e.g. a queued/deferred merge). Verify manually: gh pr view $PR_NUMBER --json state,mergedAt" >&2
     exit 7
   fi
   if [[ "$FINAL_ENFORCE" != "true" ]]; then

--- a/.claude/scripts/admin-merge.sh
+++ b/.claude/scripts/admin-merge.sh
@@ -476,6 +476,10 @@ if [[ "$MODE" == "execute" ]]; then
   FINAL_ENFORCE=$(gh api "repos/$OWNER/$REPO/branches/$BRANCH/protection/enforce_admins" --jq '.enabled' 2>/dev/null || echo "unknown")
   FINAL_MERGED=$(gh pr view "$PR_NUMBER" --json state --jq '(.state == "MERGED")' 2>/dev/null || echo "unknown")
   echo "[admin-merge] done: PR merged=$FINAL_MERGED, enforce_admins enabled=$FINAL_ENFORCE"
+  if [[ "$FINAL_MERGED" != "true" ]]; then
+    echo "WARNING: PR does not report state=MERGED — the merge may not have completed (e.g. a queued/deferred merge). Verify manually: gh pr view $PR_NUMBER --json state,mergedAt" >&2
+    exit 7
+  fi
   if [[ "$FINAL_ENFORCE" != "true" ]]; then
     echo "WARNING: enforce_admins did not report enabled=true — verify manually." >&2
     exit 7

--- a/.claude/scripts/admin-merge.sh
+++ b/.claude/scripts/admin-merge.sh
@@ -136,13 +136,13 @@ fi
 OWNER="${OWNER_REPO%/*}"
 REPO="${OWNER_REPO#*/}"
 
-PR_JSON=$(gh pr view "$PR_NUMBER" --json number,state,baseRefName,headRefName,merged 2>/dev/null || true)
+PR_JSON=$(gh pr view "$PR_NUMBER" --json number,state,baseRefName,headRefName 2>/dev/null || true)
 if [[ -z "$PR_JSON" ]]; then
   echo "ERROR: PR #$PR_NUMBER not found in $OWNER_REPO." >&2
   exit 3
 fi
 PR_STATE=$(echo "$PR_JSON" | jq -r '.state // "UNKNOWN"')
-PR_MERGED=$(echo "$PR_JSON" | jq -r '.merged // false')
+PR_MERGED=$(echo "$PR_JSON" | jq -r '(.state == "MERGED")')
 BASE_REF=$(echo "$PR_JSON" | jq -r '.baseRefName // ""')
 
 if [[ "$PR_MERGED" == "true" ]]; then
@@ -474,7 +474,7 @@ if [[ "$MODE" == "execute" ]]; then
 
   # Post-verify: protection restored + PR merged.
   FINAL_ENFORCE=$(gh api "repos/$OWNER/$REPO/branches/$BRANCH/protection/enforce_admins" --jq '.enabled' 2>/dev/null || echo "unknown")
-  FINAL_MERGED=$(gh pr view "$PR_NUMBER" --json merged --jq '.merged' 2>/dev/null || echo "unknown")
+  FINAL_MERGED=$(gh pr view "$PR_NUMBER" --json state --jq '(.state == "MERGED")' 2>/dev/null || echo "unknown")
   echo "[admin-merge] done: PR merged=$FINAL_MERGED, enforce_admins enabled=$FINAL_ENFORCE"
   if [[ "$FINAL_ENFORCE" != "true" ]]; then
     echo "WARNING: enforce_admins did not report enabled=true — verify manually." >&2

--- a/.claude/scripts/tests/admin-merge.test.sh
+++ b/.claude/scripts/tests/admin-merge.test.sh
@@ -38,9 +38,9 @@ ARGS="$*"
 case "$ARGS" in
   "repo view --json nameWithOwner --jq .nameWithOwner")
     echo "${FAKE_OWNER_REPO:-solo/repo}"; exit 0 ;;
-  "pr view "*"--json number,state,baseRefName,headRefName,merged")
+  "pr view "*"--json number,state,baseRefName,headRefName")
     if [ -n "${FAKE_PR_JSON:-}" ]; then echo "$FAKE_PR_JSON"
-    else echo '{"number":1,"state":"OPEN","baseRefName":"main","headRefName":"feat","merged":false}'; fi
+    else echo '{"number":1,"state":"OPEN","baseRefName":"main","headRefName":"feat"}'; fi
     exit 0 ;;
   "api user --jq .login")
     echo "${FAKE_USER:-solouser}"; exit 0 ;;

--- a/.claude/skills/admin-merge/SKILL.md
+++ b/.claude/skills/admin-merge/SKILL.md
@@ -30,7 +30,7 @@ This bypass is only legitimate when it does **not** skip a real human review. Th
 
 ```bash
 PR_NUM="${1:-$(gh pr view --json number --jq .number)}"
-gh pr view "$PR_NUM" --json number,title,state,merged,baseRefName --jq '{number,title,state,merged,baseRefName}'
+gh pr view "$PR_NUM" --json number,title,state,baseRefName --jq '{number,title,state,baseRefName}'
 ```
 
 If no PR is found, stop: "No PR found — pass a PR number: `/admin-merge <PR>`." If already merged/closed, stop and say so.
@@ -81,10 +81,10 @@ Note the inline `&&` failure mode loudly: if the merge fails, the final re-enabl
 After the user reports running the command (or you detect it), poll until the PR is merged:
 
 ```bash
-gh pr view "$PR_NUM" --json merged,state --jq '{merged,state}'
+gh pr view "$PR_NUM" --json state --jq '{state}'
 ```
 
-Once `merged: true`, also confirm protection was restored:
+Once `state: MERGED`, also confirm protection was restored:
 
 ```bash
 # owner/repo/branch come from the PR; <branch> is the PR base branch

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -109,7 +109,7 @@ Run only when invoked **without** `--tick`.
 ### A1. Validate the PR
 
 ```bash
-PR_JSON=$(gh pr view "$PR" --json number,state,merged,headRefOid 2>&1) || {
+PR_JSON=$(gh pr view "$PR" --json number,state,headRefOid 2>&1) || {
   echo "ERROR: PR #$PR not found or gh failed: $PR_JSON" >&2; exit 1; }
 PR_PR_STATE=$(jq -r '.state' <<<"$PR_JSON")     # OPEN | MERGED | CLOSED
 if [[ "$PR_PR_STATE" != "OPEN" ]]; then
@@ -212,7 +212,7 @@ GATE_JSON=$("$MERGE_GATE_SH" "$PR"); GATE_EXIT=$?
 case "$GATE_EXIT" in
   0|1) ;;                                  # valid gate JSON — proceed to classify
   3)  # PR not found / closed / merged — let T3's terminal handling decide (merged vs closed)
-      PR_NOW=$(gh pr view "$PR" --json state,merged --jq '{state,merged}' 2>/dev/null || echo '{}')
+      PR_NOW=$(gh pr view "$PR" --json state --jq '{state}' 2>/dev/null || echo '{}')
       # fall through to T3 with GATE_JSON unused; T3 row 1/2 classify merged/closed
       SKIP_STATE_READ=1 ;;
   *)  # exit 2/4/other — tooling/transient error. Heartbeat + skip this tick (no classify, no dispatch).
@@ -323,9 +323,9 @@ The classifier (T3) consumes `CR_BUDGET_OK` / `GREP_BUDGET_OK`: a PR whose only 
 Re-fetch the authoritative open/merged state once:
 
 ```bash
-PR_NOW=$(gh pr view "$PR" --json state,merged --jq '{state,merged}')
+PR_NOW=$(gh pr view "$PR" --json state --jq '{state}')
 PR_STATE_NOW=$(jq -r '.state' <<<"$PR_NOW")
-PR_MERGED=$(jq -r '.merged'   <<<"$PR_NOW")
+PR_MERGED=$(jq -r '(.state == "MERGED")' <<<"$PR_NOW")
 ```
 
 | # | Class | Condition | Action |

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -233,7 +233,7 @@ Proceed immediately to Phase 2 — do not ask.
 
 ### Step 2.1: Merge gate + autonomous recovery loop (issue #452)
 
-**Authority:** `.claude/scripts/merge-gate.sh` JSON on stdout is the single source of truth for merge readiness. After **every** recovery action, re-fetch the PR HEAD SHA (`gh pr view "$PR_NUM" --json headRefOid,state,merged`) and re-run `merge-gate.sh` — **no stale cache** of gate JSON across iterations.
+**Authority:** `.claude/scripts/merge-gate.sh` JSON on stdout is the single source of truth for merge readiness. After **every** recovery action, re-fetch the PR HEAD SHA (`gh pr view "$PR_NUM" --json headRefOid,state`) and re-run `merge-gate.sh` — **no stale cache** of gate JSON across iterations.
 
 **Environment (optional):** Assign defaults once before looping:
 
@@ -717,7 +717,7 @@ Read session/process state and clean up only what is **provably dead**; surface 
 ```
 
 - **Dead `/loop` jobs (auto-stop).** For each non-durable `/loop` poll in `polling_jobs[]` (or per-PR `babysit` watcher) whose target PR is **merged or closed**, stop it: set the watcher's stop flag (`.prs["$N"].babysit.stop_requested=true` via `session-state.sh --set`, same as `/babysit-pr-stop`) so the next tick exits, and record `Stopped stale /loop job (PR #N watcher — PR already merged)` in `SWEEP_AUTO_HANDLED`. The PR just merged in Phase 2 is the most common case.
-- **Stale handoffs (auto-delete).** For each `~/.claude/handoffs/pr-{N}-handoff.json`, if PR `N` is **merged** (`gh pr view N --json state,merged --jq '.merged'`), delete the file and record `Deleted handoff file pr-N-handoff.json (PR merged)` in `SWEEP_AUTO_HANDLED`. Deleting an already-gone file is a no-op (idempotent). Do **not** delete handoffs for open/un-merged PRs.
+- **Stale handoffs (auto-delete).** For each `~/.claude/handoffs/pr-{N}-handoff.json`, if PR `N` is **merged** (`gh pr view N --json state --jq '.state == "MERGED"'`), delete the file and record `Deleted handoff file pr-N-handoff.json (PR merged)` in `SWEEP_AUTO_HANDLED`. Deleting an already-gone file is a no-op (idempotent). Do **not** delete handoffs for open/un-merged PRs.
 - **Surface (never auto-act).** Add to `SWEEP_NEEDS_DECISION`: durable `CronCreate` jobs still scheduled (`CronList`), any `active_agents` entries (running subagents), monitor-mode flags (`monitoring_active=true`), and any `recovery/dirty-main-*` branches left by `dirty-main-guard.sh`. Word each as e.g. `Active subagent still running: PR #620 Phase C — stop it or let it finish?` or `Durable cron job <id> still scheduled (<prompt>) — keep or CronDelete?`.
 
 #### Step 3.9: Category 4 — Memory persistence (defers to Phase 4)


### PR DESCRIPTION
## **User description**
## Summary

`gh pr view --json merged` is not a valid field on this repo's installed `gh` version (2.48.0) — it errors immediately with `Unknown JSON field: "merged"` and lists the valid fields, which include `state` and `mergedAt` but not `merged`. This broke the documented commands in `babysit-pr/SKILL.md` and `wrap/SKILL.md` before any classification logic could run.

Fixed all 5 confirmed call sites plus 3 more of the identical bug pattern found during the required repo-wide sweep (`admin-merge/SKILL.md` ×2, `admin-merge.sh` ×3, plus its test mock):

- `babysit-pr/SKILL.md` — Arm Mode Step A1, Tick Mode T1 (gate-exit-3 fallback), Tick Mode T3 classification
- `wrap/SKILL.md` — Step 2.1 recovery-loop authority note, Step 3.8 stale-handoff cleanup
- `admin-merge/SKILL.md` — Step 1 PR identification, Step 5 merge confirmation polling
- `admin-merge.sh` — PR metadata fetch + `PR_MERGED` derivation, post-merge verification
- `admin-merge.test.sh` — updated the `gh` mock's `--json` field list and fixture JSON to match

Every site now reads `state == "MERGED"` (matching the convention already used elsewhere in this repo, e.g. `merge-gate.sh`/`pr-state.sh`) instead of a nonexistent `.merged` boolean.

**Local review note:** Both local CLIs failed twice this session — CodeRabbit hit its rate limit twice (8 min, then 2 min cooldown) and CodeAnt returned a false-clean (`issues: []`) both times while its own transcript showed `API Error: fetch failed (cause: UND_ERR_HEADERS_TIMEOUT)`. Per `cr-local-review.md`, both CLIs were dropped for the session and a manual self-review was performed instead (diff read in full, `admin-merge.test.sh` re-run to a 16/16 pass, and a final repo-wide grep confirming zero remaining `--json ...merged...`/`.merged` references).

Closes #608

## Test plan

- [x] `babysit-pr/SKILL.md` Step A1 no longer requests `merged` in `--json`; PR-state validation uses `state`
- [x] `babysit-pr/SKILL.md` Step T1 (gate-exit-3 fallback) uses `state` instead of `merged`
- [x] `babysit-pr/SKILL.md` Step T3 classification (`PR_MERGED`) derives from `state == "MERGED"` instead of `.merged`
- [x] `wrap/SKILL.md` Step 2.1 recovery-loop terminal check uses `state` instead of `merged`
- [x] `wrap/SKILL.md` Step 3.8 stale-handoff cleanup uses `state`/`mergedAt` instead of `.merged`
- [x] Manually verified `gh pr view <merged-PR> --json state,mergedAt` succeeds and correctly reports `state: "MERGED"` on this repo's installed `gh` version (tested against PR #612, gh 2.48.0)
- [x] Grepped `.claude/skills/**/SKILL.md` and `.claude/scripts/*.sh` for remaining `--json ...merged...` or `.merged` references — found and fixed 3 additional sites in `admin-merge` (SKILL.md + script + test), final sweep is clean


___

## **CodeAnt-AI Description**
**Stop relying on a missing PR field and confirm merges more reliably**

### What Changed
- Replaced `merged` lookups with PR `state` checks so commands no longer fail on `gh pr view --json merged`
- Updated admin merge flow to verify the PR is actually in `MERGED` state before reporting success
- Added a short retry for the final merge check so a successful merge is not marked as failed because the update is still catching up
- Updated tests and guidance files to match the new merge-state check

### Impact
`✅ Fewer gh CLI errors during PR checks`
`✅ Clearer admin-merge success or failure status`
`✅ Fewer false failures right after merging`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
