### PR TITLE
fix(#608): use state, not a merged field, in /wrap's merged terminal check

### DIFF
--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -262,8 +262,8 @@ After each action, append to **`WRAP_RECOVERY_AUDIT`** (free-form lines or bulle
 **Recovery loop:** For `i` from `1` through `$WRAP_RECOVERY_MAX_ITERATIONS`:
 
 1. **Terminal checks**
-   - If `gh pr view` shows `merged: true` → exit loop for Phase 3 (merged terminal — Phase 3 + 4 unchanged).
-   - If PR closed without merge → stop with status (do not merge).
+   - If `gh pr view "$PR_NUM" --json state --jq '.state'` returns `MERGED` → exit loop for Phase 3 (merged terminal — Phase 3 + 4 unchanged). Use `state`, **not** a `merged` field — `gh` has no `merged` JSON field and `--json merged` fails with `Unknown JSON field: "merged"` (issue #608).
+   - If it returns `CLOSED` → PR closed without merge; stop with status (do not merge).
 
 2. **Refresh gate (always)**  
    ```bash


### PR DESCRIPTION
## **User description**
Closes #608

## Problem

`.claude/skills/wrap/SKILL.md` Step 2.1 ("Terminal checks") instructed:

> - If `gh pr view` shows `merged: true` → exit loop for Phase 3

`gh` exposes `state`, `mergedAt`, and `mergeCommit` — but **no `merged` field**. Following that line literally fails:

```
$ gh pr view 666 --json merged --jq .merged
Unknown JSON field: "merged"
```

#608 was closed earlier today, but the fix missed this occurrence. I hit it live during a `/wrap` run on PR #650, which is why the issue was reopened.

**The consequence is worse than a bad error message.** This check sits on the merged-terminal early exit of the Step 2.1 recovery loop, so a genuinely merged PR would not be detected and the loop would burn a recovery iteration before noticing.

## Fix

Uses `--json state --jq '.state'` and branches on `MERGED` / `CLOSED`, matching the form Step 3.8 already uses. The line also now names the trap explicitly, so the next editor doesn't reintroduce it.

## Verification

Both directions, against PR #666 (merged during this session):

```
$ gh pr view 666 --json state --jq '.state'
MERGED                                    # new form works

$ gh pr view 666 --json merged --jq '.merged'
Unknown JSON field: "merged"              # old form still errors
```

`grep -rn 'json merged|,merged\b|merged: true' .claude/skills/*/SKILL.md .claude/rules/*.md` returns only the new explanatory prose — no command usage survives. `rule-lint.sh` exits 0 (corpus untouched; skills aren't counted).

## Relationship to PR #673

This supersedes the `#608` half of PR #673, which is being closed. #673 bundled this fix with a `#652` dedup implementation that **PR #661 landed first** — #661 added the same `issue-dedup.sh`, its test file, the README entry, and the workflow registration, and went further by also fixing `/issue-maker` and adding `.claude/reference/autofile-dedup.md`. Rather than reconcile two competing implementations of the same script through a 3-way conflict, #673 is closed and only the still-needed one-line fix is carried here, cut fresh from current main.

## Test plan

- [ ] `wrap/SKILL.md` merged-terminal check uses `state`, not a `merged` field
- [ ] The `CLOSED` (closed-without-merge) branch is preserved
- [ ] No `--json merged` command usage remains in any skill or rule file
- [ ] New form verified to return `MERGED` for a merged PR; old form verified to still error
- [ ] `rule-lint.sh` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix merged PR detection in `/wrap` recovery checks

### What Changed
- `/wrap` now checks PR state the right way when deciding whether to exit the recovery loop for a merged PR
- Closed PRs still stop the loop without merging
- The guidance now calls out the broken `merged` check so it is not reintroduced

### Impact
`✅ Fewer missed merged PRs`
`✅ Fewer wasted recovery iterations`
`✅ Clearer wrap retry behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
