### PR TITLE
fix(#608): read PR state via state/mergedAt, not the nonexistent merged field

### DIFF
--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -261,9 +261,14 @@ After each action, append to **`WRAP_RECOVERY_AUDIT`** (free-form lines or bulle
 
 **Recovery loop:** For `i` from `1` through `$WRAP_RECOVERY_MAX_ITERATIONS`:
 
-1. **Terminal checks**
-   - If `gh pr view` shows `merged: true` → exit loop for Phase 3 (merged terminal — Phase 3 + 4 unchanged).
-   - If PR closed without merge → stop with status (do not merge).
+1. **Terminal checks** — read the PR state with the same field set Step 3.8 uses. There is **no `merged` field** on `gh pr view --json`; requesting one fails the whole call with `Unknown JSON field: "merged"`, so the merged terminal goes undetected and the iteration is burned (issue #608):
+
+   ```bash
+   PR_STATE=$(gh pr view "$PR_NUM" --json state,mergedAt --jq '.state')
+   ```
+
+   - If `PR_STATE` is `MERGED` → exit loop for Phase 3 (merged terminal — Phase 3 + 4 unchanged).
+   - If `PR_STATE` is `CLOSED` (closed without merge) → stop with status (do not merge).
 
 2. **Refresh gate (always)**  
    ```bash


### PR DESCRIPTION
## Summary

`/wrap` Step 2.1's terminal check instructed the agent to detect a merged PR by reading `merged: true`. There is no `merged` field on `gh pr view --json`, and requesting it fails the **entire** call:

```
$ gh pr view 661 --json state,merged
Unknown JSON field: "merged"
```

Reproduced on gh 2.48.0 while wrapping PR #661. Followed verbatim, the merged terminal is never detected, so `/wrap` burns a recovery iteration on an already-merged PR instead of proceeding to Phase 3.

The fix reads `state` (with `mergedAt` alongside, matching the field set Step 3.8 already uses) and branches on `MERGED` / `CLOSED`.

## Scope change

This branch originally also implemented issue #652 (the `/wrap` auto-file dedup check). **That work landed first via PR #661**, which created `.claude/scripts/issue-dedup.sh` and the `.claude/reference/autofile-dedup.md` threshold contract independently — two threads implemented the same ticket in parallel, which is the duplicate-work failure #652 itself describes, one layer up.

Rather than close this PR and lose the #608 fix, the duplicated half has been dropped and this PR is now **#608-only** — a single-file change. Issue #652 is already closed by PR #661.

Two ideas from the dropped work were genuinely better than what merged and are captured for follow-up in #680 rather than discarded:

- Keyword derivation guidance — draw dedup terms from title **and** body, leading with identifier-shaped tokens (filenames, config keys, script names), instead of a bare keyword count.
- A single named "shared dedup contract" section that both `/wrap` call sites point at, making drift between them structurally harder.

## Test plan

- [ ] `gh pr view <N> --json state,merged` reproduces `Unknown JSON field: "merged"` on gh 2.48.0 (confirms the defect is real, not theoretical)
- [ ] `gh pr view <N> --json state,mergedAt --jq '.state'` returns `MERGED` for a merged PR and `OPEN` for an open one
- [ ] `grep -c 'merged: true' .claude/skills/wrap/SKILL.md` returns 0
- [ ] The diff touches exactly one file (`.claude/skills/wrap/SKILL.md`) — no leftover `issue-dedup.sh` or workflow changes from the dropped #652 half
- [ ] `rule-lint` passes (skill/rule corpus word budget unaffected by a net-positive doc change)

Closes #608
