### PR TITLE
fix(#624): stop config-protection.py from blocking read-only Bash access

### DIFF
--- a/.claude/hooks/config-protection.py
+++ b/.claude/hooks/config-protection.py
@@ -73,14 +73,74 @@ PROTECTED_RELATIVE_SUFFIXES = (
 
 DESTRUCTIVE_BINS = {
     'rm', 'mv', 'cp', 'rsync', 'install', 'dd', 'truncate', 'shred',
-    'chmod', 'chown', 'tee', 'sed', 'awk', 'perl', 'python', 'python3',
-    'ruby', 'node', 'touch', 'ln',
+    'chmod', 'chown', 'tee', 'touch', 'ln',
 }
 
-BARE_REDIRECT_RE = re.compile(r'^(?:\d*>{1,2}\|?|&>|\d*>&\d*)$')
+# Interpreters/utilities that are routinely invoked read-only (a lint checker,
+# a one-off analysis script, `sed -n`/`perl -ne` to print) — merely appearing
+# in a command is not a write signal. Only their in-place-edit flag is, and
+# only when they are the actual command being run (see the executable-position
+# tracking in bash_targets_protected, using ENV_ASSIGNMENT_RE/COMMAND_WRAPPER_BINS
+# below) — e.g. `grep sed file` searches for the literal text "sed", it never runs it.
+IN_PLACE_EDIT_BINS = frozenset({'sed', 'perl'})
+# Matches bare `-i`/`-i<suffix>` (dot optional — GNU sed accepts either) and
+# clustered short flags with -i last (`-ni`, `-pi`, `-npi`, `-Ei` — BSD/macOS
+# sed's common "extended regex + in-place" idiom), restricted to a safe
+# no-argument-flag letter set so it can't match an unrelated attached-arg flag
+# that happens to contain 'i' (e.g. perl's `-Ilib`, `-mstrict` — both always
+# take their value as a separate token in practice, unlike this filler set).
+# Also matches GNU's long form `--in-place[=SUFFIX]`.
+IN_PLACE_FLAG_RE = re.compile(r'^(?:-[npsalwuzrE]*i.*|--in-place(?:=.*)?)$')
+
+# A leading `VAR=value` env assignment, a thin wrapper (sudo/env/xargs/...), or
+# one of the wrapper's own flags (`sudo -u root`, `env -i`, `nice -n 10`)
+# doesn't occupy the executable slot — the real command still follows. Any
+# `-`-prefixed token is treated as "still preamble" while a wrapper is pending,
+# so a wrapper's own flag (e.g. env's unrelated `-i`) is never mistaken for
+# sed/perl's in-place flag.
+ENV_ASSIGNMENT_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*=')
+COMMAND_WRAPPER_BINS = frozenset({'sudo', 'env', 'nice', 'nohup', 'time', 'command', 'exec', 'xargs'})
+# A handful of each wrapper's flags take the NEXT token as their own argument
+# (`sudo -u root`, `nice -n 10`) rather than the target executable — without
+# this, that argument gets mistaken for the executable slot and the real
+# command (e.g. sed) right after it is missed entirely.
+WRAPPER_VALUE_FLAGS = {
+    'sudo': frozenset({'-u', '-g', '-p', '-h', '-C', '-r', '-t'}),
+    'env': frozenset({'-u', '-C', '-S'}),
+    'nice': frozenset({'-n'}),
+    'nohup': frozenset(),
+    'time': frozenset(),
+    'command': frozenset(),
+    'exec': frozenset({'-a'}),
+    'xargs': frozenset({'-I', '-n', '-P', '-d', '-s', '-a', '-E', '-L'}),
+}
+
+# Command-separator characters: in-place-flag state and executable-position
+# tracking must not leak across these, or an earlier unrelated `sed`/`perl`
+# call would make a later `grep -i` (or any other unrelated `-i`) in the same
+# compound line look like a write. shlex has no concept of shell metacharacters
+# — `cmd1;cmd2` (no spaces at all) comes back as one glued token — so these are
+# split out of every token into their own entries before the main scan runs.
+# A single `&` is excluded when adjacent to `>` (`2>&1` fd-dup, `&>file`
+# combined redirect) so those stay intact as one token for the redirect checks.
+COMMAND_SEPARATOR_SPLIT_RE = re.compile(r'(&&|\|\||;|\||\(|\)|(?<!>)&(?!>))')
+COMMAND_SEPARATOR_RE = re.compile(r'^[;&|()]+$')
+
+# Deliberately excludes fd-duplication (`2>&1`, `1>&2`): digits on both sides of
+# `>&` duplicate one existing stream onto another (e.g. merging stderr into
+# stdout for capture) — there is no file target, so it is never a write. Only
+# `N>`/`N>>`/`&>` (redirect to an actual filename) count as a write signal.
+BARE_REDIRECT_RE = re.compile(r'^(?:\d*>{1,2}\|?|&>)$')
 EMBEDDED_REDIRECT_RE = re.compile(r'(?:\d*>{1,2}\|?|&>)([^<>&].*)$')
 WRITE_FLAG_TOKENS = frozenset({'--write', '--fix', '-w', '-inplace'})
 COPY_MOVE_BINS = frozenset({'cp', 'mv'})
+
+
+def _split_command_separators(tokens: list[str]) -> list[str]:
+    expanded: list[str] = []
+    for tok in tokens:
+        expanded.extend(part for part in COMMAND_SEPARATOR_SPLIT_RE.split(tok) if part)
+    return expanded
 
 
 def normalize_path(path: str) -> str:
@@ -143,18 +203,19 @@ def should_block_edit(path: str, cwd: str | None = None) -> bool:
     return path_exists(path, cwd)
 
 
-def bash_targets_protected(cmd: str, cwd: str | None = None) -> str | None:
-    if not cmd:
-        return None
-    try:
-        tokens = shlex.split(cmd, posix=True)
-    except ValueError:
-        tokens = cmd.split()
-
+def _scan_command_segment(tokens: list[str], cwd: str | None) -> str | None:
+    """Scan one separator-free command segment for a write targeting a
+    protected path. Every piece of state here is local to this single
+    segment — nothing from an earlier or later `;`/`&&`/`|`-separated
+    segment on the same line can leak in, in either direction."""
     has_write_op = False
     protected_targets: list[str] = []
     last_copy_move: str | None = None
     copy_move_protected: list[str] = []
+    seen_in_place_capable_bin = False
+    expect_command_name = True
+    current_wrapper: str | None = None
+    expect_wrapper_flag_value = False
 
     protected_in_cmd: list[str] = []
 
@@ -171,6 +232,25 @@ def bash_targets_protected(cmd: str, cwd: str | None = None) -> str | None:
             continue
         base = tok.rsplit('/', 1)[-1]
         if tok in WRITE_FLAG_TOKENS:
+            has_write_op = True
+        if expect_command_name:
+            if expect_wrapper_flag_value:
+                # This token is a wrapper flag's own argument (e.g. the "root"
+                # in `sudo -u root`), not the target executable.
+                expect_wrapper_flag_value = False
+            elif ENV_ASSIGNMENT_RE.match(tok):
+                pass
+            elif base in COMMAND_WRAPPER_BINS:
+                current_wrapper = base
+            elif tok.startswith('-'):
+                if current_wrapper and tok in WRAPPER_VALUE_FLAGS.get(current_wrapper, ()):
+                    expect_wrapper_flag_value = True
+            else:
+                if base in IN_PLACE_EDIT_BINS:
+                    seen_in_place_capable_bin = True
+                expect_command_name = False
+                current_wrapper = None
+        elif seen_in_place_capable_bin and IN_PLACE_FLAG_RE.match(tok):
             has_write_op = True
         if base in COPY_MOVE_BINS:
             has_write_op = True
@@ -201,6 +281,30 @@ def bash_targets_protected(cmd: str, cwd: str | None = None) -> str | None:
     for target in protected_targets:
         if should_block_edit(target, cwd):
             return target
+    return None
+
+
+def bash_targets_protected(cmd: str, cwd: str | None = None) -> str | None:
+    if not cmd:
+        return None
+    try:
+        tokens = shlex.split(cmd, posix=True)
+    except ValueError:
+        tokens = cmd.split()
+    tokens = _split_command_separators(tokens)
+
+    segment: list[str] = []
+    for tok in tokens:
+        if COMMAND_SEPARATOR_RE.match(tok):
+            if segment:
+                blocked = _scan_command_segment(segment, cwd)
+                if blocked:
+                    return blocked
+                segment = []
+            continue
+        segment.append(tok)
+    if segment:
+        return _scan_command_segment(segment, cwd)
     return None
 
 

--- a/.claude/hooks/config-protection.py
+++ b/.claude/hooks/config-protection.py
@@ -150,7 +150,9 @@ def _split_into_command_segments(cmd: str) -> list[str]:
     only causes an extra (safe-direction) split, never a missed detection of
     those two specific signals in the same fragment they already are in.
     A single `&` is skipped when adjacent to `>` (`2>&1` fd-dup, `&>file`
-    combined redirect) so those stay intact for the redirect checks.
+    combined redirect), and a `|` immediately after `>` is skipped too
+    (`>|`/`>>|`, bash's noclobber-override redirect) — both stay intact as
+    one token for the redirect checks instead of being split apart.
     """
     segments: list[str] = []
     current: list[str] = []
@@ -188,6 +190,12 @@ def _split_into_command_segments(cmd: str) -> list[str]:
                 prev_ch = cmd[i - 1] if i > 0 else ''
                 next_ch = cmd[i + 1] if i + 1 < n else ''
                 if prev_ch == '>' or next_ch == '>':
+                    current.append(ch)
+                    i += 1
+                    continue
+            if ch == '|':
+                prev_ch = cmd[i - 1] if i > 0 else ''
+                if prev_ch == '>':
                     current.append(ch)
                     i += 1
                     continue

--- a/.claude/hooks/config-protection.py
+++ b/.claude/hooks/config-protection.py
@@ -92,6 +92,18 @@ IN_PLACE_EDIT_BINS = frozenset({'sed', 'perl'})
 # Also matches GNU's long form `--in-place[=SUFFIX]`.
 IN_PLACE_FLAG_RE = re.compile(r'^(?:-[npsalwuzrE]*i.*|--in-place(?:=.*)?)$')
 
+# Unlike GNU sed (which uses getopt_long and freely permutes flags after
+# positional args), perl's own switch parser stops at the first token that
+# isn't a recognized switch — that token is either the script filename or,
+# if -e/-E already supplied the code, the first @ARGV element — and every
+# token after it is data for the running script, not another perl switch.
+# `perl checker.pl -i file` never runs sed/perl's -i at all: "checker.pl"
+# already ended perl's own option parsing. A cluster ending in a bare e/E
+# (`-pe`, `-npe`) also consumes the next token as -e's inline-code value,
+# same as bare `-e`/`-E`, so that token doesn't end the option-parsing
+# phase either.
+PERL_VALUE_FLAG_RE = re.compile(r'^-[npsalwuzrE]*[eE]$')
+
 # A leading `VAR=value` env assignment, a thin wrapper (sudo/env/xargs/...), or
 # one of the wrapper's own flags (`sudo -u root`, `env -i`, `nice -n 10`)
 # doesn't occupy the executable slot — the real command still follows. Any
@@ -138,8 +150,15 @@ COPY_MOVE_BINS = frozenset({'cp', 'mv'})
 
 def _split_into_command_segments(cmd: str) -> list[str]:
     """Split a raw shell command string into command segments at unquoted,
-    unsubstituted `;`/`&&`/`||`/`|`/`&` boundaries, tracking quote and
-    `$(...)`/backtick command-substitution state char-by-char.
+    unsubstituted `;`/`&&`/`||`/`|`/`&`/newline boundaries, tracking quote
+    and `$(...)`/backtick command-substitution state char-by-char. A
+    multi-line Bash payload (a common shape for Claude Code tool calls) is
+    a sequence of commands exactly like `;`-joined ones — without this, an
+    in-place edit armed on one line stays armed for an unrelated `-i` on a
+    later line. A backslash immediately before a newline is a real bash
+    line continuation (join two physical lines into one logical line) and
+    is already preserved verbatim by the backslash-escape handling below,
+    so it does not split.
 
     This must run on the RAW string, before shlex.split() — shlex strips
     quotes, so a post-tokenization regex split can't tell a real shell
@@ -206,7 +225,7 @@ def _split_into_command_segments(cmd: str) -> list[str]:
             current = []
             i += 2
             continue
-        if ch in (';', '|', '&', '(', ')'):
+        if ch in (';', '|', '&', '(', ')', '\n'):
             if ch == '&':
                 prev_ch = cmd[i - 1] if i > 0 else ''
                 next_ch = cmd[i + 1] if i + 1 < n else ''
@@ -300,6 +319,8 @@ def _scan_command_segment(tokens: list[str], cwd: str | None) -> str | None:
     last_copy_move: str | None = None
     copy_move_protected: list[str] = []
     seen_in_place_capable_bin = False
+    in_place_bin_kind: str | None = None  # None | 'sed' | 'perl'
+    expect_perl_flag_value = False
     expect_command_name = True
     current_wrapper: str | None = None
     expect_wrapper_flag_value = False
@@ -335,8 +356,24 @@ def _scan_command_segment(tokens: list[str], cwd: str | None) -> str | None:
             else:
                 if base in IN_PLACE_EDIT_BINS:
                     seen_in_place_capable_bin = True
+                    in_place_bin_kind = base
                 expect_command_name = False
                 current_wrapper = None
+        elif in_place_bin_kind == 'perl':
+            if expect_perl_flag_value:
+                expect_perl_flag_value = False
+            elif tok.startswith('-'):
+                if IN_PLACE_FLAG_RE.match(tok):
+                    has_write_op = True
+                if PERL_VALUE_FLAG_RE.match(tok):
+                    expect_perl_flag_value = True
+            else:
+                # First non-switch token: perl's own option parsing has
+                # ended (this is the script filename, or perl's first
+                # @ARGV element if -e/-E supplied the code) — everything
+                # after is data for the running script, not another switch.
+                seen_in_place_capable_bin = False
+                in_place_bin_kind = None
         elif seen_in_place_capable_bin and IN_PLACE_FLAG_RE.match(tok):
             has_write_op = True
         if base in COPY_MOVE_BINS:

--- a/.claude/hooks/config-protection.py
+++ b/.claude/hooks/config-protection.py
@@ -128,28 +128,34 @@ WRAPPER_VALUE_FLAGS = {
 # Deliberately excludes fd-duplication (`2>&1`, `1>&2`): digits on both sides of
 # `>&` duplicate one existing stream onto another (e.g. merging stderr into
 # stdout for capture) — there is no file target, so it is never a write. Only
-# `N>`/`N>>`/`&>` (redirect to an actual filename) count as a write signal.
-BARE_REDIRECT_RE = re.compile(r'^(?:\d*>{1,2}\|?|&>)$')
-EMBEDDED_REDIRECT_RE = re.compile(r'(?:\d*>{1,2}\|?|&>)([^<>&].*)$')
+# `N>`/`N>>`/`&>`/`&>>` (redirect to an actual filename — `&>>` appends both
+# stdout and stderr) count as a write signal.
+BARE_REDIRECT_RE = re.compile(r'^(?:\d*>{1,2}\|?|&>{1,2})$')
+EMBEDDED_REDIRECT_RE = re.compile(r'(?:\d*>{1,2}\|?|&>{1,2})([^<>&].*)$')
 WRITE_FLAG_TOKENS = frozenset({'--write', '--fix', '-w', '-inplace'})
 COPY_MOVE_BINS = frozenset({'cp', 'mv'})
 
 
 def _split_into_command_segments(cmd: str) -> list[str]:
-    """Split a raw shell command string into command segments at unquoted
-    `;`/`&&`/`||`/`|`/`&` boundaries, tracking quote state char-by-char.
+    """Split a raw shell command string into command segments at unquoted,
+    unsubstituted `;`/`&&`/`||`/`|`/`&` boundaries, tracking quote and
+    `$(...)`/backtick command-substitution state char-by-char.
 
     This must run on the RAW string, before shlex.split() — shlex strips
     quotes, so a post-tokenization regex split can't tell a real shell
     separator from a literal one inside a quoted argument (e.g. a sed/perl
-    script's own `s/a;b/c;d/` substitution syntax). Splitting the wrong `;`
-    there breaks one logical command into fragments that individually don't
-    show both "sed is the executable" and "-i is present", silently missing
-    a real in-place edit. Doesn't track `$()`/backtick command-substitution
-    nesting — a `;` inside one of those is rare in practice and, worst case,
-    only causes an extra (safe-direction) split, never a missed detection of
-    those two specific signals in the same fragment they already are in.
-    A single `&` is skipped when adjacent to `>` (`2>&1` fd-dup, `&>file`
+    script's own `s/a;b/c;d/` substitution syntax) or inside a `$(...)`
+    command substitution. Splitting the wrong character there breaks one
+    logical command into fragments that individually don't show both "sed
+    is the executable" and "-i is present" (or "the write signal" and "the
+    protected path" for a substitution's parens), silently missing a real
+    write. `$(...)` nesting is tracked by depth so a nested substitution
+    (`$(echo $(date))`) stays opaque all the way to its matching `)`; a
+    backtick region is treated like a quote (no nesting — matches bash's
+    own rule that backticks can't nest without escaping). A bare `(`/`)`
+    outside any substitution (e.g. `(cmd1; cmd2)` subshell grouping) is
+    still a segment boundary — only substitution-owned parens are protected.
+    A single `&` is skipped when adjacent to `>` (`2>&1` fd-dup, `&>`/`&>>`
     combined redirect), and a `|` immediately after `>` is skipped too
     (`>|`/`>>|`, bash's noclobber-override redirect) — both stay intact as
     one token for the redirect checks instead of being split apart.
@@ -157,6 +163,7 @@ def _split_into_command_segments(cmd: str) -> list[str]:
     segments: list[str] = []
     current: list[str] = []
     quote: str | None = None
+    subst_depth = 0
     i = 0
     n = len(cmd)
     while i < n:
@@ -170,7 +177,7 @@ def _split_into_command_segments(cmd: str) -> list[str]:
                 i += 1
             i += 1
             continue
-        if ch in ('"', "'"):
+        if ch in ('"', "'", '`'):
             quote = ch
             current.append(ch)
             i += 1
@@ -179,6 +186,20 @@ def _split_into_command_segments(cmd: str) -> list[str]:
             current.append(ch)
             current.append(cmd[i + 1])
             i += 2
+            continue
+        if ch == '$' and i + 1 < n and cmd[i + 1] == '(':
+            subst_depth += 1
+            current.append(ch)
+            current.append('(')
+            i += 2
+            continue
+        if subst_depth > 0:
+            if ch == '(':
+                subst_depth += 1
+            elif ch == ')':
+                subst_depth -= 1
+            current.append(ch)
+            i += 1
             continue
         if cmd[i:i + 2] in ('&&', '||'):
             segments.append(''.join(current))

--- a/.claude/hooks/config-protection.py
+++ b/.claude/hooks/config-protection.py
@@ -101,30 +101,29 @@ IN_PLACE_FLAG_RE = re.compile(r'^(?:-[npsalwuzrE]*i.*|--in-place(?:=.*)?)$')
 ENV_ASSIGNMENT_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*=')
 COMMAND_WRAPPER_BINS = frozenset({'sudo', 'env', 'nice', 'nohup', 'time', 'command', 'exec', 'xargs'})
 # A handful of each wrapper's flags take the NEXT token as their own argument
-# (`sudo -u root`, `nice -n 10`) rather than the target executable — without
-# this, that argument gets mistaken for the executable slot and the real
-# command (e.g. sed) right after it is missed entirely.
+# (`sudo -u root`, `sudo --user root`, `nice -n 10`) rather than the target
+# executable — without this, that argument gets mistaken for the executable
+# slot and the real command (e.g. sed) right after it is missed entirely.
+# Long forms only need listing for the space-separated case (`--user root`)
+# — the `--user=root` equals-attached form is already one whole token, so it
+# can't split flag from value across two tokens in the first place.
 WRAPPER_VALUE_FLAGS = {
-    'sudo': frozenset({'-u', '-g', '-p', '-h', '-C', '-r', '-t'}),
-    'env': frozenset({'-u', '-C', '-S'}),
-    'nice': frozenset({'-n'}),
+    'sudo': frozenset({
+        '-u', '-g', '-p', '-h', '-C', '-r', '-t',
+        '--user', '--group', '--prompt', '--host', '--close-from', '--role', '--type',
+    }),
+    'env': frozenset({'-u', '-C', '-S', '--unset', '--chdir', '--split-string'}),
+    'nice': frozenset({'-n', '--adjustment'}),
     'nohup': frozenset(),
     'time': frozenset(),
     'command': frozenset(),
-    'exec': frozenset({'-a'}),
-    'xargs': frozenset({'-I', '-n', '-P', '-d', '-s', '-a', '-E', '-L'}),
+    'exec': frozenset({'-a', '--as'}),
+    'xargs': frozenset({
+        '-I', '-n', '-P', '-d', '-s', '-a', '-E', '-L',
+        '--replace', '--max-args', '--max-procs', '--delimiter', '--max-chars',
+        '--arg-file', '--eof', '--max-lines',
+    }),
 }
-
-# Command-separator characters: in-place-flag state and executable-position
-# tracking must not leak across these, or an earlier unrelated `sed`/`perl`
-# call would make a later `grep -i` (or any other unrelated `-i`) in the same
-# compound line look like a write. shlex has no concept of shell metacharacters
-# — `cmd1;cmd2` (no spaces at all) comes back as one glued token — so these are
-# split out of every token into their own entries before the main scan runs.
-# A single `&` is excluded when adjacent to `>` (`2>&1` fd-dup, `&>file`
-# combined redirect) so those stay intact as one token for the redirect checks.
-COMMAND_SEPARATOR_SPLIT_RE = re.compile(r'(&&|\|\||;|\||\(|\)|(?<!>)&(?!>))')
-COMMAND_SEPARATOR_RE = re.compile(r'^[;&|()]+$')
 
 # Deliberately excludes fd-duplication (`2>&1`, `1>&2`): digits on both sides of
 # `>&` duplicate one existing stream onto another (e.g. merging stderr into
@@ -136,11 +135,70 @@ WRITE_FLAG_TOKENS = frozenset({'--write', '--fix', '-w', '-inplace'})
 COPY_MOVE_BINS = frozenset({'cp', 'mv'})
 
 
-def _split_command_separators(tokens: list[str]) -> list[str]:
-    expanded: list[str] = []
-    for tok in tokens:
-        expanded.extend(part for part in COMMAND_SEPARATOR_SPLIT_RE.split(tok) if part)
-    return expanded
+def _split_into_command_segments(cmd: str) -> list[str]:
+    """Split a raw shell command string into command segments at unquoted
+    `;`/`&&`/`||`/`|`/`&` boundaries, tracking quote state char-by-char.
+
+    This must run on the RAW string, before shlex.split() — shlex strips
+    quotes, so a post-tokenization regex split can't tell a real shell
+    separator from a literal one inside a quoted argument (e.g. a sed/perl
+    script's own `s/a;b/c;d/` substitution syntax). Splitting the wrong `;`
+    there breaks one logical command into fragments that individually don't
+    show both "sed is the executable" and "-i is present", silently missing
+    a real in-place edit. Doesn't track `$()`/backtick command-substitution
+    nesting — a `;` inside one of those is rare in practice and, worst case,
+    only causes an extra (safe-direction) split, never a missed detection of
+    those two specific signals in the same fragment they already are in.
+    A single `&` is skipped when adjacent to `>` (`2>&1` fd-dup, `&>file`
+    combined redirect) so those stay intact for the redirect checks.
+    """
+    segments: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    i = 0
+    n = len(cmd)
+    while i < n:
+        ch = cmd[i]
+        if quote:
+            current.append(ch)
+            if ch == quote:
+                quote = None
+            elif quote == '"' and ch == '\\' and i + 1 < n:
+                current.append(cmd[i + 1])
+                i += 1
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            quote = ch
+            current.append(ch)
+            i += 1
+            continue
+        if ch == '\\' and i + 1 < n:
+            current.append(ch)
+            current.append(cmd[i + 1])
+            i += 2
+            continue
+        if cmd[i:i + 2] in ('&&', '||'):
+            segments.append(''.join(current))
+            current = []
+            i += 2
+            continue
+        if ch in (';', '|', '&', '(', ')'):
+            if ch == '&':
+                prev_ch = cmd[i - 1] if i > 0 else ''
+                next_ch = cmd[i + 1] if i + 1 < n else ''
+                if prev_ch == '>' or next_ch == '>':
+                    current.append(ch)
+                    i += 1
+                    continue
+            segments.append(''.join(current))
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    segments.append(''.join(current))
+    return segments
 
 
 def normalize_path(path: str) -> str:
@@ -287,24 +345,19 @@ def _scan_command_segment(tokens: list[str], cwd: str | None) -> str | None:
 def bash_targets_protected(cmd: str, cwd: str | None = None) -> str | None:
     if not cmd:
         return None
-    try:
-        tokens = shlex.split(cmd, posix=True)
-    except ValueError:
-        tokens = cmd.split()
-    tokens = _split_command_separators(tokens)
-
-    segment: list[str] = []
-    for tok in tokens:
-        if COMMAND_SEPARATOR_RE.match(tok):
-            if segment:
-                blocked = _scan_command_segment(segment, cwd)
-                if blocked:
-                    return blocked
-                segment = []
+    for segment_str in _split_into_command_segments(cmd):
+        segment_str = segment_str.strip()
+        if not segment_str:
             continue
-        segment.append(tok)
-    if segment:
-        return _scan_command_segment(segment, cwd)
+        try:
+            tokens = shlex.split(segment_str, posix=True)
+        except ValueError:
+            tokens = segment_str.split()
+        if not tokens:
+            continue
+        blocked = _scan_command_segment(tokens, cwd)
+        if blocked:
+            return blocked
     return None
 
 

--- a/tests/test_config_protection.py
+++ b/tests/test_config_protection.py
@@ -276,6 +276,23 @@ class ConfigProtectionBashTests(unittest.TestCase):
                 with self.subTest(cmd=cmd):
                     self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
 
+    def test_bash_noclobber_override_redirect_not_split_into_pipe(self) -> None:
+        # CodeAnt review finding: `>|` (bash's noclobber-override redirect)
+        # must survive the command-separator split intact — splitting it
+        # into `>` + `|` moves the redirect target into a separate pipeline
+        # segment with no write signal of its own, letting the write evade
+        # detection entirely.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"echo x >| {target}",
+                f"echo x>|{target}",
+                f"echo x >>| {target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
     def test_bash_blocks_in_place_edit_through_long_form_wrapper_flag(self) -> None:
         # CodeAnt review finding: a wrapper's long-form value flag
         # (`sudo --user root`, `nice --adjustment 10`) must be recognized

--- a/tests/test_config_protection.py
+++ b/tests/test_config_protection.py
@@ -230,6 +230,39 @@ class ConfigProtectionBashTests(unittest.TestCase):
                 with self.subTest(cmd=cmd):
                     self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
 
+    def test_bash_newline_is_a_command_separator(self) -> None:
+        # CodeAnt review finding: a multi-line Bash payload (common for
+        # Claude Code tool calls) is a sequence of commands just like
+        # `;`-joined ones. Without treating newline as a boundary, an
+        # in-place edit armed on one line stays armed for an unrelated -i
+        # on a later, unrelated line.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            cmd = f"sed -i 's/x/y/' notes.txt\ngrep -i pattern {target}"
+            self.assertIsNone(config_protection.bash_targets_protected(cmd))
+            # A real write on a later line must still be caught.
+            cmd2 = f"echo hi\nsed -i 's/x/y/' {target}"
+            self.assertEqual(config_protection.bash_targets_protected(cmd2), str(target))
+
+    def test_bash_perl_option_parsing_ends_at_first_non_switch_token(self) -> None:
+        # CodeAnt review finding: unlike GNU sed (which permutes flags after
+        # positional args), perl's own switch parser stops at the first
+        # non-switch token (the script filename, or its first @ARGV element
+        # if -e/-E supplied the code) -- everything after belongs to the
+        # running script, not to perl itself. `perl checker.pl -i file`
+        # never runs perl's in-place edit at all.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            cmd = f"perl checker.pl -i {target}"
+            self.assertIsNone(config_protection.bash_targets_protected(cmd))
+            # A clustered -e (e.g. -pe) still consumes the next token as its
+            # own inline-code value rather than ending option parsing, so a
+            # real -i appearing after it is still caught.
+            cmd2 = f"perl -pe 's/x/y/' -i {target}"
+            self.assertEqual(config_protection.bash_targets_protected(cmd2), str(target))
+
     def test_bash_write_op_does_not_leak_across_command_separators(self) -> None:
         # CodeAnt review finding: an earlier unrelated write (to a different
         # file) in a compound line must not cause a later plain read of a

--- a/tests/test_config_protection.py
+++ b/tests/test_config_protection.py
@@ -74,6 +74,256 @@ class ConfigProtectionBashTests(unittest.TestCase):
             blocked = config_protection.bash_targets_protected(cmd)
             self.assertIsNone(blocked)
 
+    def test_bash_allows_read_only_interpreter_invocations(self) -> None:
+        # issue #624: merely running sed/awk/perl/python/node/ruby against a
+        # protected path is not a write — only an actual write signal is.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            read_only_cmds = [
+                f"sed -n '1,5p' {target}",
+                f"awk '{{print}}' {target}",
+                f"perl -ne 'print' {target}",
+                f"python3 read_only_checker.py {target}",
+                f"python read_only_checker.py {target}",
+                f"node lint.js {target}",
+                f"ruby check.rb {target}",
+                f"python3 -i {target}",  # -i here is python's interactive flag, not in-place
+            ]
+            for cmd in read_only_cmds:
+                with self.subTest(cmd=cmd):
+                    self.assertIsNone(config_protection.bash_targets_protected(cmd))
+
+    def test_bash_blocks_perl_in_place_edit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            cmd = f"perl -i -pe 's/x/y/' {target}"
+            blocked = config_protection.bash_targets_protected(cmd)
+            self.assertEqual(blocked, str(target))
+
+    def test_bash_blocks_sed_in_place_edit_with_backup_suffix(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            cmd = f"sed -i.bak 's/x/y/' {target}"
+            blocked = config_protection.bash_targets_protected(cmd)
+            self.assertEqual(blocked, str(target))
+
+    def test_bash_blocks_explicit_write_flag_on_interpreter_script(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            cmd = f"python3 fixer.py --fix {target}"
+            blocked = config_protection.bash_targets_protected(cmd)
+            self.assertEqual(blocked, str(target))
+
+    def test_bash_blocks_tee_to_protected_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            cmd = f"tee {target}"
+            blocked = config_protection.bash_targets_protected(cmd)
+            self.assertEqual(blocked, str(target))
+
+    def test_bash_allows_read_with_trailing_stderr_merge(self) -> None:
+        # issue #624: a trailing `2>&1` (duplicating stderr onto stdout, e.g.
+        # to capture combined output) has no file target and must not be
+        # treated as a write, even though it looks like a redirect operator.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            read_only_cmds = [
+                f"cat {target} 2>&1",
+                f"bash {target} 2>&1",
+                f"cat {target} 1>&2",
+            ]
+            for cmd in read_only_cmds:
+                with self.subTest(cmd=cmd):
+                    self.assertIsNone(config_protection.bash_targets_protected(cmd))
+
+    def test_bash_blocks_write_with_trailing_stderr_merge(self) -> None:
+        # A real write (redirect to a named file) must still be caught even
+        # when followed by an unrelated fd-duplication token.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            cmd = f"sed -i 's/x/y/' {target} 2>&1"
+            blocked = config_protection.bash_targets_protected(cmd)
+            self.assertEqual(blocked, str(target))
+
+    def test_bash_blocks_clustered_in_place_short_flags(self) -> None:
+        # CodeRabbit/CodeAnt review finding: bundled short flags (-i last in
+        # the cluster) must still count as in-place edits.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"sed -ni 's/x/y/p' {target}",
+                f"perl -npi -e 's/x/y/' {target}",
+                f"perl -pi -e 's/x/y/' {target}",
+                # CodeAnt review finding: BSD/macOS sed's common "extended
+                # regex + in-place" idiom, capital E.
+                f"sed -Ei '' 's/x/y/' {target}",
+                f"sed -Ei.bak 's/x/y/' {target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
+    def test_bash_blocks_gnu_long_form_in_place(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"sed --in-place 's/x/y/' {target}",
+                f"sed --in-place=.bak 's/x/y/' {target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
+    def test_bash_allows_unrelated_attached_arg_flags_containing_i(self) -> None:
+        # perl's -I<dir> and -m<module> take an attached argument that can
+        # itself contain the letter 'i' — must not be mistaken for -i.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"perl -Ilib checker.pl {target}",
+                f"perl -mstrict checker.pl {target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertIsNone(config_protection.bash_targets_protected(cmd))
+
+    def test_bash_in_place_state_does_not_leak_across_command_separators(self) -> None:
+        # CodeRabbit/CodeAnt review finding: an earlier unrelated sed/perl call
+        # must not make a later unrelated `-i` (e.g. grep's case-insensitive
+        # flag) in the same compound line look like a write. Covers both the
+        # spaced and glued-to-the-prior-word separator styles.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            read_only_cmds = [
+                f"sed -n 'p' notes.txt; grep -i pattern {target}",
+                f"sed -n 'p' notes.txt ; grep -i pattern {target}",
+                f"sed -n 'p' notes.txt && grep -i pattern {target}",
+                f"sed -n 'p' notes.txt | grep -i pattern {target}",
+                # Fully glued, no spaces at all around the separator — shlex
+                # returns these as one token, unlike the space-padded forms
+                # above, so they exercise a different code path.
+                f"sed -n 'p' notes.txt&&grep -i pattern {target}",
+                f"sed -n 'p' notes.txt&& grep -i pattern {target}",
+                f"sed -n 'p' notes.txt |grep -i pattern {target}",
+            ]
+            for cmd in read_only_cmds:
+                with self.subTest(cmd=cmd):
+                    self.assertIsNone(config_protection.bash_targets_protected(cmd))
+
+    def test_bash_blocks_real_write_around_command_separators(self) -> None:
+        # A genuine sed/perl -i must still be caught next to a separator.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"sed -i 's/x/y/' {target}; echo done",
+                f"echo start && sed -i 's/x/y/' {target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
+    def test_bash_write_op_does_not_leak_across_command_separators(self) -> None:
+        # CodeAnt review finding: an earlier unrelated write (to a different
+        # file) in a compound line must not cause a later plain read of a
+        # protected file to be falsely blocked.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            other = pathlib.Path(tmp) / 'notes.txt'
+            other.write_text('unrelated\n', encoding='utf-8')
+            read_only_cmds = [
+                f"sed -i 's/x/y/' {other}; cat {target}",
+                f"sed -i 's/x/y/' {other} && cat {target}",
+                f"sed -i 's/x/y/' {other} | cat {target}",
+                # cp/mv target-tracking must also stay scoped to its own
+                # segment, not leak into a later unrelated read.
+                f"cp a b; cat {target}",
+            ]
+            for cmd in read_only_cmds:
+                with self.subTest(cmd=cmd):
+                    self.assertIsNone(config_protection.bash_targets_protected(cmd))
+            # The real write must still be caught wherever it lands.
+            for cmd in [
+                f"cat {other}; sed -i 's/x/y/' {target}",
+                f"echo ok && sed -i 's/x/y/' {target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
+    def test_bash_allows_in_place_bin_name_as_plain_argument(self) -> None:
+        # CodeRabbit/CodeAnt review finding: `sed`/`perl` must only arm
+        # in-place detection when they are the executable, not when their
+        # name merely appears as another command's argument (e.g. a grep
+        # search pattern) — otherwise an unrelated `-i` later in the same
+        # single command gets misread as a write.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            cmd = f"grep -l sed *.txt -i {target}"
+            self.assertIsNone(config_protection.bash_targets_protected(cmd))
+
+    def test_bash_blocks_in_place_edit_through_env_prefix_and_wrapper(self) -> None:
+        # A leading `VAR=value` or a thin wrapper (sudo/env/xargs/...) must
+        # not hide the real sed/perl executable that follows it.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"sudo sed -i 's/x/y/' {target}",
+                f"env sed -i 's/x/y/' {target}",
+                f"FOO=bar sed -i 's/x/y/' {target}",
+                f"FOO=bar BAZ=qux sed -i 's/x/y/' {target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
+    def test_bash_blocks_in_place_edit_past_wrapper_own_bare_flag(self) -> None:
+        # CodeAnt review finding: a wrapper's own bare flag (no separate-token
+        # argument) — e.g. env's unrelated -i — must not be mistaken for
+        # sed/perl's in-place flag, and must not swallow the real executable.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            cmd = f"env -i sed -i 's/x/y/' {target}"
+            self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
+    def test_bash_blocks_in_place_edit_past_wrapper_value_flag(self) -> None:
+        # CodeAnt review finding: a wrapper flag that takes its own
+        # separate-token argument (sudo's -u, nice's -n) must not be
+        # mistaken for the target executable, or the real sed/perl right
+        # after it gets missed entirely.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"sudo -u root sed -i 's/x/y/' {target}",
+                f"nice -n 10 sed -i 's/x/y/' {target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
+    def test_bash_fd_duplication_not_split_into_separators(self) -> None:
+        # `2>&1`/`1>&2` must survive the command-separator split intact —
+        # splitting on the embedded `&` would otherwise turn `2>&1` into
+        # `2>` (a real redirect operator) + `&` + `1`, reblocking reads.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"cat {target} 2>&1",
+                f"cat {target} 1>&2",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertIsNone(config_protection.bash_targets_protected(cmd))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_config_protection.py
+++ b/tests/test_config_protection.py
@@ -258,6 +258,39 @@ class ConfigProtectionBashTests(unittest.TestCase):
                 with self.subTest(cmd=cmd):
                     self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
 
+    def test_bash_quoted_separator_chars_do_not_split_the_command(self) -> None:
+        # CodeAnt review finding: splitting on separator characters AFTER
+        # shlex.split() loses quote context, so a sed/perl script's own `;`
+        # or `|` (substitution-chaining syntax, not a shell separator) got
+        # fake-split into disconnected fragments — silently missing a real
+        # in-place edit where -i (via GNU flag permutation) landed in a
+        # different fragment than the sed/perl executable it belongs to.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"sed 's/a;b/c;d/' -i {target}",
+                f"sed 's/a|b/c|d/' -i {target}",
+                f"perl -i -pe 's/a;b/c/' {target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
+    def test_bash_blocks_in_place_edit_through_long_form_wrapper_flag(self) -> None:
+        # CodeAnt review finding: a wrapper's long-form value flag
+        # (`sudo --user root`, `nice --adjustment 10`) must be recognized
+        # the same way as its short form, or the real executable after it
+        # gets missed.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"sudo --user root sed -i 's/x/y/' {target}",
+                f"nice --adjustment 10 sed -i 's/x/y/' {target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
     def test_bash_allows_in_place_bin_name_as_plain_argument(self) -> None:
         # CodeRabbit/CodeAnt review finding: `sed`/`perl` must only arm
         # in-place detection when they are the executable, not when their

--- a/tests/test_config_protection.py
+++ b/tests/test_config_protection.py
@@ -293,6 +293,47 @@ class ConfigProtectionBashTests(unittest.TestCase):
                 with self.subTest(cmd=cmd):
                     self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
 
+    def test_bash_command_substitution_parens_not_split(self) -> None:
+        # CodeAnt architect-review finding: the segmenter treated every `(`
+        # and `)` as a hard separator, including inside `$(...)` command
+        # substitution, so the write signal (-i) and the protected path
+        # ended up in different segments and the real edit evaded detection.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"sed -i $(printf 's/x/y/') {target}",
+                f"sed -i $(echo $(echo 's/x/y/')) {target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
+    def test_bash_subshell_grouping_parens_still_split(self) -> None:
+        # A bare `(...)` subshell (not a $() substitution) is still a real
+        # segment boundary — an unrelated write inside it must not leak
+        # into a later unrelated read outside it.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            other = pathlib.Path(tmp) / 'notes.txt'
+            other.write_text('unrelated\n', encoding='utf-8')
+            cmd = f"(sed -i 's/x/y/' {other}); cat {target}"
+            self.assertIsNone(config_protection.bash_targets_protected(cmd))
+
+    def test_bash_blocks_append_both_streams_redirect(self) -> None:
+        # CodeAnt review finding: `&>>` (append both stdout and stderr to a
+        # file) wasn't recognized by either redirect regex at all, so a
+        # write via `&>>` evaded detection entirely.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.coderabbit.yaml'
+            target.write_text('existing: true\n', encoding='utf-8')
+            for cmd in [
+                f"echo x &>> {target}",
+                f"echo x&>>{target}",
+            ]:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
+
     def test_bash_blocks_in_place_edit_through_long_form_wrapper_flag(self) -> None:
         # CodeAnt review finding: a wrapper's long-form value flag
         # (`sudo --user root`, `nice --adjustment 10`) must be recognized


### PR DESCRIPTION
## **User description**
## Summary

`.claude/hooks/config-protection.py` was treating a Bash command as a "write" to a protected config path far too eagerly, blocking purely read-only commands:

- `sed`, `awk`, `perl`, `python`/`python3`, `ruby`, `node` were unconditionally classified as destructive just by appearing anywhere in the command line — so `sed -n ... file`, `python3 checker.py file`, `perl -ne 'print' file` were all blocked even though none of them write.
- A trailing `2>&1` (extremely common, benign stderr-to-stdout fd-duplication) was misread as a file-write redirect by the bare-redirect regex, which is the actual root cause behind the two repros in the issue: `cat .claude/rules/.budget-soft-cap 2>&1` and `bash .github/scripts/rule-lint.sh 2>&1` were both blocked despite writing nothing.

Rather than pattern-matching on a protected path appearing anywhere in the command, the hook now requires an actual write signal:

- Shell redirection to a named file (`>`, `>>`, `&>`) — explicitly excluding fd-duplication (`2>&1`, `1>&2`), which never has a file target.
- An explicit write flag (`--write`, `--fix`, `-w`, etc.).
- `sed`/`perl`'s own in-place-edit flag (`-i`, clustered forms like `-ni`/`-pi`/`-Ei`, GNU's `--in-place`) — and only when `sed`/`perl` is the actual executable being run, not merely an argument to something else (e.g. `grep -l sed file -i` searches for the literal text "sed", it doesn't run it).

Executable-position tracking accounts for `VAR=value` env prefixes and thin wrappers (`sudo`, `env`, `nice`, `xargs`, ...), including a small table of wrapper flags that take their own argument (`sudo -u root`, `nice -n 10`), so real invocations behind these wrappers are still caught. All state is scoped per `;`/`&&`/`||`/`|`-separated command segment, so a write in one segment can't leak into (over-block) an unrelated read in another segment, and vice versa — a real regression I found and fixed during this work.

## Test plan

- [x] Read-only commands referencing a protected config path are no longer blocked (`cat`, `sed -n`, `awk`, `perl -ne`, interpreter scripts, `2>&1`-suffixed commands, the exact repro commands from the issue)
- [x] Commands that actually attempt to write to a protected path are still blocked (`sed -i`, `perl -pi`, `tee`, shell redirection, explicit write flags, wrapped/env-prefixed invocations) — no regression on the hook's core purpose
- [x] Regression tests cover both the newly-allowed read-only cases and the still-blocked write cases (33 unit tests in `tests/test_config_protection.py`, 97 total across the hook test suite, all passing on both the repo's system Python 3.9.6 and the CI matrix)
- [x] End-to-end verified via the real PreToolUse JSON payload path (`main()`), not just the internal helper functions

**Review note:** Both local review CLIs were briefly unavailable early in the session (CodeAnt 403 auth error, CodeRabbit rate limit) so an initial round relied on extensive self-review. The GitHub-side review pipeline (CodeRabbit + CodeAnt) subsequently ran across several rounds and caught real, valid bugs beyond the initial self-review — long-form wrapper flags, quote-context preservation in the command segmenter, the `>|` noclobber-override redirect, `$()` command-substitution parens, `&>>` redirect recognition, newline-as-separator, and perl's option-parsing boundary — all verified and fixed.

Closes #624


___

## **CodeAnt-AI Description**
**Stop blocking read-only shell commands from protected config files**

### What Changed
- Read-only commands like `sed -n`, `awk`, `perl -ne`, `python`, `node`, and `ruby` can now run against protected files without being blocked
- Real write actions are still blocked, including in-place edits, explicit write flags, and redirects that point to a file
- Compound commands now handle separators, quoted shell text, command substitution, wrapper commands, and newline-separated lines without mixing write signals across unrelated parts of the command

### Impact
`✅ Fewer blocked read-only checks`
`✅ Fewer false protection warnings`
`✅ Safer handling of real file writes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

