### PR TITLE
fix(#648): replace silent epoch-0 date fallback in backlog-staleness.sh with explicit to_epoch() failure

### DIFF
--- a/.claude/scripts/backlog-staleness.sh
+++ b/.claude/scripts/backlog-staleness.sh
@@ -50,6 +50,17 @@ err() {
   printf 'backlog-staleness.sh: %s\n' "$1" >&2
 }
 
+to_epoch() {
+  # Portable ISO-8601 UTC (e.g. 2026-07-21T17:13:05Z) -> epoch seconds.
+  # Tries GNU date, then BSD/macOS date. Returns non-zero (no stdout) if both
+  # fail -- callers MUST check the exit code, never assume a numeric result
+  # (a silently fabricated epoch previously corrupted TTL/age math -- #634).
+  local iso="$1"
+  date -u -d "$iso" +%s 2>/dev/null && return 0
+  date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null && return 0
+  return 1
+}
+
 DAYS=30
 EMIT_JSON=0
 
@@ -282,12 +293,16 @@ printf '%s' "$CANDIDATES_JSON" | jq -c ".[0:$CHECK_LIMIT][]" | while IFS= read -
 
   if [ "$HAS_RECENT_COMMENT" -eq 0 ] && [ "$HAS_PR_REF" = "false" ] && [ "$HAS_COMMIT_REF" -eq 0 ]; then
     LAST_ACTIVITY="${LAST_COMMENT:-$UPDATED}"
-    AGE_DAYS=$(( ( $(date -u +%s) - $(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$UPDATED" +%s 2>/dev/null || date -u -d "$UPDATED" +%s 2>/dev/null || echo 0) ) / 86400 ))
-    jq -cn --arg num "$NUM" --arg title "$TITLE" --arg last "$LAST_ACTIVITY" --arg age "$AGE_DAYS" '
-      {number: ($num|tonumber), title: $title, category: "inactive",
-       rationale: ("No activity for " + $age + " days (last updated: " + $last + "). No recent comments, PR references, or commit references."),
-       last_activity: $last, age_days: ($age|tonumber)}
-    ' >> "$TMP/flags.jsonl"
+    if UPDATED_EPOCH=$(to_epoch "$UPDATED"); then
+      AGE_DAYS=$(( ( $(date -u +%s) - UPDATED_EPOCH ) / 86400 ))
+      jq -cn --arg num "$NUM" --arg title "$TITLE" --arg last "$LAST_ACTIVITY" --arg age "$AGE_DAYS" '
+        {number: ($num|tonumber), title: $title, category: "inactive",
+         rationale: ("No activity for " + $age + " days (last updated: " + $last + "). No recent comments, PR references, or commit references."),
+         last_activity: $last, age_days: ($age|tonumber)}
+      ' >> "$TMP/flags.jsonl"
+    else
+      err "issue #$NUM: unparseable updatedAt '$UPDATED' — skipping inactive flag (treating as still-active to avoid premature cleanup)"
+    fi
   fi
 done
 

--- a/.claude/scripts/tests/backlog-staleness.test.sh
+++ b/.claude/scripts/tests/backlog-staleness.test.sh
@@ -171,6 +171,24 @@ check_json_has "Test4b: recent comment suppresses inactive flag" "$OUT" '[.[] | 
 rm -f "$TMP/comments/100.txt"
 
 # ---------------------------------------------------------------------------
+# Test 4c: malformed updatedAt — never fabricates an epoch-0 age (issue #648,
+# same failure class as #634). The value is unparseable by both GNU and BSD
+# `date`, but its year ("2020") still sorts lexicographically before the
+# --days cutoff, so it still enters the inactive-candidate set and exercises
+# the to_epoch() failure path rather than being filtered out beforehand.
+# ---------------------------------------------------------------------------
+MALFORMED_ISO="2020-13-45T99:99:99Z"
+jq -n --arg c "$NOW_ISO" --arg u "$MALFORMED_ISO" '[{number: 102, title: "Issue with a corrupted updatedAt", labels: [], assignees: [],
+  createdAt: $c, updatedAt: $u, body: "nothing interesting here"}]' > "$TMP/open.json"
+echo "[]" > "$TMP/merged.json"
+echo "[]" > "$TMP/openprs.json"
+echo "[]" > "$TMP/closed_page1.json"
+
+OUT=$(bash "$SCRIPT" --json 2>"$TMP/malformed.err")
+check_json_has "Test4c: malformed updatedAt is never flagged inactive (no fabricated epoch-0 age)" "$OUT" '[.[] | select(.number==102)] | length == 0'
+check_contains "Test4c: malformed updatedAt warns on stderr" "issue #102" "$(cat "$TMP/malformed.err")"
+
+# ---------------------------------------------------------------------------
 # Test 5: label-skip — pinned issue is never flagged inactive
 # ---------------------------------------------------------------------------
 jq -n --arg u "$OLD_ISO" '[{number: 101, title: "Pinned stale issue", labels: [{name:"pinned"}], assignees: [],


### PR DESCRIPTION
## Summary

`.claude/scripts/backlog-staleness.sh`'s inactive-issue `AGE_DAYS` computation tried BSD then GNU `date` to parse an issue's `updatedAt`, but silently fell back to epoch 0 (`|| echo 0`) if both parses failed. A genuinely malformed timestamp would therefore produce a bogus, huge `AGE_DAYS`, risking flagging a healthy issue as ancient/stale. Same failure class as #634 (fixed in PR #641 for `babysit-pr`), triggered here by bad data rather than a platform mismatch.

## Changes

- Added a `to_epoch()` helper (mirrors the `to_epoch()` pattern from PR #641 / `babysit-pr/SKILL.md`): tries GNU `date -u -d` then BSD `date -u -j -f`, returns non-zero with no stdout if both fail — never fabricates a value.
- Rewired the `AGE_DAYS` computation to use `if UPDATED_EPOCH=$(to_epoch "$UPDATED"); then ... else ...`. On success, `AGE_DAYS` is computed and the `inactive` flag is emitted unchanged. On failure, emits an `err()` warning identifying the issue number and the raw unparseable value, and **skips flagging that issue as inactive** — mirroring #634's "unparseable ⇒ treat as still-active" direction so bad data never causes premature cleanup recommendations.
- Confirmed via `grep` that this was the only `|| echo 0`-style silent date fallback in the script — no other instances of this failure class exist here.
- Added a `Test4c` case to the existing `.claude/scripts/tests/backlog-staleness.test.sh` (following the Test4a/4b conventions) pinning both directions: a well-formed timestamp still computes a real age (existing Test4a/4b), and a malformed timestamp warns on stderr and is never flagged inactive.

## Local review

- **CodeRabbit CLI** (`coderabbit review --agent --type uncommitted`): clean pass, 0 findings, no error record.
- **CodeAnt CLI**: not installed on this machine (`codeant` not found in PATH, no `~/.codeant/config.json`) — dropped for this session per the local-review fallback policy. The CodeAnt **GitHub App** will still review this PR and can satisfy the merge gate independently.

## Test plan

- [x] `bash .claude/scripts/tests/backlog-staleness.test.sh` passes (17/17, including new Test4c malformed-timestamp cases)
- [x] `bash .claude/scripts/tests/backlog-health.test.sh` still passes (18/18) — confirms composition with the modified script is unaffected
- [x] Well-formed `updatedAt` still computes a real `AGE_DAYS` and emits the `inactive` flag (Test4a, unchanged)
- [x] Malformed `updatedAt` never fabricates epoch 0 — no `inactive` flag is emitted, and a stderr warning identifies the issue number (new Test4c)
- [x] No other silent epoch-0-style date fallback exists elsewhere in `backlog-staleness.sh` (verified via `grep -n "|| echo 0"`)

Closes #648