### PR TITLE
fix(#697): scope stale-cleanup.sh + dirty-main-guard.sh to the invoking repo

### DIFF
--- a/.claude/scripts/dirty-main-guard.sh
+++ b/.claude/scripts/dirty-main-guard.sh
@@ -19,6 +19,11 @@
 #   repo is on any branch other than main — feature branches are expected
 #   to have dirty state.
 #
+#   The guarded repo is resolved from the CALLER's current directory (the
+#   invoking repo's root), never from this script's own location — the script
+#   is invoked from any project repo, including via the ~/.claude/
+#   skills-worktree checkout (issues #687/#697).
+#
 # USAGE
 #   dirty-main-guard.sh --check
 #   dirty-main-guard.sh --quarantine
@@ -109,8 +114,12 @@ done
 
 [[ -n "$MODE" ]] || usage_error "one of --check or --quarantine is required"
 
-# Resolve root repo via the canonical helper. Script lives in .claude/scripts/
-# inside the root repo, so BASH_SOURCE walks up two levels.
+# Resolve the root repo from the caller's cwd via the canonical helper.
+# SCRIPT_DIR is used only to locate repo-root.sh next to this script — the
+# guard must target the INVOKING repo, not the repo this script happens to
+# live in: passing "$SCRIPT_DIR" to repo-root.sh made cross-repo sessions
+# (invoking via ~/.claude/skills-worktree) check — and on dirty state
+# quarantine — claude-code-config's main instead (issue #697).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT_SH="$SCRIPT_DIR/repo-root.sh"
 if [[ ! -x "$REPO_ROOT_SH" ]]; then
@@ -119,8 +128,8 @@ if [[ ! -x "$REPO_ROOT_SH" ]]; then
 fi
 
 ROOT=""
-if ! ROOT="$("$REPO_ROOT_SH" "$SCRIPT_DIR" 2>/dev/null)"; then
-  echo "error: could not resolve root repo"
+if ! ROOT="$("$REPO_ROOT_SH" 2>/dev/null)"; then
+  echo "error: could not resolve root repo from the current directory"
   exit 2
 fi
 if [[ -z "$ROOT" || ! -d "$ROOT" ]]; then

--- a/.claude/scripts/stale-cleanup.sh
+++ b/.claude/scripts/stale-cleanup.sh
@@ -7,11 +7,20 @@
 #   never deletes itself. Two skills consume this script as the single source of
 #   truth for stale worktree/branch detection and safety — /pm-update (Step 8)
 #   and /pm-clean (workspace sweep) — so their results can never diverge (issue
-#   #618). Detects three classes of stale refs on the root repo:
+#   #618). Detects three classes of stale refs on the target repo's root:
 #     1. Local worktrees whose HEAD commit is older than STALE_DAYS.
 #     2. Local branches whose tip commit is older than STALE_DAYS.
 #     3. Remote branches (refs/remotes/origin/*) whose tip commit is older
 #        than STALE_DAYS.
+#
+#   TARGET REPO RESOLUTION (invoking-repo scope — issues #687/#697): the swept
+#   repo is resolved from the CALLER's current directory (or an explicit
+#   --root <path>), never from this script's own location. The script is
+#   routinely invoked from other projects via the ~/.claude/skills-worktree
+#   checkout; resolving from its own path would sweep claude-code-config's
+#   workspace no matter where the caller was standing. The open-PR safety
+#   check runs inside the resolved root for the same reason — the PR set must
+#   describe the repo actually being swept.
 #
 #   Default mode is --check (dry-run). --apply performs the deletions only
 #   for items that pass every safety check below. Nothing is ever deleted in
@@ -39,12 +48,16 @@
 #   stale-cleanup.sh --check                    # dry-run (default)
 #   stale-cleanup.sh --apply                    # delete stale items
 #   stale-cleanup.sh --check --json             # machine-readable output
+#   stale-cleanup.sh --check --root <path>      # sweep a specific repo
 #   stale-cleanup.sh --help | -h
 #
 #   --check    Report stale items without deleting. Exit 0 if none, 1 if any.
 #   --apply    Delete stale items that pass safety checks. Exit 0 on success
 #              (or no stale items), 2 on partial failure.
 #   --json     Emit a JSON object instead of human-readable text.
+#   --root     Path to (or inside) the repo to sweep. Defaults to the caller's
+#              current directory, so the sweep targets the invoking repo even
+#              when the script runs from another checkout (issues #687/#697).
 #
 # OUTPUT (human-readable, default)
 #   Stale worktrees (older than 7 days):
@@ -84,6 +97,7 @@ usage_error() {
 MODE="check"
 JSON=0
 MODE_SET=0
+ROOT_OVERRIDE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help)
@@ -101,6 +115,13 @@ while [[ $# -gt 0 ]]; do
     --json)
       JSON=1
       shift
+      ;;
+    --root)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        usage_error "--root requires a non-empty path argument"
+      fi
+      ROOT_OVERRIDE="$2"
+      shift 2
       ;;
     --)
       shift
@@ -124,6 +145,8 @@ fi
 NOW="$(date +%s)"
 THRESHOLD=$(( NOW - STALE_DAYS * 86400 ))
 
+# SCRIPT_DIR is used ONLY to locate the repo-root.sh helper next to this
+# script — never to pick the repo to sweep (see TARGET REPO RESOLUTION above).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT_SH="$SCRIPT_DIR/repo-root.sh"
 if [[ ! -x "$REPO_ROOT_SH" ]]; then
@@ -131,10 +154,21 @@ if [[ ! -x "$REPO_ROOT_SH" ]]; then
   exit 4
 fi
 
+# Resolve the repo to sweep from the caller's context — cwd by default, or an
+# explicit --root override. Passing "$SCRIPT_DIR" here was the issue-#697 bug:
+# invoked via ~/.claude/skills-worktree from another project, it swept
+# claude-code-config's workspace instead of the invoking repo's.
 ROOT=""
-if ! ROOT="$("$REPO_ROOT_SH" "$SCRIPT_DIR" 2>/dev/null)"; then
-  echo "error: could not resolve root repo" >&2
-  exit 4
+if [[ -n "$ROOT_OVERRIDE" ]]; then
+  if ! ROOT="$("$REPO_ROOT_SH" "$ROOT_OVERRIDE" 2>/dev/null)"; then
+    echo "error: could not resolve a git repo from --root: $ROOT_OVERRIDE" >&2
+    exit 4
+  fi
+else
+  if ! ROOT="$("$REPO_ROOT_SH" 2>/dev/null)"; then
+    echo "error: could not resolve a git repo from the current directory — run from inside the repo to sweep, or pass --root <path>" >&2
+    exit 4
+  fi
 fi
 if [[ -z "$ROOT" || ! -d "$ROOT" ]]; then
   echo "error: resolved root repo is empty or missing" >&2
@@ -194,7 +228,11 @@ gh_pr_page() {
   if [[ -n "$cursor" ]]; then
     query="$query created:<$cursor"
   fi
-  gh pr list --search "$query" --limit 1000 --json headRefName,createdAt 2>"$GH_TMPERR"
+  # Run gh from the resolved root: gh derives the repo from its cwd, and the
+  # PR set must describe the repo being swept — not the caller's cwd repo,
+  # which differs under --root (and differed under the pre-#697 scope bug,
+  # silently voiding the open-PR safety check).
+  ( cd "$ROOT" && gh pr list --search "$query" --limit 1000 --json headRefName,createdAt ) 2>"$GH_TMPERR"
 }
 fetch_open_prs() {
   local cursor=""

--- a/.claude/scripts/tests/stale-cleanup.test.sh
+++ b/.claude/scripts/tests/stale-cleanup.test.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# stale-cleanup.test.sh — Offline tests for the invoking-repo scope contract
+# (issue #697, contract from issue #687) in stale-cleanup.sh and
+# dirty-main-guard.sh.
+#
+# Layout: repoA hosts a copy of the scripts (simulating the
+# ~/.claude/skills-worktree checkout the bug was observed through) and carries
+# its own stale branch as a regression tripwire; repoB is the invoking repo
+# with stale/fresh/protected branches and worktrees. `gh` is stubbed on PATH;
+# it serves a fixture PR list and records its cwd so the tests can prove the
+# open-PR safety check runs inside the swept repo.
+#
+# Requires git, jq. Run from repo root: bash .claude/scripts/tests/stale-cleanup.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# Redirect HOME: scripts append to $HOME/.claude/script-usage.log, and the
+# temp git identity must not leak into (or depend on) the real ~/.gitconfig.
+export HOME="$TMP/home"
+mkdir -p "$HOME/.claude"
+git config --global user.email "test@example.com"
+git config --global user.name "Test"
+git config --global init.defaultBranch main
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "ok   — $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL — $1"; }
+
+check_json() {
+  # $1 desc, $2 json, $3 jq boolean expr — passes when the expr is truthy.
+  local desc="$1" json="$2" expr="$3"
+  if printf '%s' "$json" | jq -e "$expr" >/dev/null 2>&1; then
+    pass "$desc"
+  else
+    fail "$desc"
+  fi
+}
+
+check_eq() {
+  local desc="$1" want="$2" got="$3"
+  if [[ "$want" == "$got" ]]; then
+    pass "$desc"
+  else
+    fail "$desc (want '$want', got '$got')"
+  fi
+}
+
+check_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$desc"
+  else
+    fail "$desc (missing '$needle')"
+  fi
+}
+
+OLD_DATE="2020-01-05T00:00:00"
+commit_old() {
+  GIT_AUTHOR_DATE="$OLD_DATE" GIT_COMMITTER_DATE="$OLD_DATE" git -C "$1" commit -q -m "$2"
+}
+
+# ---- repoA: the repo the scripts live in (skills-worktree stand-in) ---------
+REPO_A="$TMP/repoA"
+mkdir -p "$REPO_A"
+git -C "$REPO_A" init -q
+echo "a" > "$REPO_A/README.md"
+git -C "$REPO_A" add README.md
+commit_old "$REPO_A" "repoA base"
+# Stale branch in repoA — must NEVER surface when sweeping from repoB. Before
+# the #697 fix, script-location resolution listed exactly this kind of ref.
+git -C "$REPO_A" branch issue-999-repoa-stale
+mkdir -p "$REPO_A/.claude/scripts"
+cp "$REPO_ROOT/.claude/scripts/stale-cleanup.sh" \
+   "$REPO_ROOT/.claude/scripts/repo-root.sh" \
+   "$REPO_ROOT/.claude/scripts/dirty-main-guard.sh" \
+   "$REPO_A/.claude/scripts/"
+SUT="$REPO_A/.claude/scripts/stale-cleanup.sh"
+GUARD="$REPO_A/.claude/scripts/dirty-main-guard.sh"
+
+# ---- repoB: the invoking repo ------------------------------------------------
+REPO_B="$TMP/repoB"
+mkdir -p "$REPO_B"
+git -C "$REPO_B" init -q
+echo "b" > "$REPO_B/README.md"
+git -C "$REPO_B" add README.md
+commit_old "$REPO_B" "repoB old base"
+OLD_SHA="$(git -C "$REPO_B" rev-parse HEAD)"
+git -C "$REPO_B" branch issue-100-repob-stale "$OLD_SHA"   # stale
+git -C "$REPO_B" branch issue-101-repob-pr "$OLD_SHA"      # old but has open PR
+git -C "$REPO_B" branch develop "$OLD_SHA"                 # old but protected
+git -C "$REPO_B" worktree add "$TMP/wtB-stale" -b issue-102-repob-wt "$OLD_SHA" >/dev/null 2>&1
+git -C "$REPO_B" worktree add "$TMP/wtB-dirty" -b issue-103-repob-dirty "$OLD_SHA" >/dev/null 2>&1
+echo "dirty" >> "$TMP/wtB-dirty/README.md"                 # uncommitted tracked change
+echo "fresh" >> "$REPO_B/README.md"
+git -C "$REPO_B" commit -q -am "repoB fresh tip"           # main tip is fresh (now)
+git -C "$REPO_B" branch issue-104-repob-fresh              # fresh — appears nowhere
+REPO_B_REAL="$(cd "$REPO_B" && pwd -P)"
+
+mkdir -p "$TMP/plain"                                      # non-repo dir for T4
+
+# ---- gh stub -----------------------------------------------------------------
+# Serves an open PR on issue-101-repob-pr and records its cwd per call: the
+# scope contract requires the open-PR check to run inside the swept repo.
+STUB_BIN="$TMP/bin"
+mkdir -p "$STUB_BIN"
+cat > "$TMP/prs.json" <<'FIXTURE'
+[{"headRefName":"issue-101-repob-pr","createdAt":"2026-07-01T00:00:00Z"}]
+FIXTURE
+cat > "$STUB_BIN/gh" <<STUB
+#!/usr/bin/env bash
+pwd -P >> "$TMP/gh-pwd.log"
+case "\$*" in
+  "pr list --search"*) cat "$TMP/prs.json" ;;
+  *) echo "[]" ;;
+esac
+STUB
+chmod +x "$STUB_BIN/gh"
+export PATH="$STUB_BIN:$PATH"
+
+# ---- T1: cwd=repoB, script living in repoA → sweeps repoB --------------------
+OUT="$(cd "$REPO_B" && "$SUT" --check --json 2>&1)"
+RC=$?
+check_eq "T1: exit 1 (stale items found)" 1 "$RC"
+check_json "T1: repoB stale branch listed" "$OUT" \
+  '.stale_local_branches | map(.branch) | index("issue-100-repob-stale") != null'
+check_json "T1: repoB stale worktree listed" "$OUT" \
+  '.stale_worktrees | any(.branch == "issue-102-repob-wt")'
+check_json "T1: repoB main worktree skipped as main" "$OUT" \
+  '.skipped_worktrees | any(.reason == "main worktree" and (.path | endswith("repoB")))'
+check_json "T1: protected branch skipped" "$OUT" \
+  '.skipped_local_branches | any(.branch == "develop" and .reason == "protected")'
+check_json "T1: open-PR branch skipped" "$OUT" \
+  '.skipped_local_branches | any(.branch == "issue-101-repob-pr" and .reason == "open PR")'
+check_json "T1: checked-out branch skipped" "$OUT" \
+  '.skipped_local_branches | any(.branch == "issue-103-repob-dirty" and .reason == "checked out in a worktree")'
+check_json "T1: dirty worktree skipped" "$OUT" \
+  '.skipped_worktrees | any((.path | endswith("wtB-dirty")) and .reason == "uncommitted tracked changes")'
+check_json "T1: fresh branch appears nowhere" "$OUT" \
+  '[.. | strings] | any(contains("issue-104-repob-fresh")) | not'
+# Negative control — the tripwire for the #697 regression: nothing from repoA
+# (its stale branch or any path under it) may appear in the output.
+check_json "T1: no repoA refs leak into the sweep (negative control)" "$OUT" \
+  '[.. | strings] | any(contains("repoA") or contains("issue-999")) | not'
+
+# ---- T2: open-PR check ran inside the swept repo -----------------------------
+GH_PWD="$(tail -1 "$TMP/gh-pwd.log" 2>/dev/null || echo "")"
+check_eq "T2: gh pr list ran from repoB root" "$REPO_B_REAL" "$GH_PWD"
+
+# ---- T1b: subdirectory of repoB still resolves repoB's root ------------------
+mkdir -p "$REPO_B/subdir"
+OUT="$(cd "$REPO_B/subdir" && "$SUT" --check --json 2>&1)"
+check_json "T1b: sweep from a repoB subdirectory finds repoB's stale branch" "$OUT" \
+  '.stale_local_branches | map(.branch) | index("issue-100-repob-stale") != null'
+
+# ---- T3: --root override beats cwd -------------------------------------------
+OUT="$(cd "$REPO_A" && "$SUT" --check --json --root "$REPO_B" 2>&1)"
+RC=$?
+check_eq "T3: exit 1 under --root" 1 "$RC"
+check_json "T3: --root repoB sweeps repoB from repoA cwd" "$OUT" \
+  '.stale_local_branches | map(.branch) | index("issue-100-repob-stale") != null'
+check_json "T3: no repoA refs under --root (negative control)" "$OUT" \
+  '[.. | strings] | any(contains("repoA") or contains("issue-999")) | not'
+GH_PWD="$(tail -1 "$TMP/gh-pwd.log" 2>/dev/null || echo "")"
+check_eq "T3: gh pr list pinned to --root repo, not cwd" "$REPO_B_REAL" "$GH_PWD"
+
+# ---- T4: cwd outside any repo, no --root → exit 4 ----------------------------
+ERR="$(cd "$TMP/plain" && "$SUT" --check 2>&1 >/dev/null)"
+RC=$?
+check_eq "T4: non-repo cwd exits 4" 4 "$RC"
+check_contains "T4: error suggests --root" "--root" "$ERR"
+
+# ---- T5: caller's-current-worktree safety skip survives ----------------------
+OUT="$(cd "$TMP/wtB-stale" && "$SUT" --check --json 2>&1)"
+check_json "T5: caller's worktree skipped, not stale" "$OUT" \
+  '(.skipped_worktrees | any((.path | endswith("wtB-stale")) and (.reason | contains("current worktree"))))
+   and (.stale_worktrees | any(.path | endswith("wtB-stale")) | not)'
+
+# ---- T6: --root with a missing value is a usage error ------------------------
+( cd "$REPO_B" && "$SUT" --check --root >/dev/null 2>&1 )
+check_eq "T6: bare --root exits 3" 3 "$?"
+( cd "$TMP/plain" && "$SUT" --check --root "$TMP/plain" >/dev/null 2>&1 )
+check_eq "T6b: --root at a non-repo path exits 4" 4 "$?"
+
+# ---- T7: dirty-main-guard resolves the invoking repo -------------------------
+# repoA's main is made dirty; repoB gets an origin and a clean pushed main.
+# Before the #697 fix the guard resolved repoA (the script's repo) and could
+# never report on repoB at all.
+echo "dirty-a" >> "$REPO_A/README.md"
+git init -q --bare "$TMP/originB.git"
+git -C "$REPO_B" remote add origin "$TMP/originB.git"
+git -C "$REPO_B" push -q origin main 2>/dev/null
+
+OUT="$(cd "$REPO_B" && "$GUARD" --check --no-fetch)"
+RC=$?
+check_eq "T7a: clean repoB reports clean (repoA dirt invisible)" 0 "$RC"
+check_eq "T7a: output is 'clean'" "clean" "$OUT"
+
+echo "unpushed" >> "$REPO_B/README.md"
+git -C "$REPO_B" commit -q -am "unpushed on main"
+OUT="$(cd "$REPO_B" && "$GUARD" --check --no-fetch)"
+RC=$?
+check_eq "T7b: unpushed commit on repoB main exits 1" 1 "$RC"
+check_contains "T7b: reports unpushed commit" "unpushed commit" "$OUT"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+echo "OK: stale-cleanup.sh + dirty-main-guard.sh — invoking-repo scope verified (issue #697)"

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -104,6 +104,9 @@ jobs:
       - name: merge-gate.sh check-run dedup integration test (issue #675)
         run: bash .claude/scripts/tests/merge-gate-ci-dedup.test.sh
 
+      - name: stale-cleanup.sh + dirty-main-guard.sh invoking-repo scope unit test (issue #697)
+        run: bash .claude/scripts/tests/stale-cleanup.test.sh
+
   # macOS system python3 is 3.9.6 (Xcode CLT) while ubuntu-latest ships 3.10+,
   # so a hook that crashes on 3.9 (e.g. eagerly-evaluated PEP 604 unions,
   # issue #560) passes the job above yet fails open locally. Pin 3.9 here.


### PR DESCRIPTION
## **User description**
Closes #697

## Summary

- **`stale-cleanup.sh`** resolved the repo to sweep from its own file location (`repo-root.sh "$SCRIPT_DIR"`), so cross-repo invocations via `~/.claude/skills-worktree` swept **claude-code-config's** workspace instead of the invoking repo's — violating the `/pm-clean` invoking-repo scope contract (issue #687). It now resolves from the caller's cwd, with a new `--root <path>` override for explicit targeting; cwd outside any repo (without `--root`) exits 4 with an actionable error.
- **Open-PR safety check pinned to the swept repo:** `gh pr list` previously ran from the caller's cwd while branches were enumerated from `$ROOT`. Under the scope bug the PR set came from a *different repo*, silently voiding the check — `--apply` could have deleted branches/worktrees whose PRs are open. The check now runs inside the resolved root (also correct under `--root`).
- **`dirty-main-guard.sh`** had the same defect: cross-repo sessions checked — and on dirty state would have **quarantined** — claude-code-config's main instead of the invoking repo's. Same one-line class of fix; callers verified compatible (CLAUDE.md session-start, `dirty-main-warn.sh` Stop hook, `/wrap`/`/fixpr` pre-force-push checks).
- **Sibling audit:** `admin-merge.sh` and `repair-worktrees.sh` already call `repo-root.sh` with no argument (cwd-based, correct); `skill-usage-snapshot.sh` is script-anchored **by design** (telemetry always targets this repo's `skill-telemetry` branch) — left as-is; `main-sync.sh` takes an explicit `--repo`.
- **All existing safety checks preserved unchanged:** main-worktree skip, caller's-current-worktree skip, uncommitted-tracked-changes skip, open-PR skip, protected names, checked-out-branch skip, TOCTOU re-checks, output shapes, exit codes.
- **Call sites unchanged:** `/pm-clean` and `/pm-update` Step 8 invoke the script from the session cwd, so the cwd-based fix covers both with no SKILL.md edits — pm-clean's documented "#687 invoking-repo scope" contract is now actually true.
- **New offline test** `.claude/scripts/tests/stale-cleanup.test.sh` (25 assertions; two-repo layout mirroring the skills-worktree shape, stubbed `gh` that records its cwd) wired into `hook-scripts.yml`.

## Test plan

- [x] Invoked from a repo not containing the script (skills-worktree shape), `--check --json` enumerates the **invoking** repo's worktrees/branches, never the script's repo (test T1 + repoA negative control; live repro from the longlove repo returned only longlove refs)
- [x] `--root <path>` sweeps the given repo regardless of cwd (T3); bare `--root` exits 3; `--root` at a non-repo path exits 4 (T6/T6b)
- [x] Open-PR safety check runs inside the swept repo — gh-cwd recorded by the stub equals the swept root in both default and `--root` modes (T2, T3)
- [x] cwd outside any git repo without `--root` → exit 4 with an error suggesting `--root` (T4)
- [x] `dirty-main-guard.sh` checks the **invoking** repo's main — clean repoB reports `clean` while repoA is dirty; unpushed commit on repoB main exits 1 (T7a/T7b)
- [x] Safety skips preserved: main worktree, caller's current worktree, uncommitted tracked changes, open PR, protected names, checked-out branches (T1, T5)
- [x] Negative control verified: the pre-fix script run in the same layout leaks repoA refs, which the new assertions catch (run manually against `git show HEAD:` copies before committing)
- [x] New test green locally (25/25) and wired into CI (`hook-scripts.yml` step)

## Review notes

- **CodeAnt CLI dropped for this session** after a persistent 403 on the initial run and the single permitted retry (known daily-cap/entitlement failure, issue #643 — re-auth does not fix it and `codeant logout` is destructive). It emitted zero findings before failing. The CodeAnt GitHub App review on this PR is unaffected and satisfies the merge gate.
- **CodeRabbit CLI local review: verified-successful run, 1 finding, declined as invalid.** The finding instructed removing the new `hook-scripts.yml` CI step for this test, with no rationale. The step matches the repo's one-step-per-test-file convention (same shape as the issue #675 steps), the test file exists and passes, the workflow YAML parses cleanly, and CI wiring is an explicit acceptance criterion of issue #697.


___

## **CodeAnt-AI Description**
**Keep stale cleanup and main-guard checks scoped to the repo you are working in**

### What Changed
- `stale-cleanup.sh` now scans the repo from your current directory by default, instead of the repo where the script lives
- Added `--root <path>` so you can point stale cleanup at a specific repo when needed
- The open-PR safety check now runs inside the repo being swept, so it checks the correct set of branches
- `dirty-main-guard.sh` now checks the repo you launched it from, so it no longer reports or quarantines the wrong project
- Added an offline test and CI run that cover cross-repo use, `--root`, non-repo error handling, and the main-guard behavior

### Impact
`✅ Correct cleanup in cross-repo sessions`
`✅ Fewer false skips or deletions from the wrong repo`
`✅ Safer main-branch checks from worktrees and nested directories`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

