### PR TITLE
fix(#640): extend session-state.sh field-type contract to per-PR nested fields

### DIFF
--- a/.claude/reference/session-state-schema.json
+++ b/.claude/reference/session-state-schema.json
@@ -1,4 +1,27 @@
 {
+  "_field_types": {
+    "_description": "Machine-readable field-type contract consumed at runtime by session-state.sh's FIELD-TYPE CONTRACT (issues #625, #640) — the single source of truth for which fields must hold a specific JSON type. `top_level` keys index the root document; `pr_nested` keys index each entry under `.prs[\"<N>\"]` (checked wherever that key appears, at any nesting depth under a PR entry). Values are the expected `jq ... | type` string. Fields absent from both maps are left unvalidated, preserving the 'preserve unknown fields' forward-compat convention documented in handoff-files.md.",
+    "top_level": {
+      "active_agents": "array",
+      "polling_jobs": "array",
+      "polling_failures": "array",
+      "polling_backoffs": "array",
+      "prs": "object",
+      "cr_quota": "object",
+      "cr_hourly": "object",
+      "greptile_daily": "object",
+      "pmm_in_flight": "object",
+      "pmm": "object"
+    },
+    "pr_nested": {
+      "last_cron_action": "object",
+      "preflight_triggered": "object",
+      "babysit": "object",
+      "wrap_sweep": "object",
+      "cr_explicit_triggers": "array",
+      "digest_streak": "number"
+    }
+  },
   "last_updated": "2026-04-29T14:00:00Z",
   "monitoring_active": true,
   "monitoring_mode": "cron",

--- a/.claude/scripts/infer-pr.sh
+++ b/.claude/scripts/infer-pr.sh
@@ -233,12 +233,34 @@ if [[ -z "$PRS_JSON" || "$PRS_JSON" == "null" ]]; then
   PRS_JSON="{}"
 fi
 
+# Defense in depth (issue #640): session-state.sh's per-PR field-type guard
+# rejects new writes that would leave `last_cron_action` as anything but an
+# object, but state files written before that guard existed can still carry
+# a malformed value (the exact corruption found in PRs #542/#544 — a bare
+# string where every consumer expects `{type, at, interval}`). Warn and
+# degrade rather than let the jq pipeline below hard-error when it indexes
+# `.last_cron_action.at`.
+MALFORMED_CRON_ACTION_KEYS="$(jq -r '
+  to_entries[]
+  | select(.value.last_cron_action != null and (.value.last_cron_action | type) != "object")
+  | .key
+' <<<"$PRS_JSON" 2>/dev/null || true)"
+if [[ -n "$MALFORMED_CRON_ACTION_KEYS" ]]; then
+  while IFS= read -r bad_pr_key; do
+    [[ -z "$bad_pr_key" ]] && continue
+    echo "infer-pr.sh: warning: PR #$bad_pr_key has a malformed last_cron_action (not an object) — ranking it as if last activity were unset (see issue #640)" >&2
+  done <<<"$MALFORMED_CRON_ACTION_KEYS"
+fi
+
 # Build the candidate list:
 #   - one record per PR key
 #   - filter to --root-repo when provided (keep entries whose recorded
 #     root_repo matches, plus entries with no recorded root_repo — their repo
 #     is simply unknown, and dropping them would hide legitimately-tracked PRs)
 #   - sort by last_cron_action.at descending (missing timestamp sorts last)
+# `.last_cron_action.at?` uses jq's `?` postfix to suppress the "Cannot index
+# string with \"at\"" error a malformed (non-object) last_cron_action would
+# otherwise raise, falling through to the `// null` default instead.
 if ! RESULT=$(jq -c \
     --arg root_repo "$ROOT_REPO" \
     '
@@ -250,7 +272,7 @@ if ! RESULT=$(jq -c \
         | {
             number: $n,
             owner_repo: ( .value.owner_repo // null ),
-            last_activity: ( .value.last_cron_action.at // null ),
+            last_activity: ( .value.last_cron_action.at? // null ),
             _root: ( .value.root_repo // null )
           }
       )

--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -150,7 +150,13 @@ if [[ "$INFER_CANDIDATES" -eq 1 ]]; then
           blocker_kind: (.value.blocker_kind // null),
           owner_repo: (.value.owner_repo // null),
           root_repo: (.value.root_repo // null),
-          last_action_at: (.value.last_cron_action.at // ""),
+          # `?` (issue #640, CodeAnt finding on PR #654) suppresses the
+          # "Cannot index string with \"at\"" error a pre-existing malformed
+          # (non-object) last_cron_action would otherwise raise — without it,
+          # ONE corrupted entry aborts this whole array comprehension and the
+          # caller falls back to printing "[]" for every candidate, not just
+          # the bad one.
+          last_action_at: (.value.last_cron_action.at? // ""),
           same_repo: (
             if $cur == "" or (.value.owner_repo // "") == "" then null
             else (.value.owner_repo == $cur) end

--- a/.claude/scripts/session-state.sh
+++ b/.claude/scripts/session-state.sh
@@ -328,6 +328,37 @@ pr_nested_key_of() {
   fi
 }
 
+# Returns the PR number when `path` is a WHOLE-entry write, e.g. `.prs["999"]`
+# -> "999" (nothing follows the PR-number selector) — as opposed to a nested
+# write like `.prs["999"].reviewer`, which returns empty here even though
+# "reviewer" isn't a known field. This distinction matters (CodeAnt finding,
+# issue #640, PR #654): pr_nested_key_of() deliberately returns empty for a
+# whole-entry write since there's no single nested key to check — but that
+# left a real gap, since a whole-entry write's value can still embed a
+# malformed known nested field (e.g. `--set '.prs["999"]={"last_cron_action":
+# "bare string"}'`) that the top-level `.prs` object-type check alone can't
+# catch. Used below to trigger a full per-known-field scan of the written
+# entry, not just the single-path check pr_nested_key_of() enables.
+pr_whole_entry_write_number_of() {
+  if [[ "$(top_level_key_of "$1")" != "prs" ]]; then
+    printf '%s' ""
+    return 0
+  fi
+  local num
+  num="$(pr_number_of "$1")"
+  if [[ -z "$num" ]]; then
+    printf '%s' ""
+    return 0
+  fi
+  local rest="${1#.prs}"
+  rest="${rest#\[*\]}"
+  if [[ -n "$rest" ]]; then
+    printf '%s' ""
+    return 0
+  fi
+  printf '%s' "$num"
+}
+
 # --- arg parsing ---
 MODE=""
 GET_PATH=""
@@ -515,6 +546,7 @@ JQ_FILTER=""
 JQ_ARGS=()
 TOUCHED_KNOWN_FIELDS=""
 TOUCHED_NESTED_CHECKS=""
+WHOLE_ENTRY_PRS=""
 for i in "${!SET_PATHS[@]}"; do
   path="${SET_PATHS[$i]}"
   value="${SET_VALUES[$i]}"
@@ -566,6 +598,18 @@ for i in "${!SET_PATHS[@]}"; do
         *) TOUCHED_NESTED_CHECKS="$TOUCHED_NESTED_CHECKS $nested_pair" ;;
       esac
     fi
+  fi
+  # Track whole-PR-entry writes (issue #640, CodeAnt finding on PR #654):
+  # `--set '.prs["999"]={...}'` replaces the entire entry in one shot, so no
+  # single nested-field path is touched above — but the embedded object can
+  # still carry a malformed known field. Record the PR number so the
+  # post-write loop below can scan every known nested key in that entry.
+  set_whole_entry_pr="$(pr_whole_entry_write_number_of "$path")"
+  if [[ "$set_whole_entry_pr" =~ ^[0-9]+$ ]]; then
+    case " $WHOLE_ENTRY_PRS " in
+      *" $set_whole_entry_pr "*) ;;
+      *) WHOLE_ENTRY_PRS="$WHOLE_ENTRY_PRS $set_whole_entry_pr" ;;
+    esac
   fi
 done
 
@@ -621,6 +665,32 @@ for nested_pair in $TOUCHED_NESTED_CHECKS; do
     exit 4
   fi
 done
+
+# Field-type contract, whole-PR-entry writes (issue #640, CodeAnt finding on
+# PR #654): a write like `.prs["999"]={...}` replaces the whole entry, so the
+# per-path tracking above never sees a specific nested-field path to check —
+# but the embedded object can still carry a malformed known field (e.g.
+# `last_cron_action` as a bare string) that the top-level `.prs` object-type
+# check alone can't catch. For every PR written as a whole entry this batch,
+# check EVERY known nested key present in the FINAL entry (absent keys are
+# type "null" and are skipped — a whole-entry write simply omitting a known
+# field is not corruption, same as any other unset nested field).
+if [[ -n "$WHOLE_ENTRY_PRS" ]]; then
+  load_field_types
+  KNOWN_NESTED_KEYS="$(printf '%s\n' "$FIELD_TYPES_NESTED" | cut -d= -f1)"
+  for whole_entry_pr in $WHOLE_ENTRY_PRS; do
+    while IFS= read -r whole_entry_key; do
+      [[ -z "$whole_entry_key" ]] && continue
+      whole_entry_expected_type="$(known_nested_field_type "$whole_entry_key")"
+      whole_entry_check_path=".prs[\"${whole_entry_pr}\"].${whole_entry_key}"
+      whole_entry_actual_type="$(jq -r "${whole_entry_check_path} | type" "$OUT_TMP" 2>/dev/null)"
+      if [[ "$whole_entry_actual_type" != "null" && "$whole_entry_actual_type" != "$whole_entry_expected_type" ]]; then
+        echo "session-state.sh: refusing to write — field '$whole_entry_check_path' would become type '$whole_entry_actual_type' but must be '$whole_entry_expected_type' (see issue #640); $STATE_FILE left unmodified" >&2
+        exit 4
+      fi
+    done <<<"$KNOWN_NESTED_KEYS"
+  done
+fi
 
 if ! mv "$OUT_TMP" "$STATE_FILE" 2>/dev/null; then
   echo "session-state.sh: could not write $STATE_FILE" >&2

--- a/.claude/scripts/session-state.sh
+++ b/.claude/scripts/session-state.sh
@@ -54,34 +54,51 @@
 #   5  Write failed — could not create temp file, could not mv into place,
 #      or jq filter pipeline failed during the atomic write.
 #
-# FIELD-TYPE CONTRACT (issue #625)
-#   A small set of top-level fields are known, from
-#   .claude/reference/session-state-schema.json, to always hold a specific
-#   JSON type — arrays (active_agents, polling_jobs, polling_failures,
-#   polling_backoffs) or objects (prs, cr_quota, cr_hourly, greptile_daily,
-#   pmm_in_flight, pmm). Fields outside this list are unvalidated, preserving
-#   forward-compatibility with the "preserve unknown fields" convention.
+# FIELD-TYPE CONTRACT (issues #625, #640)
+#   A known set of fields always hold a specific JSON type — top-level
+#   fields (arrays: active_agents, polling_jobs, polling_failures,
+#   polling_backoffs; objects: prs, cr_quota, cr_hourly, greptile_daily,
+#   pmm_in_flight, pmm) and per-PR nested fields under `.prs["<N>"]`
+#   (objects: last_cron_action, preflight_triggered, babysit, wrap_sweep;
+#   array: cr_explicit_triggers; number: digest_streak). Fields outside
+#   these lists are unvalidated, preserving forward-compatibility with the
+#   "preserve unknown fields" convention.
+#
+#   The contract is loaded at runtime from
+#   .claude/reference/session-state-schema.json's `_field_types` object —
+#   that file is the single source of truth, not a hardcoded list in this
+#   script, so the two can never drift apart. If the schema file can't be
+#   found or parsed (unusual invocation context, e.g. this script copied
+#   somewhere without its .claude/reference/ sibling), the contract is
+#   disabled for this run with a warning on stderr — --get/--set still work,
+#   just without the type guard, rather than hard-failing every state-file
+#   operation because a side file is missing.
 #
 #   --set checks the FINAL value of any touched known field after the whole
 #   batch is applied (not just the raw value passed in), so both whole-field
 #   writes (`--set '.active_agents=...'`) and element/sub-path writes
-#   (`--set '.active_agents[0]=...'`) are covered. If a touched known field
-#   would end up the wrong type, the entire batch is rejected (exit 4) and
-#   the state file is left unmodified — this is what should have caught the
-#   original corruption: a caller passed an unevaluated jq filter expression
-#   (e.g. `(.active_agents // [] | map(select(.pr_number != 71)))`) as a
-#   --set value; since it isn't valid JSON it fell into the --arg (string)
-#   branch below and was written verbatim as `.active_agents`'s value.
-#   Callers must evaluate any filter locally first (read → jq-filter → pass
-#   the resulting JSON array/object as the --set value) — see the
+#   (`--set '.active_agents[0]=...'` or, for a per-PR nested field,
+#   `--set '.prs["287"].babysit.active=...'`) are covered. If a touched
+#   known field would end up the wrong type, the entire batch is rejected
+#   (exit 4) and the state file is left unmodified — this is what should
+#   have caught the original corruption: a caller passed an unevaluated jq
+#   filter expression (e.g.
+#   `(.active_agents // [] | map(select(.pr_number != 71)))`) as a --set
+#   value; since it isn't valid JSON it fell into the --arg (string) branch
+#   below and was written verbatim as `.active_agents`'s value. Callers must
+#   evaluate any filter locally first (read → jq-filter → pass the
+#   resulting JSON array/object as the --set value) — see the
 #   read-filter-write pattern in .claude/skills/pr-monitor-and-manage/SKILL.md.
 #
-#   --get on a known field whose *stored* value doesn't match the contract
-#   (state corrupted before this guard existed, or written by something
-#   bypassing this script) prints a warning to stderr and returns a safe
-#   default (`[]`/`{}`) on stdout instead of the corrupt value, exiting 0 so
-#   existing read-modify-write callers keep working — the next validated
-#   --set through this same field then heals the corruption for good.
+#   --get on a known top-level field whose *stored* value doesn't match the
+#   contract (state corrupted before this guard existed, or written by
+#   something bypassing this script) prints a warning to stderr and returns
+#   a safe default (`[]`/`{}`) on stdout instead of the corrupt value,
+#   exiting 0 so existing read-modify-write callers keep working — the next
+#   validated --set through this same field then heals the corruption for
+#   good. Per-PR nested fields are validated on --set only (not --get):
+#   callers read them through infer-pr.sh or ad-hoc jq, not this script's
+#   --get, so there's no read-modify-write caller to protect symmetrically.
 #
 # OUTPUT
 #   --get: raw value on stdout (one line per jq output, like `jq -r`).
@@ -129,11 +146,26 @@
 #   # write pattern):
 #   session-state.sh --set '.active_agents=(.active_agents // [] | map(select(.pr_number != 71)))'
 #   # -> exit 4: field '.active_agents' would become type 'string' but must be 'array'
+#
+#   # Rejected: last_cron_action is a known object-typed per-PR nested field
+#   # (issue #640) — a bare string isn't a JSON object, so this exits 4 and
+#   # leaves the state file unmodified:
+#   session-state.sh --set '.prs["287"].last_cron_action=some bare string'
+#   # -> exit 4: field '.prs["287"].last_cron_action' would become type 'string' but must be 'object'
 
 set -euo pipefail
 printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
 
 STATE_FILE="${HOME}/.claude/session-state.json"
+
+# Sibling reference file that is the single source of truth for the
+# FIELD-TYPE CONTRACT (issues #625, #640) — resolved relative to this
+# script's own location (not $STATE_FILE's directory) so it works from every
+# known invocation path (repo-local .claude/scripts/, the skills worktree,
+# or a caller's own $SELF_DIR-relative lookup) without hardcoding an
+# absolute path.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEMA_FILE="${SCRIPT_DIR}/../reference/session-state-schema.json"
 
 print_help() {
   sed -n '/^# PURPOSE$/,/^$/p' "$0" | sed '$d; s/^# \{0,1\}//'
@@ -156,19 +188,65 @@ is_single_object_state_file() {
   jq -s -e 'length == 1 and (.[0] | type == "object")' "$1" >/dev/null 2>&1
 }
 
-# Field-type contract (issue #625) — mirrors
-# .claude/reference/session-state-schema.json. Prints the expected JSON type
-# ("array"/"object") for a known top-level field, or nothing for fields
-# outside the contract (left unvalidated for forward-compatibility). A plain
-# function rather than an associative array so this script stays compatible
-# with bash 3.2 (macOS system bash has no `declare -A`).
+# Field-type contract (issues #625, #640) — loaded once, lazily, from
+# .claude/reference/session-state-schema.json's `_field_types` object (the
+# single source of truth; see the FIELD-TYPE CONTRACT header comment). Two
+# newline-separated "key=type" caches, one for top-level fields and one for
+# per-PR nested fields, parsed by known_field_type()/known_nested_field_type()
+# below. Plain variables (not associative arrays) so this script stays
+# compatible with bash 3.2 (macOS system bash has no `declare -A`).
+FIELD_TYPES_LOADED=0
+FIELD_TYPES_TOP=""
+FIELD_TYPES_NESTED=""
+
+load_field_types() {
+  if [[ "$FIELD_TYPES_LOADED" -eq 1 ]]; then
+    return 0
+  fi
+  FIELD_TYPES_LOADED=1
+  if [[ ! -f "$SCHEMA_FILE" ]]; then
+    echo "session-state.sh: warning: field-type contract schema not found at $SCHEMA_FILE — type guard disabled for this run (see issue #640)" >&2
+    return 0
+  fi
+  local top nested
+  if ! top="$(jq -r '._field_types.top_level // {} | to_entries[] | "\(.key)=\(.value)"' "$SCHEMA_FILE" 2>/dev/null)"; then
+    echo "session-state.sh: warning: could not parse field-type contract from $SCHEMA_FILE — type guard disabled for this run (see issue #640)" >&2
+    return 0
+  fi
+  nested="$(jq -r '._field_types.pr_nested // {} | to_entries[] | "\(.key)=\(.value)"' "$SCHEMA_FILE" 2>/dev/null)" || nested=""
+  FIELD_TYPES_TOP="$top"
+  FIELD_TYPES_NESTED="$nested"
+}
+
+# Prints the expected JSON type ("array"/"object"/etc) for a known top-level
+# field per the schema-driven contract, or nothing for fields outside it
+# (left unvalidated for forward-compatibility).
 known_field_type() {
-  case "$1" in
-    active_agents|polling_jobs|polling_failures|polling_backoffs)
-      echo "array" ;;
-    prs|cr_quota|cr_hourly|greptile_daily|pmm_in_flight|pmm)
-      echo "object" ;;
-  esac
+  load_field_types
+  local key="$1" line
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    if [[ "${line%%=*}" == "$key" ]]; then
+      printf '%s' "${line#*=}"
+      return 0
+    fi
+  done <<<"$FIELD_TYPES_TOP"
+}
+
+# Prints the expected JSON type for a known per-PR nested field (e.g.
+# "last_cron_action" -> "object"), or nothing for fields outside the
+# contract. Field name only — callers resolve the concrete `.prs["<N>"].<key>`
+# check path themselves via pr_number_of()/pr_nested_key_of() below.
+known_nested_field_type() {
+  load_field_types
+  local key="$1" line
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    if [[ "${line%%=*}" == "$key" ]]; then
+      printf '%s' "${line#*=}"
+      return 0
+    fi
+  done <<<"$FIELD_TYPES_NESTED"
 }
 
 # Extract the leading top-level key from a jq path, e.g.
@@ -182,6 +260,63 @@ known_field_type() {
 # path indexes below that top-level field.
 top_level_key_of() {
   local path="${1#.}"
+  if [[ "$path" == \[* ]]; then
+    path="${path#\[}"
+    path="${path%%]*}"
+    path="${path#[\"\']}"
+    path="${path%[\"\']}"
+    printf '%s' "$path"
+  else
+    printf '%s' "${path%%[.[]*}"
+  fi
+}
+
+# Extract the PR-number key from a path whose top-level key is "prs", e.g.
+# `.prs["287"].last_cron_action` -> "287". Every known caller uses bracket
+# notation for the PR-number selector (`.prs["<N>"]`), so only that form is
+# recognized; a bare `.prs.287...` (unusual — jq requires bracket or quoted-
+# dot notation for a numeric key) returns empty, same as an absent selector.
+pr_number_of() {
+  local path="${1#.prs}"
+  if [[ "$path" != \[* ]]; then
+    printf '%s' ""
+    return 0
+  fi
+  path="${path#\[}"
+  path="${path%%]*}"
+  path="${path#[\"\']}"
+  path="${path%[\"\']}"
+  printf '%s' "$path"
+}
+
+# Extract the per-PR nested field name immediately after the PR-number
+# selector, e.g. `.prs["287"].babysit.active` -> "babysit" (the known field
+# two levels up from a subpath write — the same principle top_level_key_of()
+# applies for top-level fields, e.g. `.active_agents[0].id` -> "active_agents").
+# Returns empty if the path's top-level key isn't "prs", there's no bracket
+# PR-number selector, or nothing follows it (a whole-`.prs["<N>"]` entry
+# replacement isn't checked here — the existing top-level object-type check
+# on `prs` itself still applies).
+pr_nested_key_of() {
+  if [[ "$(top_level_key_of "$1")" != "prs" ]]; then
+    printf '%s' ""
+    return 0
+  fi
+  local path
+  path="$(pr_number_of "$1")"
+  if [[ -z "$path" ]]; then
+    printf '%s' ""
+    return 0
+  fi
+  # Re-derive the remainder after the PR-number selector (pr_number_of()
+  # only returns the extracted number, not the leftover path).
+  path="${1#.prs}"
+  path="${path#\[*\]}"
+  path="${path#.}"
+  if [[ -z "$path" ]]; then
+    printf '%s' ""
+    return 0
+  fi
   if [[ "$path" == \[* ]]; then
     path="${path#\[}"
     path="${path%%]*}"
@@ -379,6 +514,7 @@ trap "rm -f '$OUT_TMP' '$JQ_ERR' ${SEEDED_TMP:+'$SEEDED_TMP'} 2>/dev/null" EXIT
 JQ_FILTER=""
 JQ_ARGS=()
 TOUCHED_KNOWN_FIELDS=""
+TOUCHED_NESTED_CHECKS=""
 for i in "${!SET_PATHS[@]}"; do
   path="${SET_PATHS[$i]}"
   value="${SET_VALUES[$i]}"
@@ -409,6 +545,27 @@ for i in "${!SET_PATHS[@]}"; do
       *" $set_top_level_key "*) ;;
       *) TOUCHED_KNOWN_FIELDS="$TOUCHED_KNOWN_FIELDS $set_top_level_key" ;;
     esac
+  fi
+  # Same tracking for per-PR nested fields (issue #640): a touched path whose
+  # top-level key is "prs" and whose immediate post-PR-number segment is a
+  # known nested field (e.g. `.prs["287"].last_cron_action` or a deeper
+  # subpath like `.prs["287"].babysit.active`) is recorded as a "<PR>:<key>"
+  # pair so the post-write loop below can check that specific PR entry's
+  # field, not every PR in the file.
+  set_nested_key="$(pr_nested_key_of "$path")"
+  if [[ -n "$set_nested_key" ]] && [[ -n "$(known_nested_field_type "$set_nested_key")" ]]; then
+    set_pr_number="$(pr_number_of "$path")"
+    # PR numbers are always plain digits (GitHub PR numbers). Requiring that
+    # shape here — before $set_pr_number gets interpolated into the jq
+    # filter string built for nested_check_path below — keeps that
+    # interpolation injection-safe without needing full jq-string escaping.
+    if [[ "$set_pr_number" =~ ^[0-9]+$ ]]; then
+      nested_pair="${set_pr_number}:${set_nested_key}"
+      case " $TOUCHED_NESTED_CHECKS " in
+        *" $nested_pair "*) ;;
+        *) TOUCHED_NESTED_CHECKS="$TOUCHED_NESTED_CHECKS $nested_pair" ;;
+      esac
+    fi
   fi
 done
 
@@ -441,6 +598,26 @@ for set_touched_key in $TOUCHED_KNOWN_FIELDS; do
   set_actual_type="$(jq -r ".${set_touched_key} | type" "$OUT_TMP" 2>/dev/null)"
   if [[ "$set_actual_type" != "$set_expected_type" ]]; then
     echo "session-state.sh: refusing to write — field '.$set_touched_key' would become type '$set_actual_type' but must be '$set_expected_type' (see issue #625); $STATE_FILE left unmodified" >&2
+    exit 4
+  fi
+done
+
+# Field-type contract, per-PR nested fields (issue #640): same principle as
+# the top-level loop above, extended to reach fields nested under a specific
+# `.prs["<N>"]` entry — e.g. PR #542's `last_cron_action` holding a bare
+# string where every consumer (infer-pr.sh, wrap, babysit-pr) expects an
+# object. Checked against the FINAL value at the concrete `.prs["<N>"].<key>`
+# path, so sub-path writes (e.g. `.prs["287"].babysit.active=...`) are
+# covered by checking the whole `babysit` object's final type, not just the
+# raw --set value.
+for nested_pair in $TOUCHED_NESTED_CHECKS; do
+  nested_pr_number="${nested_pair%%:*}"
+  nested_field_key="${nested_pair#*:}"
+  nested_expected_type="$(known_nested_field_type "$nested_field_key")"
+  nested_check_path=".prs[\"${nested_pr_number}\"].${nested_field_key}"
+  nested_actual_type="$(jq -r "${nested_check_path} | type" "$OUT_TMP" 2>/dev/null)"
+  if [[ "$nested_actual_type" != "$nested_expected_type" ]]; then
+    echo "session-state.sh: refusing to write — field '$nested_check_path' would become type '$nested_actual_type' but must be '$nested_expected_type' (see issue #640); $STATE_FILE left unmodified" >&2
     exit 4
   fi
 done

--- a/.claude/scripts/tests/infer-pr.test.sh
+++ b/.claude/scripts/tests/infer-pr.test.sh
@@ -148,6 +148,28 @@ check_exit "root-repo filter exit" 1 "$RC"
 check_json "root filter keeps match + unknown" '[.candidates[].number] | sort | @csv' '800,802' "$OUT"
 check_json "root filter drops other repo" '[.candidates[].number] | any(. == 801)' "false" "$OUT"
 
+echo "== session-state inference: malformed last_cron_action degrades gracefully (issue #640) =="
+cat > "$HOME/.claude/session-state.json" <<EOF
+{
+  "prs": {
+    "542": {"owner_repo": "org/repo", "last_cron_action": "a bare string, not an object"},
+    "544": {"owner_repo": "org/repo", "last_cron_action": {"at": "2026-04-29T14:10:00Z"}}
+  }
+}
+EOF
+STDERR_FILE="$(mktemp)"
+OUT=$(run 2>"$STDERR_FILE"); RC=$?
+check_exit "malformed last_cron_action does not hard-error" 1 "$RC"
+check_json "malformed entry still produced as a candidate" '.candidates | length' "2" "$OUT"
+check_json "malformed entry ranks as if last_activity were unset (sorts last)" '.candidates[-1].number' "542" "$OUT"
+WARN_COUNT="$(grep -c "malformed last_cron_action" "$STDERR_FILE" 2>/dev/null || echo 0)"
+if [[ "$WARN_COUNT" -ge 1 ]]; then
+  PASS=$((PASS + 1)); echo "ok   — warns on stderr about the malformed field"
+else
+  FAIL=$((FAIL + 1)); echo "FAIL — expected a stderr warning about the malformed field, got none"
+fi
+rm -f "$STDERR_FILE"
+
 echo
 echo "== summary: $PASS passed, $FAIL failed =="
 [[ "$FAIL" -eq 0 ]] || exit 1

--- a/.claude/scripts/tests/pr-state-infer-candidates.test.sh
+++ b/.claude/scripts/tests/pr-state-infer-candidates.test.sh
@@ -90,4 +90,22 @@ echo '{"prs":{"1":{"reviewer":"cr"},"2":{"head_sha":"abc"}}}' > "$HOME/.claude/s
 out=$(bash "$SCRIPT" --infer-candidates)
 [[ "$out" == "[]" ]] || fail "no-active: expected [] got: $out"
 
-echo "OK: pr-state.sh --infer-candidates (missing file, ordering, active filter, same_repo, flag combos, empty prs)"
+# --- Case 6: a malformed last_cron_action (bare string, not object) on one
+# entry must not abort candidates for every OTHER entry (issue #640, CodeAnt
+# finding on PR #654 — pr-state.sh has the same last_cron_action.at indexing
+# pattern infer-pr.sh was already hardened against).
+cat > "$HOME/.claude/session-state.json" <<'JSON'
+{ "prs": {
+  "542": {"phase":"external_thread","reviewer":"greptile","last_cron_action":"a bare narrative string"},
+  "544": {"phase":"merged","reviewer":"greptile","last_cron_action":{"at":"2026-07-16T02:54:00Z"}}
+}}
+JSON
+out=$(bash "$SCRIPT" --infer-candidates)
+count=$(jq 'length' <<<"$out")
+[[ "$count" == "2" ]] || fail "malformed-entry: expected 2 candidates (both still present), got $count: $out"
+malformed_activity=$(jq -r '.[]|select(.number==542)|.last_action_at' <<<"$out")
+[[ "$malformed_activity" == "" ]] || fail "malformed-entry: expected empty last_action_at for #542, got: $malformed_activity"
+valid_activity=$(jq -r '.[]|select(.number==544)|.last_action_at' <<<"$out")
+[[ "$valid_activity" == "2026-07-16T02:54:00Z" ]] || fail "malformed-entry: #544's last_action_at not preserved, got: $valid_activity"
+
+echo "OK: pr-state.sh --infer-candidates (missing file, ordering, active filter, same_repo, flag combos, empty prs, malformed last_cron_action)"

--- a/.claude/scripts/tests/session-state.test.sh
+++ b/.claude/scripts/tests/session-state.test.sh
@@ -105,6 +105,43 @@ check_eq "nulling a nested prs field does not trip the object-type guard" "0" "$
 check_eq "prs stays an object with the null applied" '{"287":{"reviewer":"greptile","blocker":null}}' "$(jq -c '.prs' "$STATE_FILE")"
 
 echo
+echo "== Write-time guard: per-PR nested field contract (issue #640) =="
+reset_state
+OUT=$(run --set '.prs["999"].last_cron_action=some bare string' 2>&1); RC=$?
+check_eq "bare-string last_cron_action rejected (exit 4)" "4" "$RC"
+check_eq "error names the nested field and both types" "1" "$(grep -c "field '.prs\[\"999\"\].last_cron_action' would become type 'string' but must be 'object'" <<<"$OUT")"
+check_eq "state file never created for a rejected nested write" "1" "$([[ ! -f "$STATE_FILE" ]] && echo 1 || echo 0)"
+
+run --set '.prs["999"].last_cron_action={"type":"create","at":"2026-04-29T13:55:00Z","interval":"1m"}'
+check_eq "well-formed last_cron_action object accepted" "0" "$?"
+check_eq "last_cron_action holds the written object" '{"type":"create","at":"2026-04-29T13:55:00Z","interval":"1m"}' "$(jq -c '.prs["999"].last_cron_action' "$STATE_FILE")"
+
+OUT=$(run --set '.prs["999"].last_cron_action=overwritten with a bad string' 2>&1); RC=$?
+check_eq "a subsequent bad overwrite is still rejected (exit 4)" "4" "$RC"
+check_eq "the prior good value is untouched by the rejected overwrite" '{"type":"create","at":"2026-04-29T13:55:00Z","interval":"1m"}' "$(jq -c '.prs["999"].last_cron_action' "$STATE_FILE")"
+
+run --set '.prs["999"].reviewer=greptile'
+check_eq "a nested field NOT on the known list stays unvalidated" "0" "$?"
+check_eq "the unknown nested field is written as given" '"greptile"' "$(jq -c '.prs["999"].reviewer' "$STATE_FILE")"
+
+OUT=$(run --set '.prs["999"].babysit.active=true' 2>&1); RC=$?
+check_eq "sub-path write into a known object-typed nested field is accepted" "0" "$RC"
+check_eq "babysit ends up an object with the sub-path write applied" '{"active":true}' "$(jq -c '.prs["999"].babysit' "$STATE_FILE")"
+
+run --set '.prs["999"].cr_explicit_triggers=["2026-04-29T22:30:00Z"]'
+check_eq "well-formed array cr_explicit_triggers accepted" "0" "$?"
+OUT=$(run --set '.prs["999"].cr_explicit_triggers=2' 2>&1); RC=$?
+check_eq "number-for-array cr_explicit_triggers rejected (exit 4)" "4" "$RC"
+check_eq "error names cr_explicit_triggers and both types" "1" "$(grep -c "field '.prs\[\"999\"\].cr_explicit_triggers' would become type 'number' but must be 'array'" <<<"$OUT")"
+check_eq "prior valid cr_explicit_triggers array is untouched" '["2026-04-29T22:30:00Z"]' "$(jq -c '.prs["999"].cr_explicit_triggers' "$STATE_FILE")"
+
+OUT=$(run --set '.prs["998"].digest_streak=not-a-number' 2>&1); RC=$?
+check_eq "string-for-number digest_streak rejected (exit 4)" "4" "$RC"
+run --set '.prs["998"].digest_streak=3'
+check_eq "well-formed number digest_streak accepted" "0" "$?"
+check_eq "digest_streak holds the written number" "3" "$(jq -c '.prs["998"].digest_streak' "$STATE_FILE")"
+
+echo
 echo "== Write-time guard: unknown fields stay unvalidated (forward-compat) =="
 run --set '.monitoring_active=true' --set '.root_repo=/tmp/foo'
 check_eq "unknown-field batch write exits 0" "0" "$?"

--- a/.claude/scripts/tests/session-state.test.sh
+++ b/.claude/scripts/tests/session-state.test.sh
@@ -142,6 +142,22 @@ check_eq "well-formed number digest_streak accepted" "0" "$?"
 check_eq "digest_streak holds the written number" "3" "$(jq -c '.prs["998"].digest_streak' "$STATE_FILE")"
 
 echo
+echo "== Write-time guard: whole-PR-entry writes (issue #640, CodeAnt finding on PR #654) =="
+reset_state
+OUT=$(run --set '.prs["999"]={"phase":"B","last_cron_action":"bare string","digest_streak":"not-a-number"}' 2>&1); RC=$?
+check_eq "whole-entry write embedding a malformed known field rejected (exit 4)" "4" "$RC"
+check_eq "error names the embedded nested field" "1" "$(grep -c "field '.prs\[\"999\"\].last_cron_action' would become type 'string' but must be 'object'" <<<"$OUT")"
+check_eq "state file never created for a rejected whole-entry write" "1" "$([[ ! -f "$STATE_FILE" ]] && echo 1 || echo 0)"
+
+run --set '.prs["999"]={"phase":"B","last_cron_action":{"type":"create","at":"2026-01-01T00:00:00Z"},"digest_streak":3,"reviewer":"greptile"}'
+check_eq "well-formed whole-entry write accepted" "0" "$?"
+check_eq "whole-entry write applied correctly" '{"phase":"B","last_cron_action":{"type":"create","at":"2026-01-01T00:00:00Z"},"digest_streak":3,"reviewer":"greptile"}' "$(jq -c '.prs["999"]' "$STATE_FILE")"
+
+run --set '.prs["1000"]={"phase":"A","reviewer":"cr"}'
+check_eq "whole-entry write with no known nested fields at all accepted" "0" "$?"
+check_eq "entry with no known fields written as given" '{"phase":"A","reviewer":"cr"}' "$(jq -c '.prs["1000"]' "$STATE_FILE")"
+
+echo
 echo "== Write-time guard: unknown fields stay unvalidated (forward-compat) =="
 run --set '.monitoring_active=true' --set '.root_repo=/tmp/foo'
 check_eq "unknown-field batch write exits 0" "0" "$?"


### PR DESCRIPTION
## **User description**
Closes #640

## Summary

Repairs the two (actually three) corrupt values in the live `~/.claude/session-state.json` and extends `session-state.sh`'s FIELD-TYPE CONTRACT (issue #625) from top-level fields to known per-PR nested fields.

## Live-file repair

Audited every `.prs[N]` entry against the six known nested field names and found **three** corrupt values (the issue named two; the third turned up during the audit the issue's Notes section asked for):

- `.prs["542"].last_cron_action` — was a bare narrative string, not `{type, at, interval}`
- `.prs["544"].last_cron_action` — same shape violation
- `.prs["542"].cr_explicit_triggers` — was the number `2`, not an array of ISO timestamps

Both PRs are already merged/terminal (`blocker: "merged"`), so the fields were removed rather than reconstructed with fabricated timestamps (the AC explicitly allows either). Verified before/after with `jq -S` diff (only the 3 intended keys changed) and confirmed the file stays valid JSON post-repair. A timestamped backup was taken first (`~/.claude/session-state.json.bak-issue640-*`).

## Contract design decision (per the issue's Notes)

Went with **schema-file-driven validation**, not a hardcoded list mirroring the schema:

- `.claude/reference/session-state-schema.json` gains a machine-readable `_field_types` object (`top_level` + `pr_nested` maps) — the single source of truth.
- `session-state.sh` loads it at runtime (lazily, cached per invocation) instead of hardcoding a duplicate `case` statement, so the two can never drift apart.
- If the schema file is unreadable (unusual invocation context), the guard disables itself for that run with a stderr warning rather than hard-failing every state-file operation — fail-open, not fail-closed, matching the existing "unknown fields stay unvalidated" philosophy.

## Nested-field contract

Extended coverage to: `last_cron_action`, `preflight_triggered`, `babysit`, `wrap_sweep` (all `object`), `cr_explicit_triggers` (`array`), `digest_streak` (`number`). Sub-path writes (e.g. `.prs["287"].babysit.active=true`) are checked against the *final* value of the whole known field, same principle as the existing top-level guard. Rejection semantics match exactly: exit 4, whole batch rejected, file left unmodified.

`infer-pr.sh` gets defense-in-depth: it now warns and degrades (via jq's `?` operator) instead of hard-erroring when it walks past a pre-existing malformed `last_cron_action` — old state files written before this guard existed will still be around for a while.

## Sibling issues (#639, #638)

Checked for open PRs on both before starting — none existed, so no rebase-on-top-of-those was needed.

## Local review note

Both local CLIs were unavailable when I ran the local-review loop: CodeRabbit CLI hit its shared adaptive rate limit (19-minute wait), and CodeAnt CLI returned a persistent 403 on every file (a known, currently-unfixed CodeAnt CLI issue — re-auth doesn't clear it). Per `cr-local-review.md`'s fallback rule, I performed a careful self-review instead (including catching and fixing an unescaped-PR-number jq-interpolation issue in my own first draft). GitHub-side review (CodeRabbit/CodeAnt app/BugBot) will run as the actual merge gate.

## Test plan

- [x] `jq '.prs["542"].last_cron_action | type' ~/.claude/session-state.json` → no longer `"string"` (now `"null"` — field removed)
- [x] `infer-pr.sh --root-repo` runs clean against the repaired file (was exit 4, now exit 1 — multiple candidates, no errors)
- [x] `session-state.sh --set '.prs["999"].last_cron_action=some bare string'` → rejected, exit 4, file unmodified
- [x] The same write with a well-formed object → accepted
- [x] A nested field *not* on the known list → still accepted, unvalidated
- [x] `infer-pr.sh` against a file with a deliberately malformed value → degrades with a warning, does not hard-error
- [x] Existing `session-state.test.sh` (35 pre-existing cases) and `infer-pr.test.sh` (39 pre-existing cases) still pass unchanged
- [x] New coverage added: 18 new cases in `session-state.test.sh` (nested contract) + 4 new cases in `infer-pr.test.sh` (graceful degradation) — 96 total, all passing
- [x] CodeAnt review finding (whole-PR-entry write bypassing the nested-field guard) reproduced, fixed, and covered by new regression tests in both `session-state.test.sh` and `pr-state-infer-candidates.test.sh` (with a negative control confirming the pre-fix code fails the new test)


___

## **CodeAnt-AI Description**
**Extend session-state checks to nested PR fields and handle bad existing values safely**

### What Changed
- Saving session state now rejects wrong-value writes for known nested PR fields like `last_cron_action`, `babysit`, `cr_explicit_triggers`, and `digest_streak`
- The field-type rules are now read from the schema file, so the saved-state checks stay aligned with the documented contract
- Reads and PR sorting keep working when older state contains a broken `last_cron_action`; it now warns and treats that PR as having no recent activity instead of failing

### Impact
`✅ Fewer corrupted PR state writes`
`✅ Clearer errors for invalid nested PR fields`
`✅ Safer PR ranking when old session data is malformed`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>