### PR TITLE
fix(#663,#664): CodeAnt 403 is a daily review cap, not an auth or plan problem

### DIFF
--- a/.claude/reference/local-review-cli-failure-modes.md
+++ b/.claude/reference/local-review-cli-failure-modes.md
@@ -44,22 +44,51 @@ API Error: Access denied (403). Please run `codeant logout` and then `codeant lo
 Note `[progress] 0 files have suggestions` — the reflector runs and reports zero suggestions
 even though nothing was successfully analyzed.
 
-## Classifying a 403: entitlement vs credentials
+## Classifying a 403: the daily cap, not credentials
 
-The CLI's 403 text always says to re-authenticate. **That advice is often wrong.** A 403 is
-authorization, not authentication, and a valid token can still be denied.
+The CLI's 403 text always says to re-authenticate. **That advice is wrong, and following it is
+actively harmful** — it cannot fix a quota, it nulls the stored token, and it throws a browser
+login page at the user. On repeat it becomes an endless loop.
 
-Probe before re-authenticating:
+The real cause is an **undocumented daily cap on CLI agent reviews**. The server says so plainly;
+the CLI discards the message (see `fetchApi.js` above). Read it yourself by replaying the request
+— never echo the token:
 
 ```bash
-codeant scans orgs     # valid token -> returns {"connections":[{"organizationName":...}],"email":...}
+TOK=$(jq -r '.apiKeyV2' ~/.codeant/config.json)
+curl -sS -w '\nHTTP %{http_code}\n' -X POST \
+  'https://service.codeant.ai/extension/pr-review/agent/turn' \
+  -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+  -d '{"diff_content":"diff --git a/t.js b/t.js\n+const b=2;\n","file_content":"const b=2;\n","file_path":"t.js"}'
 ```
+
+Observed 2026-07-21:
+
+```json
+{"error":"Unable to process request. Either the API key is invalid or the daily limit of 10 for agent review has been reached."}
+```
+
+**That message names two causes with opposite remedies, so it is not decisive alone.**
+Discriminate with `codeant scans orgs`:
 
 | `scans orgs` | `review` | Diagnosis |
 |---|---|---|
 | OK | OK | Healthy |
-| OK | 403 | **Entitlement / plan / quota.** Do not re-authenticate — it will not help. Check the account plan at app.codeant.ai. |
+| OK | 403 | **Daily agent-review cap reached.** Token is fine. Do NOT re-authenticate. Drop CodeAnt for the session — the cap resets the next day. |
 | 403 | 403 | Credentials. `codeant logout` then `codeant login` (browser flow). |
+
+Further proof the request authorizes: a *minimal* payload to the same endpoint returns
+`400 {"error":"session_id is required for subsequent turns"}`. A 400 means it reached body
+validation, so auth and authorization both passed.
+
+**One `codeant review` is not one unit.** `reviewHeadless.js` batches up to 5 files per turn loop
+(`MAX_TURNS = 5`), then runs a reflector loop per file with suggestions, so one invocation issues
+several `agent/turn` calls. Budget only a few reviews per day.
+
+**The cap is invisible in the dashboard.** "AI Code Reviews: Unlimited" there describes the
+**GitHub App** surface, which has a separate counter and keeps working normally — 234 runs on the
+same day the CLI was locked out. The GitHub App also satisfies the CR-path merge gate on its own,
+so a capped CLI is never blocking.
 
 Corroborating probes when `scans orgs` succeeds but `review` does not:
 
@@ -70,8 +99,10 @@ Corroborating probes when `scans orgs` succeeds but `review` does not:
 
 Worked example (2026-07-21, `auerbachb`): `scans orgs` returned the org and account email,
 `settings repos` listed 63 onboarded repos, `secrets` ran clean, and `review` returned 403 in
-two different repos. `logout` + `login` completed successfully and installed a fresh token;
-the 403 was unchanged. Root cause was account entitlement, not credentials.
+two different repos. `logout` + `login` completed successfully and installed a fresh token; the
+403 was unchanged — **twice**. Plan was Premium ACTIVE with a seat assigned and 234 GitHub App
+reviews that same day. Root cause was the daily cap; every credential, seat, plan, and onboarding
+hypothesis was a dead end.
 
 ## The 15-file cap
 

--- a/.claude/rules/cr-local-review.md
+++ b/.claude/rules/cr-local-review.md
@@ -45,6 +45,8 @@ jq -e 'select(.type=="error")' cr.out >/dev/null && echo "FAILED RUN"
 
 A hit is a **failed run** (Timeout & fallback below), never a clean pass. An empty result is clean **only** when its error check is clean and, for CodeAnt, `meta.capped` is `false`. Failure shapes, 403 triage, 15-file cap: `.claude/reference/local-review-cli-failure-modes.md`.
 
+> **Never run `codeant logout` / `codeant login` to clear a 403.** The CLI hardcodes that advice for every 403 — it throws before reading the server's body. The real cause is an undocumented **daily cap (~10) on CLI agent reviews**, which re-auth cannot fix; running it nulls the stored token and opens a browser login page, on a loop. On a CodeAnt 403: **one retry maximum**, then drop CodeAnt for the session (Timeout & fallback) and note it in the PR body. The CodeAnt **GitHub App** is unaffected and satisfies the merge gate alone, so a capped CLI never blocks a merge.
+
 ### Never Suppress Linter Errors (NON-NEGOTIABLE)
 
 Never add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or equivalent just to pass CI. Read the lint/type errors and fix the code, even in a file you did not modify. Suppression is allowed only when the linter is provably wrong and the comment explains why.


### PR DESCRIPTION
## **User description**
Closes #663
Closes #664

## Root cause (confirmed today)

CodeAnt's CLI 403 is an **undocumented daily cap of 10 agent reviews**. Not credentials, not seats, not the plan, not repo onboarding.

The CLI hides this. Its 403 handler throws *before* reading the response body:

```js
// src/utils/fetchApi.js:52
if (response.status === 403) {
  throw new Error('Access denied (403). Please run `codeant logout` and then `codeant login`…');
}
const data = await response.json();   // <-- never reached on 403
```

Replaying the CLI's own first-turn request with curl prints what it discards:

```json
{"error":"Unable to process request. Either the API key is invalid or the daily limit of 10 for agent review has been reached."}
```

The key was provably valid — `codeant scans orgs` returned the org and account email, and a minimal payload to the same endpoint returns `400 {"error":"session_id is required for subsequent turns"}`, proving the request authorizes and reaches body validation. So of the two causes the server names, only the daily cap can apply. Full evidence: #643.

## Why this needed fixing urgently

Following the CLI's advice is **actively harmful**, not merely useless: it cannot fix a quota, it nulls the stored token, and it opens a browser login page. On repeat it is an infinite loop — it wiped the token twice today and consumed an afternoon.

Worse, `.claude/reference/local-review-cli-failure-modes.md` (added by me in #650 this morning) told the next reader a surviving 403 means **entitlement**, and to go check the plan at app.codeant.ai. That is precisely the dead end that wasted the afternoon, now enshrined in the rules corpus. This PR removes it.

## Changes

**`.claude/rules/cr-local-review.md`** (#663) — one blockquote: never run `codeant logout`/`login` to clear a 403; one retry maximum, then drop CodeAnt for the session and note it in the PR body; the GitHub App is unaffected and satisfies the merge gate alone.

**`.claude/reference/local-review-cli-failure-modes.md`** (#664) — the 403 triage section rewritten:
- names the **daily agent-review cap** instead of entitlement
- gives the curl that reads the discarded body (token read into a var, never echoed)
- notes the server message conflates *invalid key* with *daily limit*, so `codeant scans orgs` is the discriminator
- documents that **one review is not one unit** — `reviewHeadless.js` batches 5 files per turn loop (`MAX_TURNS = 5`) plus a reflector loop per file with suggestions
- records that the cap is invisible in the dashboard: "AI Code Reviews: Unlimited" describes the **GitHub App**, a separate counter that ran 234 reviews the same day the CLI was locked out
- worked example updated: every credential/seat/plan/onboarding hypothesis was a dead end

## The rule validated itself during this PR

Running local review on this very branch, CodeRabbit returned:

```
exit code: 0        stderr: clean
stdout: {"type":"error","errorType":"rate_limit","metadata":{"waitTime":"18 minutes","isProUser":true}}
```

Exit 0 with a clean stderr and zero findings. Without the stdout `type:"error"` check added in #650, that reads as a clean pass. The guard caught it roughly ten minutes after it was written.

## Local review status

Per **Timeout & fallback**, both CLIs are unavailable and are recorded here rather than silently skipped:

- **CodeAnt** — dropped: daily agent-review cap exhausted (the subject of this PR)
- **CodeRabbit** — dropped: rate limit exceeded, 18-minute cooldown

**Self-review only, which does NOT satisfy the merge gate** — this needs a GitHub-side bot review before merge. Self-review covered: markdown fence balance (even in both files), no token value echoed in any example, pointer targets resolve, blockquote renders, and `rule-lint.sh` verified after rebasing onto current main.

## Deliberate omission

#663 suggested *considering* adding the prohibition to `.claude/rules/safety.md`'s destructive-command list, since the failure mode is credential loss. I did not. `safety.md` loads for every task including ones that never touch a review CLI, and vendor-specific tool guidance dilutes a file whose value is being short and universal. The guidance lives where agents running local review will actually read it. Happy to move it if you disagree.

## Rule budget

Corpus **11,023** against the ratchet cap **11,671** — comfortably under, and below the 12,000 soft warning too, thanks to PR #660 landing mid-session. `.budget-soft-cap` untouched. Verified *after* rebasing onto current main, since CI lints the merge ref (the trap that failed CI on #650).

## Test plan

**#663**
- [ ] `cr-local-review.md` warns against `codeant logout`/`login` on a 403 and states re-auth cannot fix it
- [ ] The CodeAnt-unavailable fallback is unambiguous: one retry, then drop for the session + note in PR body
- [ ] The rule notes the CodeAnt GitHub App is unaffected
- [ ] `rule-lint.sh` exits 0

**#664**
- [ ] Reference file names the daily agent-review cap as the cause of a surviving 403
- [ ] Remediation is the curl replay that reads the discarded body, not a dashboard plan hunt
- [ ] Notes the server message conflates invalid-key with daily-limit, and that `scans orgs` discriminates
- [ ] Documents that one review consumes multiple agent-turn units
- [ ] States the GitHub App is unaffected and still satisfies the merge gate
- [ ] Corpus stays under the committed ratchet cap with `.budget-soft-cap` unmodified
- [ ] No `entitlement` / `app.codeant.ai` remediation language survives in either file

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Update CodeAnt 403 guidance to point at the daily review cap**

### What Changed
- Replaces the old advice to re-authenticate on every 403 with guidance that a CodeAnt 403 usually means the daily CLI review cap was reached
- Tells users not to run logout/login for this case, since it does not fix the cap and can wipe the saved token
- Adds a simple way to confirm the cause: compare `codeant scans orgs` with `codeant review`, and treat a working org scan with a failing review as a capped CLI session
- Clarifies that the GitHub App uses a separate limit and can still work even when the CLI is capped

### Impact
`✅ Fewer token resets after CodeAnt 403s`
`✅ Less time wasted on wrong plan or login checks`
`✅ Clearer next steps when CLI reviews hit the daily cap`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
