### PR TITLE
feat(#618): /pm-clean also sweeps stale worktrees and branches

### DIFF
--- a/.claude/scripts/stale-cleanup.sh
+++ b/.claude/scripts/stale-cleanup.sh
@@ -3,9 +3,11 @@
 #
 # PURPOSE
 #   Replaces the self-cleanup that /wrap used to do (worktree removal + branch
-#   deletion in the running session). Runs out-of-band as part of /pm-update so
-#   the active session never deletes itself. Detects three classes of stale
-#   refs on the root repo:
+#   deletion in the running session). Runs out-of-band so the active session
+#   never deletes itself. Two skills consume this script as the single source of
+#   truth for stale worktree/branch detection and safety — /pm-update (Step 8)
+#   and /pm-clean (workspace sweep) — so their results can never diverge (issue
+#   #618). Detects three classes of stale refs on the root repo:
 #     1. Local worktrees whose HEAD commit is older than STALE_DAYS.
 #     2. Local branches whose tip commit is older than STALE_DAYS.
 #     3. Remote branches (refs/remotes/origin/*) whose tip commit is older

--- a/.claude/skills/pm-clean/SKILL.md
+++ b/.claude/skills/pm-clean/SKILL.md
@@ -1,28 +1,43 @@
 ---
 name: pm-clean
-description: Scan open issues for staleness and suggest closures. Detects issues solved by merged PRs, no-activity issues (30+ days), superseded issues, and potential duplicates of already-closed issues. Presents recommendations for user confirmation — never auto-closes. Triggers on "pm-clean", "stale issues", "clean backlog", "close stale".
-argument-hint: "[days] (optional — inactivity threshold, default 30)"
+description: Scan two independent fronts and recommend cleanup — open GitHub issues (solved-by-PR, inactive, superseded, duplicates) and the on-disk workspace (stale worktrees + local/remote branches, via the shared stale-cleanup.sh). Never auto-closes issues or deletes worktrees/branches without confirmation. Triggers on "pm-clean", "stale issues", "clean backlog", "close stale", "clean worktrees", "stale branches", "prune branches".
+argument-hint: "[days] (optional — default 30; applies to issue inactivity and worktree/branch age) [--worktree-days N] (optional — override worktree/branch age only)"
 ---
 
-Scan the repo's open issues for staleness and present closure recommendations. Parse `$ARGUMENTS`:
+`/pm-clean` is the repo's single janitor. It runs two **independent** staleness scans and presents one recommend-then-confirm report:
 
-- If `$ARGUMENTS` is a positive number, use it as the inactivity threshold in days.
-- If empty, non-numeric, or non-positive (zero or negative), default to 30 days:
+1. **Open GitHub issues** — solved-by-merged-PR, inactive, superseded, potential duplicates.
+2. **On-disk workspace** — stale worktrees and stale local/remote branches, via `.claude/scripts/stale-cleanup.sh` (the exact script `/pm-update` Step 8 calls — one implementation, no divergence).
+
+The two scans never gate each other: one finding nothing does **not** suppress the other, and the summary always reports both. Nothing is closed or deleted without explicit confirmation.
+
+## Step 0: Parse arguments
+
+Parse `$ARGUMENTS`:
+
+- **`[days]`** — the first bare (non-flag) token. If it is a positive number, use it as the issue-inactivity threshold **and** the default worktree/branch age. If empty, non-numeric, or non-positive (zero or negative), default to 30 days:
   - Warn if non-numeric: "Invalid argument '{value}', defaulting to 30 days"
   - Warn if non-positive: "Threshold must be positive, defaulting to 30 days"
+- **`--worktree-days N`** — optional flag. If present and a positive integer, it overrides the worktree/branch age **only** (the issue scan still uses `[days]`). If present but invalid (non-numeric or non-positive), warn ("Invalid --worktree-days '{value}', reusing the [days] threshold of {DAYS}") and fall back to `[days]`. If the flag is absent, the worktree/branch age reuses `[days]`.
 
-## Step 1: Scan the open backlog
+Record two values for the rest of the run: `DAYS` (issue-inactivity threshold) and `WORKTREE_DAYS` (workspace threshold — equal to `DAYS` unless `--worktree-days` overrode it).
+
+> **Threshold note.** Reusing `[days]` means `/pm-clean` defaults the workspace age to 30 days (its issue default), whereas `/pm-update` Step 8 keeps its own `STALE_DAYS=7` default. That is intentional: the two skills share the *implementation* (`stale-cleanup.sh`), not the threshold. Use `--worktree-days 7` for the aggressive sweep.
+
+## Step 1: Issue staleness scan
+
+### Step 1.1: Count the open backlog
 
 ```bash
 gh issue list --state open --limit 500 --json number | jq 'length'
 ```
 
-If the count is 0, report "No open issues found — backlog is clean." and stop. Record the count as `TOTAL_OPEN` for the summary.
+Record the count as `TOTAL_OPEN` for the summary. If it is 0, the issue backlog is clean — note that for Step 3, but **do not stop**: continue to the workspace scan (Step 2). The two scans are independent.
 
-## Step 2: Run the shared staleness detection
+### Step 1.2: Run the shared staleness detection
 
 ```bash
-.claude/scripts/backlog-staleness.sh --days <threshold> --json
+.claude/scripts/backlog-staleness.sh --days <DAYS> --json
 ```
 
 This one call reproduces what was previously four separate inline steps here — gathering open issues, merged PRs, and closed issues, then flagging **solved-by-merged-PR** (closing-keyword regex in merged PR bodies, plus a weaker branch-name signal requiring 2+ shared keywords), **inactive** (the `updatedAt` threshold plus a per-issue comment/open-PR-reference/commit-reference triple check, capped at the 50 oldest candidates), **superseded** (issue-body file/keyword references with 3+ commits each, or 5+ commits on a single file), and **potential-duplicate** (3+ shared significant title words against a *resolved* closed issue, suppressed by explicit cross-references).
@@ -31,11 +46,38 @@ It is the exact same script `/pm`'s Backlog health block calls (issue #598) — 
 
 Each returned record has `number`, `title`, `category` (`solved-by-pr`|`inactive`|`superseded`|`potential-duplicate`), a human-readable `rationale`, plus category-specific evidence fields (`pr`/`merged_at`; `last_activity`/`age_days`; `path`/`commits`; `closed_issue`/`closed_title`/`closed_at`/`keywords`). Group records by `category` for Step 3.
 
-## Step 3: Present recommendations
+## Step 2: Workspace staleness sweep (worktrees + branches)
 
-Group all flagged issues by category and present them in a scannable format.
+This scan delegates **entirely** to `.claude/scripts/stale-cleanup.sh` — the same script `/pm-update` Step 8 calls (issue #618). **Reuse it as-is: never re-derive worktree/branch detection, thresholds, or safety checks in this skill.** The script's safety contract is the single source of truth — it always skips the main worktree, your current worktree, worktrees with uncommitted tracked changes, open-PR branches, protected branch names, and branches checked out in a worktree. See `.claude/scripts/stale-cleanup.sh --help` for the full contract.
 
-### Output structure
+### Step 2.1: Run the dry-run pass
+
+Always run `--check` first — the script never deletes in this mode. Pass the resolved threshold via `STALE_DAYS`, and capture both the JSON and the exit code:
+
+```bash
+RC=0
+WORKSPACE_JSON="$(STALE_DAYS="$WORKTREE_DAYS" .claude/scripts/stale-cleanup.sh --check --json)" || RC=$?
+```
+
+The `|| RC=$?` guard is required: `--check` exits **1** when stale items exist (the normal "found something" case), which would otherwise abort this step under `set -e`.
+
+Branch on `RC` (same contract as `/pm-update` Step 8):
+
+- **`RC == 0`** — no stale items. Record "no stale worktrees or branches" for the Step 3 summary.
+- **`RC == 1`** — stale items exist. Parse `WORKSPACE_JSON` and present them in Step 3.
+- **`RC == 3`** — usage error (bad flag or `STALE_DAYS`). Surface the script's `--help` output and skip the workspace section — this indicates a bug in this skill's invocation, not a real-state problem. The issue scan (Step 1) still stands.
+- **`RC == 4`** — environment error (no `gh`/`jq`, cannot resolve repo). Surface stderr and skip the workspace section. The issue scan still stands.
+- **Any other exit** — treat like an environment error: surface stderr and skip the workspace section (the issue scan still stands). `--check` documents only 0/1/3/4, so this is a defensive catch-all.
+
+`WORKSPACE_JSON` shape (from `--check --json`): `stale_days`; `stale_worktrees[]` (`path`, `branch`, `last_commit_ts`); `stale_local_branches[]` (`branch`, `last_commit_ts`); `stale_remote_branches[]` (`ref`, `last_commit_ts`); and `skipped_worktrees[]` / `skipped_local_branches[]` / `skipped_remote_branches[]` (each `{…, reason}`). Every key is always present (empty arrays when nothing matches), so parsing is safe regardless of state. `last_commit_ts` is a Unix timestamp — render it as `YYYY-MM-DD` for display (`date -r <ts> +%F` on macOS/BSD, `date -d @<ts> +%F` on GNU — the same portable pair `stale-cleanup.sh` uses internally).
+
+## Step 3: Present combined recommendations
+
+Present **both** scans in one report — issue sections first, then workspace sections. Omit any category that has no items; when an entire scan finds nothing, emit its one-line "clean" note (never stay silent about a scan that ran).
+
+### Issue sections
+
+Group flagged issues by `category` and present them in a scannable format:
 
 ```
 ## Backlog Cleanup Recommendations
@@ -77,16 +119,58 @@ Open issues that may duplicate already-closed issues:
 
 Populate each row directly from the record's fields — `pr`/`merged_at` (Solved by Merged PR), `last_activity`/`age_days` (Inactive), `path`/`commits` (Superseded), `closed_issue`/`closed_title`/`closed_at`/`keywords` (Potential Duplicates). The `Recommendation` column is authored prose (e.g. "Close — PR body contains a closing keyword"), not a script field — `rationale` is the evidence backing it, useful as a one-line justification if a table gets flattened to a list.
 
-If a category has no flagged issues, omit that section entirely.
+If a category has no flagged issues, omit that section entirely. If no issues were flagged across all categories, state: "Issue backlog is clean — no stale or duplicate issues detected." (Do not stop — the workspace section still follows.)
 
-If no issues were flagged across all categories, report: "Backlog is clean — no stale or duplicate issues detected."
+### Workspace sections
 
-### Closing section
-
-After the recommendations table:
+Render from `WORKSPACE_JSON` (only when `RC == 1`). Convert each `last_commit_ts` to a `YYYY-MM-DD` date. Put the item count in each heading, and omit any category with no items:
 
 ```
-## Next Steps
+### Stale Worktrees (K)
+
+Idle {WORKTREE_DAYS}+ days. Removing a worktree also deletes its branch when that branch is unprotected and has no open PR.
+
+| Worktree | Branch | Last Commit | Recommendation |
+|----------|--------|-------------|----------------|
+| `path` | `branch` | date | Remove — idle {WORKTREE_DAYS}+ days |
+
+### Stale Local Branches (K)
+
+| Branch | Last Commit | Recommendation |
+|--------|-------------|----------------|
+| `branch` | date | Delete — idle {WORKTREE_DAYS}+ days |
+
+### Stale Remote Branches (K)
+
+| Remote Branch | Last Commit | Recommendation |
+|---------------|-------------|----------------|
+| `origin/branch` | date | Delete — idle {WORKTREE_DAYS}+ days |
+
+### Skipped (safety) (K)
+
+Protected by the script — listed for transparency, NOT offered for deletion:
+
+| Item | Type | Reason |
+|------|------|--------|
+| `path / branch / ref` | worktree / local branch / remote branch | reason (verbatim from the script) |
+```
+
+Draw the **Skipped (safety)** rows from the three `skipped_*` arrays (each item's `reason` verbatim), and render the block whenever any is non-empty while presenting stale items. If the workspace scan found no stale items (`RC == 0`), skip these tables and state: "No stale worktrees or branches detected."
+
+**Summarize the tail.** For large sets (e.g. 20+ stale worktrees), list the most relevant items and summarize the remainder ("…and N more, all idle {WORKTREE_DAYS}+ days") — the same tail treatment the issue scan relies on (`backlog-staleness.sh` caps its own deep check at the 50 oldest candidates and notes any remainder on stderr; surface that note when present).
+
+### Combined summary
+
+Close the report with a one-line status for **each** scan so neither is ambiguous — e.g. "Backlog: 3 closure candidates · Workspace: 5 stale worktrees, 2 stale branches", or, on a fully clean repo, "Backlog is clean · No stale worktrees or branches."
+
+## Step 4: Confirm and act — two separate gates
+
+Issue closures and workspace deletions are **separate** confirmations. Declining one never affects the other — surface both asks, act only on what the user confirms.
+
+### Step 4.1: Issue closures
+
+```
+## Next Steps — Issues
 
 To close recommended issues, confirm which ones to close. I can:
 1. Close specific issues with a comment explaining why
@@ -96,15 +180,38 @@ To close recommended issues, confirm which ones to close. I can:
 Which issues should I close? (List numbers, category names, or "all")
 ```
 
+When the user confirms closures, close each issue with a comment:
+
+```bash
+# Replace 42 with the actual issue number and customize the rationale
+gh issue close 42 --comment "Closing: [rationale from the recommendation]. Identified by backlog cleanup scan."
+```
+
+### Step 4.2: Workspace deletions
+
+Only if the workspace scan surfaced stale items (`RC == 1`) and the user explicitly confirms. Ask separately, e.g. "Apply the stale workspace cleanup above? (worktrees removed, local + remote branches deleted)". `--apply` removes **every** listed stale item — the script has no per-item selection — so if the user wants to keep any, they decline and handle it manually.
+
+On explicit confirmation:
+
+```bash
+APPLY_RC=0
+STALE_DAYS="$WORKTREE_DAYS" .claude/scripts/stale-cleanup.sh --apply || APPLY_RC=$?
+```
+
+The script re-runs the same detection (state may have changed since the dry-run), re-applies every safety check, then attempts each deletion. Report the `removed:` / `failed:` lines verbatim:
+
+- **`APPLY_RC == 0`** — all deletions succeeded.
+- **`APPLY_RC == 2`** — one or more deletions failed; surface the `failed:` lines. Do not retry automatically — some failures (e.g. network errors on remote-branch deletion) need user intervention.
+
+If the user declines, report: "Workspace cleanup: dry-run only — nothing deleted."
+
 ## Rules
 
 - **NEVER auto-close issues.** Always present recommendations and wait for user confirmation.
+- **NEVER delete worktrees or branches without explicit confirmation.** `/pm-clean` NEVER runs `stale-cleanup.sh --apply` on its own — consistent with the "never auto-close" rule and `/pm-update` Step 8. The `--check` dry-run is the user's only chance to spot a false positive before anything is removed.
+- **The two scans are independent.** One finding nothing must not suppress the other; the summary reports both, always.
+- **Delegate workspace detection — never reimplement it.** `stale-cleanup.sh` is the shared source of truth for worktree/branch staleness and safety (issue #618, mirroring the `/pm` ↔ `/pm-clean` #598 precedent). `/pm-update` Step 8 calls the same script; keep them in sync by changing only the script, never by forking its logic into this skill.
 - **Be conservative with "superseded" and "duplicate" flags.** False positives waste the user's time reviewing issues that shouldn't be closed. Only flag when evidence is clear.
-- **Include rationale for every recommendation.** The user should be able to evaluate each suggestion without reading the full issue.
-- **Handle large backlogs gracefully.** `backlog-staleness.sh` already caps the inactive-candidate deep check at the 50 oldest issues and notes any remainder on stderr — surface that note in the summary when present.
+- **Include rationale for every recommendation.** The user should be able to evaluate each suggestion without reading the full issue or inspecting the worktree.
+- **Handle large backlogs gracefully.** `backlog-staleness.sh` already caps the inactive-candidate deep check at the 50 oldest issues and notes any remainder on stderr — surface that note in the summary when present. Apply the same summarize-the-tail treatment to large workspace result sets.
 - **Respect issue labels.** `backlog-staleness.sh` already skips issues labeled `pinned`, `do-not-close`, `long-term`, or `epic` in the inactive, superseded, and duplicate checks (still checking them for solved-by-PR, since that's a factual signal, not a judgment call) — no extra filtering needed here.
-- **When the user confirms closures**, close each issue with a comment:
-  ```bash
-  # Replace 42 with the actual issue number and customize the rationale
-  gh issue close 42 --comment "Closing: [rationale from the recommendation]. Identified by backlog cleanup scan."
-  ```

--- a/.claude/skills/pm-update/SKILL.md
+++ b/.claude/skills/pm-update/SKILL.md
@@ -162,6 +162,8 @@ If nothing changed in the auto-generated sections, say so: "Infrastructure and A
 
 `/wrap` no longer self-removes the running worktree or deletes its branch (issue #338). Stale cleanup is `/pm-update`'s job — invoke `.claude/scripts/stale-cleanup.sh` to detect and (after user confirmation) prune long-abandoned refs.
 
+> **Shared implementation (issue #618).** `/pm-clean` now calls this same `stale-cleanup.sh` for its workspace sweep — `stale-cleanup.sh` is the single source of truth for stale worktree/branch detection and safety, so the two skills can never diverge (mirroring the `/pm` ↔ `/pm-clean` #598 shared-script precedent). This step's behavior is unchanged; keep both callers in sync by changing only the script. `/pm-update` runs it at the `STALE_DAYS=7` default below; `/pm-clean` runs it at its own threshold (default 30, see that skill).
+
 ### Step 8.1: Run the dry-run pass
 
 Always run `--check` first. The script never deletes in this mode.


### PR DESCRIPTION
## **User description**
## What & why

Today `/pm-clean` scans only open GitHub *issues*, while stale worktree/branch cleanup is buried in `/pm-update` Step 8. This makes `/pm-clean` the **single janitor**: alongside its issue-staleness scan it now runs an **independent** workspace sweep (stale worktrees + local/remote branches) by reusing the exact same `.claude/scripts/stale-cleanup.sh` — no reimplementation of detection or safety, mirroring the `/pm` ↔ `/pm-clean` shared-script precedent (#598).

Closes #618

## Changes

- **`.claude/skills/pm-clean/SKILL.md`** — new **Step 2** dry-run (`stale-cleanup.sh --check --json`) + **Step 3** workspace sections styled like the issue categories (per-item rationale + the script's verbatim "Skipped (safety)" reasons). The two scans are independent (one clean never suppresses the other; combined summary reports both). **Step 4** splits confirmation into two separate gates — workspace deletion never runs `--apply` without explicit confirmation. Frontmatter/`argument-hint` reframed away from issue-only.
- **Threshold** — `[days]` (default 30) is reused for worktree/branch age, with an optional **`--worktree-days N`** override (resolves the issue's open question: reuse-by-default + override). `/pm-update` keeps its own `STALE_DAYS=7` default; the shared thing is the *implementation*, not the threshold.
- **`.claude/skills/pm-update/SKILL.md`** — Step 8 gains a shared-ownership note (no behavioral change).
- **`.claude/scripts/stale-cleanup.sh`** — header PURPOSE comment notes both callers (doc-only; detection/safety logic **untouched**).

## Test plan

- [x] In a repo with known stale worktrees + branches, `/pm-clean` lists them in a workspace section alongside the issue recommendations.
- [x] A worktree with uncommitted changes / an open PR / the current worktree / main appears under "Skipped (safety)", not offered for deletion.
- [x] Confirming removes only the confirmed worktrees/branches; declining leaves everything intact (workspace gate is separate from the issue-closure gate).
- [x] Running `/pm-update` still performs the same sweep with identical results on the same repo state (one shared implementation, no divergence).
- [x] `/pm-clean` on a clean repo reports **both** "backlog is clean" and "no stale worktrees or branches."
- [x] Threshold: `[days]` drives both scans by default; `--worktree-days N` overrides worktree/branch age only.

## Notes

- **Local review:** the CodeRabbit CLI hit its free-OSS rate limit (~24 min reset) and the CodeAnt CLI is not installed on this machine, so a careful **self-review** stood in per `cr-local-review.md` (both CLIs unavailable → self-review). The embedded bash/JSON in the skill was cross-checked against `stale-cleanup.sh` ground truth: all 7 JSON keys/field names match, and RC 0/1/3/4 handling matches the script's documented exit codes. The GitHub review path (CodeRabbit / CodeAnt / BugBot bots) is the real merge gate and runs on a separate quota.
- Skill-conventions audit passes (exit 0; the description-length WARN is non-blocking and consistent with sibling skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add workspace cleanup to `/pm-clean` alongside issue cleanup**

### What Changed
- `/pm-clean` now reviews both open issues and the on-disk workspace in one run
- It can flag stale worktrees and stale local or remote branches, while still showing issue cleanup recommendations
- The issue scan and workspace scan run separately, so a clean result in one area does not hide problems in the other
- Worktree and branch cleanup still needs explicit confirmation before anything is removed

### Impact
`✅ Fewer stale worktrees`
`✅ Safer branch cleanup`
`✅ Clearer cleanup review`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>