### PR TITLE
fix(#708): detect CodeRabbit rate-limit via description text, not commit-status state

### DIFF
--- a/.claude/reference/cr-polling-commands.md
+++ b/.claude/reference/cr-polling-commands.md
@@ -18,7 +18,7 @@ gh api "repos/{owner}/{repo}/commits/{SHA}/statuses" \
 
 **Completion signal:** `status: "completed"` + `conclusion: "success"` = review done.
 
-**Fast-path rate-limit signal:** check-run with `conclusion: "failure"` and `output.title` containing "rate limit" (case-insensitive), OR status `state: "failure"`/`"error"` with `description` containing "rate limit" → escalate immediately regardless of elapsed minutes (do not wait out CR's 12-min ceiling); check BugBot (`cursor[bot]`) first. If BugBot already posted a review, use it. If not, wait up to 10 min for BugBot. If BugBot also times out, trigger Greptile (see `bugbot.md`).
+**Fast-path rate-limit signal:** check-run with `conclusion: "failure"` and `output.title` containing "rate limit" (case-insensitive), OR status `description` containing "rate limit" — CodeRabbit reports this status as non-blocking `state: "success"`, so do not gate on `state` — → escalate immediately regardless of elapsed minutes (do not wait out CR's 12-min ceiling); check BugBot (`cursor[bot]`) first. If BugBot already posted a review, use it. If not, wait up to 10 min for BugBot. If BugBot also times out, trigger Greptile (see `bugbot.md`).
 
 ## CI Health Check — every poll cycle
 

--- a/.claude/scripts/escalate-review.sh
+++ b/.claude/scripts/escalate-review.sh
@@ -188,7 +188,7 @@ CR_RATE_LIMITED="$(jq -r '
   or
   (
     [.commit_statuses[]
-     | select(((.context // "") | test("CodeRabbit"; "i")) and (((.state // "") == "failure") or ((.state // "") == "error")))
+     | select((.context // "") | test("CodeRabbit"; "i"))
      | select((text | test("rate limit"; "i")))]
     | length
   ) > 0

--- a/.claude/scripts/tests/escalate-review.test.sh
+++ b/.claude/scripts/tests/escalate-review.test.sh
@@ -261,8 +261,28 @@ OUT=$(run_script); RC=$?
 check_eq "exit 0" 0 "$RC"
 check_eq "STATUS=trigger_greptile" "STATUS=trigger_greptile" "$OUT"
 
+############################################################################
+echo "== Scenario (k): CR commit-status rate-limit via state:success + description only (issue #708) -> skips CR gate immediately, no 12-min wait =="
+reset_state
+write_commits "$(ts_seconds_ago 60)"   # recent push (AGE_SECONDS well under 720) — proves no dependency on the AGE_SECONDS fallback
+CR_STATUS_RATE_LIMITED='{"context": "CodeRabbit", "state": "success", "description": "Review rate limited"}'
+jq -n \
+  --arg owner "$OWNER" --arg repo "$REPO" --arg sha "$HEAD_SHA" \
+  --argjson bugbot_run "$BUGBOT_CHECK_RUN_OK" \
+  --argjson status "$CR_STATUS_RATE_LIMITED" \
+  '{
+    pr: {owner: $owner, repo: $repo, head_sha: $sha},
+    check_runs: {all: [$bugbot_run]},
+    commit_statuses: [$status],
+    comments: {reviews: [], inline: [], conversation: []}
+  }' > "$TMP/state.json"
+export FIXTURE_STATE_JSON="$TMP/state.json"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=switch_bugbot" "STATUS=switch_bugbot" "$OUT"
+
 echo
-echo "== Scenario K: check-run data still comes only from pr-state.sh's bundle (#675) =="
+echo "== Scenario L: check-run data still comes only from pr-state.sh's bundle (#675) =="
 # escalate-review.sh reads check-runs via pr-state.sh's `check_runs.all`, which is
 # deduped at the source (newest check suite per (app, name)). That inheritance is
 # the whole reason this script needs no dedup of its own — so guard it: a direct

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -880,9 +880,9 @@ jq -r '
 
 For each bot present in `.bot_statuses` or the current-head check-runs:
 
-- `state: success` → review completed on this SHA. Clean-pass signal.
+- `description` containing "rate limit" (case-insensitive) → CR rate-limited, fall back to Greptile per `cr-github-review.md`. CodeRabbit reports this as non-blocking `state: "success"` — check this **before** the `state: success` clean-pass rule below, not just on `failure`/`error`.
+- `state: success` (and not the rate-limit case above) → review completed on this SHA. Clean-pass signal.
 - `state: pending` or check-run `status != "completed"` → bot still running. **Do NOT declare CLEAN.** Emit `REVIEW_PENDING` and stop.
-- `state: failure` / `error` with "rate limit" in `description` → CR rate-limited, fall back to Greptile per `cr-github-review.md`.
 - No activity from CodeRabbit, Graphite, CodeAnt, or Cursor after a pushed fix commit → the Step 3b trigger check should already have posted the reviewer-specific comment. Emit `REVIEW_PENDING` and re-run `/fixpr` after the reviewer responds.
 
 ---

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -880,8 +880,8 @@ jq -r '
 
 For each bot present in `.bot_statuses` or the current-head check-runs:
 
-- `description` containing "rate limit" (case-insensitive) → CR rate-limited, fall back to Greptile per `cr-github-review.md`. CodeRabbit reports this as non-blocking `state: "success"` — check this **before** the `state: success` clean-pass rule below, not just on `failure`/`error`.
-- `state: success` (and not the rate-limit case above) → review completed on this SHA. Clean-pass signal.
+- **CodeRabbit specifically** (by status `context` / bot name) with `description` containing "rate limit" (case-insensitive) → CR rate-limited, fall back to Greptile per `cr-github-review.md`. CodeRabbit reports this as non-blocking `state: "success"` — check this **before** the `state: success` clean-pass rule below, not just on `failure`/`error`. Other bots are not subject to this rule — a Greptile or other status whose text happens to contain "rate limit" is not CR rate-limiting and falls through to the rules below.
+- `state: success` (and not the CodeRabbit rate-limit case above) → review completed on this SHA. Clean-pass signal.
 - `state: pending` or check-run `status != "completed"` → bot still running. **Do NOT declare CLEAN.** Emit `REVIEW_PENDING` and stop.
 - No activity from CodeRabbit, Graphite, CodeAnt, or Cursor after a pushed fix commit → the Step 3b trigger check should already have posted the reviewer-specific comment. Emit `REVIEW_PENDING` and re-run `/fixpr` after the reviewer responds.
 

--- a/.claude/skills/go-on/SKILL.md
+++ b/.claude/skills/go-on/SKILL.md
@@ -163,7 +163,7 @@ gh api "repos/{owner}/{repo}/commits/$SHA/statuses" \
   --jq '.[] | select(.context | test("CodeRabbit"; "i")) | {state: .state, description: .description}'
 ```
 
-**Rate limit detection:** If check-run shows `conclusion: "failure"` with title containing "rate limit" (case-insensitive), OR status shows `state: "failure"`/`state: "error"` with description containing "rate limit":
+**Rate limit detection:** If check-run shows `conclusion: "failure"` with title containing "rate limit" (case-insensitive), OR status shows `description` containing "rate limit" — CodeRabbit reports this status as non-blocking `state: "success"`, so do not gate on `state`:
 - `[ACTION]` — CR is rate-limited. Check BugBot (second-tier reviewer) before falling through to Greptile — BugBot auto-triggers on every push, so it may already have responded while CR was blocked:
   ```bash
   gh api "repos/{owner}/{repo}/pulls/$PR_NUM/reviews?per_page=100" \


### PR DESCRIPTION
Closes #708

## Summary

CodeRabbit's rate-limit commit status reports `state: "success"` (non-blocking) with the message only in `description` — e.g. `{"context":"CodeRabbit","state":"success","description":"Review rate limited"}`. Every place in this repo that detected CR rate-limiting from commit statuses required `state == "failure"/"error"` before the text match, so this real-world shape was never caught by the fast path:

- `escalate-review.sh`'s `CR_RATE_LIMITED` jq predicate (`commit_statuses[]` branch) — now matches on the "rate limit" text alone.
- `go-on/SKILL.md` Step 6 and `cr-polling-commands.md`'s "Fast-path rate-limit signal" bullet — prose corrected to match.
- `fixpr/SKILL.md` Step 5d — also reordered: the `state: success` clean-pass rule was checked *before* the rate-limit rule, which would have shadowed a rate-limited status as a false clean-pass even after a naive text-only fix.
- Added a new offline test scenario (`escalate-review.test.sh` Scenario (k)) that reproduces the bug (would assert `STATUS=polling_cr` pre-fix) and proves the fix (`STATUS=switch_bugbot`, escalating immediately instead of waiting out the 12-minute `AGE_SECONDS` fallback).

Without this fix, detection still eventually converges via the 12-minute fallback in `escalate-review.sh` — this is a correctness/consistency fix, not a live incident.

## Local review note

Both local review CLIs were unavailable this session: CodeAnt CLI is not installed on this machine, and CodeRabbit CLI hit its own free-tier rate limit (`"Rate limit exceeded"`, 29-minute cooldown — apt, given the subject of this PR). Did a careful self-review of the diff instead; relying on the GitHub-side CodeRabbit/BugBot/Greptile chain to satisfy the merge gate.

## Test plan

- [x] `escalate-review.sh`'s `CR_RATE_LIMITED` predicate detects CodeRabbit's real-world `state: "success"` + `description: "Review rate limited"` commit status immediately (no 12-min wait) — verified via new Scenario (k), `STATUS=switch_bugbot`.
- [x] `go-on/SKILL.md` Step 6, `fixpr/SKILL.md` Step 5d, and `cr-polling-commands.md`'s rate-limit bullet all describe the same detection shape as the code.
- [x] New offline test scenario in `escalate-review.test.sh` covers the `commit_statuses` `state: "success"` shape and passes.
- [x] Existing `escalate-review.test.sh` scenarios still pass (no regression to the check-run `conclusion: "failure"` path) — 26/26 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of CodeRabbit rate-limit signals, including successful commit statuses that contain rate-limit messaging.
  - Automated review workflows now bypass blocked CodeRabbit checks and continue with the appropriate fallback review process.

- **Documentation**
  - Clarified polling and escalation guidance for rate-limit conditions and review-bot timeouts.

- **Tests**
  - Added coverage for successful rate-limit status responses and immediate review-flow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->