### PR TITLE
docs(#610): document confirmed Graphite outage since 2026-05-08

### DIFF
--- a/.claude/reference/codeant-graphite-supplemental.md
+++ b/.claude/reference/codeant-graphite-supplemental.md
@@ -12,6 +12,16 @@ Full detail extracted from `.claude/rules/cr-github-review.md`. Parallel supplem
 
 CodeAnt and Graphite are parallel supplements; the primary chain stays CR → BugBot → Greptile.
 
+## Graphite — Known Outage (issue #610, confirmed 2026-07-21)
+
+**Status: confirmed non-functional repo-wide, not a per-PR or docs-only-skip pattern.** Graphite (`graphite-app[bot]`) engaged normally — real review comments plus a completed `Graphite / AI Reviews` check-run — on 11 PRs between 2026-04-28 and 2026-05-08 (last: PR #453). Every PR opened since (85 PRs total, #463 through #612, spanning 2026-06-11 to 2026-07-21 — 82 merged, 3 still open as of this writing) shows **zero** Graphite activity of any kind: no comments, no reviews, and critically **no check-run at all**. This was verified across PRs touching pure docs (#463, #480) and PRs touching actual scripts (#500 `escalate-review.sh`, #604 `pr-preflight.sh`), so file type is not the variable.
+
+**Why this rules out "intentional docs-only skip":** a functioning Graphite install posts a completed `Graphite / AI Reviews` check-run even when it has no findings to comment on (see PR #453). Total absence of that check-run means the GitHub App isn't running against this repo at all — most likely uninstalled, suspended, or a billing/plan lapse on the `auerbachb` org — not a content-based filtering decision. This is an external-service state we have no API access to (installation/billing endpoints 404/401 for a non-admin token), so diagnosis and re-enablement is a **user action**: check the [Graphite app](https://github.com/apps/graphite-app) installation for this org/repo and the AI-review toggle/billing status at `app.graphite.com`. Tracked in [issue #614](https://github.com/auerbachb/claude-code-config/issues/614).
+
+**Decision: kept in the active trigger set, not removed.** `pr-preflight.sh`, `fixpr` Step 3b, `/monitor`, and `maybe-trigger-ai-review.sh` still post `@graphite-app re-review` for a missing Graphite. Rationale: the trigger is a single uncapped PR comment (cheap, self-healing — it'll start working again the moment the app is fixed) versus the cost of ripping Graphite out of four call sites and rewriting ~20 existing `pr-preflight.test.sh` cases for what is very likely a fixable external-service issue rather than a design flaw. Re-open the "drop from trigger set" option only if Graphite is still silent well after the user confirms the GitHub App is reinstalled/enabled.
+
+**Diagnostic method for future re-checks:** don't rely on comment/review absence alone — a silent-but-installed app and a fully-uninstalled app both show zero comments. Check for the `Graphite / AI Reviews` check-run on the PR's HEAD commit (`gh api repos/{owner}/{repo}/commits/{sha}/check-runs --jq '.check_runs[] | select(.app.slug=="graphite-app")'`); its presence (even with a "nothing to report" conclusion) means the app is alive, and its total absence across several consecutive triggered PRs is the reliable signal of an outage.
+
 ## CodeAnt Local CLI
 
 `codeant-cli` (npm) is a separate local/pre-push capability, distinct from the PR-side `codeant-ai[bot]` role above — it does **not** itself satisfy the GitHub merge gate (`cr-merge-gate.md`, `merge-gate-reviewer-paths.md`); treat it as advisory, same as the rest of CodeAnt's supplemental status in this repo.

--- a/.claude/scripts/maybe-trigger-ai-review.sh
+++ b/.claude/scripts/maybe-trigger-ai-review.sh
@@ -7,6 +7,11 @@
 #   3) @graphite-app re-review
 # Optional 4th: /pr-review-help (see pm-config.md).
 #
+# Graphite known outage (issue #610, confirmed 2026-07-21): the graphite trigger
+# above has produced zero engagement since 2026-05-08 — external GitHub App
+# issue, kept anyway (cheap, self-healing). See
+# .claude/reference/codeant-graphite-supplemental.md.
+#
 # Config: `.claude/pm-config.md` section **Complexity triggers** (see template in repo).
 # Env vars COMPLEXITY_THRESHOLD_SCORE, COMPLEXITY_FIRST_CR_ROUND, COMPLEXITY_CADENCE_ROUNDS
 # override file values when set.

--- a/.claude/scripts/pr-preflight.sh
+++ b/.claude/scripts/pr-preflight.sh
@@ -546,6 +546,10 @@ fi
 
 # --- 4. reviewer-trigger check ---
 # Ordered list: key | bot-login | trigger-string. Greptile intentionally absent.
+# Graphite known outage (issue #610, confirmed 2026-07-21): zero engagement (no
+# comments, no check-runs) on every PR since 2026-05-08 — external GitHub App
+# issue, not fixable from this script. Kept in the trigger set anyway (cheap,
+# self-healing) — see .claude/reference/codeant-graphite-supplemental.md.
 REVIEWER_KEYS=(codeant coderabbit cursor graphite)
 # Bash 3.2-compatible (macOS default ships Bash 3.2): NO associative arrays.
 # `declare -A` is a syntax error on Bash 3 and, under `set -euo pipefail`, aborts

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -379,6 +379,8 @@ The script only dismisses **`CHANGES_REQUESTED`** reviews where **`commit_id` â‰
 
 Only run this step when Step 3 made a push. If Step 3 skipped the commit/push, skip this step too.
 
+> **Graphite known outage (issue #610):** the `@graphite-app re-review` trigger below has produced zero engagement (no comments, no check-runs) on any PR since 2026-05-08 â€” a confirmed external GitHub App issue, not something this step can fix. Still posted (cheap, self-healing); see `.claude/reference/codeant-graphite-supplemental.md` for evidence and the re-enablement path.
+
 Re-resolve the hourly helper path (Step 3 may not have run in the same shell):
 
 ```bash

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -27,6 +27,8 @@ Audit the open PR backlog and confirm that **all four AI code reviewers** have a
 | BugBot (Cursor) | `cursor[bot]` | `@cursor review` |
 | Graphite | `graphite-app[bot]` | `@graphite-app re-review` |
 
+> **Graphite known outage (issue #610):** Graphite has shown zero engagement — no comments, no check-runs — on every PR since 2026-05-08 (confirmed repo-wide, not per-PR or docs-only). A ❌ in the Graphite column most likely reflects this ongoing outage, not a fresh gap; see `.claude/reference/codeant-graphite-supplemental.md` for evidence and the re-enablement path. Still triggered per Step 5 — the outage is a user-side fix (GitHub App reinstall/billing), not a reason to stop auditing.
+
 `/monitor` is **audit-and-trigger only**. It is the action-oriented sibling of read-only `/status`: where `/status` reports merge-readiness, `/monitor` reports *reviewer coverage* and closes gaps. It does **not** drive the fix/resolve loop (that stays with `/fixpr` and the per-PR coding threads) and it never auto-flips drafts, auto-merges, or modifies review-bot config.
 
 ## Scope boundaries (HARD STOPS)


### PR DESCRIPTION
## **User description**
## Summary

Investigates Issue #610 (Graphite `graphite-app[bot]` not engaging on PR reviews). **Root cause confirmed: broken integration, not a docs-only skip.**

### Evidence

- Graphite engaged normally — real review comments plus a completed `Graphite / AI Reviews` check-run — on 11 PRs between 2026-04-28 and 2026-05-08 (last: PR #453).
- Every PR opened since (85 PRs total, #463 through #612, spanning 2026-06-11 to 2026-07-21 — 82 merged, 3 still open at time of check) shows **zero** Graphite activity of any kind: no comments, no reviews, and critically **no check-run at all**.
- Verified this holds across both docs-only PRs (#463, #480) and code/script-touching PRs (#500 touched `escalate-review.sh`, #604 touched `pr-preflight.sh`) — ruling out a content/file-type-based skip.
- The total absence of even a check-run is the key signal: a functioning Graphite install posts a completed `Graphite / AI Reviews` check-run even when it has nothing to report (see PR #453). Its total absence means the GitHub App isn't running against this repo at all — most likely uninstalled, suspended, or a billing/plan lapse on the `auerbachb` org.
- No API access to confirm/fix this directly (`installation` endpoint 404s, app-JWT 401s for a non-admin token) — filed as follow-up [Issue #614](https://github.com/auerbachb/claude-code-config/issues/614) for the user to check the GitHub App dashboard.

### Changes

- `.claude/reference/codeant-graphite-supplemental.md` — new "Known Outage" section with full evidence, the diagnostic method for future re-checks (check-run presence, not just comments), and the decision rationale.
- `.claude/skills/monitor/SKILL.md`, `.claude/skills/fixpr/SKILL.md`, `.claude/scripts/pr-preflight.sh`, `.claude/scripts/maybe-trigger-ai-review.sh` — pointer notes at each active Graphite trigger call site referencing the known outage, so a `❌ Graphite` gap isn't repeatedly mistaken for a fresh per-PR issue.
- **Decision: kept Graphite in the active trigger set** (not removed) — the `@graphite-app re-review` trigger is a single uncapped comment (cheap, self-healing once the app is fixed), versus rewriting ~20 existing tests in `pr-preflight.test.sh` for what is very likely a fixable external-service issue. Re-open the "drop from trigger set" option only if still silent after the user confirms the app is reinstalled.
- Memory `graphite-bot-no-engagement-observed.md` updated to reflect the resolved investigation.

### Local review

- CodeAnt CLI: clean pass (0 issues, both before and after the fix below).
- CodeRabbit CLI: found 1 valid finding (imprecise PR count/range wording — fixed), then hit rate limits twice in a row (6 min, then 30 min) on the re-verification pass. Per `cr-local-review.md`'s 2-error drop rule, dropped for this session; the one finding it surfaced was fixed before the drop.

Closes #610

## Test plan

- [x] Root cause determined (broken integration vs. intentional docs-only skip vs. something else) — confirmed **broken integration** (external GitHub App outage), not docs-only skip.
- [x] If broken: either fixed, or a follow-up issue filed with the fix plan — filed [Issue #614](https://github.com/auerbachb/claude-code-config/issues/614) with concrete steps for the user (check GitHub App installation + `app.graphite.com` billing/AI-review toggle); this is a real wall for the coding agent (no API access to app installation/billing settings).
- [x] ~~If intentional skip behavior: documented so it's not repeatedly mistaken for a missing-reviewer gap~~ N/A — confirmed broken integration (see item 1 above), not intentional skip; the known-outage doc/pointers already serve the same "don't re-litigate" purpose.


___

## **CodeAnt-AI Description**
**Document the Graphite outage and keep the trigger in place**

### What Changed
- Added a clear note that Graphite has been silent on every PR since 2026-05-08, with no comments and no check-run, so missing Graphite activity should be treated as an external outage
- Explained how to verify the outage in future reviews and where to check the GitHub App setup to restore it
- Added the same outage note to the review and preflight guidance so users understand why Graphite is still being triggered

### Impact
`✅ Clearer Graphite outage diagnosis`
`✅ Fewer false alarms about missing reviews`
`✅ Easier Graphite re-enablement checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

