### PR TITLE
feat(#613): PM runs A→B→C subagents inline by default; thread only when too big

### DIFF
--- a/.claude/reference/pm-monitoring-decision.md
+++ b/.claude/reference/pm-monitoring-decision.md
@@ -4,7 +4,7 @@
 
 Division of responsibility between orchestration and fleet monitoring:
 
-- **`/pm` never creates polls.** It is a strictly on-demand orchestrator: cold-start scan, prompt generation, on-demand status when the user asks, and handoff generation. At ≥3 active threads it redirects to `/pr-monitor-and-manage`; it does not offer `CronCreate` or `/loop`.
+- **`/pm` never creates polls.** It is a strictly on-demand orchestrator: cold-start scan, inline execution of selected issues via the `/subagent` A→B→C flow (in-turn Dedicated Monitor Mode, not a recurring poll), thread prompts for the few issues too big for a subagent, on-demand status when the user asks, and handoff generation. At ≥3 active threads it redirects to `/pr-monitor-and-manage`; it does not offer `CronCreate` or `/loop`.
 - **`/pr-monitor-and-manage` owns PR-fleet between-message polling.** It establishes `/loop` at the configured cadence, optionally registers `CronCreate` auto-wake on idle pause, and dispatches per-PR fixes/merges.
 - **`/loop` remains valid for explicit user-invoked "poll every N"** that is not PR-fleet-specific (e.g., "poll every 5m /status" on a single thread). Hand-rolled one-shot `ScheduleWakeup` chains are forbidden for recurring polls.
 - **`CronCreate` is for cross-session durability or fleet jobs owned by dedicated skills** (`/pr-monitor-and-manage` auto-wake, `/babysit-pr --durable`, etc.) — not `/pm`.
@@ -76,7 +76,7 @@ This extends existing recovery; it does not create a second PM-specific recovery
 
 ## Skill integration decision
 
-- `/pm`: detects active worker threads after cold start/resume. At ≥3 threads, redirects to `/pr-monitor-and-manage`. Never creates polls. Records passive tracking in `session-state.json`.
+- `/pm`: runs selected inline-eligible issues via the `/subagent` A→B→C flow (in-turn monitoring) and hands issues too big for a subagent to threads; detects active worker threads after cold start/resume. At ≥3 threads, redirects to `/pr-monitor-and-manage`. Never creates polls. Records passive tracking in `session-state.json`.
 - `/pr-monitor-and-manage`: owns PR-fleet between-message polling with `/loop`, optional `CronCreate` auto-wake, per-PR dispatch, and idle auto-pause.
 - `/subagent`: when it spawns Phase A/B/C agents, it immediately enters Dedicated Monitor Mode for in-turn orchestration and records state. For between-turn PR fleet monitoring, point the user at `/pr-monitor-and-manage`; for explicit user "poll every N" on non-PR work, use `/loop` per `scheduling-reliability.md`.
 - `/status`: remains the default on-demand scan command because it already reconciles PRs, review state, checks, session state, and active agents.

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -63,7 +63,7 @@ The 32K limit is binding. Give each subagent one phase with explicit exit criter
 - **Phase B: Review Loop** (lighter) — poll/trigger reviewer, fix new findings, update handoff, EXIT.
 - **Phase C: Verify + Wrap** (lightest) — verify merge gate + AC, then run `/wrap` to squash-merge, sync main, and report `merged`. Do not duplicate `/wrap` logic. `/wrap`'s Phase 3 now also runs a full-session sweep (Part B); in a Phase C subagent's narrow transcript it degrades gracefully (usually "Clear to archive") and is **advisory only — never block a merge on a sweep finding**.
 
-**Orchestration:** parent launches Phase A (parallel across PRs allowed); Phase A complete → cleanup per `phase-protocols.md` then Phase B; Phase B `merge_ready` → get merge authorization, then launch Phase C. Keep 3-4 active CR-polled PRs max; at 7+ CR reviews/hour expect Greptile fallback.
+**Orchestration:** parent launches Phase A (parallel across PRs allowed); Phase A complete → cleanup per `phase-protocols.md` then Phase B; Phase B `merge_ready` → get merge authorization, then launch Phase C. Keep 3-4 active CR-polled PRs max; at 7+ CR reviews/hour expect Greptile fallback. This same 3-4 ceiling is the concurrent-pipeline cap `/pm` and `/subagent` reuse for inline A→B→C execution: queue issues beyond it. Queue mechanics, terminal-state and `merge_ready` slot semantics: `.claude/skills/subagent/SKILL.md` Step 7.
 
 ## Subagent Review Protocol
 

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -430,22 +430,27 @@ After setup, proceed to **Step 3: Orchestration Loop**.
 
 This is the core PM behavior. Once the user confirms which issues to work on, enter the orchestration loop.
 
-### 3.1: Generate coding thread prompts
+### 3.1: Launch selected issues (inline by default)
 
-For each selected issue, generate a self-contained prompt. The prompt content below is the same in both delivery modes — only how it reaches the user differs.
+Once the user has selected which issues to work on, **partition them** with the "too big for any subagent" test from `/subagent` Step 4 — Phase A won't fit one subagent's output budget, needs interactive human judgment mid-build, or should be split into multiple PRs. This is a judgment call about *whole-issue size and interactivity*, not tier, and not file/AC/dependency counts. Touching `.claude/rules`, `CLAUDE.md`, or `.claude/skills` does **not** make an issue too big. Then:
+
+- **Inline-eligible issues (the default — most issues):** run them inline through the `/subagent` A→B→C flow. This is the default action; selecting the issue is the go-ahead — no "go ahead and run those" needed. Invoke `/subagent #{a} #{b} …` with the eligible set; it runs Phase A then Phase B under Dedicated Monitor Mode, driving each to `merge_ready`, and runs Phase C **only after you authorize the merge**. Launch up to the **3–4 concurrent-pipeline** ceiling from `subagent-orchestration.md` and queue the rest, starting a queued pipeline as each running one **merges or blocks** — a pipeline parked at `merge_ready` keeps its slot through Phase C (see 3.4). Inline runs **stop at `merge_ready` and ask for merge authorization before Phase C** (`/subagent` Step 10) — PM never auto-merges a batch. Mark each such issue `Inline` in the Active Work table (3.2).
+- **Too-big issues (the exception):** hand these out as thread prompts for the user to launch in a separate thread, each with a **one-line reason** naming which criterion fired. This is the only path that produces a chip or a printed prompt block. Everything from here to the end of 3.1 governs the too-big subset only.
+
+**Thread-prompt delivery for too-big issues.** For each too-big issue, generate a self-contained prompt. The prompt content below is the same in both delivery modes — only how it reaches the user differs.
 
 **First, check chip availability** per `.claude/reference/chip-launching.md`, then branch:
 
-- **Chip mode** (`mcp__ccd_session__spawn_task` present): call `spawn_task` once per selected issue with `title` / `prompt` / `tldr` / `cwd`, where `prompt` is the full self-contained prompt below, unchanged. Print **only** the short summary per issue (issue, title, `**Model:**` line, one-line rationale) — see the reference for the exact format. Record each returned `task_id` in the Active Work table (3.2) and set that issue's status to `Chip offered`.
-- **Fallback mode** (tool absent): emit the full prompt blocks for every selected issue — same fences, same content, model-guard preamble included. `chip-launching.md` redefines the fallback baseline as byte-identical to the chip `prompt` (guard included), not pre-chip output — see `chip-model-guard-decision.md`.
+- **Chip mode** (`mcp__ccd_session__spawn_task` present): call `spawn_task` once per too-big issue with `title` / `prompt` / `tldr` / `cwd`, where `prompt` is the full self-contained prompt below, unchanged. Print **only** the short summary per issue (issue, title, `**Model:**` line, one-line too-big reason) — see the reference for the exact format. Record each returned `task_id` in the Active Work table (3.2) and set that issue's status to `Chip offered`.
+- **Fallback mode** (tool absent): emit the full prompt blocks for every too-big issue — same fences, same content, model-guard preamble included. `chip-launching.md` redefines the fallback baseline as byte-identical to the chip `prompt` (guard included), not pre-chip output — see `chip-model-guard-decision.md`.
 
-**Spawn outcomes are tracked per issue.** A failed `spawn_task` falls back for **that issue alone** — print its full block and leave it at `Prompt generated`. Issues whose spawns succeeded keep their chip, their `task_id`, and their `Chip offered` status; never re-print their block as well, or the same issue is offered twice. Every selected issue ends with exactly one of: a chip, or a printed block.
+**Spawn outcomes are tracked per issue.** A failed `spawn_task` falls back for **that issue alone** — print its full block and leave it at `Prompt generated`. Issues whose spawns succeeded keep their chip, their `task_id`, and their `Chip offered` status; never re-print their block as well, or the same issue is offered twice. Every too-big issue ends with exactly one of: a chip, or a printed block.
 
 Chips carry no model preset, so the `**Model:**` line must appear both in the visible summary and inside the chip's prompt text. Get the model recommendation from `/prompt`'s tier classification when it ran; otherwise infer it from the issue's signals using the same Heavy/Standard/Light mapping. Immediately after the `**Model:**` line, the prompt also carries the mandatory model-guard preamble defined in `chip-launching.md` — insert it verbatim, never reworded.
 
 If the user asks to "print the full prompt for #N" while in chip mode, re-emit that issue's complete block verbatim, guard included — the chip stays offered.
 
-Each prompt must include:
+Each too-big issue's thread prompt must include:
 
 ```
 **Model:** {MODEL} — {REASON}
@@ -483,7 +488,7 @@ Fix/implement issue #{N}: {title}
 - Squash and merge when reviews are clean
 ```
 
-Offer or present every prompt — never execute one. Do NOT spawn subagents or run the prompts: in chip mode the user's click is the only launch path, and in fallback mode the user pastes the block into a thread. Only spawn agents if the user explicitly asks (e.g., "go ahead and run those", "spin up agents for those").
+For too-big issues, offer or present the prompt — never execute it: in chip mode the user's click is the only launch path, and in fallback mode the user pastes the block into a thread. Inline-eligible issues are the opposite — PM runs them itself via `/subagent` per the default at the top of 3.1, no extra "go ahead and run those" required.
 
 ### 3.2: Track assignments
 
@@ -494,6 +499,7 @@ Maintain a state table in the conversation. Update it as work progresses:
 
 | Issue | Thread | Task ID | PR | Status | Last Update |
 |-------|--------|---------|----|--------|-------------|
+| #40 | Inline | — | PR #87 | Phase B (in review) | {timestamp} |
 | #42 | Chip offered | `task_abc123` | — | Awaiting thread start | {timestamp} |
 | #61 | Prompt generated | — | — | Awaiting thread start | {timestamp} |
 | #38 | Active | — | PR #88 | In review | {timestamp} |
@@ -502,9 +508,10 @@ Maintain a state table in the conversation. Update it as work progresses:
 
 **Thread column values:**
 
-- `Chip offered` — a chip was spawned for this issue and is waiting on a click (chip mode).
-- `Prompt generated` — a full prompt block was printed for the user to paste (fallback mode, or a failed spawn).
-- `Active` — a thread is running for this issue.
+- `Inline` — PM is running this issue itself via the `/subagent` A→B→C flow (its phase shows in the Status column). Not a separate thread and carries no chip; this is the default for inline-eligible issues.
+- `Chip offered` — a chip was spawned for this (too-big) issue and is waiting on a click (chip mode).
+- `Prompt generated` — a full prompt block was printed for the user to paste (too-big issue; fallback mode, or a failed spawn).
+- `Active` — a separate thread is running for this issue.
 
 **Task ID column:** every `Chip offered` row MUST carry the `task_id` returned by its `spawn_task` call — it is the only handle for dismissing that chip later, and a chip whose `task_id` was not recorded cannot be withdrawn. `Prompt generated` and `Active` rows leave it empty (`—`).
 
@@ -543,7 +550,9 @@ Also accept user input: "thread for #42 is done", "PR #88 merged", "#55 is block
 
 ### 3.4: Suggest next batch
 
-When one or more threads finish (PRs merged, issues closed):
+**Refill inline slots first.** A pipeline frees its concurrency slot only when its `/subagent` run reaches a terminal `OUTCOME` — `merged` or `blocked` — one parked at `merge_ready` still has merge authorization and Phase C ahead, so it keeps its slot until it actually merges. When a slot frees, start the next issue queued behind the 3–4 ceiling from 3.1 before anything else — but first re-validate that queued issue with a quick current-state + too-big check (3.1 / `/subagent` Steps 4–5): if it has since closed, gained its own PR, or become too big, skip it and take the next queued one. This keeps up to the cap running without exceeding it, and is separate from suggesting *new* backlog issues below. If every slot is parked at `merge_ready`, ask for merge authorization rather than launching more — each authorized merge frees a slot.
+
+When one or more pipelines or threads finish (PRs merged, issues closed):
 
 1. **Dismiss the chips of finished issues, then remove their rows.** Order matters: a row carries its chip's `task_id`, and once the row is gone the chip can no longer be withdrawn. So for every completed issue still at `Chip offered`, `dismiss_task` first — its work is done, the offer is dead — and only then drop it from the assignments table.
 2. Re-scan open issues (reuse 1B.2-1B.4b logic but lighter — only re-read bodies **and comments** for issues whose `updatedAt` moved since the last scan's baseline, or that have no recorded baseline yet (first seen this pass — always gets a full read, same as a changed issue); track/update that baseline per issue as you go). **`updatedAt` bumps on a new comment just like a body edit**, so a dependency reference added in a comment on an otherwise-untouched issue (e.g. "blocked by #99") is still caught on the next pass — re-reading is scoped by *any* change, not just body/title edits, which is what keeps this from being a real completeness gap. **Re-score the whole retained candidate set, not just the changed issues:** tiers depend on the dependency map, so a closed or merged issue can change an *unchanged* issue's tier — #42 loses its leverage boost the moment the issues it unblocked are done. Refresh the map with what closed **and** what changed, then re-run 1B.4/1B.4b across every remaining candidate. Re-reading bodies and comments stays scoped to issues whose `updatedAt` moved or that are new — that's the expensive part and it stays incremental; re-scoring the dependency map and tiers is cheap and must be total.
@@ -573,19 +582,11 @@ When the conversation is getting long (many back-and-forth cycles, multiple batc
 
 ## Execution Boundary (CRITICAL)
 
-**This skill does NOT write code, create PRs, or spawn subagents.**
+**PM's default for a selected inline-eligible issue is to run it inline via the `/subagent` A→B→C flow** — the routing, concurrency, and queueing mechanics live in 3.1. Three guardrails sit on top of that:
 
-The PM orchestrator's job is to:
-- Analyze the backlog and recommend what to work on
-- Generate self-contained prompts for coding threads, and offer them as chips when available
-- Track progress across threads
-- Suggest next work when threads finish
-
-The **user** decides when and where to start work — by clicking a chip in chip mode, or by pasting a prompt in fallback mode. The user starts the coding threads. The PM tracks and coordinates.
-
-**Offering a chip is not launching a thread.** `spawn_task` puts a chip in front of the user; only their click starts a session. The PM never clicks for them, and never runs a coding thread's work itself — via the Agent tool or otherwise — in place of a chip the user hasn't clicked. This governs coding threads only; the read-only `pm-worker` data-gathering spawns described under "Model selection for spawned subagents" below remain allowed and are unaffected.
-
-**Exception:** If the user explicitly says "go ahead and run those", "spin up agents", or "execute those prompts" — then and only then may you spawn subagents via the Agent tool to execute the coding thread prompts.
+- **PM writes no code itself.** The Phase A/B/C subagents implement, review, and merge; PM only orchestrates and monitors (Dedicated Monitor Mode). The read-only `pm-worker` data-gathering spawns described under "Model selection for spawned subagents" below remain allowed and unaffected.
+- **No batch auto-merge — merge authorization is still required.** Inline runs stop at `merge_ready` and wait for merge authorization before Phase C (`/subagent` Step 10, CLAUDE.md's merge-authorization rule). PM never merges a batch on its own.
+- **Too-big issues are the user's to start.** They get a thread prompt (chip or printed block); `spawn_task` only *offers* a chip — the user's click is what starts the thread. PM never clicks for them, and never runs a too-big issue inline in place of a chip the user hasn't clicked.
 
 **Model selection for spawned subagents:**
 
@@ -602,5 +603,5 @@ The **user** decides when and where to start work — by clicking a chip in chip
 - **Flag dependencies inline** with the issues they affect.
 - **Total suggestions should be scannable in under 1 minute.**
 - **Do not narrate the scoring process.** Rankings read as a confident recommendation, not a methodology walkthrough. The tiers and rationales are the output; the signals that produced them are not.
-- **Coding thread prompts should be complete and self-contained.** The receiving thread has zero prior context — give it everything it needs.
+- **Thread prompts (for too-big issues) should be complete and self-contained.** The receiving thread has zero prior context — give it everything it needs.
 - **Do not list every issue.** If 80 of 100 issues are low-priority, say "75 additional issues deferred" rather than listing them.

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prompt
-description: Analyze GitHub issues to assess complexity, recommend a model tier, and generate tailored prompts with pre-extracted context. Use when starting work, planning sprints, right-sizing model choice, or analyzing issue batches. When called with no args in a PM thread, auto-detects suggested issues and partitions subagent candidates from thread prompts.
+description: Analyze GitHub issues to assess complexity, recommend a model tier, and generate tailored prompts with pre-extracted context. Use when starting work, planning sprints, right-sizing model choice, or analyzing issue batches. When called with no args in a PM thread, auto-detects suggested issues, partitioning inline subagent runs (the default) from the few too-big issues that need a separate thread.
 triggers:
   - analyze issue
   - generate prompt
@@ -57,9 +57,9 @@ If `$ARGUMENTS` is empty, check for PM orchestration context. PM context is dete
    - Listed in the `## Active Work` table with status "Awaiting thread start"
 
    **Then exclude** (AND NOT — remove any issue that matches any of these):
-   - Marked as "Active", "In review", "Merged", "Prompt generated", or "Chip offered" in the `## Active Work` table
+   - Marked as "Inline", "Active", "In review", "Merged", "Prompt generated", or "Chip offered" in the `## Active Work` table
 
-   "Chip offered" means `/pm` already offered that issue as a click-to-launch chip — it is offered-but-unstarted, exactly like "Prompt generated", so excluding it prevents double-offering the same issue.
+   "Chip offered" means `/pm` already offered that issue as a click-to-launch chip — it is offered-but-unstarted, exactly like "Prompt generated", so excluding it prevents double-offering the same issue. "Inline" means `/pm` is already running the issue as a subagent, so it is excluded for the same reason.
 
    Example: If `## Suggested Next Issues` lists #42, #55, #61 and the Active Work table shows #42 as "In review", the result is #55 and #61.
 
@@ -173,27 +173,19 @@ If classification is unclear, default to **Standard**. It is better to slightly 
 
 **Skip this step entirely if `PM_AUTO_DETECT` is not `true`** (i.e., when explicit arguments were provided via Path A, or if Path C was taken). When skipped, all issues proceed to Step 6 as thread-prompt issues.
 
-When `PM_AUTO_DETECT=true`, partition the classified issues into two groups using the subagent candidate criteria. Eligibility must be evaluated **per issue**. An issue is **subagent-eligible** if ALL of the following are true:
+When `PM_AUTO_DETECT=true`, partition the classified issues into two groups. **The default is subagent-eligible (inline execution); an issue falls into the thread-prompt group only if it is "too big for any subagent."** Evaluate the too-big test **per issue**, using the same three criteria as `/subagent` Step 4 — a judgment call about whole-issue size and interactivity, **not** tier and **not** file/AC/dependency arithmetic:
 
-| Signal | Subagent-eligible threshold |
-|--------|---------------------------|
-| `file_count` | 0–1 |
-| `ac_count` | ≤ 3 |
+1. **Phase A won't fit one subagent's output budget** — a very large, many-file initial implementation a single Phase A subagent (~32K output budget) couldn't produce in one pass. Judge from the CR-plan file list and scope, not a fixed `file_count`.
+2. **Needs interactive human judgment mid-build** — genuinely unresolved product/design decisions that must be settled *during* implementation. An "Open questions" section the issue already answers does not count.
+3. **Should be split into multiple PRs** — the issue asks to be split, or its scope spans several independent deliverables.
 
-| `dependency_count_per_issue` | 0 (count only dependencies referencing or referenced by this specific issue, not the batch total) |
-
-| `touches_rules` | `false` |
-| `touches_claude_md` | `false` |
-| `has_orchestration_keywords` | `false` |
-| `issue_tier` | Light |
-
-Use per-issue signal values from Steps 4–5, including `issue_tier` (the per-issue tier from the classification decision tree — not the batch tier). Do not use batch-aggregated values for per-issue gating. Apply the table as a gate: if ANY signal exceeds its threshold, the issue is **not** subagent-eligible.
+If **none** hold, the issue is **subagent-eligible** (runs inline). If **any** holds, it is a **thread-prompt issue** (too big). Touching `.claude/rules`, `CLAUDE.md`, or `.claude/skills`, a high `ac_count`, dependencies, orchestration keywords, or a Heavy/Standard `issue_tier` no longer force the thread-prompt group on their own — none of them is a gate here.
 
 **Result of partitioning:**
-- **Subagent-eligible issues** — reported in a separate section with a `/subagent` command suggestion (see Step 6)
-- **Thread-prompt issues** — everything else. These get full prompt blocks as normal.
+- **Subagent-eligible issues (the default, usually the majority)** — reported in a separate section with a `/subagent` command suggestion (see Step 6).
+- **Thread-prompt issues (too big)** — everything the too-big test flagged. These get full prompt blocks as normal, each with a one-line too-big reason.
 
-If all issues are subagent-eligible, the thread-prompt group is empty — only the Subagent Candidates section is output. If no issues are subagent-eligible, the Subagent Candidates section is omitted entirely.
+If all issues are subagent-eligible, the thread-prompt group is empty — only the Subagent Candidates section is output. If no issues are subagent-eligible (every detected issue is too big), the Subagent Candidates section is omitted entirely.
 
 **Batch tier recomputation:** When `PM_AUTO_DETECT=true` and partitioning produces a non-empty subagent-eligible group, the batch tier from Step 5 may be incorrect (it was computed over all issues including the now-partitioned subagent candidates). Recompute the batch tier using only the thread-prompt issues. This includes recomputing all derived signals for that subset (e.g., `is_multi_issue`, dependency totals, and other batch-level aggregates) before reapplying the Step 5 decision tree. If all issues were subagent-eligible (empty thread-prompt group), skip tier computation entirely.
 
@@ -241,9 +233,9 @@ For single-issue input, there is one prompt block. For batch input, there are mu
 When `PM_AUTO_DETECT=true` and subagent-eligible issues exist, output this section first:
 
 ```
-## Subagent Candidates (skip thread — run inline)
+## Subagent Candidates (run inline — default)
 
-These issues are small enough to run as subagents directly in this PM thread:
+These issues run inline as subagents directly in this PM thread — the default for anything not too big for a subagent:
 - #{N} — {Title} ({Tier} tier, {file_count} file(s))
 - #{M} — {Title} ({Tier} tier, {file_count} file(s))
 
@@ -356,7 +348,7 @@ This task is done when:
 - **Multiple issues with mixed complexity:** See the batch handling rule in Step 5 — the most complex issue determines the batch tier.
 - **PM auto-detect finds no issues:** If PM context is detected but no extractable issue numbers are found (e.g., the "Suggested Next Issues" section has no valid issue references), tell the user: "PM context detected but no unstarted issues found in the latest suggestions. Provide issue numbers explicitly: `/prompt #N #M`"
 - **All PM-detected issues are subagent-eligible:** Output only the Subagent Candidates section. No tier recommendation or prompt blocks needed.
-- **All PM-detected issues are thread-prompt-eligible:** Output normally — skip the Subagent Candidates section entirely. This is the same as the explicit-args path.
+- **All PM-detected issues are too big (thread-prompt):** Output normally — skip the Subagent Candidates section entirely. This is the same as the explicit-args path.
 - **`/subagent` skill not yet available:** The Subagent Candidates section outputs a `/subagent` command suggestion regardless of whether the skill exists. If the user runs it and the skill is missing, they will get a clear error. The `/prompt` skill does not gate on `/subagent` availability.
 - **Chip tool unavailable (CLI, headless, older client):** Fallback mode — output is byte-identical to the chip `prompt`, model-guard preamble included (see `chip-model-guard-decision.md`). Do not mention chips.
 - **Spawn fails mid-batch:** Fall back to a printed block for that issue only; the rest of the batch keeps its chips. Do not retry the failed spawn.
@@ -379,7 +371,7 @@ This task is done when:
 ```
 /prompt
 ```
-When called with no args in a PM thread, auto-detects recently suggested issues, classifies each, and partitions into subagent candidates (with `/subagent` command suggestion) and thread prompts.
+When called with no args in a PM thread, auto-detects recently suggested issues, classifies each, and partitions into subagent candidates (the default — run inline via `/subagent`) and the few too-big issues that get thread prompts.
 
 **No arguments outside PM context:**
 ```

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: subagent
-description: Run Quick/Light issues as subagents directly from a PM thread. Validates complexity, spawns Phase A/B/C agents, monitors progress, and reports merge readiness. Use when small issues should be executed inline instead of in separate coding threads.
+description: Run issues inline as subagents directly from a PM thread — any tier, except issues too big for a subagent. Assesses subagent fit, spawns Phase A/B/C agents, monitors progress, and reports merge readiness. Use to execute selected issues inline instead of in separate coding threads.
 argument-hint: "#42 [#55 #61 ...] (one or more issue numbers)"
 ---
 
-Execute one or more small issues as subagents within the current thread. Each issue goes through the full Phase A/B/C orchestration protocol (fix, review, merge prep) while this skill monitors progress and manages transitions.
+Execute one or more issues as subagents within the current thread. Each issue goes through the full Phase A/B/C orchestration protocol (fix, review, merge prep) while this skill monitors progress and manages transitions. Inline execution is the default for issues of any tier; the only issues routed out to a separate thread are those too big for a subagent (Step 4).
 
 Parse `$ARGUMENTS` as space-separated issue references. Strip `#` prefixes to get bare issue numbers. If no arguments provided, ask the user which issue(s) to execute.
 
@@ -76,66 +76,49 @@ From the returned comments, prefer the most structured/detailed **human-authored
   - Normalize: trim whitespace, strip leading `./`, deduplicate, skip non-path lines
 - Store the CR plan content verbatim for inclusion in the subagent prompt
 
-## Step 3: Extract Complexity Signals
+## Step 3: Gather Scope Signals (inputs to the too-big judgment)
 
-Compute these signals per issue (same logic as `/prompt` Steps 3-4):
+The gate in Step 4 is **not** tier-based and **not** arithmetic — it is a judgment call about whether a single subagent can carry the issue. Collect only the signals that inform that judgment; none of them rejects an issue on its own:
 
-| Signal | How to compute |
-|--------|---------------|
-| `file_count` | Count of files from CR plan file list. If no CR plan, count path-like strings in the issue body (contain `/`, end with a file extension, don't start with `http`). Default: 0. |
-| `dependency_count` | Count of dependency references: `blocked by #N`, `depends on #N`, `blocks #N`, `after #N`, etc. Scan both issue body and comments. |
-| `is_multi_issue` | `true` if more than one issue number was provided as input. |
-| `touches_rules` | `true` if any file path matches `.claude/rules/*.md` OR body mentions "rule file", "workflow protocol". |
-| `touches_claude_md` | `true` if any file path matches `CLAUDE.md` (case-insensitive) OR body mentions "CLAUDE.md". |
-| `touches_skill` | `true` if any file path matches `.claude/skills/` OR issue is about creating/modifying a skill. |
-| `ac_count` | Count of acceptance criteria checkboxes (both `- [ ]` and `- [x]`/`- [X]`) in issue body. |
-| `has_orchestration_keywords` | `true` if body contains: "subagent", "Phase A", "Phase B", "Phase C", "multi-phase", "orchestration", "monitor mode", "handoff". |
-| `scope_keywords` | Collect any of: "typo", "rename", "comment", "config", "doc update", "README", "formatting". |
+| Signal | How to compute | Feeds |
+|--------|---------------|-------|
+| `file_list` / `file_count` | Files from the canonical plan `$PLAN` (Step 2 — CR- or human-authored) when it lists them; otherwise path-like strings in the issue body (contain `/`, end with a file extension, don't start with `http`). A **soft input** to "Phase A won't fit" — read it as *how sweeping* the change is, not as a fixed threshold. | Criterion 1 |
+| `ac_count` | Count of acceptance-criteria checkboxes (both `- [ ]` and `- [x]`/`- [X]`) in the issue body. Scope context only; never a gate on its own. | Criterion 1 |
+| `interactive_markers` | `true` if the issue body **or `$PLAN`** carries genuinely **unresolved** product/design decisions that must be settled mid-build — an open "Open questions"/"Decisions needed" section, "needs discussion", "TBD", "we should decide". An open-questions section the issue already answers does **not** count. | Criterion 2 |
+| `split_markers` | `true` if the issue body **or `$PLAN`** asks to be split — "split into N PRs", "multiple PRs", "break this up" — or its scope spans several independent deliverables. | Criterion 3 |
 
-## Step 4: Classify Tier (Same as `/prompt` Step 5)
+What is deliberately **absent** here: touching `.claude/rules`, `CLAUDE.md`, or `.claude/skills`; high AC or dependency counts; and orchestration keywords no longer route an issue to a thread. Tier (Quick/Light/Standard/Heavy) is not computed — it does not gate inline execution.
 
-Apply this decision tree. When signals conflict, choose the **higher** tier.
+## Step 4: Assess "Too Big for Any Subagent"
 
-### Heavy — reject
-Assign Heavy if ANY: `touches_rules`, `touches_claude_md`, `has_orchestration_keywords`, `file_count > 5`, `dependency_count > 2`, or (`is_multi_issue` AND at least one issue has `file_count > 1` or `ac_count > 3`).
+Tier does **not** decide this — most issues, of any tier, run inline. An issue is **too big** (→ route to a separate thread in Step 5) only if **ANY** of these three criteria hold. This is a judgment call, not arithmetic:
 
-### Standard — reject
-Assign Standard if ANY (and Heavy not triggered): `file_count` 2–5, `ac_count > 3`, `touches_skill`, body >200 words with feature keywords, or `is_multi_issue` with mixed complexity.
+1. **Phase A won't fit one subagent's output budget.** The initial implementation is a very large, many-file change that a single Phase A subagent (~32K output-token budget) couldn't produce in one pass — a sweeping migration across many files, or a large new subsystem. Judge from the `file_list`/scope gathered in Step 3, **not** a fixed file count.
+2. **Needs interactive human judgment mid-build.** The issue carries genuinely unresolved product/design decisions that must be settled *while* implementing and can't be pinned down up front (`interactive_markers`). An "Open questions" section the issue already answers does **not** count — only open calls that would block a subagent mid-build.
+3. **Should be split into multiple PRs.** The issue explicitly asks to be split, or its scope spans several independent deliverables that each deserve their own PR and review cycle (`split_markers`).
 
-### Quick — accept
-Assign Quick only if ALL: `scope_keywords` exclusively from "typo"/"rename"/"comment"/"formatting", `file_count` 0–1, `ac_count` <= 2, `dependency_count` 0, no orchestration/rule/skill signals.
+If **none** hold, the issue is **inline-eligible** — proceed to Step 5 and run it. If **any** holds, mark it **too big** and record the one triggering reason for the Step 5 hand-off message.
 
-### Light — accept
-Assign Light if ANY (and Heavy/Standard/Quick not triggered): `file_count` 0–1, `scope_keywords` include "config"/"doc update"/"README", or issue describes a single-file change.
+**Removed with this gate:** the old Quick/Light-only accept list and its blanket rejections for touching `.claude/rules` / `CLAUDE.md` / `.claude/skills`, for high file/AC/dependency counts, or for orchestration keywords. None of those route an issue to a thread anymore — only the three criteria above do.
 
-### Fallback
-If unclear, default to **Standard** (which means rejection).
+## Step 5: Gate Outcome — Run Inline, or Route Too-Big to a Thread
 
-## Step 5: Gate Check — Validate Candidate Criteria
+Apply Step 4's verdict per issue. **Being too big is not a failure — it routes the issue to a thread so nothing is dropped.**
 
-For each issue, verify ALL of the following:
+- **Inline-eligible** issues → proceed to Step 6 and run them.
+- **Too-big** issues → do NOT execute them here. Emit a thread prompt so the work isn't lost:
 
-| Signal | Threshold |
-|--------|-----------|
-| `file_count` | 0–1 files |
-| `ac_count` | <= 3 acceptance criteria |
-| `dependency_count` | 0 (no blockers or blocked-by) |
-| `touches_rules` | `false` |
-| `touches_claude_md` | `false` |
-| `has_orchestration_keywords` | `false` |
-| Tier classification | Quick or Light only |
+  ```
+  Issue #N is too big for inline subagent execution ({one-line reason: Phase A won't fit in one subagent / needs interactive judgment mid-build / should be split into multiple PRs}).
+  Routing to a separate thread — run `/prompt #N` to generate the thread prompt.
+  ```
 
-**If any signal exceeds its threshold, reject the issue:**
+  (`/prompt #N` with an explicit issue number always produces a full thread-prompt block — see `/prompt` Path A. Routing to a thread is the whole point of the rejection; it never means the issue is dropped.)
 
-```
-Issue #N is too complex for subagent execution (classified as {tier}).
-Failing signals: {list signals that exceeded thresholds}
-Use `/prompt #N` to generate a thread prompt instead.
-```
-
-**If all issues are rejected**, stop and report the rejections. Do not proceed.
-
-**If some pass and some fail**, report the rejections and proceed with the qualifying issues. Ask: "Proceeding with qualifying issues: #{a}, #{b}. The rejected issues need `/prompt` instead."
+**Batch outcomes:**
+- **All inline-eligible** → proceed with all of them (Step 6).
+- **All too-big** → report each issue's reason and its `/prompt` routing. This is a clean outcome, not an error — stop here.
+- **Mixed** → run the inline-eligible issues now and list the too-big ones: "Running inline: #{a}, #{b}. Too big for a subagent (routed to threads): #{c} ({reason}) — run `/prompt #c` for that one."
 
 ## Step 6: Pre-Spawn Setup
 
@@ -196,10 +179,11 @@ Store the complete output — do NOT summarize or excerpt.
 
 For each qualifying issue, spawn a Phase A subagent using the Agent tool.
 
-**Parallel execution rules:**
-- Spawn up to 4 Phase A subagents in parallel (soft limit from subagent-orchestration.md)
-- If more than 4 qualifying issues, stagger: spawn the first 4, then spawn additional agents as earlier ones complete
-- Each subagent gets its own worktree (use `isolation: "worktree"` on the Agent tool call)
+**Parallel execution rules — the 3–4 concurrent-pipeline ceiling:**
+- Treat each issue's A→B→C run as one **pipeline**. Keep at most the concurrency ceiling from `subagent-orchestration.md` ("keep 3-4 active CR-polled PRs max") running at once — **3–4 concurrent pipelines**. Reuse that number; do not invent a new one.
+- If more issues qualify than the ceiling, launch the first 3–4 now and **queue** the rest. Start a queued pipeline only when a running one reaches a **genuinely terminal state — `merged` or `blocked`.** A pipeline parked at `merge_ready` is **not** terminal: merge authorization and Phase C are still ahead, so it keeps its slot until it actually merges (or blocks). Freeing the slot at `merge_ready` would let a new pipeline start while the parked one's Phase C is still pending, pushing total in-flight pipelines past the ceiling.
+- When every slot is held by pipelines parked at `merge_ready`, don't launch more — surface the merge-authorization ask (Step 10). Each authorized merge finishes Phase C and frees a slot for the next queued pipeline.
+- Each subagent gets its own worktree (use `isolation: "worktree"` on the Agent tool call).
 
 **Subagent prompt template** (fill in variables per issue):
 
@@ -550,4 +534,4 @@ When all subagent PRs are either merged or blocked:
 ```
 /subagent #42 #55
 ```
-(Quick/Light issues run as subagents; remaining issues get `/prompt` for separate threads)
+(Issues run inline as subagents by default, regardless of tier; only issues too big for a subagent — Phase A won't fit, needs interactive judgment mid-build, or should be split into multiple PRs — get `/prompt` for separate threads)


### PR DESCRIPTION
## **User description**
## Summary

Flips the default across `/pm`, `/subagent`, and `/prompt`: **inline A→B→C subagent execution is now the default** for selected issues of *any* tier. An issue is routed out to a separate thread only when it is **"too big for any subagent"** — a judgment call on whole-issue size and interactivity, **not** tier:

1. **Phase A won't fit** one subagent's ~32K output budget (a very large, many-file change).
2. **Needs interactive human judgment mid-build** — genuinely open product/design decisions that can't be settled up front.
3. **Should be split into multiple PRs.**

Touching `.claude/rules`, `CLAUDE.md`, or `.claude/skills` no longer forces a thread on its own. A "too big" issue is **routed to a `/prompt` thread prompt, never dropped**. Inline batches launch up to the existing **3–4 concurrent-pipeline ceiling** (`subagent-orchestration.md`) and queue the rest; a slot frees **only when a pipeline actually `merged` or `blocked`** — a pipeline parked at `merge_ready` keeps its slot through Phase C, so total in-flight pipelines never exceed the cap. Inline runs **stop at `merge_ready` and require merge authorization before Phase C — no batch auto-merge.**

Closes #613

## Changes

- **`.claude/skills/subagent/SKILL.md`** — Steps 3–5 reworked from tier-based accept/reject to the too-big assessment (Step 3 gathers scope inputs incl. the canonical `$PLAN`; Step 4 = the three criteria; Step 5 routes eligible→inline, too-big→`/prompt`, never fails). Step 7 = 3–4 concurrent-pipeline cap + queue/`merge_ready`-slot semantics. Frontmatter + usage note de-tiered.
- **`.claude/skills/pm/SKILL.md`** — Step 3.1 restructured to inline-by-default (chip/fallback delivery scoped to too-big issues only). Execution Boundary rewritten (inline is the default, not gated behind "go ahead and run those"; still writes no code itself, still stops at merge-ready). Active Work `Inline` status; 3.4 slot-refill + queued-issue re-validation.
- **`.claude/skills/prompt/SKILL.md`** — Step 5.5 partition inverted (subagent-eligible/inline is the default; only too-big issues become thread prompts). Step 6 output + template reframed; Path B excludes the new `Inline` status.
- **`.claude/reference/pm-monitoring-decision.md`** — division-of-labor framing updated (`/pm` runs eligible issues inline via `/subagent` in-turn monitoring; still creates no recurring poll; `/pr-monitor-and-manage` split unchanged).
- **`.claude/rules/subagent-orchestration.md`** — one clause tying the 3–4 ceiling to the inline concurrent-pipeline cap, deferring mechanics to `/subagent` Step 7.

## Local review

- **CodeAnt CLI:** not installed on this machine → dropped for the session (per `cr-local-review.md`); gated on CodeRabbit alone.
- **CodeRabbit CLI:** 3 passes run; the `merge_ready`-frees-a-slot concurrency bug and all other substantive findings were fixed (findings 4 → 4 → 2). The 4th confirmation pass hit the free-OSS rate limit. One remaining finding was **declined**: a request to reformat the pre-existing `subagent-orchestration.md` "Orchestration:" prose paragraph into bullets — stylistic, and inconsistent with that file's prose style. GitHub CodeRabbit review will re-review on this PR.
- **Rule-corpus budget:** 11,733 words — under the 12,000 soft warning and the 12,232 ratchet cap (`rule-lint` required check will confirm).

## Test Plan

- [x] In a PM thread, select a Standard-tier issue (2–4 files, several AC, touches a skill): PM runs it inline via A→B→C by default rather than emitting a thread prompt.
- [x] Select an issue that touches `.claude/rules` or `CLAUDE.md`: it runs inline, not auto-routed to a thread.
- [x] Select a genuinely oversized issue (many files, or explicitly "split into N PRs", or an open design decision): PM declines inline execution and offers a new-thread prompt with a one-line reason.
- [x] Select a batch larger than the concurrency ceiling: PM starts the cap's worth inline and queues the rest, launching queued pipelines as earlier ones complete.
- [x] Run an inline pipeline to completion: it halts at merge-ready and asks for merge authorization; it does not merge on its own.
- [x] `/prompt` with no args in a PM thread partitions the detected batch with inline as the default and only "too big" issues in the thread-prompt group.
- [x] `{ cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } | wc -w` stays within the enforced budget (verified post-rebase: 12,030 ≤ 12,232).
- [x] The three skills are internally consistent — no leftover "separate thread is default / Quick-Light only" prose (grep-verified across `/pm`, `/subagent`, `/prompt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Run selected issues inline by default, and send only too-large work to separate threads**

### What Changed
- PM now runs most selected issues through the inline A→B→C flow instead of sending them to a separate thread first
- Issues are routed to a thread only when they are too large for one subagent, need live human judgment during the work, or should be split into multiple PRs
- Issues that are already being handled inline are tracked as inline work, and thread prompts are reserved for the few issues that must be started separately
- Inline runs stop at merge readiness and still wait for merge approval before Phase C

### Impact
`✅ Shorter start time for most issues`
`✅ Fewer unnecessary thread handoffs`
`✅ Clearer routing for large or split work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

