### PR TITLE
fix(#587): extend skill-first reflex to spawned subagents

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -84,11 +84,20 @@ Agent tool call:
            branch protection, .env, or a safety.md 'Never' item), structured like
            /admin-merge: exact command + one-line reason.
 
+           SKILLS: Before hand-rolling a multi-step task, check whether an existing
+           skill already does this job — invoke it via the Skill tool instead of
+           reimplementing from memory. Clear match -> invoke immediately. Borderline
+           match -> note it in your exit report, then proceed on your own judgment.
+           No match -> stay silent. Never auto-invoke an authorization-carrying skill
+           (/merge, /wrap, /pr-monitor-and-manage) on a fuzzy match — and this never
+           overrides your own phase's assigned task. Full rules:
+           .claude/rules/skill-first.md.
+
            Existing findings to fix:
            <paste findings here>"
 ```
 
-The SAFETY and MINDSET blocks are mandatory in every subagent prompt (see `.claude/rules/safety.md`). The example above shows where to place them — between the task context and any findings payload.
+The SAFETY, MINDSET, and SKILLS blocks are mandatory in every subagent prompt (see `.claude/rules/safety.md` and `.claude/rules/skill-first.md`). The example above shows where to place them — between the task context and any findings payload.
 
 The agent definition provides the workflow rules. The prompt provides the runtime context. The parent no longer needs to read and embed all rule files manually.
 

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -185,6 +185,10 @@ If you're running low on tokens with work remaining:
 2. Print the exit report with `OUTCOME: exhaustion` and `NEXT_PHASE: A`
 3. Exit cleanly — do NOT squeeze in one more tool call
 
+## Skill-First Reflex
+
+Before hand-rolling any side-task not covered by the workflow above, check whether an existing skill already does it — invoke it via the Skill tool. Clear match → invoke immediately. Borderline match → note it in your exit report and proceed on your own judgment; don't block the phase waiting for an answer. No match → stay silent. Never auto-invoke `/merge`, `/wrap`, or `/pr-monitor-and-manage` on a fuzzy match. This never overrides the Workflow steps above (Steps 1-7, or the Merge-Conflict Workflow) — those ARE your assigned procedure, not something to second-guess against the skill catalog. Full rules: `.claude/rules/skill-first.md`.
+
 ## Autonomy Rules
 
 Every step above is **autonomous** — do NOT ask "should I fix this?" or "should I push?" Just do it. The only exception: if you encounter a finding that would require a fundamental architectural change, note it in the handoff file's `notes` field and let the parent decide.

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -299,6 +299,10 @@ If running low on tokens:
 3. Print exit report with `OUTCOME: exhaustion`
 4. Exit cleanly
 
+## Skill-First Reflex
+
+Before hand-rolling any side-task not covered by the review-loop procedures above, check whether an existing skill already does it — invoke it via the Skill tool. Clear match → invoke immediately. Borderline match → note it in your exit report and proceed on your own judgment; don't block the phase waiting for an answer. No match → stay silent. Never auto-invoke `/merge`, `/wrap`, or `/pr-monitor-and-manage` on a fuzzy match. This never overrides the CR/BugBot/Greptile procedures above — those ARE your assigned procedure, not something to second-guess against the skill catalog. Full rules: `.claude/rules/skill-first.md`.
+
 ## Autonomy Rules
 
 Every step is autonomous. Do NOT ask "should I poll?", "should I fix this?", or "should I trigger Greptile?" Just do it. The Phase Transition Autonomy table governs all decisions — every transition listed as "Always do" requires no permission.

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -180,6 +180,10 @@ HANDOFF_FILE: ~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json
 
 **Note:** Do NOT delete the handoff file. The parent deletes it only after `OUTCOME: merged` and GitHub confirms the PR is merged.
 
+## Skill-First Reflex
+
+Before hand-rolling any side-task not covered by Steps 1-3 above, check whether an existing skill already does it — invoke it via the Skill tool. Clear match → invoke immediately. Borderline match → note it in your exit report and proceed on your own judgment; don't block the phase waiting for an answer. No match → stay silent. Never auto-invoke `/merge` or `/pr-monitor-and-manage` on a fuzzy match — and Step 3's mandated `/wrap` execution is your assigned task, not a fuzzy match, so keep running it as instructed. Full rules: `.claude/rules/skill-first.md`.
+
 ## Autonomy Rules
 
 AC verification and merge gate checking are autonomous. The merge decision is user-gated before Phase C launch: the parent must either ask the user before launching Phase C or pass explicit authorization already provided by the user in the prompt. Once authorized Phase C starts, `/wrap` is set-and-forget and must not ask additional confirmation questions.

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -182,7 +182,7 @@ HANDOFF_FILE: ~/.claude/handoffs/pr-{{PR_NUMBER}}-handoff.json
 
 ## Skill-First Reflex
 
-Before hand-rolling any side-task not covered by Steps 1-3 above, check whether an existing skill already does it — invoke it via the Skill tool. Clear match → invoke immediately. Borderline match → note it in your exit report and proceed on your own judgment; don't block the phase waiting for an answer. No match → stay silent. Never auto-invoke `/merge` or `/pr-monitor-and-manage` on a fuzzy match — and Step 3's mandated `/wrap` execution is your assigned task, not a fuzzy match, so keep running it as instructed. Full rules: `.claude/rules/skill-first.md`.
+Before hand-rolling any side-task not covered by Steps 1-3 above, check whether an existing skill already does it. You don't have Skill tool access (`allowed-tools` is `Read, Glob, Grep, Bash`) — read the skill's `SKILL.md` directly and follow it, the same way Step 3 reads and executes `/wrap` without invoking the Skill tool. Clear match → read and follow it. Borderline match → note it in your exit report and proceed on your own judgment; don't block the phase waiting for an answer. No match → stay silent. Never treat `/merge` or `/pr-monitor-and-manage` as a fuzzy-match default — and Step 3's mandated `/wrap` execution is your assigned task, not a fuzzy match, so keep running it as instructed. Full rules: `.claude/rules/skill-first.md`.
 
 ## Autonomy Rules
 

--- a/.claude/agents/pm-worker.md
+++ b/.claude/agents/pm-worker.md
@@ -79,6 +79,10 @@ If the report shows the `cr-plan-on-issue.yml` workflow as `[MISSING]`, install 
 
 If branch protection is `[MISSING]`, report to the parent — branch protection changes require user confirmation per `.claude/rules/repo-bootstrap.md`.
 
+## Skill-First Reflex
+
+Before hand-rolling a task not covered by "Task: Issue Creation" or "Task: Repo Bootstrap" above, check whether an existing skill already does it — invoke it via the Skill tool (e.g. a status/recap request that isn't actually issue creation or bootstrap). Clear match → invoke immediately. Borderline match → note it in your exit report and proceed on your own judgment; don't block waiting for an answer. No match → stay silent. Never auto-invoke `/merge`, `/wrap`, or `/pr-monitor-and-manage` on a fuzzy match. Full rules: `.claude/rules/skill-first.md`.
+
 ## Autonomy Rules
 
 - Issue creation: autonomous

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -97,6 +97,10 @@ Spawn the **researcher** agent when:
 
 Prefer `general-purpose` when the task may reasonably need to write a file (e.g., "research X and save a report to docs/"), or when the task is part of an implementation loop (Phase A/B/C have their own dedicated agents).
 
+## Skill-First Note
+
+You cannot invoke skills — `Skill` is not in your `allowed-tools`. If your findings suggest an existing skill already covers likely follow-up work (e.g. `/status`, `/monitor`, `/recap`), name it in RECOMMENDATIONS instead of describing a bespoke procedure; the parent decides whether to invoke it.
+
 ## Autonomy Rules
 
 Research is fully autonomous. Do not ask the parent "should I look at X?" or "want me to check Y too?" — make the call and report what you found. If the scope is unclear, interpret it broadly and note your interpretation in `SCOPE`.

--- a/.claude/rules/skill-first.md
+++ b/.claude/rules/skill-first.md
@@ -29,6 +29,8 @@ Subagents inherit the parent's instruction **snapshot** at spawn — they never 
 
 Subagents run autonomously and can't pause for a user answer, so the ladder adapts: borderline match → note it in the exit report and proceed on your own judgment, don't block the phase waiting for input.
 
+**Requires `Skill` tool access.** Paste the block below only into spawns that have it — `phase-a-fixer`, `phase-b-reviewer`, `pm-worker`, and most ad-hoc spawns. Agents lacking `Skill` (e.g. `phase-c-merger`, `researcher`) carry an adapted, non-invoking note in their own `.claude/agents/*.md` definition instead — don't paste this block there.
+
 ```text
 SKILLS: Before hand-rolling a multi-step task, check whether an existing skill
 already does this job — invoke it via the Skill tool instead of reimplementing
@@ -36,7 +38,6 @@ from memory (only Skill-tool calls reach ~/.claude/skill-usage.log). Clear match
 -> invoke immediately. Borderline match -> note it in your exit report, then
 proceed on your own judgment; do not block waiting for an answer. No match ->
 stay silent. Never auto-invoke an authorization-carrying skill (/merge, /wrap,
-/pr-monitor-and-manage) on a fuzzy match — and this never overrides your own
-phase's assigned task (e.g. Phase C's mandated /wrap run is the assigned task,
-not a fuzzy match). Full rules: .claude/rules/skill-first.md.
+/pr-monitor-and-manage) on a fuzzy match — running one as your assigned job
+isn't a fuzzy match. Full rules: .claude/rules/skill-first.md.
 ```

--- a/.claude/rules/skill-first.md
+++ b/.claude/rules/skill-first.md
@@ -18,4 +18,25 @@
 
 Skills encode hard-won process. Hand-rolling does the work worse and skips `~/.claude/skill-usage.log`, undercounting live skills and poisoning prune audits (issue #431) and durable telemetry (issue #572).
 
-Scope: parent-agent sessions. Subagents run from narrow agent definitions — extending the reflex to them is a follow-up (see issue #571 Notes).
+Scope: parent-agent sessions read this file directly; subagents reach it via "Reaching Subagents" below (issue #587).
+
+## Reaching Subagents
+
+Subagents inherit the parent's instruction **snapshot** at spawn — they never re-read this file from disk afterward (verified during PR #585). Two paths deliver the reflex anyway:
+
+1. **Custom agent types** (`phase-a-fixer`, `phase-b-reviewer`, `phase-c-merger`, `pm-worker`) carry a short embedded reminder in their own `.claude/agents/*.md` definition, loaded as system context regardless of prompt content.
+2. **Everyone else** (ad-hoc / `general-purpose` spawns with no custom definition) gets the verbatim `SKILLS:` block below, pasted into every spawn prompt per `subagent-orchestration.md`'s "How to Spawn Subagents" checklist.
+
+Subagents run autonomously and can't pause for a user answer, so the ladder adapts: borderline match → note it in the exit report and proceed on your own judgment, don't block the phase waiting for input.
+
+```text
+SKILLS: Before hand-rolling a multi-step task, check whether an existing skill
+already does this job — invoke it via the Skill tool instead of reimplementing
+from memory (only Skill-tool calls reach ~/.claude/skill-usage.log). Clear match
+-> invoke immediately. Borderline match -> note it in your exit report, then
+proceed on your own judgment; do not block waiting for an answer. No match ->
+stay silent. Never auto-invoke an authorization-carrying skill (/merge, /wrap,
+/pr-monitor-and-manage) on a fuzzy match — and this never overrides your own
+phase's assigned task (e.g. Phase C's mandated /wrap run is the assigned task,
+not a fuzzy match). Full rules: .claude/rules/skill-first.md.
+```

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -13,7 +13,7 @@ Use `.claude/agents/` definitions; they embed phase rules. Every Agent call must
 4. Runtime context: PR/issue/branch, repo, handoff path, HEAD SHA, reviewer, and optional pre-fetched findings.
 5. The verbatim `SAFETY:` block from `safety.md`.
 6. The verbatim `MINDSET:` block from `safety.md` (try CLI before handoff — see "Capability Discovery").
-7. The verbatim `SKILLS:` block from `skill-first.md` (skill-first reflex for subagents — see "Reaching Subagents").
+7. The verbatim `SKILLS:` block from `skill-first.md` (skill-first reflex for subagents — see "Reaching Subagents") for `phase-a-fixer`, `phase-b-reviewer`, and `pm-worker`. **Skip it for `phase-c-merger`** — its `allowed-tools` excludes `Skill`, so the invoke-oriented block doesn't apply; its own agent definition carries an adapted, non-invoking note instead.
 
 See `.claude/agents/README.md` for the full placeholder reference and spawning examples.
 

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -13,6 +13,7 @@ Use `.claude/agents/` definitions; they embed phase rules. Every Agent call must
 4. Runtime context: PR/issue/branch, repo, handoff path, HEAD SHA, reviewer, and optional pre-fetched findings.
 5. The verbatim `SAFETY:` block from `safety.md`.
 6. The verbatim `MINDSET:` block from `safety.md` (try CLI before handoff — see "Capability Discovery").
+7. The verbatim `SKILLS:` block from `skill-first.md` (skill-first reflex for subagents — see "Reaching Subagents").
 
 See `.claude/agents/README.md` for the full placeholder reference and spawning examples.
 


### PR DESCRIPTION
## **User description**
## Summary

Follow-up from PR #585 / issue #571. `.claude/rules/skill-first.md` made **parent-agent** sessions invoke matching skills via the Skill tool (clear match → invoke, borderline → one-line suggestion, none → silence), but explicitly deferred subagents. This PR extends the reflex to spawned subagents.

**Constraint (verified during PR #585):** subagents inherit the parent's instruction **snapshot** at spawn — they never re-read `CLAUDE.md`/`.claude/rules/*.md` from disk afterward. So the nudge has to live in content that's already part of every spawn:

1. **`.claude/rules/skill-first.md`** — new "Reaching Subagents" section explaining the two delivery paths, plus a verbatim `SKILLS:` block (same style/tone as the existing `SAFETY:`/`MINDSET:` blocks) that subagents can carry. The ladder is adapted for autonomous execution: borderline match → note it in the exit report and proceed on your own judgment, instead of asking the user (subagents can't pause for an answer).
2. **`.claude/rules/subagent-orchestration.md`** — added the `SKILLS:` block as item 7 of the mandatory "How to Spawn Subagents" checklist, alongside the existing `SAFETY:`/`MINDSET:` items. This is how ad-hoc / `general-purpose` spawns (no custom agent definition) get the reflex.
3. **`.claude/agents/phase-a-fixer.md`, `phase-b-reviewer.md`, `phase-c-merger.md`, `pm-worker.md`** — each gets a short embedded "Skill-First Reflex" section. Since these `.md` files are loaded as system context at spawn regardless of prompt content, this is the most reliable delivery path for the four custom agent types. Each is careful to note the reflex never overrides the agent's own mandated procedure (e.g. Phase C's `/wrap` execution is its assigned task, not a "fuzzy match").
4. **`.claude/agents/researcher.md`** — gets a lighter "Skill-First Note" instead, since its `allowed-tools` frontmatter has no `Skill` tool. It's told to name a matching skill in its `RECOMMENDATIONS` output rather than invoke one.
5. **`.claude/agents/README.md`** — spawning-pattern example updated to show the `SKILLS:` block alongside `SAFETY:`/`MINDSET:`.

Preserved verbatim throughout: the authorization guard that never lets a fuzzy match auto-invoke `/merge`, `/wrap`, or `/pr-monitor-and-manage`. No new telemetry needed — Skill-tool calls from subagents already log to `~/.claude/skill-usage.log` (confirmed during the PR #585 demo).

## Review note

Local dual-CLI review: **CodeAnt CLI** (`codeant review --uncommitted --headless`) ran clean — 0 issues across all 8 changed files, nothing skipped/capped. **CodeRabbit CLI** (`coderabbit review --agent --type uncommitted`) was rate-limited for the entire session (11 retry attempts over ~10 minutes, still `rate_limit` on every attempt) — dropped per `cr-local-review.md`'s CLI timeout/fallback rule. GitHub-side CodeRabbit review will still run during the PR review loop.

Closes #587

## Test plan

- [x] `.claude/rules/skill-first.md` documents how the skill-first reflex reaches subagents (two delivery paths) and includes a verbatim `SKILLS:` block
- [x] `.claude/rules/subagent-orchestration.md`'s "How to Spawn Subagents" checklist requires the `SKILLS:` block on every spawn that has Skill tool access (`phase-a-fixer`, `phase-b-reviewer`, `pm-worker`), and explicitly skips it for `phase-c-merger`, whose `allowed-tools` excludes `Skill`
- [x] Each of `phase-a-fixer.md`, `phase-b-reviewer.md`, `phase-c-merger.md`, `pm-worker.md` embeds a Skill-First Reflex section that does not conflict with (and explicitly defers to) that agent's own mandated procedure
- [x] `researcher.md` gets an adapted note reflecting its lack of `Skill` tool access
- [x] The authorization guard (never auto-invoke `/merge`, `/wrap`, or `/pr-monitor-and-manage` on a fuzzy match) is preserved verbatim in the `SKILLS:` block and in `phase-a-fixer`, `phase-b-reviewer`, `pm-worker`; `phase-c-merger`'s adapted version omits `/wrap` from that list since running it via Step 3 is its explicitly authorized assigned task, not a fuzzy match
- [x] Rules corpus word count stays under the `.claude/rules/.budget-soft-cap` ratchet cap (verified: 12,000 words vs. 12,232 cap)


___

## **CodeAnt-AI Description**
**Extend skill-first guidance to subagents**

### What Changed
- Subagents now get the skill-first reminder at spawn, so they can suggest or invoke an existing skill instead of hand-rolling follow-up work.
- The guidance now covers both custom agents and ad-hoc subagent spawns, and tells them to note borderline matches in their exit report rather than stopping for confirmation.
- Research and phase agents now clearly avoid auto-invoking authorization-heavy skills unless the match is clear, while keeping their own assigned workflow unchanged.

### Impact
`✅ Fewer missed skill invocations in subagents`
`✅ More consistent follow-up handling across agent types`
`✅ Less manual rework from hand-crafted side tasks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

