### PR TITLE
fix(#677): route /issue-maker dedup through shared issue-dedup.sh

### DIFF
--- a/.claude/skills/issue-maker/SKILL.md
+++ b/.claude/skills/issue-maker/SKILL.md
@@ -148,23 +148,75 @@ For each issue the user describes (see Step 6 for batches):
 
 ## Step 4: Dedup search
 
-Before creating, search open and recently-closed issues for likely duplicates and surface any matches.
+Before drafting further, search open and recently-closed issues for likely duplicates and surface any matches.
+
+Dedup runs through the **shared retrieval script** `issue-dedup.sh` — the same one `/wrap` uses (`wrap/SKILL.md` Step 3.3a). **Do not hand-roll a `gh issue list --search` call here.** This step used to run its own `"<keywords> in:title"` query; that inline query is the defect issue #652 documented, and routing every auto-dedup path through one script is what stops the call sites drifting into it again.
+
+**Resolve the script once per invocation**, before the first dedup run. `/issue-maker` is a global skill — in a repo that is not this config repo a bare `.claude/scripts/…` path does not exist, and the skills-worktree copy is the one that does:
 
 ```bash
-# Extract 2–5 significant keywords from the proposed title (drop stopwords/punctuation).
-KEYWORDS="<significant words from the title>"
-if [ -n "$KEYWORDS" ]; then
-  gh issue list --repo "$REPO" --state open \
-    --search "$KEYWORDS in:title" --json number,title,url --limit 5
-  gh issue list --repo "$REPO" --state closed \
-    --search "$KEYWORDS in:title closed:>$(date -d '30 days ago' +%F 2>/dev/null || date -v-30d +%F)" \
-    --json number,title,url --limit 5
+DEDUP_SH=""
+for candidate in \
+  "$HOME/.claude/skills-worktree/.claude/scripts/issue-dedup.sh" \
+  "$HOME/.claude/scripts/issue-dedup.sh" \
+  ".claude/scripts/issue-dedup.sh"; do
+  if [[ -x "$candidate" ]]; then DEDUP_SH="$candidate"; break; fi
+done
+```
+
+**Build the search terms from the proposed title *and* the description material** — the user's own words plus their answers to the clarifying questions. (This step runs *before* the body is drafted in Step 5, so the body-to-be is that description material.) Lead with identifier-shaped tokens — filenames, config keys, script names — then add the few words that name the underlying problem.
+
+> **Do not extract "2–5 significant keywords" from the title.** That older instruction was not merely narrow, it was backwards — see *Why the old query failed* below. The script ranks and queries the terms itself; hand it the distinctive ones and let it work.
+
+```bash
+TERMS="<identifiers first, then problem words, drawn from title + description>"
+
+# Keep stderr — it carries the reason (API error, bad repo) that the
+# `dedup unavailable` message has to name.
+DEDUP_ERR=$(mktemp)
+DEDUP_JSON=""; DEDUP_RC=0
+if [ -n "$DEDUP_SH" ]; then
+  DEDUP_JSON=$("$DEDUP_SH" --terms "$TERMS" --repo "$REPO" 2>"$DEDUP_ERR") || DEDUP_RC=$?
+else
+  DEDUP_RC=127        # sentinel: script not installed at any candidate path
 fi
 ```
 
-- **Guard:** if no significant keywords remain, skip the dedup search.
-- **Matches found (default mode):** list them and ask *"Similar issues found — create anyway? (y/N)"*.
-- **Rapid-fire:** show matches but proceed unless there is an **exact title match** (then block and ask).
+`--repo "$REPO"` keeps the search on the target repo established in Step 1, consistent with every other `gh issue …` call in this skill. The script searches open issues plus issues closed within the last 30 days by default — the same recently-closed window this step used to spell out inline; pass `--closed-days N` to widen it.
+
+**Exit `0` is the only "searched" outcome — treat every non-zero code as `dedup unavailable`.** Reading the table as a closed set is the trap: a code not listed here must still fail toward "unavailable", never toward "clean".
+
+| `DEDUP_RC` | Meaning | What to do |
+|------------|---------|------------|
+| `0` | Search ran | Classify `.candidates` — an empty array is a genuine "no match" |
+| `2` | Usage error (e.g. `TERMS` came out empty) | **dedup unavailable** |
+| `3` | No usable terms after stopword filtering | **dedup unavailable** |
+| `4` | `gh` / GitHub API error — reason in `$DEDUP_ERR` | **dedup unavailable** |
+| `127` | Script not resolved at any candidate path | **dedup unavailable** |
+| _anything else_ | Unknown failure | **dedup unavailable** |
+
+**`dedup unavailable` is not "no duplicates found."** Say so plainly — *"Dedup search unavailable (\<reason\>) — I could not check for duplicates"* — naming the reason from `$DEDUP_ERR` where there is one, and let the user decide with that caveat in hand. Reporting a failed search as a clean one is how a duplicate gets filed with false confidence.
+
+**Classify each candidate** by reading its `title` and `excerpt`: does it cover the *same underlying problem*, not merely the same area of the codebase (same test as `wrap/SKILL.md` Step 3.3a)? `specificity` calibrates — a candidate matched at the full conjunction width shares most of the finding's vocabulary, while a `specificity: 1` hit matched on a single anchor term and is usually weak at best.
+
+| Verdict | Test | How to surface it |
+|---------|------|-------------------|
+| **Strong** | Same root cause or same fix — acting on that issue would resolve this too. | Lead with it and recommend commenting there instead: *"#N looks like the same problem — comment there instead of opening a new issue? (comment / create anyway)"* |
+| **Weak** | Same component or adjacent symptom but a distinct fix — or you are simply unsure. | Show it, then proceed to draft. If the user creates, offer a `Possibly duplicates #N` line in the body. |
+| **None** | No candidate covers this ground. | Proceed to draft normally — no prompt. |
+
+**Surface, never suppress.** `/wrap` auto-files, so a strong match there *replaces* the filing. `/issue-maker` asks — so classification decides what the user sees and how it is ranked, never whether the issue gets filed. Show the candidate's number, title, and excerpt and let them make the call.
+
+**Bias toward filing.** A duplicate ticket costs one `gh issue close`; a real issue folded into an unrelated ticket disappears. When torn between strong and weak, choose **weak**.
+
+**Rapid-fire** still runs dedup and still proceeds without asking — show candidates inline and block only on an **exact title match**. Report `dedup unavailable` inline rather than blocking on it.
+
+**Why the old query failed.** The replaced inline search ran `"$KEYWORDS in:title"` over open and recently-closed issues. Two defects, both verified against real tickets in this repo:
+
+1. **Title-only scope.** Duplicates that restate a problem in different words share *body* text, not title text. #638 and #647 have almost no title words in common, so #638 was unreachable from any title query built out of #647's finding.
+2. **Unbounded conjunction.** GitHub ANDs every bare term, so each added keyword makes the query *stricter*, not better targeted. For the #663 finding a 4-term query matched nothing but the new issue itself, while querying its anchor terms individually surfaced #643 as the top hit.
+
+`issue-dedup.sh` fixes both mechanically — `in:title,body`, plus a conjunction pass *and* a per-anchor-term pass whose results are merged and ranked — and deliberately returns **candidates, not a verdict**: broader recall means noisier top hits, and taking `.[0]` from a body search will confidently return an unrelated issue.
 
 ---
 


### PR DESCRIPTION
## **User description**
## What this changes

`/issue-maker`'s dedup step now runs through the shared `issue-dedup.sh` instead of its own `gh issue list --search "$KEYWORDS in:title"` queries.

This is the third call site of the contract PR #673 established. Issue #652 named this gap explicitly — `/issue-maker` "did not catch this case either, since it searches titles only" — and it was left out of #673 to keep that PR scoped to #652's acceptance criteria.

**The defect, in one line:** a duplicate that restates a problem in different words was unreachable, because the search only read titles and got *stricter* with every keyword added.

## Why the old query failed

Both defects are verified against real tickets in this repo, and are now documented in the step itself so a future edit does not reintroduce them:

1. **Title-only scope.** Duplicates that restate a problem in different words share *body* text, not title text. #638 and #647 have almost no title words in common, so #638 was unreachable from any title query built out of #647's finding.
2. **Unbounded conjunction.** GitHub ANDs bare terms, so each added keyword narrows the result set. The mandated "2–5 significant keywords" was actively harmful at the top of its range.

## Notable decisions

- **Terms come from title *and* description material.** `/issue-maker` runs dedup *before* the body is drafted (Step 3 orders reflect → dedup → draft), so "title and body" here means the user's description plus their clarifying answers. The step says so explicitly rather than referencing a body that does not exist yet.
- **Surface, never suppress.** `/wrap` auto-files and must therefore *decide* — a strong match there replaces the filing. `/issue-maker` asks, so classification orders and annotates what the user sees and never suppresses a filing on their behalf. Strong and weak matches both surface in the confirmation prompt with number, title, and excerpt.
- **Every non-zero exit is `dedup unavailable`.** Framed as an open set, not a closed table, so an unlisted future exit code still fails toward "unavailable" rather than "clean". stderr is captured so the reason can be named to the user.
- **`--repo "$REPO"` is passed**, consistent with every other `gh issue …` call in the skill (a small, deliberate divergence from `/wrap`, which passes `--repo` only for cross-repo wraps).

## ⚠️ Merge order — depends on PR #673

`.claude/scripts/issue-dedup.sh` is introduced by **PR #673**, which is still open. This PR is documentation-only and degrades gracefully — with the script absent, the resolution ladder yields an empty `DEDUP_SH` and the step reports `dedup unavailable` rather than erroring or claiming the tracker is clean. Safe to review in parallel, but **merge after #673**.

## Review-tooling note (local review)

Both local CLIs were unavailable for this change; per `cr-local-review.md` this fell back to self-review, recorded here rather than silently omitted:

- **CodeRabbit CLI** — hung past the 2-minute bound with no output; dropped for the session rather than retried, because the CLI shares one adaptive quota with the GitHub review that actually gates the merge.
- **CodeAnt CLI** — `API Error: Access denied (403)`, the persistent account-wide entitlement failure tracked in #643. Not re-authenticated (`codeant logout/login` has wiped the token before). It also mis-scoped the diff, reporting 5 changed files against this worktree's 1.

**Self-review caught two real defects in the first draft**, both fixed before commit: the exit-code table omitted exit `2` (which the script really does return on empty `--terms` — verified), and `2>/dev/null` was discarding the very stderr reason the `dedup unavailable` message is supposed to name.

## Verification already run

| Check | Result |
|-------|--------|
| `#647`-style terms now surface `#638` | ✅ `#638` returned at **rank 1, specificity 4** — the exact duplicate the old query could not reach |
| Exit `0` (search ran) | ✅ 5 candidates returned |
| Exit `2` (empty terms) | ✅ `error: --terms is required` |
| Exit `3` (all stopwords) | ✅ well-formed empty result |
| Exit `4` (bad repo) | ✅ reason captured from stderr |
| Unresolved script → `127` sentinel | ✅ routes to `dedup unavailable` |
| Resolution ladder precedence | ✅ `wt → home → cwd → UNRESOLVED` |
| `bash -n` on extracted snippets | ✅ clean |
| No inline `gh issue list` remains | ✅ only prose forbidding it |
| Rule-corpus budget | n/a — skill files are not scored; corpus unchanged at 11,079 words |

## Test plan

- [ ] Step 4 calls `issue-dedup.sh` — both the open and recently-closed inline queries are gone
- [ ] Script resolved via the three-candidate lookup (skills-worktree → `$HOME` → cwd), so the skill works in repos with no local `.claude/scripts/`
- [ ] Unresolvable script reports `dedup unavailable`, never "no duplicates found"
- [ ] Terms are drawn from the proposed title **and** description material, identifiers first
- [ ] The obsolete "2–5 significant keywords" instruction is gone, and nothing implies more keywords means better matching
- [ ] Exit `0` handled as "searched" (empty candidate list is a genuine no-match)
- [ ] Exits `2`, `3`, `4` and any other non-zero handled as "no dedup signal"
- [ ] Candidates classified strong/weak/none by the same test as `wrap/SKILL.md` Step 3.3a
- [ ] Classification surfaces in the confirmation prompt rather than suppressing a filing
- [ ] `--repo "$REPO"` passed through
- [ ] Rapid-fire still runs dedup and still blocks only on an exact title match
- [ ] The step documents *why* title-only and unbounded-conjunction searching fail

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Update /issue-maker dedup to use the shared duplicate search flow**

### What Changed
- `/issue-maker` now uses the shared `issue-dedup.sh` duplicate check instead of its own title-only search.
- The dedup step now looks at both the issue title and the description material, which helps catch duplicates that use different wording.
- When duplicate checking cannot run, it now reports that clearly instead of treating it as a clean no-duplicate result.
- Strong and weak duplicate matches are shown to the user with the issue number, title, and excerpt so they can choose whether to continue.

### Impact
`✅ Fewer duplicate issues filed`
`✅ Clearer duplicate warnings`
`✅ Better duplicate checks for reworded reports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
