### PR TITLE
fix(#669): classify CodeRabbit auto-reply ack as acknowledgment in pr-state.sh

### DIFF
--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -403,7 +403,8 @@ CONVO=$(run_gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per
 #         "next review (will be) available in"; BugBot usage-limit notices — "couldn't run - usage limit
 #         reached" / "this run hit a usage or spend limit"; "full review triggered", BugBot clean-pass
 #         "found no new issues", BugBot BUGBOT_REVIEW zero-issue summary, CR error stub
-#         "Oops, something went wrong")
+#         "Oops, something went wrong"; CR auto-reply ack marker
+#         "<!-- This is an auto-generated reply by CodeRabbit -->")
 #         are checked FIRST. They mean CR/BugBot has issued a clean pass, reported a rate/usage limit
 #         instead of reviewing, posted a review-started ack, or emitted a transient error — regardless
 #         of any quoted earlier finding language. CR wraps its Fair-Usage notice in a "Full review
@@ -418,6 +419,11 @@ CONVO=$(run_gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per
 #         thread — there is no *other* active finding for an early override to mask — so hoisting it
 #         here cannot produce a false clean. Marker-only, mirroring the addressed marker: the prose
 #         "Withdrawing the finding" is NOT matched, avoiding the #557 generic-phrase false-ack risk.
+#         The CR auto-reply ack marker (#669) is likewise safe in tier 1: CR posts it only on its own
+#         reply-ack comments ("Received — CodeRabbit is reviewing…"), which never carry their own
+#         findings. Keyed on the HTML marker, not the prose "Received — CodeRabbit is reviewing",
+#         so a real finding quoting that phrase cannot be falsely reclassified (#557 discipline).
+#         Case-insensitive "i" flag, consistent with CR-authored boilerplate (subject to casing drift).
 #      2. The specific "actionable comments posted: 0" and "no actionable comments were
 #         generated" checks MUST precede the general "actionable comments posted" finding
 #         check — otherwise the general pattern swallows clean CR summaries as findings.
@@ -459,6 +465,7 @@ if [[ -n "$SINCE" ]]; then
       elif test("found no new issues"; "i") then {class: "acknowledgment", reason: "BugBot clean pass"}
       elif (test("<!--\\s*BUGBOT_REVIEW\\s*-->"; "") and (test("found [1-9][0-9]* potential issue"; "i") | not)) then {class: "acknowledgment", reason: "BugBot zero-issue summary"}
       elif test("Oops, something went wrong"; "i") then {class: "acknowledgment", reason: "CR error stub / transient noise"}
+      elif test("<!--\\s*This is an auto-generated reply by CodeRabbit\\s*-->"; "i") then {class: "acknowledgment", reason: "CR auto-reply ack"}
       elif test("\\b(critical|major|minor|nitpick|p[0-2])\\b"; "i") then {class: "finding", reason: "severity keyword"}
       elif test("🔴|🟠|🟡"; "") then {class: "finding", reason: "severity badge"}
       elif test("actionable comments posted"; "i") then {class: "finding", reason: "actionable phrase"}

--- a/.claude/scripts/tests/pr-state-classify.test.sh
+++ b/.claude/scripts/tests/pr-state-classify.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Unit test for the `classify` jq function inside `pr-state.sh --since`
-# (issues #535, #557, #575).
+# (issues #535, #557, #575, #669).
 #
 # Verifies that comment bodies observed misclassified in the wild are now correctly
 # classified as acknowledgments, and that existing patterns are not regressed:
@@ -548,6 +548,46 @@ class="${result%%|*}"
   || fail "Bug7a: bare prose 'withdrawing the finding' — expected finding, got $class"
 
 # ---------------------------------------------------------------------------
+# Bug 8: CodeRabbit auto-reply ack (issue #669)
+#
+# When you reply to a CR thread, CodeRabbit posts an automated acknowledgment
+# comment tagged with the HTML marker:
+#   <!-- This is an auto-generated reply by CodeRabbit -->
+# followed by "Received — CodeRabbit is reviewing…" prose. Pre-fix, this matched
+# no branch and fell through to default → finding, producing 5 phantom findings
+# during /wrap Phase 1 on PR #659 (one per replied thread) on a PR whose merge
+# gate was fully met.
+# Was: default → finding; Should be: CR auto-reply ack → acknowledgment
+#
+# Fixture: faithful reproduction of the auto-reply body — marker plus prose.
+# ---------------------------------------------------------------------------
+BODY='<!-- This is an auto-generated reply by CodeRabbit -->
+
+@auerbachb: Received — CodeRabbit is reviewing the changes. I will report back once the analysis is complete.'
+result=$(classify_body "$BODY")
+class="${result%%|*}"; reason="${result##*|}"
+if [[ "$class" == "acknowledgment" && "$reason" == "CR auto-reply ack" ]]; then
+  pass "Bug8: CR auto-reply ack marker → acknowledgment"
+else
+  fail "Bug8: CR auto-reply ack — expected acknowledgment/CR auto-reply ack, got $class/$reason"
+fi
+
+# ---------------------------------------------------------------------------
+# Bug8a: MARKER-ONLY GUARD — prose "Received — CodeRabbit is reviewing" WITHOUT
+# the HTML marker must NOT reclassify (mirrors Bug4c and Bug7a).
+#
+# The marker-only decision avoids the #557 generic-phrase false-ack risk: a real
+# finding that happens to quote the phrase "Received — CodeRabbit is reviewing"
+# (e.g., a PR body or test describing the ack flow) still reaches the finding
+# tier. Verified to FAIL if a prose-phrase override for "Received" or "CodeRabbit
+# is reviewing" is ever added; re-run this guard if you touch the branch.
+# ---------------------------------------------------------------------------
+result=$(classify_body "**nitpick:** the error handler logs 'Received — CodeRabbit is reviewing' before the timeout fires, leaking internal state.")
+class="${result%%|*}"
+[[ "$class" == "finding" ]] && pass "Bug8a: finding quoting 'Received — CodeRabbit is reviewing' without marker → finding (prose not an override)" \
+  || fail "Bug8a: finding quoting CR auto-reply prose — expected finding, got $class"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""
@@ -555,4 +595,4 @@ echo "Results: $PASS passed, $FAIL failed"
 if [[ "$FAIL" -gt 0 ]]; then
   exit 1
 fi
-echo "OK: pr-state.sh classify — all fixtures and regressions passed (issues #535, #557, #575)"
+echo "OK: pr-state.sh classify — all fixtures and regressions passed (issues #535, #557, #575, #669)"

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -805,6 +805,7 @@ jq -r '
    - `found no new issues` (case-insensitive) → `acknowledgment` (BugBot clean-pass review body: "✅ Bugbot reviewed your changes and found no new issues!")
    - `<!-- BUGBOT_REVIEW -->` marker present AND body does NOT match `found [1-9][0-9]* potential issue` → `acknowledgment` (BugBot zero-issue summary). This MUST be checked before the generic `issues? found` finding pattern below. Non-zero BugBot summaries ("found 3 potential issues") keep the `<!-- BUGBOT_REVIEW -->` marker but match the non-zero guard and fall through to the finding tier.
    - `Oops, something went wrong` (case-insensitive) → `acknowledgment` (CodeRabbit transient error stub — not an actionable finding)
+   - HTML marker `<!-- This is an auto-generated reply by CodeRabbit -->` (case-insensitive) → `acknowledgment` (CR auto-reply ack — CR posts this on its own reply-ack comments, e.g. "Received — CodeRabbit is reviewing…"; observed producing phantom findings on PR #659 while wrapping #638, issue #669). Marker-only to avoid the #557 generic-phrase risk: the prose "Received — CodeRabbit is reviewing" is NOT matched, so a real finding quoting that phrase still reaches the finding tier. Safe in tier 1 unlike the §4 walkthrough marker: reply-ack comments never carry their own findings, so an early override cannot mask an active finding.
 2. **Finding patterns**:
    - Severity keywords `\b(critical|major|minor|nitpick|p[0-2])\b` or badges `🔴|🟠|🟡`
    - Actionable phrases: `actionable comments posted` (non-zero), `issues? found`, `findings?:`, `potential[_ ]issue`


### PR DESCRIPTION
## **User description**
## Summary

- Adds a tier-1 marker-keyed override in `pr-state.sh`'s `classify` function so CR's auto-reply ack comment (`<!-- This is an auto-generated reply by CodeRabbit -->`) classifies as `acknowledgment` instead of falling through to `default → finding`
- Mirrors the rule in `fixpr/SKILL.md` §5b tier-1 list (keeps the two sources of truth in sync)
- Adds `Bug8`/`Bug8a` regression pair in `pr-state-classify.test.sh` pinning both directions

Closes #669

## Root cause

CodeRabbit posts an auto-generated reply whenever you reply to one of its threads (`<!-- This is an auto-generated reply by CodeRabbit -->` … `@user: Received — CodeRabbit is reviewing…`). This matched no branch in `classify` and fell through to `default → finding`. On PR #659 this produced 5 phantom findings in `/wrap`'s Phase 1 scan — one per replied thread — on a PR whose merge gate was fully met.

## Design notes

- **Marker-only** (not the prose "Received — CodeRabbit is reviewing") per #557 discipline: a real finding quoting that phrase would be falsely reclassified otherwise
- **Case-insensitive `"i"` flag** — consistent with existing CR-authored boilerplate markers (upstream wording, subject to casing drift)
- **Safe in tier 1** unlike the §4 walkthrough marker (#575): reply-ack comments never carry their own findings, so an early override cannot mask an active finding
- Placed **after "CR error stub", before severity keyword** — existing Bug4/Bug7 tests unaffected (rate-limit and withdrawn-marker branches fire before the new branch)

## Local review

- CodeRabbit CLI: rate limit hit on both attempts — dropped for this session (OSS free tier exhausted)
- CodeAnt CLI: not installed
- Self-review performed: changes minimal and targeted; all 43 tests pass

## Test plan

- [x] A CodeRabbit auto-generated reply classifies as `acknowledgment`, not `finding`
- [x] A genuine finding that happens to quote the phrase "Received — CodeRabbit is reviewing" still classifies as `finding` (negative control)
- [x] `pr-state-classify.test.sh` gains a regression case pinning both directions
- [x] `/wrap` Phase 1 on a fully-resolved PR reports zero findings


___

## **CodeAnt-AI Description**
**Treat CodeRabbit reply-ack comments as acknowledgments**

### What Changed
- CodeRabbit’s auto-generated reply comments are now recognized as acknowledgments instead of being counted as findings
- The rule matches the reply marker itself, so quoting the reply text alone still does not change how a real finding is classified
- Added regression coverage for both the auto-reply case and the no-marker case
- Updated the classification guidance to include the new CodeRabbit reply-ack rule

### Impact
`✅ Fewer phantom findings in PR scans`
`✅ Cleaner merge-gate results after replying to CodeRabbit threads`
`✅ Safer handling of quoted review text`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
