### PR TITLE
fix(#685): classify gh errors in clean-behind-check.sh — drop baseRefOid, exit 4 on tooling errors

### DIFF
--- a/.claude/scripts/clean-behind-check.sh
+++ b/.claude/scripts/clean-behind-check.sh
@@ -37,9 +37,12 @@
 # File-overlap uses GitHub's three-dot compare (compare/{head}...{base}), which
 # reports files changed from merge-base(head, base) to the base tip = the base
 # delta, without any local fetch. GitHub caps compare file lists at 300 files;
-# that is comfortably above any realistic clean-BEHIND diff. The base side of the
-# compare is the base branch tip SHA (baseRefOid), not the ref name, so a
-# slash-named base branch (e.g. release/2026.07) needs no path escaping.
+# that is comfortably above any realistic clean-BEHIND diff. The base tip SHA is
+# resolved via `gh api repos/.../git/ref/heads/<base>` (the git-ref REST path,
+# which handles slash-named branches like release/2026.07 natively — no URL
+# escaping needed). If that call fails, the compare falls back to the ref name.
+# NOTE: gh 2.48.0 does not support `baseRefOid` on `gh pr view --json`; the
+# git-ref API call is the gh-version-safe way to get the base tip SHA.
 #
 # Usage:
 #   clean-behind-check.sh <pr_number> [--reviewer cr|bugbot|greptile]
@@ -142,15 +145,31 @@ fi
 OWNER="${OWNER_REPO%/*}"
 REPO="${OWNER_REPO#*/}"
 
-PR_JSON=$(gh pr view "$PR_NUMBER" --json number,state,headRefOid,baseRefName,baseRefOid,mergeStateStatus,mergeable,files 2>/dev/null || true)
-if [[ -z "$PR_JSON" ]] || ! jq -e . >/dev/null 2>&1 <<<"$PR_JSON"; then
-  echo "ERROR: PR #$PR_NUMBER not found in $OWNER_REPO." >&2
-  exit 3
+# `baseRefOid` is NOT requested here — gh 2.48.0 does not support it on
+# `gh pr view --json` and the call fails with "Unknown JSON field: baseRefOid".
+# The base tip SHA is resolved separately via the git-ref REST path below.
+# Adopt the pr-state.sh (PR #616) error-classification pattern: capture 2>&1,
+# then distinguish genuine not-found (exit 3) from other tooling errors (exit 4).
+RC=0
+PR_JSON=$(gh pr view "$PR_NUMBER" --json number,state,headRefOid,baseRefName,mergeStateStatus,mergeable,files 2>&1) || RC=$?
+if [[ "$RC" -ne 0 ]]; then
+  if echo "$PR_JSON" | grep -qiE 'not found|could not resolve|no pull request'; then
+    echo "ERROR: PR #$PR_NUMBER not found in $OWNER_REPO." >&2
+    exit 3
+  else
+    echo "ERROR: gh pr view failed for PR #$PR_NUMBER: $PR_JSON" >&2
+    exit 4
+  fi
+fi
+# A zero-exit gh call that emits unparseable output is a tooling error (exit 4),
+# not proof the PR doesn't exist.
+if ! jq -e . >/dev/null 2>&1 <<<"$PR_JSON"; then
+  echo "ERROR: gh pr view returned unparseable output for PR #$PR_NUMBER: $PR_JSON" >&2
+  exit 4
 fi
 PR_STATE=$(jq -r '.state // "UNKNOWN"' <<<"$PR_JSON")
 HEAD_SHA=$(jq -r '.headRefOid // ""' <<<"$PR_JSON")
 BASE_REF=$(jq -r '.baseRefName // ""' <<<"$PR_JSON")
-BASE_SHA=$(jq -r '.baseRefOid // ""' <<<"$PR_JSON")
 MERGE_STATE=$(jq -r '.mergeStateStatus // ""' <<<"$PR_JSON")
 MERGEABLE=$(jq -r '.mergeable // ""' <<<"$PR_JSON")
 
@@ -162,6 +181,12 @@ if [[ -z "$HEAD_SHA" || -z "$BASE_REF" ]]; then
   echo "ERROR: could not determine HEAD SHA / base ref for PR #$PR_NUMBER." >&2
   exit 4
 fi
+
+# Resolve the base tip SHA via the git-ref REST path (gh-2.48.0-compatible,
+# handles slash-named branches like release/2026.07 natively). This is best-effort:
+# if the call fails, BASE_SHA stays empty and the existing COMPARE_BASE fallback
+# below uses the ref name — no new exit path for this call.
+BASE_SHA=$(gh api "repos/$OWNER/$REPO/git/ref/heads/$BASE_REF" --jq '.object.sha' 2>/dev/null || true)
 
 # --------------------------------------------------------------------------
 # Resolve sibling helpers (prefer next-to-self, then global installs)
@@ -261,8 +286,9 @@ fi
 # compare/{head_sha}...{base_sha}: base=head_sha, head=base tip → files changed
 # from merge-base(head_sha, base) to the base tip = the BASE DELTA. `ahead_by`
 # is how many commits the base tip is ahead of the merge base (new main commits).
-# Use the base tip SHA (baseRefOid), not the ref name, so a slash-named base
-# branch does not produce an invalid compare path; fall back to the ref name.
+# Prefer the base tip SHA resolved via git/ref/heads above (gh-2.48.0-compatible);
+# fall back to the ref name when the SHA fetch failed. Using the SHA avoids
+# path-escaping issues with slash-named base branches (e.g. release/2026.07).
 COMPARE_BASE="${BASE_SHA:-$BASE_REF}"
 COMPARE_JSON="$(gh api "repos/$OWNER/$REPO/compare/$HEAD_SHA...$COMPARE_BASE" 2>/dev/null || true)"
 if [[ -z "$COMPARE_JSON" ]] || ! jq -e . >/dev/null 2>&1 <<<"$COMPARE_JSON"; then

--- a/.claude/scripts/clean-behind-check.sh
+++ b/.claude/scripts/clean-behind-check.sh
@@ -153,7 +153,7 @@ REPO="${OWNER_REPO#*/}"
 RC=0
 PR_JSON=$(gh pr view "$PR_NUMBER" --json number,state,headRefOid,baseRefName,mergeStateStatus,mergeable,files 2>&1) || RC=$?
 if [[ "$RC" -ne 0 ]]; then
-  if echo "$PR_JSON" | grep -qiE 'not found|could not resolve|no pull request'; then
+  if echo "$PR_JSON" | grep -qiE 'no pull request|could not resolve to a pullrequest'; then
     echo "ERROR: PR #$PR_NUMBER not found in $OWNER_REPO." >&2
     exit 3
   else

--- a/.claude/scripts/tests/clean-behind-check.test.sh
+++ b/.claude/scripts/tests/clean-behind-check.test.sh
@@ -204,6 +204,16 @@ expect_rc 4 "other gh error (unknown field) → exit 4"
 grep_absent "not found in" "exit-4 path must NOT print the not-found message"
 grep_ok 'Unknown JSON field' "exit-4 path surfaces the real gh error text"
 
+# 15. Repo-level gh error must NOT be mis-classified as PR not found → exit 4 (not exit 3).
+FAKE_PRVIEW_ERR='GraphQL: Could not resolve to a Repository with the login of "solo" and the name "repo". (organization)' run 999
+expect_rc 4 "repo-level not-found routes to exit 4 (not misclassified as PR missing)"
+grep_absent "not found in" "repo-level error must NOT print the PR-not-found message"
+
+# 16. Generic HTTP 404 error must NOT be mis-classified as PR not found → exit 4.
+FAKE_PRVIEW_ERR='HTTP 404 Not Found' run 999
+expect_rc 4 "HTTP 404 not-found routes to exit 4 (not misclassified as PR missing)"
+grep_absent "not found in" "HTTP 404 error must NOT print the PR-not-found message"
+
 # 13. Base-SHA-fetch failure: git/ref/heads call fails → ref-name fallback, still exit 0.
 FAKE_BASEREF_FAIL=1 run 1
 expect_rc 0 "base-SHA fetch failure → ref-name fallback, still safe to offer (exit 0)"

--- a/.claude/scripts/tests/clean-behind-check.test.sh
+++ b/.claude/scripts/tests/clean-behind-check.test.sh
@@ -47,6 +47,9 @@ EOF
 chmod +x "$SCRIPTS/ac-checkboxes.sh"
 
 # --- Fake gh (safe defaults describe a green, clean-BEHIND, no-overlap PR). ---
+# Emulates gh 2.48.0: rejects any `pr view` field list containing `baseRefOid`.
+# FAKE_PRVIEW_ERR: if set, `pr view` prints this to stderr and exits 1 (error injection).
+# FAKE_BASEREF_FAIL: if set to 1, the git/ref/heads call exits 1 (fallback test).
 cat > "$BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 ARGS="$*"
@@ -54,11 +57,27 @@ case "$ARGS" in
   "repo view --json nameWithOwner --jq .nameWithOwner")
     echo "${FAKE_OWNER_REPO:-solo/repo}"; exit 0 ;;
   *"pr view "*"headRefOid"*)
+    # Reject baseRefOid in the field list (gh 2.48.0 does not support it)
+    if echo "$ARGS" | grep -q 'baseRefOid'; then
+      echo 'Unknown JSON field: "baseRefOid"' >&2; exit 1
+    fi
+    # Allow injecting a gh error for error-classification tests
+    if [[ -n "${FAKE_PRVIEW_ERR:-}" ]]; then
+      echo "$FAKE_PRVIEW_ERR" >&2; exit 1
+    fi
     jq -cn \
       --arg ms "${FAKE_MERGESTATE:-BEHIND}" \
       --arg mg "${FAKE_MERGEABLE:-MERGEABLE}" \
       --argjson files "${FAKE_PR_FILES:-[\"mine.txt\"]}" \
-      '{number:1,state:"OPEN",headRefOid:"deadbeefcafedeadbeefcafedeadbeefcafedead",baseRefName:"main",baseRefOid:"ba5eba5eba5eba5eba5eba5eba5eba5eba5eba5e",mergeStateStatus:$ms,mergeable:$mg,files:($files|map({path:.}))}'
+      '{number:1,state:"OPEN",headRefOid:"deadbeefcafedeadbeefcafedeadbeefcafedead",baseRefName:"main",mergeStateStatus:$ms,mergeable:$mg,files:($files|map({path:.}))}'
+    exit 0 ;;
+  *"git/ref/heads/"*)
+    # Best-effort base-SHA resolution; simulate failure via FAKE_BASEREF_FAIL=1
+    if [[ "${FAKE_BASEREF_FAIL:-0}" == "1" ]]; then
+      echo "ERROR: failed to resolve ref" >&2; exit 1
+    fi
+    jq -cn --arg sha "${FAKE_BASE_SHA:-ba5eba5eba5eba5eba5eba5eba5eba5eba5eba5e}" \
+      '{"object":{"sha":$sha}}'
     exit 0 ;;
   *compare/*)
     jq -cn \
@@ -94,6 +113,9 @@ expect_field() {  # expect_field <jq-filter> <want> <desc>
 }
 grep_ok() {    # grep_ok <pattern> <desc>
   if printf '%s\n' "$OUT" | grep -q "$1"; then ok "$2"; else bad "$2 (output: $OUT)"; fi
+}
+grep_absent() {  # grep_absent <pattern> <desc> — asserts pattern is NOT in $OUT
+  if printf '%s\n' "$OUT" | grep -q "$1"; then bad "$2 (pattern '$1' found but should be absent; output: $OUT)"; else ok "$2"; fi
 }
 
 # 1. Green PR, clean BEHIND, base delta does NOT touch PR files → safe (exit 0),
@@ -163,6 +185,37 @@ run
 expect_rc 2 "missing PR number → exit 2"
 run 1 --reviewer bogus
 expect_rc 2 "invalid --reviewer value → exit 2"
+
+# 10. gh 2.48.0 regression: open PR still resolves without baseRefOid in field list.
+#     The stub now rejects baseRefOid, so the happy-path tests above already cover
+#     this implicitly; this is an explicit regression assertion.
+run 1
+expect_rc 0 "open PR resolves correctly with baseRefOid absent from field list (gh 2.48.0 regression)"
+expect_field '.safe_to_offer' 'true' "safe_to_offer true when baseRefOid absent"
+
+# 11. Genuine not-found: gh error text matches not-found phrases → exit 3.
+FAKE_PRVIEW_ERR='GraphQL: Could not resolve to a PullRequest with the number of 999. (repository.pullRequest)' run 999
+expect_rc 3 "genuine not-found gh error → exit 3"
+grep_ok "not found" "not-found message surfaced on exit 3"
+
+# 12. Other gh error (unknown field, rate-limit, network): → exit 4, no not-found message.
+FAKE_PRVIEW_ERR='Unknown JSON field: "wat"' run 1
+expect_rc 4 "other gh error (unknown field) → exit 4"
+grep_absent "not found in" "exit-4 path must NOT print the not-found message"
+grep_ok 'Unknown JSON field' "exit-4 path surfaces the real gh error text"
+
+# 13. Base-SHA-fetch failure: git/ref/heads call fails → ref-name fallback, still exit 0.
+FAKE_BASEREF_FAIL=1 run 1
+expect_rc 0 "base-SHA fetch failure → ref-name fallback, still safe to offer (exit 0)"
+expect_field '.safe_to_offer' 'true' "safe_to_offer true even when BASE_SHA not resolved"
+
+# 14. Static: ensure `pr view` never requests `baseRefOid` in actual code (regression guard).
+#     Exclude comment lines (# ...) — the script documents the removed field in comments.
+if grep -E 'pr view.*baseRefOid' "$SRC" | grep -v '^[[:space:]]*#' >/dev/null 2>&1; then
+  bad "source must not request baseRefOid via 'pr view' in code (gh 2.48.0 compat)"
+else
+  ok "source does not request baseRefOid via 'pr view' in code (gh 2.48.0 compat)"
+fi
 
 echo "----------------------------------------"
 echo "clean-behind-check.test.sh: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## **User description**
## Summary

`clean-behind-check.sh` returned exit 3 ("PR not found") for demonstrably open PRs because:
1. `gh pr view --json` requested `baseRefOid`, which gh 2.48.0 does not support → `Unknown JSON field` error + empty stdout
2. The call site used `2>/dev/null || true`, conflating ALL gh failures with not-found

This forced `/fixpr` onto the rebase treadmill instead of surfacing the `/admin-merge` offer.

**Fix 1:** Drop `baseRefOid` from the `gh pr view --json` field list. Resolve the base tip SHA separately via `gh api repos/.../git/ref/heads/$BASE_REF --jq .object.sha` (gh-2.48.0-compatible; handles slash-named branches natively). On failure, the existing `COMPARE_BASE="${BASE_SHA:-$BASE_REF}"` fallback applies — no new exit path.

**Fix 2:** Adopt the `pr-state.sh` (PR #616) error-classification pattern: capture `2>&1` with `RC=0; ... || RC=$?`; on non-zero exit grep case-insensitively for `not found|could not resolve|no pull request` → exit 3 (genuine not-found); anything else → exit 4 surfacing gh's real error text. Zero-exit unparseable JSON also routes to exit 4.

Closes #685

## Test plan

- [x] `clean-behind-check.sh` no longer requests `baseRefOid` from `gh pr view` — an open PR resolves correctly under gh 2.48.0
- [x] A genuine not-found (gh error text matching not-found phrases) still exits 3 with the not-found message
- [x] Any other gh failure at the PR-metadata fetch (unknown JSON field, network error) exits 4 and surfaces gh's real error text — never the "not found" message
- [x] Base tip SHA is still resolved for the three-dot compare, with graceful fallback to the base ref name when the SHA fetch fails
- [x] Regression tests added: fake `gh` emulates gh 2.48.0 by rejecting any `pr view` field list containing `baseRefOid`; explicit cases for not-found → exit 3, other gh error → exit 4 without "not found", base-SHA failure → ref-name fallback exit 0, and static grep asserting `pr view.*baseRefOid` absent from code
- [x] Full test suite passes: `bash .claude/scripts/tests/clean-behind-check.test.sh` → 46 passed, 0 failed

## Local review note

Both local CLIs were unavailable at commit time: CodeRabbit hit the free OSS rate limit (8-min cooldown), CodeAnt is not installed in this environment. Self-review conducted — changes are scoped to two files, all logic paths are exercised by the expanded offline test suite.


___

## **CodeAnt-AI Description**
Fix PR checking so GitHub errors are reported correctly

### What Changed
- Open pull requests are no longer mistaken for “not found” when GitHub CLI returns an error
- GitHub CLI compatibility now works with versions that do not support `baseRefOid`, so valid PRs can be checked again
- The base branch SHA is fetched separately for compare checks, with a fallback to the branch name if that lookup fails
- Tests now cover real not-found errors, other GitHub CLI failures, and the base-SHA fallback path

### Impact
`✅ Fewer false "PR not found" errors`
`✅ Fewer failed checks with gh 2.48.0`
`✅ Clearer PR check errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>