### PR TITLE
fix(#642): treat local-CLI false-clean runs as failures, not clean passes

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -19,6 +19,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `codeowner-bot-approvals.md` — CODEOWNERS handling for review bots and stale-approval re-trigger commands
 - `merge-gate-reviewer-paths.md` — per-reviewer merge-gate path details (CR/CodeAnt, BugBot, Greptile)
 - `codeant-graphite-supplemental.md` — CodeAnt and Graphite supplemental polling on the CR path
+- `local-review-cli-failure-modes.md` — how CodeAnt/CodeRabbit fake a clean pass on failure, 403 triage, 15-file cap (#642)
 - `wrap-fixpr-delegation.md` — `/wrap` Step 2.1 → full `/fixpr` recovery handoff contract
 - `graphql-thread-resolution.md` — full GraphQL queries/mutations for resolving PR review threads
 - `exit-report-format.md` — full structured exit report block specification

--- a/.claude/reference/local-review-cli-failure-modes.md
+++ b/.claude/reference/local-review-cli-failure-modes.md
@@ -1,0 +1,126 @@
+# Local Review CLIs — Failure Modes
+
+Diagnostic detail behind the NON-NEGOTIABLE check in `.claude/rules/cr-local-review.md`
+("A 'clean' result may be a failed run"). That rule owns enforcement; this file explains
+what the failures look like and how to classify them.
+
+**Both CLIs exit `0` on total failure, and each hides the error on a different stream.**
+Checking one stream catches one CLI and misses the other:
+
+| CLI | Exit | Failure appears on | Looks like |
+|---|---|---|---|
+| CodeAnt | `0` | **stderr** | `API Error` / `[error] Failed to review`; stdout JSON stays `{"issues": []}` |
+| CodeRabbit | `0` | **stdout** | NDJSON record `{"type":"error","errorType":"rate_limit",...}` |
+
+Observed with `codeant` v0.5.1 and `coderabbit` v0.6.5 on 2026-07-21.
+
+## The false-clean
+
+On total API failure, `codeant review` produces a result that is indistinguishable from a
+clean review on every channel an agent would normally check:
+
+| Signal | Value on total failure | Usable? |
+|---|---|---|
+| Exit code | `0` | No — `if codeant review ...; then` reads as success |
+| stdout `issues` | `[]` | No — identical to a genuine clean pass |
+| stdout `meta.reviewed_files` | every file listed | No — means *attempted*, not reviewed |
+| stdout `meta.skipped` | `[]` | No |
+| stdout `meta.capped` | `false` | No |
+| **stderr** | `API Error` / `[error] Failed to review` | **Yes — the only signal** |
+
+There is no failure field anywhere in the JSON. The canonical agent invocation
+`codeant review --all --headless > out.json` discards stderr, leaving `out.json` a clean,
+self-consistent lie. Any check that reads only the JSON can never detect this.
+
+Real captured stderr from a 6-file run where zero files were reviewed:
+
+```
+[files] Reviewing 6 file(s)
+API Error: Access denied (403). Please run `codeant logout` and then `codeant login` to re-authenticate.
+[error] Failed to review services/insight-service/src/...: Access denied (403). ...
+[progress] 0 files have suggestions, running reflector...
+```
+
+Note `[progress] 0 files have suggestions` — the reflector runs and reports zero suggestions
+even though nothing was successfully analyzed.
+
+## Classifying a 403: entitlement vs credentials
+
+The CLI's 403 text always says to re-authenticate. **That advice is often wrong.** A 403 is
+authorization, not authentication, and a valid token can still be denied.
+
+Probe before re-authenticating:
+
+```bash
+codeant scans orgs     # valid token -> returns {"connections":[{"organizationName":...}],"email":...}
+```
+
+| `scans orgs` | `review` | Diagnosis |
+|---|---|---|
+| OK | OK | Healthy |
+| OK | 403 | **Entitlement / plan / quota.** Do not re-authenticate — it will not help. Check the account plan at app.codeant.ai. |
+| 403 | 403 | Credentials. `codeant logout` then `codeant login` (browser flow). |
+
+Corroborating probes when `scans orgs` succeeds but `review` does not:
+
+- `codeant settings repos` — confirms the repo is onboarded (rules out repo-level cause)
+- `codeant secrets --last-commit` — a different feature on the same token; if it runs, the
+  token is broadly fine and the denial is specific to the review feature
+- Run `review` in a second onboarded repo — same 403 in both means account-level, not repo-level
+
+Worked example (2026-07-21, `auerbachb`): `scans orgs` returned the org and account email,
+`settings repos` listed 63 onboarded repos, `secrets` ran clean, and `review` returned 403 in
+two different repos. `logout` + `login` completed successfully and installed a fresh token;
+the 403 was unchanged. Root cause was account entitlement, not credentials.
+
+## The 15-file cap
+
+`meta.max_files` is `15`. On a larger change set:
+
+- `meta.capped` becomes `true`
+- files beyond the 15th land in `meta.skipped` with reason `exceeded 15-file limit`
+- `issues` still reports `[]` for every skipped file
+
+A capped run therefore looks clean for the untouched remainder. Reviewing a 40-file change in
+one invocation yields real coverage of at most 15 files.
+
+Workarounds:
+
+- Scope with `--include` and run per directory or per service
+- Split into multiple runs and union the findings
+- Always read `meta.capped` and `meta.skipped` before treating a run as full coverage
+
+## CodeRabbit: failure on stdout, exit 0
+
+`coderabbit review --agent` emits NDJSON on stdout. On rate-limit exhaustion it exits `0`
+with a **clean stderr** and signals the failure as a record in the stdout stream:
+
+```json
+{"type":"error","errorType":"rate_limit","message":"Rate limit exceeded","recoverable":true,
+ "metadata":{"isProUser":true,"waitTime":"28 minutes","orgAttributed":true}}
+```
+
+A run that produced only `review_context` and `status` records — with no `review`/finding
+records — reviewed nothing, regardless of exit code. Check for a terminal `type: "error"`
+record before treating absence of findings as a clean pass:
+
+```bash
+coderabbit review --agent >cr.out 2>cr.err
+jq -e 'select(.type=="error")' cr.out >/dev/null && echo "FAILED RUN - not a clean pass"
+```
+
+`metadata.waitTime` gives the cooldown. Per `cr-local-review.md`, a rate-limited CLI is a
+dropped CLI for the session — note it in the PR body; do not retry more than once.
+
+Related: a CodeRabbit *GitHub* check-run can report `success` while its description says
+"Review rate limited" — read the description, not the state.
+
+## CodeAnt auth storage
+
+`codeant login` is a browser flow (prints a URL, polls every 10s, 10-minute timeout) and
+stores the key as `apiKeyV2` in `~/.codeant/config.json`. `codeant logout` nulls that field
+but leaves the key present in the file. Never print or commit the value — inspect shape only:
+
+```bash
+jq 'map_values(if type=="string" then {length:length} elif .==null then "NULL" else type end)' ~/.codeant/config.json
+```

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -4,7 +4,7 @@
 > **Ask first:** Never — fix findings autonomously.
 > **Never:** Trigger Greptile before checking if BugBot already posted a review. Include `@cursor` in reply comments (may trigger a re-review). Ignore BugBot findings.
 
-BugBot is the **second-tier** reviewer (Cursor, per-seat) between CR and Greptile: **CR → BugBot → Greptile → self-review.** Parallel CodeAnt/Graphite: `cr-github-review.md`.
+BugBot is the **second-tier** reviewer (Cursor, per-seat) between CR and Greptile. Chain and parallel CodeAnt/Graphite: `cr-github-review.md`.
 
 **Always-trigger:** CI posts `@cursor review` on every PR open/push (`cursor-review-pr-comment.yml`); GitHub auto-trigger is unreliable — see `feedback_bugbot_auto_trigger_unreliable.md`.
 
@@ -19,9 +19,9 @@ BugBot is the **second-tier** reviewer (Cursor, per-seat) between CR and Greptil
 
 ## Polling for BugBot Reviews
 
-Poll alongside CR every 60 seconds on all three endpoints (same pattern — `pulls/{N}/reviews`, `pulls/{N}/comments`, `issues/{N}/comments` with `per_page=100`). Filter by `.user.login == "cursor[bot]"`.
+Poll alongside CR every 60 s on all three endpoints — same pattern as `cr-github-review.md` **Polling**. Filter by `.user.login == "cursor[bot]"`.
 
-**Fallback timing:** Do not maintain a separate CR-owned BugBot timeout here. The escalation gate decides whether to keep polling, switch to BugBot, trigger Greptile, or self-review. Once BugBot owns the PR, keep 60 s cadence and use the `Cursor Bugbot` completion signal below.
+**Fallback timing:** Do not maintain a separate CR-owned BugBot timeout here — the escalation gate owns that decision (`cr-github-review.md`). Once BugBot owns the PR, keep 60 s cadence and use the `Cursor Bugbot` completion signal below.
 
 **Completion signal:** BugBot creates a CI check-run named `Cursor Bugbot` that transitions to `status: "completed"` when the review finishes. The `conclusion` field is `neutral` when BugBot posted findings (still counts as a completed review — `neutral` is not a failure). Completion can also be detected via BugBot review comments appearing on any of the three endpoints.
 
@@ -33,7 +33,7 @@ BugBot becomes the active reviewer (`reviewer: bugbot`) when:
 1. The escalation gate returns `STATUS=switch_bugbot`, and
 2. The caller persists sticky ownership with `.claude/scripts/reviewer-of.sh <PR_NUMBER> --sticky bugbot`.
 
-**Sticky assignment:** Once a PR is assigned to BugBot (CR failed, BugBot responded), it stays on BugBot unless BugBot also fails — then Greptile takes over permanently.
+**Sticky assignment:** canonical in `cr-github-review.md` (Timeout & Fallback).
 
 ## Processing BugBot Findings
 
@@ -45,7 +45,7 @@ Verify all findings against actual code. Fix all valid findings in one commit, p
 
 ## Merge Gate
 
-**A clean BugBot review satisfies the merge gate alone.** CR path needs an explicit `APPROVED` on current HEAD (see `cr-merge-gate.md` Step 1).
+**A clean BugBot review on current HEAD satisfies the merge gate alone** (`cr-merge-gate.md` Step 1).
 
 ## Re-Reviews
 

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -25,7 +25,7 @@ Before the first poll tick:
 
 Run before the first poll tick and before any new review trigger on fresh push, resume, or post-compaction re-entry.
 
-1. Fetch all 3 comment endpoints (`per_page=100`): reviews, inline comments, issue comments.
+1. Fetch all 3 comment endpoints (**Polling** below).
 2. Identify unresolved findings from `coderabbitai[bot]`, `cursor[bot]`, `greptile-apps[bot]`, `codeant-ai[bot]`, or `graphite-app[bot]` (no fix reply, code unchanged, not outdated/resolved).
 3. **If ANY unresolved findings exist: invoke `/fixpr` now** — do NOT request a new review on top of unaddressed feedback.
 4. Do not poll/request review until step 3 completes.
@@ -61,7 +61,7 @@ Verdicts: `gate_met`, `polling_cr`, `switch_bugbot`, `trigger_greptile`, `budget
 
 ### Rate Limits & Behavior (Pro Tier)
 
-**Cap:** ~**8** CR PR reviews/hour (plan on 8). Batch fixes into one commit/push; max **2** explicit `@coderabbitai full review`/PR/hour (surface the user at the 2nd recorded trigger). On cooldown/exhaustion, local review first, then escalate CR → BugBot → Greptile → self-review. Consumption tracked via `cr-review-hourly.sh`. Full caps and script flags: `.claude/reference/cr-rate-limits.md`.
+**Cap:** ~**8** CR PR reviews/hour (plan on 8). Batch fixes into one commit/push; max **2** explicit `@coderabbitai full review`/PR/hour (surface the user at the 2nd recorded trigger). On cooldown/exhaustion, local review first, then escalate per **Timeout & Fallback** below. Consumption tracked via `cr-review-hourly.sh`. Full caps and script flags: `.claude/reference/cr-rate-limits.md`.
 
 ### Polling
 

--- a/.claude/rules/cr-local-review.md
+++ b/.claude/rules/cr-local-review.md
@@ -30,7 +30,20 @@ After implementation, before push. Optional mid-development. Run from repo root:
 2. Union the findings — verify each against the actual code before fixing
 3. Fix **all valid findings**
 4. Run both CLIs again
-5. Repeat until **each available CLI** returns no findings
+5. Repeat until **each available CLI** returns a verified-successful run with no findings
+
+### A "clean" result may be a failed run (NON-NEGOTIABLE)
+
+**Both CLIs exit `0` on total failure**, each hiding the error on a different stream — CodeAnt on **stderr**, CodeRabbit as a stdout NDJSON `type: "error"` record. Capture both streams and check before trusting any "no findings":
+
+```bash
+codeant review --all --headless >ca.json 2>ca.err
+grep -qE 'API Error|\[error\]|40[13]' ca.err && echo "FAILED RUN"
+coderabbit review --agent >cr.out 2>cr.err
+jq -e 'select(.type=="error")' cr.out >/dev/null && echo "FAILED RUN"
+```
+
+A hit is a **failed run** (Timeout & fallback below), never a clean pass. An empty result is clean **only** when its error check is clean and, for CodeAnt, `meta.capped` is `false`. Failure shapes, 403 triage, 15-file cap: `.claude/reference/local-review-cli-failure-modes.md`.
 
 ### Never Suppress Linter Errors (NON-NEGOTIABLE)
 
@@ -43,9 +56,8 @@ Never add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or equival
 
 ### Exit criteria
 
-- **One clean pass on both CLIs** (or on the surviving CLI + PR-body note; one clean self-review if both are unavailable)
-- Once clean, commit all changes and push the branch
-- **This transition is automatic.** After a clean pass, IMMEDIATELY commit and push — do not ask "should I push now?" or "ready to create a PR?"
+- **One verified-successful clean pass on both CLIs** (or on the surviving CLI + PR-body note; one clean self-review if both are unavailable). "No findings" alone is not a clean pass.
+- Once clean, commit and push immediately — this transition is automatic, do not ask
 
 ### Post-Clean: Push, PR, GitHub Review
 

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -42,16 +42,16 @@ The merge gate depends on which reviewer owns the PR:
 **BugBot path** (CR failed, BugBot responded, Greptile never triggered — sticky; see `bugbot.md`):
 
 - 1 clean BugBot review on the current HEAD SHA satisfies the gate (BugBot's completion signals are reliable).
-- After fixing BugBot findings, CI already posted `@cursor review` on that push; `/fixpr` also posts it after agent pushes. If BugBot still hasn't completed after polling, post `@cursor review` again — duplicates are acceptable (see `bugbot.md`).
-- Stay on BugBot — do not switch back to CR. Ignore late CR reviews.
+- Re-review after fixes: see `bugbot.md` (**Re-Reviews**).
+- Sticky (`cr-github-review.md`); ignore late CR reviews.
 
-**Greptile path** (Greptile was triggered at any point — both CR and BugBot failed — sticky assignment, see `greptile.md`):
+**Greptile path** (triggered at any point — both CR and BugBot failed — sticky; see `greptile.md`):
 
 - Severity-gated: merge-ready when ANY of these hold:
   1. **Clean review:** no findings (thumbs-up with no inline comments).
   2. **No P0 findings:** only P1/P2 findings present — fix all of them, push, reply to threads; no re-review required.
   3. **P0 fixed + re-review clean:** P0 findings were present, fixed, and a re-triggered `@greptileai` review came back clean.
-- Stay on Greptile — do not switch back to CR or BugBot. Ignore any late CR/BugBot reviews.
+- Sticky (`cr-github-review.md`); ignore late CR/BugBot reviews.
 - Max 3 Greptile reviews per PR (initial + up to 2 P0 re-reviews). At 3 with persistent P0, self-review and report blocker.
 
 **If CR, BugBot, and Greptile are all down:** self-review for risk reduction only. A clean self-review does NOT satisfy the gate; report the blocker.

--- a/.claude/rules/greptile.md
+++ b/.claude/rules/greptile.md
@@ -4,7 +4,7 @@
 > **Ask first:** Never — fix findings autonomously.
 > **Never:** Trigger Greptile before both CR AND BugBot have failed. Ignore Greptile findings. Switch a PR back to CR/BugBot after Greptile has been triggered. Include `@greptileai` in reply comments (triggers a paid re-review with no learning benefit).
 
-Greptile is the **last-resort paid** AI code reviewer — only triggered when both CR and BugBot (Cursor) have failed. Review chain: **CR → BugBot → Greptile → self-review.** CodeAnt/Graphite: `cr-github-review.md`.
+Greptile is the **last-resort paid** AI code reviewer — only triggered when both CR and BugBot (Cursor) have failed. Chain and supplemental CodeAnt/Graphite: `cr-github-review.md`.
 
 **Escalation gate:** `cr-github-review.md` owns triggers/STOP conditions. This file only defines Greptile behavior after `escalate-review.sh` returns `STATUS=trigger_greptile`.
 
@@ -35,7 +35,7 @@ Applies to 2nd/3rd triggers only; initial trigger requires only the budget check
 
 ### Sticky Assignment
 
-**Once Greptile is triggered for a PR, it stays on Greptile permanently.** Do not switch back to CR or BugBot. After fixing findings, only re-trigger `@greptileai` for P0 findings. Merge gate is severity-dependent — see `cr-merge-gate.md` (Step 1) and `.claude/reference/merge-gate-reviewer-paths.md`.
+Sticky per `cr-github-review.md`: once triggered, Greptile owns the PR permanently. Re-trigger `@greptileai` only for P0 findings. Merge gate is severity-dependent — see **Merge Gate** below.
 
 ## Polling for Greptile Response
 


### PR DESCRIPTION
## **User description**
Closes #642

## Problem

Both local review CLIs **exit `0` on total failure**, and each hides the error on a *different* stream. "No findings" was therefore indistinguishable from "nothing was reviewed":

| CLI | Exit | Error appears on | stdout on total failure |
|---|---|---|---|
| CodeAnt | `0` | **stderr** (`API Error`, `[error] Failed to review`) | `{"issues": []}`, every file under `meta.reviewed_files`, `skipped: []`, `capped: false` |
| CodeRabbit | `0` | **stdout** (NDJSON `{"type":"error"}`) | clean stderr |

The canonical invocation in the rule, `codeant review --all --headless > out.json`, discards the only channel that carries CodeAnt's failure. There is no failure field anywhere in the JSON, so checking stdout alone can never detect it.

`cr-local-review.md` defined the exit criterion as "Repeat until each available CLI returns no findings". A totally failed run returns no findings, so an agent following the rule as written would treat an outage as a clean pass and push.

## Observed 2026-07-21

**CodeAnt** on a 6-file commit — zero files actually reviewed, yet the JSON reported full clean coverage:

```
API Error: Access denied (403). Please run `codeant logout` and then `codeant login` to re-authenticate.
[error] Failed to review services/insight-service/src/...: Access denied (403). ...
[progress] 0 files have suggestions, running reflector...
```
```json
{ "issues": [], "meta": { "reviewed_files": [6 files], "skipped": [], "capped": false, "max_files": 15 } }
```

**CodeRabbit** while reviewing *this very PR* — exit `0`, clean stderr, failure only on stdout:

```json
{"type":"error","errorType":"rate_limit","message":"Rate limit exceeded",
 "metadata":{"isProUser":true,"waitTime":"28 minutes"}}
```

The CodeRabbit case is why the fix covers both streams: the first draft of this rule grepped stderr only and would have caught CodeAnt but missed CodeRabbit.

## Changes

- **`cr-local-review.md`** — new NON-NEGOTIABLE section requiring both streams be captured and checked before any run counts as a clean pass. Fix-loop step 5 and Exit criteria now require a *verified-successful* run; "no findings" alone is explicitly not a clean pass.
- **`.claude/reference/local-review-cli-failure-modes.md`** (new) — failure-shape tables, the entitlement-vs-credentials 403 triage matrix, the undocumented 15-file cap, auth storage. Reference files are not auto-loaded, so this costs no rule budget.
- **Dedup trims** in `bugbot.md`, `greptile.md`, `cr-github-review.md`, `cr-merge-gate.md` — sticky-assignment, the review chain, and the three-endpoint polling list were each stated in several files. Copies replaced with pointers to the canonical statement. **No semantic edits.**

### Secondary findings folded in

- **A 403 is authorization, not authentication.** The CLI's "run `logout` then `login`" text misdiagnoses it. On 2026-07-21 a full re-auth installed a fresh valid token and the 403 was unchanged. The rule now points at a `codeant scans orgs` probe to tell the two apart. Root cause tracked in #643.
- **Undocumented 15-file cap.** `meta.max_files: 15`; overflow goes to `meta.skipped` with reason `exceeded 15-file limit` and `capped: true`, while `issues` still reads `[]` for the remainder. A 40-file diff yields real coverage of at most 15 files.

## Rule budget

Corpus 12,201 → **12,220**, under the committed ratchet cap of **12,232**. `rule-lint.sh` passes. `.budget-soft-cap` is deliberately **unchanged** — no `--update-cap` — so the ratchet stays armed and the next growth forces the next dedup pass. The pre-existing soft warning (>12,000) is unchanged by this PR.

## Local review status

Per the Timeout & fallback rule, **both CLIs were unavailable for this change** and are noted here rather than silently skipped:

- **CodeAnt** — dropped: 403 account-wide (#643)
- **CodeRabbit** — dropped: rate limit exceeded, 28-minute cooldown

Self-review was performed instead, and **does not satisfy the merge gate** — this PR needs a GitHub-side bot review before merge.

Self-review included empirically testing both detection snippets against real captured output rather than assuming they work:

| Test | Expected | Result |
|---|---|---|
| CodeRabbit `jq` check vs real rate-limited stdout | detect failure | PASS |
| CodeRabbit `jq` check vs synthetic clean NDJSON | no false positive | PASS |
| CodeAnt `grep` check vs real 403 stderr | detect failure | PASS |
| CodeAnt `grep` check vs synthetic clean stderr | no false positive | PASS |

Note: the CodeAnt pattern `40[13]` can in principle match a path containing `401`/`403`. That fails safe (a clean run treated as failed), which is the correct direction for this check.

## Test plan

- [x] `rule-lint.sh` passes; corpus under the ratchet cap with `.budget-soft-cap` unmodified
- [x] `cr-local-review.md` requires checking stderr (CodeAnt) and stdout (CodeRabbit) before a clean pass
- [x] Exit criteria no longer permit "no findings" alone to constitute a clean pass
- [x] `meta.reviewed_files` documented as attempted, not reviewed
- [x] 15-file cap documented with the `--include` / multi-run workaround
- [x] 403 entitlement-vs-credentials triage documented with the `scans orgs` probe
- [x] Both detection snippets verified against real failing and clean output
- [x] Dedup trims preserve every canonical statement; each pointer target resolves to a real section
- [x] New reference file is listed in `.claude/reference/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Require a verified successful local review before treating “no findings” as clean**

### What Changed
- Local review now counts as clean only when both review tools finish successfully and no failure signal appears in either output stream.
- CodeAnt failures are called out as stderr-only errors, and CodeRabbit failures are called out as stdout error records, so a quiet exit code alone is no longer enough.
- The review rules now stop relying on “no findings” by itself, and the merge flow points to the shared sticky-review guidance instead of repeating old path-specific instructions.
- Added a reference guide for local review failure cases, including false-clean runs, 403 triage, and the 15-file review limit.

### Impact
`✅ Fewer false clean reviews`
`✅ Safer local review decisions`
`✅ Clearer failure handling for CodeAnt and CodeRabbit`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

