### PR TITLE
feat(#657): triage forgotten open PRs (>3 days) at /pm startup

### DIFF
--- a/.claude/scripts/forgotten-pr-triage.sh
+++ b/.claude/scripts/forgotten-pr-triage.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# forgotten-pr-triage.sh — detect + classify "forgotten" open PRs (issue #657).
+#
+# PURPOSE:
+#   Surfaces the author's open PRs that have gone quiet — last activity older
+#   than a threshold (default 3 days) — and recommends, per PR, whether to
+#   close it or merge it. Consumed by /pm's startup triage block (rendered
+#   after "## Your Open PRs"); strictly read-only, so /pm owns every mutation
+#   behind its own confirmation gates.
+#
+# AGE BASIS:
+#   "Forgotten" is measured against `updatedAt` (last activity), NOT
+#   `createdAt` — a PR touched yesterday is not forgotten even if it was
+#   opened last week. A PR is forgotten when its last activity is strictly
+#   MORE than --days days ago.
+#
+# CLOSE CLASSIFIER (exactly two signals; first match wins, else "merge"):
+#   1. linked-issue-closed — the PR body's `Closes/Fixes #N` issue is CLOSED
+#      (via pr-issue-ref.sh + `gh issue view`). Rationale: "linked issue #N
+#      closed". Checked first (cheap: no git fetch).
+#   2. superseded / already in main — the PR contributes zero net-new commits
+#      to main (all commits already landed, by reachability or patch-id
+#      equivalence, so this also covers "another merged PR covers it"). Tested
+#      with `git cherry <base> <pr-head>` counting `+` lines. Rationale:
+#      "superseded / already in main".
+#   CI/conflict state is deliberately NOT a close signal — a red or conflicted
+#   PR classifies "merge" and fails the merge gate visibly downstream.
+#
+# USAGE:
+#   forgotten-pr-triage.sh [--days N] [--author LOGIN] [--json]
+#   forgotten-pr-triage.sh --help | -h
+#
+#   --days N        Forgotten threshold in days. Default 3. Non-numeric or
+#                   non-positive values fall back to 3 with a stderr warning.
+#   --author LOGIN  GitHub login whose open PRs are enumerated. Default "@me"
+#                   (the authenticated user). /pm passes its resolved $GH_USER.
+#   --json          Emit a JSON array on stdout. Default emits one
+#                   tab-separated line per PR: "number\trecommendation\trationale".
+#
+# OUTPUT:
+#   One record per forgotten PR. JSON record shape:
+#     {"number": N, "title": "...", "url": "...", "headRefName": "...",
+#      "updatedAt": "...Z", "age_days": N,
+#      "recommendation": "close"|"merge", "rationale": "..."}
+#   `rationale` is empty for "merge". Zero forgotten PRs is a valid result
+#   (prints "[]" / no lines) — NOT an error.
+#
+# EXIT CODES (match backlog-staleness.sh — the consumer reads --json, so
+# "found" is not a distinct code):
+#   0  OK — ran to completion (including the zero-forgotten case)
+#   2  Usage error (unknown flag, --days/--author requires a value)
+#   3  Environment error (gh/jq/git missing or not a git repo; gh API failure)
+#
+# READ-ONLY CONTRACT:
+#   No PR is closed/merged, no branch deleted, nothing pushed. Git fetches use
+#   `--refmap=''` and land only in FETCH_HEAD + the object store — no
+#   remote-tracking ref (e.g. origin/main), branch, index, or working-tree
+#   change. "Read-only" is w.r.t. refs/branches/worktree/index/PRs.
+#
+# CONFIGURATION (env):
+#   FORGOTTEN_REMOTE       git remote to fetch from. Default "origin".
+#   FORGOTTEN_BASE_BRANCH  branch fetched (into FETCH_HEAD) as the "already in
+#                          main" comparison base. Default "main".
+#   FORGOTTEN_BASE_REF     optional explicit LOCAL ref used as the base instead
+#                          of fetching (no ref writes). Handy for tests. Unset
+#                          by default (the base branch is fetched).
+#
+# EXAMPLES:
+#   .claude/scripts/forgotten-pr-triage.sh --json
+#   .claude/scripts/forgotten-pr-triage.sh --days 7 --author octocat
+#
+# DEPENDENCIES:
+#   - gh CLI (authenticated), git, jq, bash 3.2+ (macOS-compatible)
+
+set -uo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
+
+print_help() {
+  # Print only the leading comment block (stops at the first non-comment line)
+  # so usage text never bleeds into executable lines like `set -uo pipefail`.
+  awk 'NR==1{next} !/^#/{exit} {sub(/^# ?/,""); print}' "$0"
+}
+
+err() {
+  printf 'forgotten-pr-triage.sh: %s\n' "$1" >&2
+}
+
+DAYS=3
+AUTHOR="@me"
+EMIT_JSON=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    --days)
+      if [ $# -lt 2 ] || [ -z "${2-}" ]; then
+        err "--days requires a value"
+        exit 2
+      fi
+      DAYS="$2"
+      shift 2
+      ;;
+    --days=*)
+      DAYS="${1#--days=}"
+      shift
+      ;;
+    --author)
+      if [ $# -lt 2 ] || [ -z "${2-}" ]; then
+        err "--author requires a value"
+        exit 2
+      fi
+      AUTHOR="$2"
+      shift 2
+      ;;
+    --author=*)
+      AUTHOR="${1#--author=}"
+      shift
+      ;;
+    --json)
+      EMIT_JSON=1
+      shift
+      ;;
+    *)
+      err "unknown flag: $1"
+      err "Run with --help for usage."
+      exit 2
+      ;;
+  esac
+done
+
+# Validate --days: non-numeric or non-positive falls back to 3 with a warning,
+# rather than a hard failure (mirrors backlog-staleness.sh's --days handling).
+case "$DAYS" in
+  ''|*[!0-9]*)
+    err "Invalid --days value '$DAYS', defaulting to 3 days"
+    DAYS=3
+    ;;
+  *)
+    if [ "$DAYS" -le 0 ]; then
+      err "Threshold must be positive, defaulting to 3 days"
+      DAYS=3
+    fi
+    ;;
+esac
+
+command -v gh >/dev/null 2>&1 || { err "gh CLI not found"; exit 3; }
+command -v jq >/dev/null 2>&1 || { err "jq not found"; exit 3; }
+command -v git >/dev/null 2>&1 || { err "git not found"; exit 3; }
+
+# Supersession checks (signal a) need a real git repo for `git fetch` /
+# `git cherry`. Without one, signal (a) simply never fires — linked-issue
+# detection (signal b) still works — so a non-repo is a soft degrade, not a
+# hard error. Track it and warn once.
+GIT_OK=1
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  GIT_OK=0
+  err "not inside a git repository — supersession (already-in-main) checks are skipped"
+fi
+
+REMOTE="${FORGOTTEN_REMOTE:-origin}"
+BASE_BRANCH="${FORGOTTEN_BASE_BRANCH:-main}"
+# Optional explicit LOCAL base ref (e.g. a test fixture ref). When set and
+# resolvable it is used directly — no fetch, no ref writes.
+BASE_REF_OVERRIDE="${FORGOTTEN_BASE_REF:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PR_ISSUE_REF="$SCRIPT_DIR/pr-issue-ref.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# Portable ISO-8601 (…Z) → epoch seconds. BSD date first, GNU date fallback.
+# Prints 0 when it cannot parse (caller treats 0 as "unparseable").
+to_epoch() {
+  local iso="$1"
+  date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$iso" +%s 2>/dev/null \
+    || date -u -d "$iso" +%s 2>/dev/null \
+    || echo 0
+}
+
+# Resolve the comparison base once up front as a concrete commit SHA — never a
+# persistent ref. `--refmap=''` keeps the fetch in FETCH_HEAD + the object store
+# only (no origin/main remote-tracking write), so the script stays read-only;
+# capturing the SHA now means later per-PR fetches that overwrite FETCH_HEAD
+# don't disturb the base. Failure (offline, no remote) is non-fatal — signal (a)
+# is simply skipped.
+BASE_OK=0
+BASE_SHA=""
+if [ "$GIT_OK" -eq 1 ]; then
+  if [ -n "$BASE_REF_OVERRIDE" ]; then
+    BASE_SHA="$(git rev-parse --verify -q "${BASE_REF_OVERRIDE}^{commit}" 2>/dev/null || echo "")"
+    [ -z "$BASE_SHA" ] && err "base ref override '$BASE_REF_OVERRIDE' does not resolve — supersession checks are skipped"
+  elif git fetch --refmap='' -q "$REMOTE" "$BASE_BRANCH" >/dev/null 2>&1; then
+    BASE_SHA="$(git rev-parse FETCH_HEAD 2>/dev/null || echo "")"
+    [ -z "$BASE_SHA" ] && err "could not resolve fetched $REMOTE $BASE_BRANCH — supersession checks are skipped"
+  else
+    err "could not fetch $REMOTE $BASE_BRANCH — supersession checks are skipped"
+  fi
+  [ -n "$BASE_SHA" ] && BASE_OK=1
+fi
+
+# is_superseded <pr_number> — 0 (true) when the PR contributes zero net-new
+# commits to BASE_REF, i.e. every commit is already reachable from or
+# patch-equivalent to something on main. Non-zero otherwise, or when the PR
+# head cannot be fetched (can't determine → not superseded → defaults to merge).
+# Fetches into FETCH_HEAD only (a transient fetch artifact, always overwritten)
+# so nothing persistent is written — keeps the script read-only.
+is_superseded() {
+  local n="$1"
+  [ "$BASE_OK" -eq 1 ] || return 1
+  # `refs/pull/N/head` resolves the PR's tip regardless of fork origin;
+  # `--refmap=''` keeps it in FETCH_HEAD only (no ref written).
+  if ! git fetch --refmap='' -q "$REMOTE" "refs/pull/$n/head" >/dev/null 2>&1; then
+    return 1
+  fi
+  local head_sha
+  head_sha="$(git rev-parse FETCH_HEAD 2>/dev/null)" || return 1
+  [ -n "$head_sha" ] || return 1
+  # `git cherry <upstream> <head>` prints one line per commit in <head>: `+`
+  # when the change is NOT present upstream, `-` when an equivalent patch
+  # already is. Zero `+` lines ⇒ nothing net-new ⇒ superseded / already in main.
+  # Check cherry's own exit code FIRST: a failed cherry emits nothing, and
+  # `grep -c` on empty input returns "0" — which would otherwise be misread as
+  # "zero net-new commits" and wrongly recommend close.
+  local cherry_out cherry_rc
+  cherry_out="$(git cherry "$BASE_SHA" "$head_sha" 2>/dev/null)"; cherry_rc=$?
+  [ "$cherry_rc" -eq 0 ] || return 1   # cherry failed → indeterminate → not superseded
+  local plus
+  plus="$(printf '%s\n' "$cherry_out" | grep -c '^+' || true)"
+  [ "${plus:-1}" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Enumerate the author's open PRs.
+# ---------------------------------------------------------------------------
+PR_LIMIT=200
+if ! OPEN_PRS="$(gh pr list --state open --author "$AUTHOR" --limit "$PR_LIMIT" \
+    --json number,title,updatedAt,headRefName,url 2>"$TMP/prs.err")"; then
+  err "gh pr list (open, author=$AUTHOR) failed: $(cat "$TMP/prs.err")"
+  exit 3
+fi
+if [ "$(printf '%s' "$OPEN_PRS" | jq 'length')" -eq "$PR_LIMIT" ]; then
+  err "Open PR count hit the ${PR_LIMIT}-item fetch cap — results may be incomplete."
+fi
+
+NOW="$(date -u +%s)"
+CUTOFF=$(( NOW - DAYS * 86400 ))
+
+: > "$TMP/forgotten.jsonl"
+
+# Iterate PRs. The pipe puts the loop in a subshell, so classifications are
+# appended to a temp JSONL file (persists past the subshell) rather than a
+# shell array — same pattern backlog-staleness.sh uses.
+printf '%s' "$OPEN_PRS" \
+  | jq -r '.[] | [(.number|tostring), .updatedAt, .headRefName, .url, .title] | @tsv' \
+  | while IFS=$'\t' read -r NUM UPDATED HEADREF URL TITLE; do
+      EPOCH="$(to_epoch "$UPDATED")"
+      if [ "$EPOCH" -eq 0 ]; then
+        err "could not parse updatedAt '$UPDATED' for PR #$NUM — skipping"
+        continue
+      fi
+      # Forgotten ⇔ last activity strictly MORE than --days days ago.
+      if [ "$EPOCH" -ge "$CUTOFF" ]; then
+        continue
+      fi
+      AGE_DAYS=$(( (NOW - EPOCH) / 86400 ))
+
+      REC="merge"
+      RATIONALE=""
+
+      # Signal (b): linked issue closed (cheap — no git). First match wins.
+      ISSUE=""
+      if [ -x "$PR_ISSUE_REF" ]; then
+        ISSUE="$("$PR_ISSUE_REF" "$NUM" 2>/dev/null || true)"
+      else
+        err "pr-issue-ref.sh not found at $PR_ISSUE_REF — linked-issue signal skipped for #$NUM"
+      fi
+      if [ -n "$ISSUE" ]; then
+        # Capture gh's own exit code: a network/auth/API failure must surface as
+        # an indeterminate signal on stderr, not silently degrade into a normal
+        # "merge" recommendation as though the issue were open.
+        ISTATE="$(gh issue view "$ISSUE" --json state --jq '.state' 2>/dev/null)"; istate_rc=$?
+        if [ "$istate_rc" -ne 0 ]; then
+          err "could not fetch issue #$ISSUE state for PR #$NUM (gh exit $istate_rc) — linked-issue close signal skipped for this PR"
+        elif [ "$ISTATE" = "CLOSED" ]; then
+          REC="close"
+          RATIONALE="linked issue #$ISSUE closed"
+        fi
+      fi
+
+      # Signal (a): superseded / already in main (only if not already close).
+      if [ "$REC" = "merge" ] && is_superseded "$NUM"; then
+        REC="close"
+        RATIONALE="superseded / already in main"
+      fi
+
+      jq -cn \
+        --arg num "$NUM" --arg title "$TITLE" --arg url "$URL" \
+        --arg head "$HEADREF" --arg updated "$UPDATED" \
+        --arg age "$AGE_DAYS" --arg rec "$REC" --arg rat "$RATIONALE" '
+        {number: ($num|tonumber), title: $title, url: $url,
+         headRefName: $head, updatedAt: $updated, age_days: ($age|tonumber),
+         recommendation: $rec, rationale: $rat}
+      ' >> "$TMP/forgotten.jsonl"
+    done
+
+# ---------------------------------------------------------------------------
+# Emit (sorted oldest-first so the most-forgotten surface at the top).
+# ---------------------------------------------------------------------------
+if [ "$EMIT_JSON" -eq 1 ]; then
+  jq -c -s 'sort_by(.age_days) | reverse' "$TMP/forgotten.jsonl" 2>/dev/null || echo "[]"
+else
+  jq -r -s 'sort_by(.age_days) | reverse | .[] | [.number, .recommendation, .rationale] | @tsv' \
+    "$TMP/forgotten.jsonl" 2>/dev/null || true
+fi
+
+exit 0

--- a/.claude/scripts/tests/forgotten-pr-triage.test.sh
+++ b/.claude/scripts/tests/forgotten-pr-triage.test.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Offline tests for forgotten-pr-triage.sh (issue #657).
+# Stubs `gh` with fixture JSON/values; runs inside a real temp git repo with a
+# file-based `origin` remote carrying refs/pull/<N>/head refs, so the
+# supersession ("already in main") check exercises the real `git fetch` +
+# `git cherry` path. Requires jq, git. Run from repo root:
+#   bash .claude/scripts/tests/forgotten-pr-triage.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/.claude/scripts/forgotten-pr-triage.sh"
+
+TMP="$(mktemp -d)"
+TMP_HOME="$(mktemp -d)"
+REMOTE_DIR="$TMP/origin.git"
+REPO_DIR="$TMP/repo"
+cleanup() { rm -rf "$TMP" "$TMP_HOME"; }
+trap cleanup EXIT
+export HOME="$TMP_HOME"
+mkdir -p "$HOME/.claude"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "ok   — $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL — $1"; }
+
+check_json_has() {
+  local desc="$1" json="$2" expr="$3"
+  if echo "$json" | jq -e "$expr" >/dev/null 2>&1; then
+    pass "$desc"
+  else
+    fail "$desc"
+  fi
+}
+
+check_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$desc"
+  else
+    fail "$desc (missing '$needle')"
+  fi
+}
+
+check_line() {
+  # Exact whole-line match (anchored) — stronger than substring check_contains.
+  local desc="$1" line="$2" hay="$3"
+  if printf '%s\n' "$hay" | grep -Fxq "$line"; then
+    pass "$desc"
+  else
+    fail "$desc (missing exact line '$line')"
+  fi
+}
+
+days_ago_iso() {
+  # Portable N-days-ago ISO-8601 (…Z). BSD date first, GNU date fallback.
+  local n="$1"
+  date -u -v-"${n}"d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "${n} days ago" +%Y-%m-%dT%H:%M:%SZ
+}
+
+# ---------------------------------------------------------------------------
+# Build a bare "origin" and a working repo wired to it.
+#   main:    base
+#   pr-101:  base + C   (superseded — C is cherry-picked onto main as C')
+#   pr-102:  base + D   (net-new → merge)
+#   pr-103:  base + E   (body "Closes #55"; issue #55 CLOSED → close)
+#   pr-105:  base + F   (body "Closes #66"; issue #66 OPEN  → merge)
+#   #104:    fresh (updatedAt = now) → filtered out by age, never fetched
+# ---------------------------------------------------------------------------
+git init -q --bare "$REMOTE_DIR"
+git -c init.defaultBranch=main init -q "$REPO_DIR"
+cd "$REPO_DIR"
+git config user.email "test@example.com"
+git config user.name "Test"
+git branch -M main 2>/dev/null || true
+
+echo base > base.txt
+git add base.txt
+git commit -q -m "base"
+git remote add origin "$REMOTE_DIR"
+git push -q origin main
+git fetch -q origin
+
+# pr-101 — will be superseded
+git checkout -q -b pr-101 main
+echo c101 > f101.txt; git add f101.txt; git commit -q -m "change 101"
+PR101_SHA="$(git rev-parse HEAD)"
+git push -q origin "pr-101:refs/pull/101/head"
+
+# pr-102 — net-new
+git checkout -q -b pr-102 main
+echo d102 > f102.txt; git add f102.txt; git commit -q -m "feat 102"
+git push -q origin "pr-102:refs/pull/102/head"
+
+# pr-103 — linked issue closed
+git checkout -q -b pr-103 main
+echo e103 > f103.txt; git add f103.txt; git commit -q -m "feat 103"
+git push -q origin "pr-103:refs/pull/103/head"
+
+# pr-105 — linked issue open
+git checkout -q -b pr-105 main
+echo f105 > f105.txt; git add f105.txt; git commit -q -m "feat 105"
+git push -q origin "pr-105:refs/pull/105/head"
+
+# Cherry-pick pr-101's commit onto main (equivalent patch already in main),
+# then publish — this is what makes pr-101 "superseded / already in main".
+git checkout -q main
+GIT_EDITOR=true git cherry-pick "$PR101_SHA" >/dev/null
+git push -q origin main
+git fetch -q origin
+
+# ---------------------------------------------------------------------------
+# Fixtures: PR list + per-PR bodies + linked-issue states.
+# ---------------------------------------------------------------------------
+OLD_ISO="2026-01-01T00:00:00Z"                       # >3 days old, stays so
+RECENT_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"          # now → not forgotten
+
+jq -n --arg old "$OLD_ISO" --arg recent "$RECENT_ISO" '
+  [ {number:101, title:"PR 101", updatedAt:$old,    headRefName:"pr-101", url:"http://x/101"},
+    {number:102, title:"PR 102", updatedAt:$old,    headRefName:"pr-102", url:"http://x/102"},
+    {number:103, title:"PR 103", updatedAt:$old,    headRefName:"pr-103", url:"http://x/103"},
+    {number:104, title:"PR 104", updatedAt:$recent, headRefName:"pr-104", url:"http://x/104"},
+    {number:105, title:"PR 105", updatedAt:$old,    headRefName:"pr-105", url:"http://x/105"} ]
+' > "$TMP/prs.json"
+
+mkdir -p "$TMP/pr_body" "$TMP/issue_state"
+echo "just a change, no closing keyword"  > "$TMP/pr_body/101.txt"
+echo "another change, no closing keyword" > "$TMP/pr_body/102.txt"
+echo "feature work. Closes #55"           > "$TMP/pr_body/103.txt"
+echo "some fresh work"                    > "$TMP/pr_body/104.txt"
+echo "feature work. Closes #66"           > "$TMP/pr_body/105.txt"
+echo "CLOSED" > "$TMP/issue_state/55.txt"
+echo "OPEN"   > "$TMP/issue_state/66.txt"
+
+# ---------------------------------------------------------------------------
+# gh stub — handles the three call shapes this feature makes:
+#   pr list ...                         → the PR-list fixture (no --jq)
+#   pr view <N> --json body --jq ...    → that PR's body text (pr-issue-ref.sh)
+#   issue view <N> --json state --jq ...→ that issue's state (OPEN/CLOSED)
+# ---------------------------------------------------------------------------
+STUB_BIN="$TMP/bin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/gh" <<STUB
+#!/usr/bin/env bash
+set -uo pipefail
+args="\$*"
+case "\$args" in
+  "pr list "*)
+    cat "$TMP/prs.json"
+    ;;
+  "pr view "*)
+    n=\$(echo "\$args" | sed -n 's/^pr view \([0-9]*\).*/\1/p')
+    if [ -f "$TMP/pr_body/\${n}.txt" ]; then cat "$TMP/pr_body/\${n}.txt"; else echo ""; fi
+    ;;
+  "issue view "*)
+    n=\$(echo "\$args" | sed -n 's/^issue view \([0-9]*\).*/\1/p')
+    if [ -f "$TMP/issue_state/\${n}.txt" ]; then cat "$TMP/issue_state/\${n}.txt"; else echo ""; fi
+    ;;
+  *)
+    echo "gh stub: unhandled args: \$args" >&2
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$STUB_BIN/gh"
+export PATH="$STUB_BIN:$PATH"
+
+# ---------------------------------------------------------------------------
+# Test 1: full fixture, --json — classifications + age filter + exit 0
+# ---------------------------------------------------------------------------
+OUT="$(cd "$REPO_DIR" && bash "$SCRIPT" --days 3 --json 2>"$TMP/t1.err")"
+RC=$?
+[[ "$RC" == "0" ]] && pass "Test1: exit 0 on full fixture" || fail "Test1: exit code ($RC)"
+check_json_has "Test1a: #101 → close (superseded / already in main)" "$OUT" \
+  '[.[] | select(.number==101 and .recommendation=="close" and .rationale=="superseded / already in main")] | length == 1'
+check_json_has "Test1b: #102 → merge (net-new commits)" "$OUT" \
+  '[.[] | select(.number==102 and .recommendation=="merge")] | length == 1'
+check_json_has "Test1c: #103 → close (linked issue #55 closed)" "$OUT" \
+  '[.[] | select(.number==103 and .recommendation=="close" and .rationale=="linked issue #55 closed")] | length == 1'
+check_json_has "Test1d: #105 → merge (linked issue #66 open)" "$OUT" \
+  '[.[] | select(.number==105 and .recommendation=="merge")] | length == 1'
+check_json_has "Test1e: #104 excluded — newer than threshold" "$OUT" \
+  '[.[] | select(.number==104)] | length == 0'
+check_json_has "Test1f: exactly 4 forgotten PRs" "$OUT" 'length == 4'
+check_json_has "Test1g: merge rationale is empty" "$OUT" \
+  '[.[] | select(.recommendation=="merge" and .rationale != "")] | length == 0'
+
+# ---------------------------------------------------------------------------
+# Test 2: default (TSV) output shape — exact records, exact count
+# ---------------------------------------------------------------------------
+OUT="$(cd "$REPO_DIR" && bash "$SCRIPT" --days 3 2>/dev/null)"
+N_LINES="$(printf '%s\n' "$OUT" | grep -c . || true)"
+[[ "$N_LINES" == "4" ]] && pass "Test2: exactly 4 TSV records" || fail "Test2: expected 4 TSV records, got $N_LINES"
+# @tsv of a "merge" record has an empty 3rd field → a trailing tab.
+check_line "Test2a: exact TSV line for #101 close" "$(printf '101\tclose\tsuperseded / already in main')" "$OUT"
+check_line "Test2b: exact TSV line for #102 merge" "$(printf '102\tmerge\t')" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Test 3: threshold — nothing forgotten → [] exit 0 (empty is valid)
+# ---------------------------------------------------------------------------
+OUT="$(cd "$REPO_DIR" && bash "$SCRIPT" --days 100000 --json 2>/dev/null)"
+RC=$?
+[[ "$RC" == "0" ]] && pass "Test3a: huge --days exits 0" || fail "Test3a: exit code ($RC)"
+[[ "$OUT" == "[]" ]] && pass "Test3b: huge --days emits []" || fail "Test3b: output ($OUT)"
+
+# ---------------------------------------------------------------------------
+# Test 4: --days validation fallback (non-numeric, non-positive) — warning AND
+# the effective threshold after fallback is exactly 3 days.
+# ---------------------------------------------------------------------------
+ERR="$(cd "$REPO_DIR" && bash "$SCRIPT" --days abc --json 2>&1 >/dev/null)"
+check_contains "Test4a: non-numeric --days warns and defaults to 3" "defaulting to 3 days" "$ERR"
+ERR="$(cd "$REPO_DIR" && bash "$SCRIPT" --days 0 --json 2>&1 >/dev/null)"
+check_contains "Test4b: non-positive --days warns and defaults to 3" "defaulting to 3 days" "$ERR"
+
+# Boundary: after fallback, threshold is exactly 3 — a PR 4 days idle is
+# forgotten, a PR 2 days idle is not. Uses a dedicated 2-PR fixture (restored
+# afterward) so it never perturbs the shared 5-PR fixture the other tests use.
+ISO_2D="$(days_ago_iso 2)"
+ISO_4D="$(days_ago_iso 4)"
+cp "$TMP/prs.json" "$TMP/prs.orig.json"
+jq -n --arg d2 "$ISO_2D" --arg d4 "$ISO_4D" '
+  [ {number:201, title:"PR 201", updatedAt:$d2, headRefName:"pr-201", url:"http://x/201"},
+    {number:202, title:"PR 202", updatedAt:$d4, headRefName:"pr-202", url:"http://x/202"} ]
+' > "$TMP/prs.json"
+OUT="$(cd "$REPO_DIR" && bash "$SCRIPT" --days abc --json 2>/dev/null)"
+check_json_has "Test4c: 4-days-idle #202 IS forgotten at fallback threshold 3" "$OUT" \
+  '[.[] | select(.number==202)] | length == 1'
+check_json_has "Test4d: 2-days-idle #201 NOT forgotten at fallback threshold 3" "$OUT" \
+  '[.[] | select(.number==201)] | length == 0'
+cp "$TMP/prs.orig.json" "$TMP/prs.json"
+
+# ---------------------------------------------------------------------------
+# Test 5: usage error on unknown flag
+# ---------------------------------------------------------------------------
+(cd "$REPO_DIR" && bash "$SCRIPT" --bogus >/dev/null 2>&1)
+[[ "$?" == "2" ]] && pass "Test5: unknown flag exits 2" || fail "Test5: unknown flag exit code"
+
+# ---------------------------------------------------------------------------
+# Test 6: read-only — HEAD, branch, and worktree/index all untouched after a run
+# ---------------------------------------------------------------------------
+git -C "$REPO_DIR" checkout -q main
+BEFORE="$(git -C "$REPO_DIR" rev-parse HEAD)"
+BEFORE_BRANCH="$(git -C "$REPO_DIR" symbolic-ref --quiet --short HEAD)"
+BEFORE_STATUS="$(git -C "$REPO_DIR" status --porcelain)"
+# Full ref snapshot — proves fetches never mutate persistent refs
+# (e.g. refs/remotes/origin/main), only FETCH_HEAD + the object store.
+BEFORE_REFS="$(git -C "$REPO_DIR" show-ref)"
+(cd "$REPO_DIR" && bash "$SCRIPT" --days 3 --json >/dev/null 2>&1)
+AFTER="$(git -C "$REPO_DIR" rev-parse HEAD)"
+AFTER_BRANCH="$(git -C "$REPO_DIR" symbolic-ref --quiet --short HEAD)"
+AFTER_STATUS="$(git -C "$REPO_DIR" status --porcelain)"
+AFTER_REFS="$(git -C "$REPO_DIR" show-ref)"
+[[ "$BEFORE" == "$AFTER" ]] && pass "Test6: HEAD unchanged (read-only)" || fail "Test6: HEAD moved"
+[[ "$BEFORE_BRANCH" == "$AFTER_BRANCH" ]] && pass "Test6: branch unchanged" || fail "Test6: branch changed"
+[[ "$BEFORE_STATUS" == "$AFTER_STATUS" ]] && pass "Test6: worktree/index unchanged" || fail "Test6: worktree changed"
+[[ "$BEFORE_REFS" == "$AFTER_REFS" ]] && pass "Test6: refs unchanged (no origin/main mutation)" || fail "Test6: refs mutated"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+echo "OK: forgotten-pr-triage.sh — all fixtures passed (issue #657)"

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -134,6 +134,8 @@ fi
 2. Any issues that were in-progress but whose PRs are now missing or stale
 3. Remaining open issues not yet assigned
 
+**Then run Step 1D (Forgotten-PR triage, below) and print its `## Forgotten PRs` block** — always-on on the resume path too, rendered after the recovered-PR context above.
+
 Proceed with current assignments by default. State: "Continuing with current assignments. Say 're-prioritize' to change strategy."
 
 Then proceed to **Step 2: Active Monitoring Setup** (resume mode restores passive tracking — see Step 2).
@@ -277,11 +279,14 @@ Incorporate the answer, finalize the ranking, and continue to 1B.5.
 
 ### 1B.5: Present recommendations
 
-**First, run Step 1C (Backlog & workspace cleanup, below) — the full inline `/pm-clean` flow — ahead of everything else in this step, with its confirm gates resolved (acted on or declined) before any ranking output** (unless `--no-clean` / `fast` was passed, which prints only the ranking-only health line and skips the gates). Then, when `$GH_USER` is set, lead the output with user-scoped sections before the general backlog ranking. These always take precedence over backlog pickup — they represent work already on the user's plate.
+**First, run Step 1C (Backlog & workspace cleanup, below) — the full inline `/pm-clean` flow — ahead of everything else in this step, with its confirm gates resolved (acted on or declined) before any ranking output** (unless `--no-clean` / `fast` was passed, which prints only the ranking-only health line and skips the gates). Then, when `$GH_USER` is set, lead the output with user-scoped sections before the general backlog ranking. These always take precedence over backlog pickup — they represent work already on the user's plate. **Immediately after `## Your Open PRs`, run Step 1D (Forgotten-PR triage, below) and print its `## Forgotten PRs` block** — like Step 1C it is always-on and informational, and it renders before `## Suggested Next Issues`. If `$GH_USER` is unset so no `## Your Open PRs` section renders, the block still appears — `forgotten-pr-triage.sh` defaults to `@me` — placed after whatever user-scoped sections did render (or on its own if none), still before `## Suggested Next Issues`.
 
 ```
 ## Your Open PRs
 {List of open PRs authored by $GH_USER with last update time — or "none" if empty}
+
+## Forgotten PRs (>N days)
+{Step 1D output — the forgotten set with per-PR close/merge recommendations, or a one-line "none" note when empty. Informational; never alters the ranking below.}
 
 ## PRs Awaiting Your Review
 {List of open PRs where $GH_USER is a requested reviewer — or "none" if empty}
@@ -395,6 +400,55 @@ When `estimate_message` is set instead of `estimate` (the 30-day closure rate is
 ```
 
 If `candidate_count` is 0, drop the "defer/close candidates" line rather than showing a zero. This fallback stays purely informational — it never enumerates the flagged issues and never prompts for action; the full interactive cleanup is the default (no flag).
+
+---
+
+## Step 1D: Forgotten-PR triage (always-on)
+
+Runs on **every** `/pm` invocation, no flag required — both 1A.4 (resume) and 1B.5 (cold start) call it, rendering its block **immediately after `## Your Open PRs` and before `## Suggested Next Issues`**. Like Step 1C it is informational-first: printing the block never alters 1B.3 narrowing, 1B.4 scoring, or the 1B.4b judgment check. Its scope is deliberately narrow — a **one-shot startup triage** of PRs you have likely forgotten, then a hand-off. It does **not** enter a monitoring loop; continuous PR-fleet monitoring remains `/pr-monitor-and-manage`'s job (bounded by #460/#522).
+
+### 1D.1: Detection
+
+```bash
+# Threshold defaults to 3 days; override via FORGOTTEN_PR_DAYS (or a pm-config.md
+# "Forgotten PR threshold" note resolved into it). --author defaults to @me; pass
+# $GH_USER when Step 0 resolved it. The script re-validates --days and falls back
+# to 3 on a non-numeric/non-positive value, so a bad override degrades safely.
+DAYS="${FORGOTTEN_PR_DAYS:-3}"
+.claude/scripts/forgotten-pr-triage.sh --json --days "$DAYS" ${GH_USER:+--author "$GH_USER"}
+```
+
+`forgotten-pr-triage.sh` (read-only — it never closes, merges, or deletes) enumerates your open PRs, keeps those whose **last activity** (`updatedAt`, the documented age basis) is strictly more than the threshold ago, and classifies each `close` or `merge` using exactly two close signals (first match wins; otherwise `merge`):
+
+- **linked issue closed** — the PR's `Closes/Fixes #N` issue is already `CLOSED` (rationale `linked issue #N closed`).
+- **superseded / already in main** — the PR contributes zero net-new commits to `main` (every commit already landed, including via another merged PR, by `git cherry` patch-id equivalence; rationale `superseded / already in main`).
+
+CI/conflict state is **not** a close signal — a red or conflicted PR is surfaced as a `merge` candidate and will fail the gate visibly downstream. Each JSON record carries `number`, `title`, `url`, `headRefName`, `age_days`, `recommendation`, and `rationale`, so the block below renders and the action paths act without extra `gh` calls. Exit `0` (including the empty set) is success; only exit `2`/`3` (usage / environment) is a real error to surface.
+
+### 1D.2: Render
+
+```
+## Forgotten PRs (>N days)
+
+- **PR #123 — {title}** — {age_days}d idle → **close** (superseded / already in main)
+- **PR #130 — {title}** — {age_days}d idle → **close** (linked issue #99 closed)
+- **PR #141 — {title}** — {age_days}d idle → **merge**
+```
+
+`N` is the active `--days` threshold (default 3). If the forgotten set is empty, print a single line — `## Forgotten PRs — none older than N days` — and skip the action paths entirely.
+
+### 1D.3: Close flow (confirmation-gated)
+
+For every `close`-classified PR, present the PR and its rationale and **ask for explicit confirmation** before touching anything (recommend → confirm → apply, mirroring `/pm-clean`). Declining leaves the PR open.
+
+- On confirmation: `gh pr close <N> --comment "<rationale>"`.
+- **Separately** — a second, independent gate, never bundled with the close confirmation — offer to delete the PR's head branch. When confirmed, delete `<headRefName>` honoring `stale-cleanup.sh`'s branch-deletion safety rules (never a protected name — `main`/`master`/`develop`; never a branch checked out in a worktree), skipping with a one-line note if any check fails. Do **not** reimplement those safety checks — treat `stale-cleanup.sh` as their source of truth; its out-of-band sweep (via `/pm-update`) also reaps the branch later once it ages past the stale threshold.
+
+### 1D.4: Merge flow (confirmation-gated, delegated to `/wrap`)
+
+For the `merge`-classified PRs, present them and require an explicit **"yes"** per CLAUDE.md's merge-authorization rule — no auto-merge. Declining leaves everything unmerged. The "yes" is the authorization; do not add a second per-PR merge prompt.
+
+On confirmation, **dispatch one subagent per approved PR that executes the `/wrap #N` workflow** (the arbitrary-PR form) so the existing merge gate + AC verification + squash-merge run unchanged — **do not reimplement merge logic**. Spawn per `.claude/agents/README.md` and `subagent-orchestration.md`: `subagent_type: "phase-c-merger"`, `mode: "bypassPermissions"`, explicit `model: "sonnet"`, the verbatim SAFETY block, and the handoff path. Respect the **3–4 concurrent-pipeline ceiling** from `subagent-orchestration.md` — launch up to the cap and queue the rest, starting a queued merge as each running one finishes. This is a one-shot hand-off: once the merge subagents are dispatched, Step 1D is done — it does not poll them (polling is monitoring, which belongs to `/pr-monitor-and-manage`).
 
 ---
 

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -19,6 +19,8 @@ Thread-level **PR fleet manager**. This skill turns the current thread into a de
 
 This is a **set-and-monitor** command. Once invoked it acknowledges the mode, establishes a `/loop`, and at every tick reprints the fleet table and acts. The **parent thread** never edits feature code directly — it dispatches subagents to do that work — and never drifts into unrelated work.
 
+> **Scope vs `/pm`'s forgotten-PR triage (issue #657).** `/pm` runs a **one-shot** startup triage of *forgotten* PRs (last activity older than a few days), recommends close/merge, and hands merges off to `/wrap` subagents — then it stops. This skill is the opposite: **continuous** fleet monitoring on a recurring `/loop`, driving *every* open PR to merge-ready or a named hard block tick after tick. Reach for `/pm`'s triage to clear a backlog of stale PRs once at startup; reach for `/pr-monitor-and-manage` to actively babysit the whole fleet until it is clean.
+
 ---
 
 ## Step 0: Enter PR-fleet-manager mode (MANDATORY, first tick only)

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -17,6 +17,7 @@ Wrap up the current PR and session. This is the "we're done here" command that h
 - /wrap includes everything /merge does, plus follow-ups and lessons. Don't run both.
 - Phase C invokes this skill after gate and AC verification; keep merge, main-sync, follow-up, and cleanup behavior here so Phase C and `/wrap` cannot drift.
 - **Target PR:** `/wrap` operates on the PR resolved in Step 1.1. Pass an explicit reference (`/wrap <URL>`, `/wrap #N`, `/wrap N`) to wrap a PR that is **not** on the current branch — common in orchestration threads that ran `/fixpr <URL>` against another worktree. With no argument, Step 1.1's cascade infers the PR; see **Step 1.1: Identify the PR**.
+- **Callers of the `/wrap #N` form:** Phase C (`phase-c-merger`), `/pr-monitor-and-manage` (merge-ready fleet PRs), and **`/pm`'s one-shot forgotten-PR triage** (issue #657) all merge an already-open PR by dispatching this workflow rather than reimplementing merge logic — the merge gate, AC verification, and squash-merge live here so every caller stays consistent.
 
 ## Execution Model
 

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -89,6 +89,9 @@ jobs:
       - name: issue-dedup.sh body-search unit test (issue #652)
         run: bash .claude/scripts/tests/issue-dedup.test.sh
 
+      - name: forgotten-pr-triage.sh classifier unit test (issue #657)
+        run: bash .claude/scripts/tests/forgotten-pr-triage.test.sh
+
   # macOS system python3 is 3.9.6 (Xcode CLT) while ubuntu-latest ships 3.10+,
   # so a hook that crashes on 3.9 (e.g. eagerly-evaluated PEP 604 unions,
   # issue #560) passes the job above yet fails open locally. Pin 3.9 here.


### PR DESCRIPTION
## **User description**
## Summary

Adds a one-shot **forgotten-PR triage** to `/pm` startup: it flags the author's open PRs whose last activity is older than a threshold (default **3 days**, configurable) and, per PR, recommends **close** or **merge** — then gates every action behind explicit confirmation.

- **New read-only detector** `.claude/scripts/forgotten-pr-triage.sh` (modeled on `backlog-staleness.sh`). Enumerates the author's open PRs, keeps those whose **`updatedAt` (last activity)** is strictly more than `--days N` (default 3) ago, and classifies each with exactly two close signals (first match wins, else `merge`):
  - **linked issue closed** — reuses `pr-issue-ref.sh`, then `gh issue view` (rationale `linked issue #N closed`).
  - **superseded / already in main** — `git cherry` patch-id overlap counts zero net-new commits vs `main` (also captures "another merged PR covers it"; rationale `superseded / already in main`).
  - CI/conflict state is **not** a close signal — a red/conflicted PR is a `merge` candidate and fails the gate visibly. Emits JSON or TSV; exit codes match `backlog-staleness.sh` (0 incl. empty / 2 usage / 3 env). Strictly read-only.
- **`/pm` Step 1D** (always-on, informational — Step 1C convention), rendered right after `## Your Open PRs`, before `## Suggested Next Issues`. Two confirmation-gated action paths: **close** (with a separate, independent branch-delete gate reusing `stale-cleanup.sh` safety) and **merge** (dispatches `/wrap #N` subagents — merge logic not reimplemented — capped at the 3–4 concurrent-pipeline ceiling).
- **Scope docs** in `/wrap` and `/pr-monitor-and-manage` delineate this one-shot startup triage from continuous fleet monitoring.
- **Offline test** `forgotten-pr-triage.test.sh` (real temp git repo + file-based `origin` with `refs/pull/N/head` refs exercises the real `git cherry` path), wired into CI (`hook-scripts.yml`). macOS bash 3.2-safe.

Closes #657

## Acceptance Criteria
- [x] Startup detection of open PRs older than a configurable threshold (default 3 days); age basis = last-activity (`updatedAt`), documented in the script header + Step 1D
- [x] Close classifier uses exactly the two chosen signals — superseded/already-in-main **and** linked-issue-closed — each with its specific rationale
- [x] All other forgotten PRs → **merge** recommendation, presented for explicit confirmation (no auto-merge)
- [x] On "yes", merges dispatch `/wrap #N` subagents (existing merge gate + AC + squash-merge reused), capped at the 3–4 concurrent ceiling
- [x] Closing is confirmation-gated; branch delete offered as a separate gate reusing `stale-cleanup.sh` safety
- [x] Scope delineated vs `/pr-monitor-and-manage` (one-shot triage + hand-off, not continuous monitoring)

## Test Plan
- [x] PR >3 days old, changes already in `main` → **close** ("superseded / already in main") — `Test1a`
- [x] PR >3 days old, linked issue closed → **close** ("linked issue #N closed") — `Test1c`
- [x] Healthy PR >3 days old → **merge**; on confirm a `/wrap #N` subagent merges — `Test1b`/`Test1d` + Step 1D.4 prose
- [x] PR newer than the threshold → not flagged — `Test1e`, `Test4c`/`Test4d` (near-3-day boundary)
- [x] Declining leaves every PR open/unmerged; nothing acts without confirmation — Step 1D.3/1D.4 (both gated)
- [x] Detector is strictly read-only (HEAD, branch, worktree unchanged) — `Test6`
- [x] `--days` configurable with safe fallback to 3 on bad input — `Test4a`–`Test4d`
- [x] Empty forgotten set → `[]`, exit 0 — `Test3`
- [x] Test wired into `hook-scripts.yml` CI

## Notes
- **Local review:** CodeRabbit CLI's 5 findings were applied (config threshold wired via `FORGOTTEN_PR_DAYS`/`--days`; `$GH_USER`-unset placement clarified; TSV/boundary/read-only test assertions strengthened). A follow-up local CodeRabbit run hit the free-OSS **rate limit** (47-min reset) and CodeAnt CLI isn't installed locally — both dropped for the session per `cr-local-review.md`; GitHub CodeRabbit + CodeAnt will review here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add startup triage for forgotten open PRs**

### What Changed
- `/pm` now shows a new “Forgotten PRs” section for open PRs whose last activity is older than the chosen threshold, with a per-PR recommendation to either close or merge.
- PRs are marked for close only when their linked issue is already closed or they no longer add anything new compared with `main`; otherwise they stay as merge candidates.
- Closing and merging remain confirmation-gated, and merges are handed off to `/wrap` so the existing merge flow is reused.
- Added offline test coverage for the new triage behavior, including age filtering, close/merge recommendations, and read-only behavior.
- Updated the surrounding skill docs to explain when this one-shot triage appears and how it differs from continuous PR monitoring.

### Impact
`✅ Faster cleanup of stale open PRs`
`✅ Fewer forgotten PRs left sitting open`
`✅ Clearer close-or-merge guidance at startup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>