### PR TITLE
fix(#675): dedupe check-runs so stale superseded failures don't block merge gate

### DIFF
--- a/.claude/reference/merge-gate-reviewer-paths.md
+++ b/.claude/reference/merge-gate-reviewer-paths.md
@@ -2,6 +2,20 @@
 
 Full path-specific rules extracted from `.claude/rules/cr-merge-gate.md` Step 1. The rule file keeps the polling exit criterion and step headers; this file holds per-path semantics. **`merge-gate.sh` is authoritative** — re-read its JSON when in doubt.
 
+## Check-run dedup — all paths (#675)
+
+Every check-run read goes through `.claude/scripts/check-runs-dedup.sh` before anything classifies it: `ci-status.sh`, `merge-gate.sh`, `pr-state.sh` (and so `escalate-review.sh`), and `pr-preflight.sh`.
+
+GitHub keeps a record for **every** run of a check on a commit, and each re-trigger opens a new check suite — so the `commits/{sha}/check-runs` endpoint returns an old failed run right next to the new passing one. The endpoint's `filter=latest` does not help; it is latest-per-*suite*. GitHub's own PR page resolves each check name to its newest run, and the dedup does the same:
+
+- Runs are grouped by `(app, check name)`; only the group's newest `check_suite.id` survives.
+- **All** runs in that newest suite are kept, so matrix legs sharing a name stay separate and a failing leg is never masked by a passing sibling.
+- Ordering is by `check_suite.id`, not `completed_at` — an in-progress run has no `completed_at`, and a still-running newest run must read as *pending*, not as the older run's failure.
+- Same-named checks from different apps never collapse into each other.
+- A run with no `check_suite.id` is retained regardless: dropping a run can only mask a failure, so unknown data fails toward blocking.
+
+**Consequence for polling:** a check that failed and was re-run stops blocking the moment the newer run lands — no rebase or new push required. If tooling still reports a failure GitHub's merge box shows as green, suspect the fetch bypassed the helper, not the dedup rule.
+
 ## CR path
 
 Applies when neither BugBot nor Greptile was triggered (`merge-gate.sh` reviewer `cr`).
@@ -23,7 +37,7 @@ Applies when neither BugBot nor Greptile was triggered (`merge-gate.sh` reviewer
 `codeant-ai[bot]`; parallel to CR — see `cr-github-review.md`.
 
 - **Applies** when CodeAnt has review/comment on current HEAD **or** a CodeAnt check-run on that commit.
-- **Clean:** `APPROVED` on HEAD **or** completed CodeAnt check with `conclusion: success`.
+- **Clean:** `APPROVED` on HEAD **or** completed CodeAnt check with `conclusion: success` — read from the deduped list, so a superseded CodeAnt success no longer counts as clean when a newer CodeAnt run failed (#675).
 - **Retraction:** `CHANGES_REQUESTED` blocks only if newer than latest clean signal on that SHA. Threads: Step 1c in `cr-merge-gate.md`.
 
 ## BugBot path

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -43,6 +43,8 @@ Before running `gh pr merge` on ANY PR, verify ALL CI check-runs are complete an
 
 **If any check-run has a blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`): DO NOT MERGE.** Read the failure output, fix, push, and merge only after ALL checks complete with non-blocking conclusions.
 
+Check-runs are deduped per `(app, check name)` to the newest check suite before classification, matching GitHub's merge box — a re-run supersedes its earlier result, so a stale failure never blocks (#675, `check-runs-dedup.sh`).
+
 Applies to ALL merge paths: `gh pr merge`, `/merge`, `/wrap`, Phase C verify-and-wrap.
 
 ## Step 1c — All Review Threads Resolved (NON-NEGOTIABLE)

--- a/.claude/scripts/check-runs-dedup.sh
+++ b/.claude/scripts/check-runs-dedup.sh
@@ -85,15 +85,17 @@ done
 # `-s` slurps the concatenated-object stream into an array; the normalizer below
 # then flattens whichever of the accepted shapes each element turns out to be.
 #
-# Non-object elements are deliberately NOT filtered out: `.app` on a scalar raises
-# a jq error, which surfaces as exit 5 here and as a parse error in the caller.
-# Silently dropping unparseable entries could hide a failing run.
+# Non-object elements are deliberately NOT filtered out: a scalar inside an array
+# raises a jq error in group_by, and a top-level scalar raises an explicit error
+# in the normalizer itself — both surface as exit 5 here and as a parse error in
+# the caller. Silently dropping unparseable entries could hide a failing run or
+# let malformed input read as a legitimate zero-check result.
 DEDUPED=$(jq -s -c '
   [ .[]
     | if type == "array" then .[]
       elif (type == "object" and has("check_runs")) then (.check_runs[]?)
       elif type == "object" then .
-      else empty
+      else error("unexpected top-level \(type) in check-runs input")
       end
   ]
   | group_by([.app.slug, .app.id, .name])

--- a/.claude/scripts/check-runs-dedup.sh
+++ b/.claude/scripts/check-runs-dedup.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# check-runs-dedup.sh — Collapse a check-run list to one verdict per check,
+# newest check suite wins (issue #675).
+#
+# Why this exists: GitHub keeps a check-run record for EVERY run of a check on a
+# commit. Re-triggering a workflow on the same SHA (a PR-body edit re-firing a
+# required workflow, a manual re-run) creates a NEW check suite, so the
+# `commits/{sha}/check-runs` endpoint returns the old failed run alongside the new
+# passing one. The endpoint's default `filter=latest` does not help — it is
+# latest-per-*suite*, and each re-trigger is its own suite. GitHub's own PR page
+# and merge box resolve each check name to its newest run; tooling that reads the
+# raw list instead reports a superseded failure as currently blocking, refusing a
+# merge GitHub itself shows as green.
+#
+# Dedup rule: group runs by (app identity, check name); within each group find the
+# highest `check_suite.id`; retain ALL runs belonging to that newest suite.
+#
+#   - Newest-SUITE-per-name, never latest-single-RUN-per-name. Matrix legs share a
+#     name within one suite, so keeping only one run per name would let a passing
+#     leg mask a failing sibling.
+#   - The group key includes the app, so same-named checks from different apps
+#     (e.g. two bots both publishing "lint") never collapse into each other.
+#   - Ordering is by `check_suite.id`, not `completed_at`: an in-progress run has
+#     `completed_at: null`, so time-ordering would let an older FAILED run outrank
+#     the newest still-running one and report a check as failing when the honest
+#     answer is "not finished yet". `check_suite.id` is the only ordering key
+#     present on runs in every status. Same-second re-runs also tie on timestamps.
+#   - Runs whose `check_suite.id` is null are retained regardless of their group's
+#     newest suite. Dropping a run can only ever MASK a failure, so unknown data
+#     fails toward blocking.
+#
+# Retained run objects are emitted with every field intact — callers read varying
+# fields (`conclusion`, `status`, `output.title`, `details_url`, `html_url`).
+#
+# Usage:
+#   check-runs-dedup.sh < check-runs.json
+#   check-runs-dedup.sh --help
+#
+# Input (stdin) — any shape the callers already produce:
+#   - a bare JSON array of check-run objects            (pr-state.sh)
+#   - a single {"check_runs": [...]} object             (merge-gate.sh)
+#   - a `gh api --paginate` stream of concatenated objects of either form
+#   - a stream of bare check-run objects, as produced by
+#     `gh api --paginate --jq '.check_runs[]?'` (the --jq filter runs once PER
+#     PAGE, so the output is concatenated objects, not one array)
+#
+# Output (stdout): a single compact JSON array of the retained check-run objects.
+# Empty input yields `[]` — callers relying on a `total == 0` sentinel (see
+# ci-status.sh) still see zero runs rather than an error.
+#
+# Exit codes:
+#   0 — deduped array written to stdout
+#   2 — usage error
+#   5 — stdin could not be parsed as check-run JSON
+
+set -uo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
+
+print_usage() {
+  awk '
+    NR == 1 { next }
+    /^# Usage:/ { in_block = 1 }
+    in_block && !/^#/ { exit }
+    in_block {
+      sub(/^# ?/, "")
+      print
+    }
+  ' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unexpected argument: $1 (input is read from stdin)" >&2
+      print_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+# `-s` slurps the concatenated-object stream into an array; the normalizer below
+# then flattens whichever of the accepted shapes each element turns out to be.
+#
+# Non-object elements are deliberately NOT filtered out: `.app` on a scalar raises
+# a jq error, which surfaces as exit 5 here and as a parse error in the caller.
+# Silently dropping unparseable entries could hide a failing run.
+DEDUPED=$(jq -s -c '
+  [ .[]
+    | if type == "array" then .[]
+      elif (type == "object" and has("check_runs")) then (.check_runs[]?)
+      elif type == "object" then .
+      else empty
+      end
+  ]
+  | group_by([.app.slug, .app.id, .name])
+  | map(
+      ([.[] | .check_suite.id | select(. != null)] | max) as $newest
+      | if $newest == null then .
+        else [ .[] | select((.check_suite.id == null) or (.check_suite.id == $newest)) ]
+        end
+    )
+  | add // []
+' 2>/dev/null)
+
+if [[ -z "$DEDUPED" ]]; then
+  echo "ERROR: could not parse check-runs JSON from stdin" >&2
+  exit 5
+fi
+
+printf '%s\n' "$DEDUPED"

--- a/.claude/scripts/ci-status.sh
+++ b/.claude/scripts/ci-status.sh
@@ -223,7 +223,7 @@ fi
 # check counts as currently blocking, and this script reports a commit as failing
 # that GitHub's own merge box shows as green (issue #675). Applies to both input
 # paths: the stdin caller hands us its raw fetch, same as the live fetch above.
-CHECK_RUNS_DEDUP="$(dirname "$0")/check-runs-dedup.sh"
+CHECK_RUNS_DEDUP="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-runs-dedup.sh"
 if [[ ! -x "$CHECK_RUNS_DEDUP" ]]; then
   echo "ERROR: check-runs-dedup.sh not found or not executable at $CHECK_RUNS_DEDUP" >&2
   exit 5

--- a/.claude/scripts/ci-status.sh
+++ b/.claude/scripts/ci-status.sh
@@ -6,6 +6,12 @@
 # Blocking conclusions: failure, timed_out, action_required, startup_failure, stale.
 # Non-blocking: success, neutral, skipped, cancelled.
 #
+# Check-runs are deduped through check-runs-dedup.sh before classification: per
+# (app, check name) only runs from that check's newest check suite are counted, so a
+# superseded failure from an earlier re-trigger on the same commit stops blocking the
+# moment a newer run of that check lands (issue #675). This matches what GitHub's own
+# merge box shows. Matrix legs sharing a name inside the newest suite are all kept.
+#
 # Used by .claude/scripts/merge-gate.sh (internally) and can be called standalone
 # from any skill/agent that needs a CI-only health check without running the full
 # merge gate.
@@ -52,7 +58,7 @@
 #   2 — usage error
 #   3 — blocking failures present (failing>0)               [caller: FIX]
 #   4 — SHA or PR not found
-#   5 — gh / network / jq error
+#   5 — gh / network / jq error, or check-runs-dedup.sh missing / unusable
 #
 # Exit-code priority when both failing and in_progress are present: 3 (fix) wins over
 # 1 (wait) — a broken check is actionable immediately while the in-progress ones might
@@ -210,8 +216,19 @@ else
   fi
 fi
 
-# gh --paginate concatenates per-page objects; flatten to a single check_runs array.
-RUNS_JSON=$(echo "$CHECK_RUNS_RAW" | jq -s '[.[].check_runs[]?]' 2>/dev/null || true)
+# Flatten the per-page objects `gh --paginate` concatenates AND collapse the result
+# to one verdict per check (newest check suite wins) — both done by
+# check-runs-dedup.sh, so every consumer of check-runs classifies the same set.
+# Without the dedup, a superseded failed run from an earlier re-trigger of the same
+# check counts as currently blocking, and this script reports a commit as failing
+# that GitHub's own merge box shows as green (issue #675). Applies to both input
+# paths: the stdin caller hands us its raw fetch, same as the live fetch above.
+CHECK_RUNS_DEDUP="$(dirname "$0")/check-runs-dedup.sh"
+if [[ ! -x "$CHECK_RUNS_DEDUP" ]]; then
+  echo "ERROR: check-runs-dedup.sh not found or not executable at $CHECK_RUNS_DEDUP" >&2
+  exit 5
+fi
+RUNS_JSON=$(printf '%s\n' "$CHECK_RUNS_RAW" | "$CHECK_RUNS_DEDUP" 2>/dev/null || true)
 if [[ -z "$RUNS_JSON" ]]; then
   echo "ERROR: could not parse check-runs JSON" >&2
   exit 5

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -212,12 +212,34 @@ die_api() {
   exit 4
 }
 
+# Same fail-closed shape as die_api, for failures that are ours rather than
+# GitHub's — blaming "gh api failed" for a missing local helper sends whoever
+# reads `missing` after the wrong problem.
+die_local() {
+  emit_json false "${REVIEWER_OVERRIDE:-unknown}" "unknown" "[\"$1\"]" "$HEAD_SHA" "$(emit_empty_ci)" "$MERGE_STATE" "$MERGEABLE" "$REVIEW_DECISION" "$(emit_empty_code_owner_bots)" '[]' 0
+  exit 4
+}
+
 if ! CHECK_RUNS_RAW=$(gh api --paginate "repos/$OWNER/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" 2>/dev/null); then
   die_api "check-runs"
 fi
-# `gh --paginate` concatenates per-page objects; flatten to a single
-# {check_runs: [...]} object so downstream `.check_runs[]` jq queries work.
-CHECK_RUNS_JSON=$(echo "$CHECK_RUNS_RAW" | jq -s '{check_runs: [.[].check_runs[]?]}' 2>/dev/null || true)
+# `gh --paginate` concatenates per-page objects; flatten AND dedup (newest check
+# suite wins per (app, check name) — see check-runs-dedup.sh), then re-wrap as a
+# single {check_runs: [...]} object so downstream `.check_runs[]` jq queries work.
+#
+# The CI pass/fail verdict is NOT classified here — that stays delegated to
+# ci-status.sh below, which dedups its own input too (the transform is idempotent,
+# so feeding it an already-deduped list changes nothing). Deduping at the fetch is
+# for this script's OTHER reader of the raw list: the CodeAnt supplemental gate
+# further down scans for a *successful* CodeAnt check-run. Given a stale success
+# and a newer failure of the same check on one SHA, the undeduped list would hand
+# it the superseded success and pass the gate — the same bug as issue #675, but
+# failing toward merge instead of away from it.
+CHECK_RUNS_DEDUP="$(dirname "$0")/check-runs-dedup.sh"
+if [[ ! -x "$CHECK_RUNS_DEDUP" ]]; then
+  die_local "check-runs-dedup.sh not found or not executable at $CHECK_RUNS_DEDUP"
+fi
+CHECK_RUNS_JSON=$(printf '%s\n' "$CHECK_RUNS_RAW" | "$CHECK_RUNS_DEDUP" 2>/dev/null | jq -c '{check_runs: .}' 2>/dev/null || true)
 if [[ -z "$CHECK_RUNS_JSON" ]] || ! echo "$CHECK_RUNS_JSON" | jq -e . >/dev/null 2>&1; then
   die_api "check-runs parse"
 fi

--- a/.claude/scripts/pr-preflight.sh
+++ b/.claude/scripts/pr-preflight.sh
@@ -402,9 +402,18 @@ fi
 # Check-runs on the HEAD commit. Keyed by commit, so a matching app slug is a
 # strong HEAD-freshness signal (verified: Cursor posts `Cursor Bugbot` under
 # slug `cursor`). Non-fatal: one signal among several.
+# Fetches whole run objects and reads the slug off the deduped set, so this script
+# sees the same check-runs view as ci-status.sh and pr-state.sh (issue #675). The
+# slug SET is provably unchanged by that dedup — grouping is per (app, check name)
+# and every group keeps at least one run, so no app can lose its only run. It is
+# applied anyway to keep one shared view across all three consumers, and to stay
+# correct if this extraction ever widens past `app.slug` to a field a superseded
+# run could distort.
 if [[ -n "$HEAD_SHA" ]]; then
   gh api --paginate "repos/{owner}/{repo}/commits/$HEAD_SHA/check-runs?per_page=100" \
-    --jq '.check_runs[]? | (.app.slug // empty)' >>"$SLUGS_TMP" 2>/dev/null || true
+    --jq '.check_runs[]?' 2>/dev/null \
+    | "$(cd "$(dirname "$0")" && pwd)/check-runs-dedup.sh" 2>/dev/null \
+    | jq -r '.[] | (.app.slug // empty)' >>"$SLUGS_TMP" 2>/dev/null || true
 fi
 
 # ISO-8601 UTC (`...Z`) timestamps from the GitHub API sort lexicographically,

--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -347,8 +347,13 @@ UNRESOLVED=$(echo "$ALL_THREADS" | jq '[.[] | select(.isResolved == false)]')
 # check suite's runs are kept, so a superseded failure from an earlier re-trigger on
 # this SHA is not reported as currently failing. `--jq` runs once per page, so the
 # fetch emits a stream of bare run objects — one of the shapes the helper accepts.
+CHECK_RUNS_DEDUP="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-runs-dedup.sh"
+if [[ ! -x "$CHECK_RUNS_DEDUP" ]]; then
+  echo "ERROR: check-runs-dedup.sh not found or not executable at $CHECK_RUNS_DEDUP" >&2
+  exit 5
+fi
 CHECK_RUNS=$(run_gh api --paginate "repos/$OWNER/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
-  --jq '.check_runs[]' | "$(cd "$(dirname "$0")" && pwd)/check-runs-dedup.sh")
+  --jq '.check_runs[]' | "$CHECK_RUNS_DEDUP")
 
 CR_SPLIT=$(echo "$CHECK_RUNS" | jq '
   def is_blocking: . == "failure" or . == "timed_out" or . == "action_required" or . == "startup_failure" or . == "stale";

--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -343,8 +343,12 @@ UNRESOLVED=$(echo "$ALL_THREADS" | jq '[.[] | select(.isResolved == false)]')
 # ----------------------------------------------------------------------
 # 3. CI check-runs (paginated)
 # ----------------------------------------------------------------------
+# Deduped before classification (issue #675): per (app, check name) only the newest
+# check suite's runs are kept, so a superseded failure from an earlier re-trigger on
+# this SHA is not reported as currently failing. `--jq` runs once per page, so the
+# fetch emits a stream of bare run objects — one of the shapes the helper accepts.
 CHECK_RUNS=$(run_gh api --paginate "repos/$OWNER/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
-  --jq '.check_runs[]' | jq -s '.')
+  --jq '.check_runs[]' | "$(cd "$(dirname "$0")" && pwd)/check-runs-dedup.sh")
 
 CR_SPLIT=$(echo "$CHECK_RUNS" | jq '
   def is_blocking: . == "failure" or . == "timed_out" or . == "action_required" or . == "startup_failure" or . == "stale";

--- a/.claude/scripts/tests/check-runs-dedup.test.sh
+++ b/.claude/scripts/tests/check-runs-dedup.test.sh
@@ -168,6 +168,12 @@ check_eq "" "$OUT" "unparseable stdin writes no partial output"
 run '["oops"]'
 check_eq 5 "$RC" "a non-object entry exits 5 rather than being silently discarded"
 
+# A top-level scalar is malformed input, not an empty check-run list — it must
+# exit 5, never read as a legitimate zero-check result.
+run '"malformed"'
+check_eq 5 "$RC" "a top-level scalar exits 5 rather than reading as zero checks"
+check_eq "" "$OUT" "a top-level scalar writes no partial output"
+
 "$SUT" bogus </dev/null >/dev/null 2>&1
 check_eq 2 "$?" "an unexpected positional argument exits 2"
 

--- a/.claude/scripts/tests/check-runs-dedup.test.sh
+++ b/.claude/scripts/tests/check-runs-dedup.test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# check-runs-dedup.test.sh — Offline unit tests for check-runs-dedup.sh (issue #675).
+#
+# The helper is pure stdin -> stdout, so these need no gh stub and no network.
+# Run from repo root: bash .claude/scripts/tests/check-runs-dedup.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SUT="$REPO_ROOT/.claude/scripts/check-runs-dedup.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# The helper appends to $HOME/.claude/script-usage.log; point it at the sandbox.
+export HOME="$TMP/home"; mkdir -p "$HOME/.claude"
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+OUT=""
+RC=0
+run() { OUT=$(printf '%s' "$1" | "$SUT" 2>/dev/null); RC=$?; }
+
+check_eq() { # expected actual label
+  if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected: $1, got: $2)"; fi
+}
+
+# Sorted, comma-joined `id` list of the retained runs — order-independent so the
+# assertions don't depend on jq's group_by ordering.
+ids() { echo "$OUT" | jq -r '[.[].id] | sort | map(tostring) | join(",")'; }
+
+# A check-run with the fields the dedup keys on. Extra fields are added per-case.
+run_json() { # id name conclusion suite_id app_slug app_id [status]
+  jq -cn --argjson id "$1" --arg name "$2" --arg concl "$3" --argjson suite "$4" \
+         --arg slug "$5" --argjson appid "$6" --arg status "${7:-completed}" \
+    '{id:$id, name:$name, status:$status,
+      conclusion:(if $concl == "null" then null else $concl end),
+      check_suite:{id:$suite}, app:{slug:$slug, id:$appid}}'
+}
+
+# --------------------------------------------------------------------------
+# 1. Input shapes — every form the callers actually produce.
+# --------------------------------------------------------------------------
+A=$(run_json 1 test failure 100 gha 1)
+B=$(run_json 2 test success 200 gha 1)
+
+run ""
+check_eq "[]" "$OUT" "empty stdin yields an empty array"
+check_eq 0 "$RC" "empty stdin exits 0 (feeds the total==0 sentinel, not an error)"
+
+run "[]"
+check_eq "[]" "$OUT" "empty array yields an empty array"
+
+run '{"check_runs":[]}'
+check_eq "[]" "$OUT" "empty check_runs object yields an empty array"
+
+run "[$A,$B]"
+check_eq "2" "$(ids)" "bare array input (pr-state.sh shape)"
+
+run "{\"check_runs\":[$A,$B]}"
+check_eq "2" "$(ids)" "single {check_runs:[...]} object (merge-gate.sh shape)"
+
+run "{\"check_runs\":[$A]}{\"check_runs\":[$B]}"
+check_eq "2" "$(ids)" "concatenated per-page objects (gh --paginate shape)"
+
+run "$A
+$B"
+check_eq "2" "$(ids)" "stream of bare run objects (gh --paginate --jq '.check_runs[]?' shape)"
+
+# --------------------------------------------------------------------------
+# 2. The core bug: a superseded failure must not survive.
+# --------------------------------------------------------------------------
+run "{\"check_runs\":[$(run_json 1 test failure 100 gha 1),$(run_json 2 test failure 200 gha 1),$(run_json 3 test success 300 gha 1)]}"
+check_eq "3" "$(ids)" "3 runs of one name across 3 suites -> only the newest suite's run survives"
+
+run "{\"check_runs\":[$(run_json 3 test success 300 gha 1),$(run_json 1 test failure 100 gha 1)]}"
+check_eq "3" "$(ids)" "newest suite wins regardless of input order"
+
+# --------------------------------------------------------------------------
+# 3. Matrix legs — newest-SUITE-per-name, not latest-single-RUN-per-name.
+# --------------------------------------------------------------------------
+run "{\"check_runs\":[$(run_json 1 test failure 100 gha 1),$(run_json 2 test success 200 gha 1),$(run_json 3 test failure 200 gha 1)]}"
+check_eq "2,3" "$(ids)" "all legs sharing a name in the newest suite are retained"
+
+run "{\"check_runs\":[$(run_json 1 test success 200 gha 1),$(run_json 2 test success 200 gha 1),$(run_json 3 test failure 200 gha 1)]}"
+check_eq "1,2,3" "$(ids)" "a failing leg is never masked by passing siblings in the same suite"
+
+# --------------------------------------------------------------------------
+# 4. Group key — app identity and name both participate.
+# --------------------------------------------------------------------------
+run "{\"check_runs\":[$(run_json 1 lint failure 100 appA 11),$(run_json 2 lint success 200 appB 22)]}"
+check_eq "1,2" "$(ids)" "same name from two different apps never collapses"
+
+run "{\"check_runs\":[$(run_json 1 lint failure 100 gha 1),$(run_json 2 test success 200 gha 1)]}"
+check_eq "1,2" "$(ids)" "different names in the same app never collapse"
+
+# A concatenated string key would fuse ("a-b" + "c") with ("a" + "b-c"); the
+# array key cannot. Both runs must survive as distinct groups.
+run "{\"check_runs\":[$(run_json 1 c failure 100 a-b 1),$(run_json 2 b-c success 200 a 2)]}"
+check_eq "1,2" "$(ids)" "slug/name boundary is unambiguous (no string-concat key collision)"
+
+# --------------------------------------------------------------------------
+# 5. Unknown ordering data fails toward blocking, never toward silence.
+# --------------------------------------------------------------------------
+NO_SUITE='{"id":9,"name":"test","status":"completed","conclusion":"failure","app":{"slug":"gha","id":1}}'
+run "{\"check_runs\":[$NO_SUITE,$(run_json 2 test success 200 gha 1)]}"
+check_eq "2,9" "$(ids)" "a run with no check_suite.id is retained beside the newest suite"
+
+run "{\"check_runs\":[$NO_SUITE]}"
+check_eq "9" "$(ids)" "a group with only null suite ids retains everything"
+
+NULL_SUITE='{"id":8,"name":"test","status":"completed","conclusion":"failure","check_suite":{"id":null},"app":{"slug":"gha","id":1}}'
+run "{\"check_runs\":[$NULL_SUITE,$(run_json 2 test success 200 gha 1)]}"
+check_eq "2,8" "$(ids)" "an explicit null check_suite.id is retained too"
+
+APP_NULL='{"id":7,"name":"test","status":"completed","conclusion":"failure","check_suite":{"id":100},"app":null}'
+run "{\"check_runs\":[$APP_NULL,$(run_json 2 test success 200 gha 1)]}"
+check_eq "2,7" "$(ids)" "a null app is its own group rather than being folded into a named app"
+
+# --------------------------------------------------------------------------
+# 6. Ordering key is check_suite.id, not completed_at.
+#    An in-progress run has completed_at: null — time-ordering would let the
+#    older FAILED run win and report a failure where the answer is "not done".
+# --------------------------------------------------------------------------
+OLD_FAILED='{"id":1,"name":"test","status":"completed","conclusion":"failure","completed_at":"2026-07-21T10:00:00Z","check_suite":{"id":100},"app":{"slug":"gha","id":1}}'
+NEW_RUNNING='{"id":2,"name":"test","status":"in_progress","conclusion":null,"completed_at":null,"check_suite":{"id":200},"app":{"slug":"gha","id":1}}'
+run "{\"check_runs\":[$OLD_FAILED,$NEW_RUNNING]}"
+check_eq "2" "$(ids)" "an in-progress newest run outranks an older failed run (completed_at is null)"
+
+# Same-second re-runs tie on timestamps but not on suite id.
+TIE_A='{"id":1,"name":"test","status":"completed","conclusion":"failure","completed_at":"2026-07-21T10:00:00Z","check_suite":{"id":100},"app":{"slug":"gha","id":1}}'
+TIE_B='{"id":2,"name":"test","status":"completed","conclusion":"success","completed_at":"2026-07-21T10:00:00Z","check_suite":{"id":200},"app":{"slug":"gha","id":1}}'
+run "{\"check_runs\":[$TIE_A,$TIE_B]}"
+check_eq "2" "$(ids)" "same-second re-runs are ordered by suite id, not by timestamp"
+
+# --------------------------------------------------------------------------
+# 7. Retained objects are passed through untouched.
+# --------------------------------------------------------------------------
+RICH='{"id":5,"name":"test","status":"completed","conclusion":"failure","check_suite":{"id":300},
+       "app":{"slug":"gha","id":1},"output":{"title":"2 failed"},
+       "details_url":"https://example.test/d","html_url":"https://example.test/h","started_at":"2026-07-21T09:00:00Z"}'
+run "{\"check_runs\":[$RICH]}"
+check_eq "2 failed" "$(echo "$OUT" | jq -r '.[0].output.title')" "output.title survives"
+check_eq "https://example.test/d" "$(echo "$OUT" | jq -r '.[0].details_url')" "details_url survives"
+check_eq "https://example.test/h" "$(echo "$OUT" | jq -r '.[0].html_url')" "html_url survives"
+check_eq "true" "$(echo "$OUT" | jq --argjson r "$RICH" -e '.[0] == $r' >/dev/null && echo true || echo false)" \
+  "the retained run object is byte-identical to the input run"
+
+# --------------------------------------------------------------------------
+# 8. Idempotency — merge-gate.sh dedups, then ci-status.sh dedups its output again.
+# --------------------------------------------------------------------------
+ONCE=$(printf '%s' "{\"check_runs\":[$(run_json 1 test failure 100 gha 1),$(run_json 2 test success 200 gha 1),$(run_json 3 test failure 200 gha 1)]}" | "$SUT" 2>/dev/null)
+TWICE=$(printf '%s' "$ONCE" | "$SUT" 2>/dev/null)
+check_eq "$ONCE" "$TWICE" "running the dedup on its own output changes nothing"
+
+# --------------------------------------------------------------------------
+# 9. Error and usage contracts.
+# --------------------------------------------------------------------------
+run "not json"
+check_eq 5 "$RC" "unparseable stdin exits 5"
+check_eq "" "$OUT" "unparseable stdin writes no partial output"
+
+# A scalar where a run object belongs must fail loudly, not be silently dropped —
+# dropping an unclassifiable entry could hide a failing run.
+run '["oops"]'
+check_eq 5 "$RC" "a non-object entry exits 5 rather than being silently discarded"
+
+"$SUT" bogus </dev/null >/dev/null 2>&1
+check_eq 2 "$?" "an unexpected positional argument exits 2"
+
+HELP_OUT=$("$SUT" --help 2>/dev/null); HELP_RC=$?
+check_eq 0 "$HELP_RC" "--help exits 0"
+if echo "$HELP_OUT" | grep -q "check-runs-dedup.sh"; then
+  ok "--help prints the usage block"
+else
+  bad "--help prints the usage block (got: $HELP_OUT)"
+fi
+
+echo "----------------------------------------"
+echo "check-runs-dedup.test.sh: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/.claude/scripts/tests/ci-status.test.sh
+++ b/.claude/scripts/tests/ci-status.test.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# ci-status.test.sh — Offline unit tests for ci-status.sh check-run dedup (issue #675).
+#
+# Most cases drive the `--check-runs-stdin` path with a full 40-char SHA, which
+# makes zero gh calls — no stub, no network. A separate section stubs `gh` to prove
+# the live-fetch path dedups identically, since the acceptance criteria cover both.
+#
+# Run from repo root: bash .claude/scripts/tests/ci-status.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Run the real script in place: it resolves check-runs-dedup.sh next to itself.
+SUT="$REPO_ROOT/.claude/scripts/ci-status.sh"
+SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+export HOME="$TMP/home"; mkdir -p "$HOME/.claude"
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+check_eq() { # expected actual label
+  if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected: $1, got: $2)"; fi
+}
+
+OUT=""
+RC=0
+run_stdin() { OUT=$(printf '%s' "$1" | "$SUT" "$SHA" --format json --check-runs-stdin 2>/dev/null); RC=$?; }
+
+field() { echo "$OUT" | jq -r "$1"; }
+
+cr() { # id name conclusion suite_id [app_slug] [status]
+  jq -cn --argjson id "$1" --arg name "$2" --arg concl "$3" --argjson suite "$4" \
+         --arg slug "${5:-gha}" --arg status "${6:-completed}" \
+    '{id:$id, name:$name, status:$status,
+      conclusion:(if $concl == "null" then null else $concl end),
+      check_suite:{id:$suite}, app:{slug:$slug, id:1}}'
+}
+bundle() { printf '{"check_runs":[%s]}' "$(IFS=,; echo "$*")"; }
+
+# --------------------------------------------------------------------------
+# 1. Superseded failure — the reported bug. Old failed run + newer passing run
+#    of the same check on one SHA must read as clean.
+# --------------------------------------------------------------------------
+run_stdin "$(bundle "$(cr 1 test failure 100)" "$(cr 2 test failure 200)" "$(cr 3 test success 300)")"
+check_eq 0 "$RC" "superseded failure: exit 0 (clean), not 3"
+check_eq 0 "$(field .failing)" "superseded failure: failing == 0"
+check_eq 1 "$(field .total)" "superseded failure: only the newest suite's run is counted"
+check_eq 1 "$(field .passing)" "superseded failure: the newest run is the passing one"
+check_eq "[]" "$(echo "$OUT" | jq -c '.blocking')" "superseded failure: nothing in blocking"
+
+# Summary format must agree with the JSON.
+SUMMARY=$(printf '%s' "$(bundle "$(cr 1 test failure 100)" "$(cr 3 test success 300)")" \
+  | "$SUT" "$SHA" --format summary --check-runs-stdin 2>/dev/null)
+check_eq "CI: 1/1 passed" "$SUMMARY" "superseded failure: summary line is clean"
+
+# --------------------------------------------------------------------------
+# 2. Matrix legs sharing a name inside the newest suite are all classified;
+#    a failing leg must not be masked by a passing sibling.
+# --------------------------------------------------------------------------
+run_stdin "$(bundle "$(cr 1 test failure 100)" "$(cr 2 test success 200)" "$(cr 3 test failure 200)")"
+check_eq 3 "$RC" "matrix legs: failing leg still exits 3"
+check_eq 1 "$(field .failing)" "matrix legs: the failing leg is counted"
+check_eq 2 "$(field .total)" "matrix legs: both legs of the newest suite are counted"
+check_eq 3 "$(field '.blocking[0].id')" "matrix legs: the failing leg appears in blocking"
+
+# --------------------------------------------------------------------------
+# 3. Newest run in progress while an older run of that name failed -> WAIT.
+# --------------------------------------------------------------------------
+run_stdin "$(bundle "$(cr 1 test failure 100)" "$(cr 2 test null 200 gha in_progress)")"
+check_eq 1 "$RC" "newest run in progress: exit 1 (WAIT), not 3"
+check_eq 0 "$(field .failing)" "newest run in progress: superseded failure is not counted"
+check_eq 1 "$(field .in_progress)" "newest run in progress: counted as in progress"
+check_eq "test" "$(field '.in_progress_runs[0].name')" "newest run in progress: named in in_progress_runs"
+
+# `queued` is the other non-completed status.
+run_stdin "$(bundle "$(cr 1 test failure 100)" "$(cr 2 test null 200 gha queued)")"
+check_eq 1 "$RC" "newest run queued: exit 1 (WAIT), not 3"
+
+# --------------------------------------------------------------------------
+# 4. Regression guard — the ordinary single-run-per-name case is unchanged.
+# --------------------------------------------------------------------------
+run_stdin "$(bundle "$(cr 1 lint success 100)" "$(cr 2 test failure 100)")"
+check_eq 3 "$RC" "distinct names, one failing: exit 3 unchanged"
+check_eq 1 "$(field .failing)" "distinct names: the failing check is still counted"
+check_eq 2 "$(field .total)" "distinct names: nothing is collapsed away"
+
+run_stdin "$(bundle "$(cr 1 lint success 100)" "$(cr 2 test success 100)")"
+check_eq 0 "$RC" "distinct names, all passing: exit 0 unchanged"
+
+# A genuinely failing newest run still blocks even with an older passing run.
+run_stdin "$(bundle "$(cr 1 test success 100)" "$(cr 2 test failure 200)")"
+check_eq 3 "$RC" "newest run failing (older passed): exit 3 — dedup does not hide live failures"
+
+# Every blocking conclusion in the documented set survives dedup.
+for concl in failure timed_out action_required startup_failure stale; do
+  run_stdin "$(bundle "$(cr 1 test success 100)" "$(cr 2 test "$concl" 200)")"
+  check_eq 3 "$RC" "blocking conclusion '$concl' on the newest run still exits 3"
+done
+
+# Non-blocking conclusions stay non-blocking.
+for concl in success neutral skipped cancelled; do
+  run_stdin "$(bundle "$(cr 1 test failure 100)" "$(cr 2 test "$concl" 200)")"
+  check_eq 0 "$RC" "non-blocking conclusion '$concl' on the newest run exits 0"
+done
+
+# --------------------------------------------------------------------------
+# 5. Same name from two different apps must not collapse into each other.
+# --------------------------------------------------------------------------
+run_stdin "$(bundle "$(cr 1 lint failure 100 appA)" "$(cr 2 lint success 200 appB)")"
+check_eq 3 "$RC" "same name, two apps: appA's failure is not masked by appB's success"
+check_eq 2 "$(field .total)" "same name, two apps: both are counted"
+
+# --------------------------------------------------------------------------
+# 6. Zero-check-runs sentinel is untouched by dedup.
+# --------------------------------------------------------------------------
+run_stdin '{"check_runs":[]}'
+check_eq 1 "$RC" "empty check-run list: exit 1 (sentinel), not 0"
+check_eq 0 "$(field .total)" "empty check-run list: total 0"
+check_eq 1 "$(field .in_progress)" "empty check-run list: sentinel counted as in progress"
+check_eq "(no check-runs reported yet)" "$(field '.in_progress_runs[0].name')" "empty check-run list: sentinel entry preserved"
+check_eq "null" "$(field '.in_progress_runs[0].id')" "empty check-run list: sentinel id is null"
+
+# --------------------------------------------------------------------------
+# 7. Error contracts on the stdin path are unchanged.
+# --------------------------------------------------------------------------
+printf '' | "$SUT" "$SHA" --format json --check-runs-stdin >/dev/null 2>&1
+check_eq 2 "$?" "empty stdin with --check-runs-stdin exits 2"
+
+run_stdin 'not json'
+check_eq 5 "$RC" "unparseable stdin exits 5"
+
+# --------------------------------------------------------------------------
+# 8. Live-fetch path — same dedup, proven with a gh stub.
+# --------------------------------------------------------------------------
+BIN="$TMP/bin"; mkdir -p "$BIN"
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  "repo view --json nameWithOwner --jq .nameWithOwner")
+    echo "solo/repo"; exit 0 ;;
+  *check-runs*)
+    printf '%s' "$FAKE_CHECK_RUNS"; exit 0 ;;
+esac
+echo "unexpected gh call: $ARGS" >&2
+exit 1
+EOF
+chmod +x "$BIN/gh"
+
+run_live() { OUT=$(PATH="$BIN:$PATH" FAKE_CHECK_RUNS="$1" "$SUT" "$SHA" --format json 2>/dev/null); RC=$?; }
+
+run_live "$(bundle "$(cr 1 test failure 100)" "$(cr 2 test failure 200)" "$(cr 3 test success 300)")"
+check_eq 0 "$RC" "live fetch: superseded failure exits 0"
+check_eq 0 "$(field .failing)" "live fetch: failing == 0"
+check_eq 1 "$(field .total)" "live fetch: only the newest suite's run is counted"
+
+run_live "$(bundle "$(cr 1 test success 100)" "$(cr 2 test failure 200)")"
+check_eq 3 "$RC" "live fetch: a failing newest run still exits 3"
+
+# Paginated responses are flattened and deduped across pages.
+run_live "$(bundle "$(cr 1 test failure 100)")$(bundle "$(cr 2 test success 200)")"
+check_eq 0 "$RC" "live fetch: dedup spans pages of a --paginate response"
+check_eq 1 "$(field .total)" "live fetch: cross-page duplicate collapsed to the newest suite"
+
+echo "----------------------------------------"
+echo "ci-status.test.sh: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/.claude/scripts/tests/escalate-review.test.sh
+++ b/.claude/scripts/tests/escalate-review.test.sh
@@ -262,6 +262,27 @@ check_eq "exit 0" 0 "$RC"
 check_eq "STATUS=trigger_greptile" "STATUS=trigger_greptile" "$OUT"
 
 echo
+echo "== Scenario K: check-run data still comes only from pr-state.sh's bundle (#675) =="
+# escalate-review.sh reads check-runs via pr-state.sh's `check_runs.all`, which is
+# deduped at the source (newest check suite per (app, name)). That inheritance is
+# the whole reason this script needs no dedup of its own — so guard it: a direct
+# `commits/<sha>/check-runs` fetch added here later would silently reintroduce the
+# superseded-run bug, and no behavioral test would catch it.
+ESCALATE_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../escalate-review.sh"
+if grep -qE 'commits/[^"]*/check-runs' "$ESCALATE_SRC"; then
+  check_eq "no direct check-runs fetch in escalate-review.sh" "absent" "present"
+else
+  check_eq "no direct check-runs fetch in escalate-review.sh" "absent" "absent"
+fi
+# ...and it does still read the bundle, so the guard above cannot pass by the
+# script having dropped check-runs entirely.
+if grep -q 'check_runs\.all' "$ESCALATE_SRC"; then
+  check_eq "escalate-review.sh reads check_runs.all from the bundle" "present" "present"
+else
+  check_eq "escalate-review.sh reads check_runs.all from the bundle" "present" "absent"
+fi
+
+echo
 echo "== summary: $PASS passed, $FAIL failed =="
 [[ "$FAIL" -eq 0 ]] || exit 1
 echo "OK: escalate-review.sh tests passed"

--- a/.claude/scripts/tests/merge-gate-ci-dedup.test.sh
+++ b/.claude/scripts/tests/merge-gate-ci-dedup.test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# merge-gate-ci-dedup.test.sh — Offline integration tests proving merge-gate.sh
+# stops blocking on superseded check-runs (issue #675).
+#
+# merge-gate.sh does not classify CI itself; it delegates to ci-status.sh via
+# --check-runs-stdin. These tests assert the deduped verdict actually reaches the
+# gate's emitted JSON and its `missing` list — and, via the negative controls, that
+# a genuinely failing check still blocks.
+#
+# Also covers the gate's OTHER reader of the raw check-run list: the CodeAnt
+# supplemental gate, which scans for a *successful* CodeAnt check-run. Undeduped,
+# a stale success would satisfy it while a newer CodeAnt failure sat right beside
+# it — a false clean in the merge-permitting direction.
+#
+# Only `gh` is stubbed; merge-gate.sh, ci-status.sh and check-runs-dedup.sh are the
+# real scripts, run in place so they resolve each other as siblings.
+#
+# Run from repo root: bash .claude/scripts/tests/merge-gate-ci-dedup.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SUT="$REPO_ROOT/.claude/scripts/merge-gate.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# Sandbox HOME: no session-state.json, so reviewer resolution stays deterministic.
+export HOME="$TMP/home"; mkdir -p "$HOME/.claude"
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+check_eq() { # expected actual label
+  if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected: $1, got: $2)"; fi
+}
+
+HEAD_SHA="deadbeefcafedeadbeefcafedeadbeefcafedead"
+
+# --- Fake gh: only the endpoints merge-gate.sh actually calls. ---------------
+BIN="$TMP/bin"; mkdir -p "$BIN"
+cat > "$BIN/gh" <<EOF
+#!/usr/bin/env bash
+ARGS="\$*"
+case "\$ARGS" in
+  "repo view --json nameWithOwner --jq .nameWithOwner")
+    echo "solo/repo"; exit 0 ;;
+  *"pr view "*headRefOid*)
+    jq -cn '{number:1, state:"OPEN", headRefOid:"$HEAD_SHA", baseRefName:"main",
+             mergeStateStatus:"CLEAN", mergeable:"MERGEABLE", reviewDecision:"APPROVED"}'
+    exit 0 ;;
+  *check-runs*)
+    printf '%s' "\$FAKE_CHECK_RUNS"; exit 0 ;;
+  *pulls/*/reviews*)
+    printf '%s' "\${FAKE_REVIEWS:-[]}"; exit 0 ;;
+  *pulls/*/comments*)
+    printf '%s' "\${FAKE_PR_COMMENTS:-[]}"; exit 0 ;;
+  *issues/*/comments*)
+    printf '%s' "\${FAKE_ISSUE_COMMENTS:-[]}"; exit 0 ;;
+  *graphql*)
+    jq -cn '{data:{repository:{pullRequest:{reviewThreads:{nodes:[]}}}}}'; exit 0 ;;
+  *contents/*)
+    # No CODEOWNERS file — merge-gate.sh tolerates the 404.
+    echo "Not Found" >&2; exit 1 ;;
+esac
+echo "unexpected gh call: \$ARGS" >&2
+exit 1
+EOF
+chmod +x "$BIN/gh"
+
+OUT=""
+RC=0
+run_gate() { # $1 = check-runs JSON
+  OUT=$(PATH="$BIN:$PATH" FAKE_CHECK_RUNS="$1" \
+        FAKE_REVIEWS="${FAKE_REVIEWS:-[]}" \
+        "$SUT" 1 --reviewer cr 2>/dev/null)
+  RC=$?
+}
+
+# Is there a "CI has N failing check-run(s)" entry in `missing`?
+has_ci_failing_entry() { echo "$OUT" | jq -e '[.missing[]? | select(startswith("CI has") and contains("failing"))] | length > 0' >/dev/null && echo yes || echo no; }
+has_ci_incomplete_entry() { echo "$OUT" | jq -e '[.missing[]? | select(startswith("CI has") and contains("incomplete"))] | length > 0' >/dev/null && echo yes || echo no; }
+has_codeant_no_clean_entry() { echo "$OUT" | jq -e '[.missing[]? | select(contains("no successful CodeAnt check-run"))] | length > 0' >/dev/null && echo yes || echo no; }
+
+# `completed_at` matters here in a way it does not for ci-status.sh: the CodeAnt
+# supplemental gate reads it to find CodeAnt's latest clean signal, and a run
+# without one reads as "no successful check". Ids ascend with suite recency in
+# these fixtures, so deriving the timestamp from the id keeps them ordered.
+cr() { # id name conclusion suite_id [app_slug] [status]
+  jq -cn --argjson id "$1" --arg name "$2" --arg concl "$3" --argjson suite "$4" \
+         --arg slug "${5:-gha}" --arg status "${6:-completed}" \
+    '{id:$id, name:$name, status:$status,
+      conclusion:(if $concl == "null" then null else $concl end),
+      completed_at:(if $status == "completed" then "2026-07-21T10:00:0\($id)Z" else null end),
+      check_suite:{id:$suite}, app:{slug:$slug, id:1}}'
+}
+bundle() { printf '{"check_runs":[%s]}' "$(IFS=,; echo "$*")"; }
+
+# --------------------------------------------------------------------------
+# 1. The reported bug: superseded failure must not block the gate.
+# --------------------------------------------------------------------------
+run_gate "$(bundle "$(cr 1 test failure 100)" "$(cr 2 test success 200)")"
+check_eq 0 "$(echo "$OUT" | jq -r '.ci_status.failing')" "superseded failure: ci_status.failing == 0"
+check_eq 1 "$(echo "$OUT" | jq -r '.ci_status.total')" "superseded failure: only the newest suite's run counted"
+check_eq "no" "$(has_ci_failing_entry)" "superseded failure: no 'CI has N failing check-run(s)' entry in missing"
+
+# --------------------------------------------------------------------------
+# 2. Negative control — a genuinely failing newest run must still block.
+#    Without this, test 1 could pass simply because the gate never emits the entry.
+# --------------------------------------------------------------------------
+run_gate "$(bundle "$(cr 1 test success 100)" "$(cr 2 test failure 200)")"
+check_eq 1 "$(echo "$OUT" | jq -r '.ci_status.failing')" "live failure: ci_status.failing == 1"
+check_eq "yes" "$(has_ci_failing_entry)" "live failure: 'CI has N failing check-run(s)' entry present"
+check_eq "false" "$(echo "$OUT" | jq -r '.met')" "live failure: gate not met"
+
+# --------------------------------------------------------------------------
+# 3. Newest run of a check still running, older run failed -> incomplete, not failing.
+# --------------------------------------------------------------------------
+run_gate "$(bundle "$(cr 1 test failure 100)" "$(cr 2 test null 200 gha in_progress)")"
+check_eq 0 "$(echo "$OUT" | jq -r '.ci_status.failing')" "newest in progress: failing == 0"
+check_eq "no" "$(has_ci_failing_entry)" "newest in progress: no failing entry"
+check_eq "yes" "$(has_ci_incomplete_entry)" "newest in progress: reported as incomplete instead"
+
+# --------------------------------------------------------------------------
+# 4. Matrix legs — a failing leg in the newest suite still blocks.
+# --------------------------------------------------------------------------
+run_gate "$(bundle "$(cr 1 test failure 100)" "$(cr 2 test success 200)" "$(cr 3 test failure 200)")"
+check_eq 1 "$(echo "$OUT" | jq -r '.ci_status.failing')" "matrix legs: failing leg still counted"
+check_eq "yes" "$(has_ci_failing_entry)" "matrix legs: failing entry present (not masked by its sibling)"
+
+# --------------------------------------------------------------------------
+# 5. CodeAnt supplemental gate reads the same deduped view.
+#    Stale CodeAnt success + newer CodeAnt failure on one SHA: the superseded
+#    success must NOT count as CodeAnt's clean signal.
+# --------------------------------------------------------------------------
+run_gate "$(bundle "$(cr 1 "CodeAnt AI" success 100 codeant-ai)" "$(cr 2 "CodeAnt AI" failure 200 codeant-ai)")"
+check_eq "yes" "$(has_codeant_no_clean_entry)" \
+  "CodeAnt: a superseded successful check-run no longer satisfies the CodeAnt gate"
+
+# Negative control — when the newest CodeAnt run IS successful, the gate is satisfied.
+run_gate "$(bundle "$(cr 1 "CodeAnt AI" failure 100 codeant-ai)" "$(cr 2 "CodeAnt AI" success 200 codeant-ai)")"
+check_eq "no" "$(has_codeant_no_clean_entry)" \
+  "CodeAnt: a current successful check-run still satisfies the CodeAnt gate"
+check_eq 0 "$(echo "$OUT" | jq -r '.ci_status.failing')" \
+  "CodeAnt: the superseded CodeAnt failure does not block CI either"
+
+# --------------------------------------------------------------------------
+# 6. Zero check-runs still reads as incomplete, never as clean.
+# --------------------------------------------------------------------------
+run_gate '{"check_runs":[]}'
+check_eq 0 "$(echo "$OUT" | jq -r '.ci_status.total')" "empty check-run list: total 0"
+check_eq "yes" "$(has_ci_incomplete_entry)" "empty check-run list: still reported incomplete"
+check_eq "false" "$(echo "$OUT" | jq -r '.met')" "empty check-run list: gate not met"
+
+echo "----------------------------------------"
+echo "merge-gate-ci-dedup.test.sh: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/.claude/scripts/tests/pr-preflight.test.sh
+++ b/.claude/scripts/tests/pr-preflight.test.sh
@@ -465,6 +465,39 @@ check_eq "others still triggered" "3" "$(actions | grep -c '^COMMENT')"
 no_checks
 
 ############################################################################
+echo "== Scenario 14b: re-run check suites on one SHA still prove engagement (#675) =="
+# The check-run fetch now reads whole run objects and pipes them through
+# check-runs-dedup.sh before pulling app.slug. A reviewer whose check re-ran on
+# this SHA (superseded suite 100 + current suite 200) must still read as engaged:
+# the dedup keeps the newest suite's run, which carries the same slug.
+view_ready; commit_ok
+write_check_runs '{"check_runs":[
+  {"app":{"slug":"cursor","id":1},"name":"Cursor Bugbot","status":"completed","conclusion":"failure","check_suite":{"id":100}},
+  {"app":{"slug":"cursor","id":1},"name":"Cursor Bugbot","status":"completed","conclusion":"neutral","check_suite":{"id":200}}]}'
+write_reviews "$EMPTY"; write_pull_comments "$EMPTY"; write_issue_comments "$EMPTY"
+OUT=$(run_json 493); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "cursor still already-present after dedup" "already-present" "$(jq -r '.reviewers.cursor.status' <<<"$OUT")"
+check_eq "cursor not re-triggered" "0" "$(actions | grep -cF '@cursor review')"
+no_checks
+
+############################################################################
+echo "== Scenario 14c: same check name from two apps keeps BOTH slugs (#675) =="
+# Grouping is per (app, name), so two vendors publishing an identically named
+# check never collapse into one another — both reviewers stay recognized.
+view_ready; commit_ok
+write_check_runs '{"check_runs":[
+  {"app":{"slug":"cursor","id":1},"name":"review","status":"completed","conclusion":"success","check_suite":{"id":100}},
+  {"app":{"slug":"codeant-ai","id":2},"name":"review","status":"completed","conclusion":"success","check_suite":{"id":200}}]}'
+write_reviews "$EMPTY"; write_pull_comments "$EMPTY"; write_issue_comments "$EMPTY"
+OUT=$(run_json 493); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "both apps recognized from one check name" "already-present already-present" \
+  "$(jq -r '[.reviewers.cursor.status, .reviewers.codeant.status] | join(" ")' <<<"$OUT")"
+check_eq "only the 2 reviewers without a check-run are triggered" "2" "$(actions | grep -c '^COMMENT')"
+no_checks
+
+############################################################################
 echo "== Scenario 15: issue comment BEFORE head date is stale → re-triggered =="
 view_ready; commit_ok; no_checks
 write_reviews "$EMPTY"; write_pull_comments "$EMPTY"

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -95,6 +95,15 @@ jobs:
       - name: session-state write lock — unit + concurrency (issue #639)
         run: bash .claude/scripts/tests/state-lock.test.sh
 
+      - name: check-runs-dedup.sh unit test (issue #675)
+        run: bash .claude/scripts/tests/check-runs-dedup.test.sh
+
+      - name: ci-status.sh check-run dedup unit test (issue #675)
+        run: bash .claude/scripts/tests/ci-status.test.sh
+
+      - name: merge-gate.sh check-run dedup integration test (issue #675)
+        run: bash .claude/scripts/tests/merge-gate-ci-dedup.test.sh
+
   # macOS system python3 is 3.9.6 (Xcode CLT) while ubuntu-latest ships 3.10+,
   # so a hook that crashes on 3.9 (e.g. eagerly-evaluated PEP 604 unions,
   # issue #560) passes the job above yet fails open locally. Pin 3.9 here.


### PR DESCRIPTION
## **User description**
Closes #675

## What was broken

GitHub keeps a check-run record for **every** run of a check on a commit, and each re-trigger opens a new check suite. So `commits/{sha}/check-runs` hands back the old failed run right next to the new passing one. The endpoint's default `filter=latest` doesn't help — it is latest-per-*suite*, and each re-trigger is its own suite.

GitHub's own PR page and merge box resolve each check name to its newest run. Our tooling read the raw list instead, so a superseded failure counted as currently blocking: the merge gate refused, and polling loops kept dispatching fix work, on a PR GitHub already showed as green.

## What changed

New `.claude/scripts/check-runs-dedup.sh` — stdin to stdout, so every consumer pipes through one implementation (matching this repo's subprocess reuse convention; there is no shared bash library to source).

**Dedup rule:** group runs by `(app, check name)`, keep only the group's newest `check_suite.id`, retain **all** runs in that suite.

Three details worth flagging:

- **Newest-suite-per-name, never latest-single-run-per-name.** Matrix legs share a name within one suite, so keeping one run per name would let a passing leg mask a failing sibling.
- **Ordered by `check_suite.id`, not `completed_at`.** This is load-bearing, not a tie-break preference: an in-progress run has `completed_at: null`, so time-ordering would let an older *failed* run outrank the newest still-running one and report a failure where the honest answer is "not finished yet". Same-second re-runs also tie on timestamps.
- **A run with no `check_suite.id` is retained regardless.** Dropping a run can only ever *mask* a failure, so unknown data fails toward blocking.

Consumers wired through it: `ci-status.sh` (both the live-fetch and `--check-runs-stdin` paths), `pr-state.sh`, `pr-preflight.sh`. `merge-gate.sh` inherits the CI verdict through its existing `--check-runs-stdin` delegation — no second classifier was added.

`escalate-review.sh` needs no change: its only direct `gh` call is `pulls/{N}/commits`, and its check-run data comes from `pr-state.sh`'s `check_runs.all` bundle, so it inherits the dedup. A structural guard in `escalate-review.test.sh` pins that, so a direct fetch added later can't silently reintroduce the bug.

## One deliberate scope addition

CodeRabbit's plan scoped `merge-gate.sh`'s CodeAnt supplemental gate out. I brought it in, because it is the same bug failing in the *dangerous* direction.

`merge-gate.sh` picks `LATEST_CA_CHECK_OK_AT` — the latest **successful** CodeAnt check-run — from the raw list. If CodeAnt ran twice on one SHA (old success, newer failure), the superseded success sets `CODEANT_CHECK_OK=true` and the gate **passes**. So `merge-gate.sh` now dedups once at the fetch, giving the whole script one view.

This does not weaken the acceptance criterion that the gate inherit the fix solely via delegation: classification still lives only in `ci-status.sh`, which re-dedups its own input (the transform is idempotent by construction, and that idempotency is pinned by a test). Both directions are covered by tests — a superseded CodeAnt success no longer satisfies the gate, and a *current* CodeAnt success still does.

## Local review — both CLIs failed, disclosed per `cr-local-review.md`

Neither local CLI produced a usable pass on this change set, so this went out on a self-review. Both failures are pre-existing and unrelated to this diff:

- **CodeRabbit CLI:** `rate_limit` — "Rate limit exceeded", 18-minute wait. Not retried locally on purpose: the CLI and the GitHub-side review share one adaptive quota, so burning rounds here starves the merge-gate review this PR needs.
- **CodeAnt CLI:** `Access denied (403)` on **every** batch — the persistent, account-wide entitlement failure tracked in #643, which re-auth does not fix. Its `issues: 0` is a false clean, not a pass: `meta.reviewed_files` lists all 13 files, and all 13 errored. A first `--all` run also capped at 15 files and spent them on stale-base files while skipping 6 of mine; the narrower `--uncommitted` retry got the right 13 and still 403'd on every batch.

Verification therefore leaned on the test suite plus a live run of all three consumers against a real PR (#581) — `ci-status.sh`, `pr-state.sh`, and `merge-gate.sh` each reported 4/4 passing with output shapes and exit codes unchanged.

## Test plan

New: `check-runs-dedup.test.sh` (34 assertions), `ci-status.test.sh` (44), `merge-gate-ci-dedup.test.sh` (17). All three are wired into `hook-scripts.yml`. Full suite: 22/22 files pass, plus 5 Python unittest modules.

- [x] `ci-status.sh` dedupes before classification — for each check name only the newest suite's runs count; superseded suites are dropped
- [x] Matrix legs sharing a name within the newest suite are ALL retained, so a failing leg can't be masked by a passing sibling
- [x] Dedup key includes the app — same-named checks from different apps never collapse
- [x] SHA with {old failed run, newer passing run} of one check → `ci-status.sh` exits 0; `merge-gate.sh` `ci_status` shows `failing: 0`
- [x] SHA whose newest run of a check has a blocking conclusion → still exit 3 with that check in `blocking` (all five blocking conclusions covered)
- [x] Newest run of a check in progress while an older run failed → exit 1 (WAIT), not 3
- [x] `merge-gate.sh` inherits the CI verdict solely via the `ci-status.sh --check-runs-stdin` delegation — no separate raw classification in the gate path
- [x] `pr-state.sh` and `pr-preflight.sh` apply the same dedup to their independently fetched lists via the shared helper
- [x] Zero-check-runs sentinel (`total == 0` reported as in-progress, exit 1) unchanged
- [x] Negative controls: a genuinely failing newest run still blocks, and a current CodeAnt success still satisfies the CodeAnt gate — so the "no longer blocking" assertions can't pass vacuously
- [x] Live check on a real PR: `ci-status.sh`, `pr-state.sh`, `merge-gate.sh` agree, shapes and exit codes unchanged
- [x] Rule corpus within budget (11,289 words against the 11,671 cap); `rule-lint.sh` passes


___

## **CodeAnt-AI Description**
**Stop stale check failures from blocking merge and review flows**

### What Changed
- Check results are now deduped so only the newest run for each check counts, matching what GitHub shows on the PR page and merge box
- A superseded failed rerun no longer blocks CI once a newer run for that same check exists
- Matrix jobs and checks from different apps stay separate, so a failing leg is still visible and not overwritten by a passing sibling
- The shared deduped view is now used by CI status, merge gating, PR state, and preflight reviewer detection
- Added tests that cover reruns, in-progress checks, matrix legs, multiple apps, and the merge gate's CodeAnt check handling

### Impact
`✅ Fewer false merge blocks`
`✅ Clearer CI status on rerun checks`
`✅ Safer matrix job reporting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

