### PR TITLE
feat(#701): PM routing audit + PM-context inline gate on chip surfaces

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -56,6 +56,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `graphite-stacked-prs-research-2026-05.md` — stacked PR economics (#418 / #433)
 - `codeant-code-quality-eval-2026-06.md` — deeper CodeAnt Code Quality integration eval; verdict: keep advisory (#444)
 - `instruction-set-audit-2026-07.md` — 1-month instruction-set size & optimization re-check; verdict: keep caps (#462)
+- `pm-routing-audit-2026-07.md` — thread-vs-inline routing effectiveness audit of #613; ground-truth attribution + the shared PM-context inline gate for chip surfaces (#701)
 
 ### Diagrams (mermaid stubs and indexes)
 

--- a/.claude/reference/chip-launching.md
+++ b/.claude/reference/chip-launching.md
@@ -8,6 +8,20 @@ Canonical mechanics for offering a coding-thread prompt as a **task chip** the u
 
 > **NON-NEGOTIABLE — execution boundary.** Offering a chip is NOT launching a thread. Skills NEVER auto-launch: no Agent-tool spawn, no session start, no work begun on the user's behalf. **The user's chip click is the only launch path.** This does not widen any skill's existing explicit-ask exception (e.g. `/pm`'s "go ahead and run those") — it narrows nothing and grants nothing new.
 
+## PM-context inline gate (before offering a chip)
+
+Per [#613](https://github.com/auerbachb/claude-code-config/issues/613), inline execution is the default for subagent-fit work; a separate thread is for work too big for a subagent. `/pm`, `/prompt`, and `/subagent` already partition inline-vs-thread with `/subagent` Step 4's three-criterion too-big test, so they satisfy this by construction. The **chip surfaces that do not partition** — `/wave`, `/issue-maker`, `/start-issue` — apply this gate **before offering a standalone-thread chip** for subagent-fit work. Audit + rationale: `pm-routing-audit-2026-07.md` (#701).
+
+Check for **live PM context with a free inline slot**:
+
+- **PM context** — a `## Active Work` table is present in the thread (its canonical home, `/pm` 3.2). Its non-terminal rows (`Inline`, `Active`, `Chip offered`, `Prompt generated`) are the in-flight count, `IN_FLIGHT`.
+- **Free slot** — `IN_FLIGHT` is below the 3–4 concurrent-pipeline ceiling (`.claude/rules/subagent-orchestration.md`, derived from CodeRabbit throughput in `cr-rate-limits.md`).
+- **Subagent-fit** — the issue is not "too big for any subagent" by `/subagent` Step 4's three criteria.
+
+**All three hold → prefer inline:** recommend the issue be run inline via `/subagent #N` in the PM thread (or queued behind the ceiling), *instead of* spawning a separate-thread chip. **Any false → offer the chip as before:** no PM context (the common standalone case), a full pipeline, or a too-big issue each make the thread the right hand-off. **Every separate-thread offer made while an inline slot was free must carry a one-line "too big because X" rationale** naming which of `/subagent` Step 4's three criteria forced the thread.
+
+This gate chooses only which *recommendation* to surface — it **never launches anything** (the execution boundary above is absolute). Reuse the existing `## Active Work` / `IN_FLIGHT` state; do not invent a parallel ledger.
+
 ## Availability detection
 
 Chip mode is active **only** when the `mcp__ccd_session__spawn_task` tool is present in the session. Otherwise (CLI, headless, older client) the skill is in **fallback mode**.

--- a/.claude/reference/pm-routing-audit-2026-07.md
+++ b/.claude/reference/pm-routing-audit-2026-07.md
@@ -1,0 +1,143 @@
+# PM Routing Audit — Thread vs Inline Subagents — July 2026
+
+**Issue(s):** [#701](https://github.com/auerbachb/claude-code-config/issues/701) (investigate why PM still routes work to threads over inline subagents)
+
+**Date:** 2026-07-22
+
+**Related precedent:** [#613](https://github.com/auerbachb/claude-code-config/issues/613) (inline-by-default landed here — this audits why practice still skews to threads and closes the residual gaps); [harness-model-audit-2026-06.md](harness-model-audit-2026-06.md) (the FU-5 outcome-telemetry gap this audit inherits verbatim)
+
+**Current fleet (for model-line context):** Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5.
+
+---
+
+## Why this audit, and why now
+
+[#613](https://github.com/auerbachb/claude-code-config/issues/613) (merged **2026-07-21**) flipped the PM default: issues a PM thread picks up should run **inline** as `A→B→C` subagents the thread manages itself, with a separate coding thread reserved only for work genuinely **too big for a subagent**. The intended payoff was fewer tabs to babysit — one PM thread coordinating everything.
+
+The observed behavior hadn't caught up: a large share of recent Sonnet-tier work looked like it was still being handed out as standalone coding threads. #701 asked for an **effectiveness audit** of the inline-first change before tightening anything: establish ground truth (is the spend actually thread sprawl?), verify #613 is live, then walk every surface that decides "thread vs inline" and make inline the aggressive default everywhere it fits.
+
+This document is **audit-first**. Its tightening changes are deliberately small and are confined to the three non-conforming surfaces; it changes **no** load-bearing rule and does **not** raise the concurrency ceiling.
+
+---
+
+## Headline finding
+
+**The "too many threads" diagnosis is confirmed for the pre-#613 period — and #613 is already working where it is exercised. The residual sprawl is not `/pm` misrouting; it is that most coding work never enters a PM thread at all.** It starts thread-first through `/start-issue` (often from an `/issue-maker` chip), so inline-first routing never gets consulted.
+
+| Question (AC) | Verdict | Basis |
+|---------------|---------|-------|
+| AC1 — Is recent spend thread sprawl or healthy inline work? | **Sprawl confirmed pre-#613; improving post-#613** | Pre-#613: 118 coding-thread-lifecycle skill calls vs **1** inline (`/subagent`) call. Post-#613: inline share rose to ~16% (31 vs 6), and **5 of 6** post-merge PM sessions ran issues inline. |
+| AC2 — Is #613's inline-first routing actually live? | **Yes — deployed and encoded** | `~/.claude/skills-worktree` HEAD == `origin/main` (`ebef5cb`); deployed `pm`/`subagent` copies carry the inline-first + three-criterion too-big + 3–4 queue language. |
+| AC3 — Per-surface audit of every thread-vs-inline decision | **Done** (table below) | `/pm`, `/prompt`, `/subagent` conform; `/wave`, `/issue-maker`, `/start-issue` offered chips with no PM-context/slot check. |
+| AC4 — Inline the default on every surface; thread offers carry a "too big because X" rationale | **Closed** | New shared **PM-context inline gate** in `chip-launching.md`, referenced by the three gap surfaces. |
+| AC5 — Queue-over-spawn when the 3–4 slots are full | **Already satisfied** | `/pm` 3.1/3.4, `/subagent` Step 7, `subagent-orchestration.md` line 66 — no rule-corpus edit needed. |
+| AC6 — Follow-ups filed for anything too big to land here | **Done** | FU-1 [#710](https://github.com/auerbachb/claude-code-config/issues/710) (telemetry pipeline / the inherited FU-5 gap); FU-2 [#711](https://github.com/auerbachb/claude-code-config/issues/711) (`/wave` global symlink). |
+
+---
+
+## Phase 1 — Ground truth
+
+### Task 1: Rough spend attribution (threads vs inline)
+
+**Method.** There is **no** spend/thread-type telemetry in this repo (the FU-5 gap from `harness-model-audit-2026-06.md` is still unbuilt). `~/.claude/skill-usage.log` records only `timestamp · skill · session_id` — invocation counts, **not** model tier or token spend. So this is a **proxy for thread count, not Sonnet spend**. Sessions were clustered by `session_id` and classified: a session containing `/pm` or `/wave` is a *PM-orchestration* session; one containing a coding-lifecycle skill (`start-issue`, `fixpr`, `wrap`, `go-on`, `merge`, `babysit-pr`, `merge-conflict`, `admin-merge`) or a standalone `/subagent` is a *coding thread*. Data window: 2026-05-01 → 2026-07-22 (287 entries, 132 sessions), bucketed at the #613 merge date (2026-07-21).
+
+**Findings.**
+
+| Metric | Pre-#613 (≤07-20) | Post-#613 (07-21→) |
+|--------|-------------------|--------------------|
+| Coding-thread-lifecycle skill calls | **118** | 31 |
+| Inline `/subagent` calls | **1** | **6** |
+| Inline share of execution calls | ~0.8% | ~16% |
+| `/subagent` calls co-located with `/pm`/`/wave` | 0 | 5 of 6 |
+| `/start-issue` (new coding thread) | 17 | 8 |
+| PM-orchestration sessions | 0 | 6 |
+
+**Reading.** Pre-#613, coding was executed through threads essentially 100% of the time — inline was ~1% of the picture. Post-#613 the inline path is genuinely being used: 5 of the 6 PM sessions since the merge ran their issues inline (`[pm,subagent]`, one also `[pm,pm-clean,subagent,wave]`), and inline rose to ~16% of execution calls. **The mechanism works when PM is the entry point.** But `/start-issue` still fired 8 times post-merge and 18 of 35 post-merge sessions are coding threads — most work still starts thread-first, bypassing PM entirely.
+
+**Caveats (do not over-read):**
+- **Proxy, not spend.** The log has no model/token data; inline `pm-worker`/Phase C also run on Sonnet, so raw Sonnet spend cannot separate sprawl from health even in principle. Only FU-1's telemetry pipeline can turn this proxy into a real spend attribution.
+- **Invisible inline workers.** Agent-tool subagents spawned by `/subagent` do **not** write their own `skill-usage.log` lines (only Skill-tool calls are logged), so inline phase workers appear only via the parent `/subagent` invocation — the inline share is if anything *understated*.
+- **Small post window.** #613 is ~1.5 days old in this data (72 of 287 entries). Post-#613 numbers are **directional**; part of the honest answer is "give the new default more sessions."
+
+### Task 2: #613 deployment liveness
+
+- **Deployed copies match main.** `~/.claude/skills-worktree` is at `ebef5cb`, identical to `origin/main`. Deployed `pm`, `subagent`, `issue-maker`, `start-issue`, `prompt` SKILL.md files are byte-identical to the repo's `main`.
+- **Inline-first is encoded.** Deployed `pm/SKILL.md` carries "inline by default" / "too big for any subagent" / "Inline-eligible"; deployed `subagent/SKILL.md` carries the three-criterion "Too Big for Any Subagent" test and the 3–4 queue mechanic.
+- **Deployment anomaly (minor, tangential):** `~/.claude/skills/wave` has **no global symlink** — `/wave` resolves only project-locally inside this repo, so it is unavailable from other repos/sessions. This does not affect routing (its one logged use worked in-repo) and is not a code fix (the symlink is a local post-merge op per `skill-symlinks.md`); tracked as **FU-2** so it isn't lost.
+
+---
+
+## Phase 2 — Per-surface routing audit
+
+Each surface's current thread-vs-inline criterion, whether it honors #613, and the gap.
+
+| Surface | Current thread-vs-inline criterion | Honors #613? | Gap |
+|---------|-----------------------------------|--------------|-----|
+| **`/pm`** (Step 3.1/3.4) | Partitions selected issues with `/subagent` Step 4's three-criterion too-big test; runs inline-eligible issues via `A→B→C`; thread chip **only** for too-big, each with a one-line reason; queues beyond the 3–4 ceiling. | **Yes** | None. Canonical implementation of #613. |
+| **`/subagent`** (Steps 4–7) | Three-criterion too-big test decides inline vs route-to-thread; inline is default of any tier; 3–4 concurrent pipelines, queue the rest. | **Yes** | None. Owns the too-big test the others reuse. |
+| **`/prompt`** (Step 5.5, Path B) | In PM auto-detect, partitions subagent-eligible (inline) vs too-big (thread prompt) via the same three criteria; one-line too-big reason. Path A (explicit args) always prints full blocks — but that is a user *asking for a prompt*, not a routing default. | **Yes** | None (Path A is user-directed, not a routing decision). |
+| **`/wave`** (Step 7) | Offers the whole independent set as chips; caps by `IN_FLIGHT` vs the 3–4 ceiling; surfaces `/subagent` as an inline alternative only as a trailing aside. | **Partial** | Chips are the default framing even inside a PM thread with free inline slots; inline is buried. |
+| **`/issue-maker`** (Step 9c) | Offers a coding chip **unconditionally** on every created issue (points at `/start-issue`). No PM-context/slot check. | **No** | Fresh subagent-fit issue in an active PM context is offered a standalone thread rather than flowed into the inline queue. (Rarely fires — capture mode refuses in-thread orchestration — but the leak is real.) |
+| **`/start-issue`** (Step 7) | Offers a coding chip (or prints a ready-to-code block) **unconditionally** after worktree setup. No PM-context/slot check. | **No** | Same leak as `/issue-maker`: within a PM session with a free slot, subagent-fit work still gets a separate-thread chip. |
+
+**Why the three gap surfaces predate the fix:** `/pm`, `/prompt`, `/subagent` all run the too-big *partition* before deciding thread-vs-inline. The three chip surfaces were written before #613 and offer a chip as an unconditional hand-off — they never consult PM context or inline-slot availability, so even a user sitting in a PM thread with three free slots gets a new-tab chip.
+
+---
+
+## Phase 3 — What changed
+
+### The shared PM-context inline gate (`chip-launching.md`)
+
+A single canonical gate, defined once in the shared chip contract and referenced by the three gap surfaces (DRY — no divergent per-skill copies). Before offering a **standalone thread** chip for subagent-fit work, a surface checks for **live PM context with a free inline slot**:
+
+- **PM context** — a `## Active Work` table is present (the canonical home, `/pm` 3.2); its non-terminal rows are `IN_FLIGHT`.
+- **Free slot** — `IN_FLIGHT` is below the 3–4 concurrent-pipeline ceiling (`subagent-orchestration.md`, derived from CR throughput in `cr-rate-limits.md`).
+- **Subagent-fit** — the issue is not too big by `/subagent` Step 4's three criteria.
+
+When all three hold → **prefer inline**: recommend `/subagent #N` in the PM thread (or queue behind the ceiling) rather than a chip. When any is false — no PM context (the common standalone case), pipeline full, or too big — offer the chip as before, and **any separate-thread offer made while an inline slot was free carries a one-line "too big because X" rationale**.
+
+**The execution boundary is untouched.** The gate never launches anything — it only chooses which *recommendation* to surface. The user's action (running `/subagent`, or clicking a chip) remains the only execution path (`chip-launching.md` "execution boundary", NON-NEGOTIABLE).
+
+**Honest scope of the fix.** The gate closes the in-PM-session leak, which is correct and necessary. It is **not** sufficient to end sprawl on its own: the data shows most work enters thread-first via `/start-issue` with *no* PM session, where a chip is the right hand-off (there is no inline pipeline to use). Ending that residual is a workflow-adoption matter (make PM-first the habit) plus **FU-1** telemetry to actually measure spend rather than proxy it.
+
+### Queue-over-spawn (AC5) — verified, no change needed
+
+`/pm` (3.1 "queue the rest… starting a queued pipeline as each running one merges or blocks"; 3.4 "Refill inline slots first"), `/subagent` (Step 7 parallel-execution rules), and `subagent-orchestration.md` line 66 ("The same 3-4 ceiling is the inline A→B→C pipeline cap for `/pm` and `/subagent` — queue issues beyond it") already encode queue-over-spawn with the ceiling's CR-throughput basis ("at 7+ CR reviews/hour expect Greptile fallback"); `/wave` Step 6 carries the explicit `cr-rate-limits.md` citation. **No rule-corpus edit was made** — adding a redundant cross-reference to the auto-loaded corpus (11,373 words against an 11,671 ratchet cap) would duplicate text that already exists.
+
+---
+
+## What NOT to change
+
+- **The 3–4 concurrent-pipeline ceiling.** Its binding constraint is CodeRabbit review throughput (~8 reviews/hour shared across all open PRs, `cr-rate-limits.md`), **not** subagent slots — chip-launched threads and inline pipelines draw from the same budget. Raising it is a reviewed rule edit in `subagent-orchestration.md`, explicitly out of scope for #701.
+- **The chip execution boundary.** "Skills never auto-launch; the user's click is the only launch path" is non-negotiable (`chip-launching.md`). The gate re-frames the *recommendation*; it must never be read as license to spawn.
+- **Model tier ≠ routing.** Tier (Heavy/Standard/Light) does not gate inline vs thread — `/subagent` Step 4 is explicit that any tier runs inline. Do not re-couple them.
+- **Standalone chip behavior.** Outside PM context, `/start-issue` and `/issue-maker` chips are the correct hand-off and stay unchanged — do not suppress them.
+
+---
+
+## Follow-up issues
+
+### FU-1 — Real spend/thread-type telemetry pipeline — [#710](https://github.com/auerbachb/claude-code-config/issues/710) *(infrastructure; inherits the FU-5 gap from harness-model-audit-2026-06.md)*
+
+- **Problem:** No pipeline attributes token/Sonnet spend to threads vs inline subagents. `skill-usage.log` records invocation counts only, so every attribution here is a *thread-count proxy*, not a spend measurement (AC1 could only be answered "even roughly").
+- **AC:** Lightweight capture of per-session model tier and (where available) token spend, tagged thread vs inline; a `*-report.sh` that summarizes the thread-vs-inline split; this audit's AC1 re-runnable against real spend rather than a proxy.
+
+### FU-2 — `/wave` missing its global skill symlink — [#711](https://github.com/auerbachb/claude-code-config/issues/711) *(local deploy hygiene)*
+
+- **Problem:** `~/.claude/skills/wave` is absent, so `/wave` is unavailable outside this repo (Task 2 anomaly). Per `skill-symlinks.md` every skill should be symlinked through the skills-worktree.
+- **AC:** `~/.claude/skills/wave -> ~/.claude/skills-worktree/.claude/skills/wave` exists and resolves; `ls -la ~/.claude/skills/` shows it alongside the others. (Local op, not a repo code change — filed so it isn't dropped.)
+
+**Next cadence:** re-run this audit once FU-1's telemetry exists (real spend attribution) and after ~2–4 weeks of post-#613 PM sessions accumulate, to confirm the inline share keeps climbing and the gate measurably cut chip-launched threads within PM sessions.
+
+---
+
+## Audit coverage vs issue #701 acceptance criteria
+
+| #701 AC | How this audit addresses it |
+|---------|-----------------------------|
+| Ground truth: attribute recent spend to threads vs inline | Phase 1 Task 1 — thread-count proxy over `skill-usage.log`, bucketed at the #613 merge, with explicit "proxy not spend" caveats. Diagnosis confirmed pre-#613, improving post. |
+| Verify #613 is actually live | Phase 1 Task 2 — deployed copies == `origin/main`; inline-first language encoded; `/wave` symlink anomaly noted. |
+| Audit every thread-vs-inline surface | Phase 2 per-surface table for `/pm`, `/prompt`, `/subagent`, `/wave`, `/issue-maker`, `/start-issue`. |
+| Tighten routing; inline default; "too big because X" on thread offers | Phase 3 — shared PM-context inline gate in `chip-launching.md`, referenced by the three gap surfaces; one-line rationale required on slot-available thread offers. |
+| Queue-over-spawn when slots full | AC5 — verified already satisfied in `/pm`, `/subagent`, `subagent-orchestration.md`; no rule change needed. |
+| Follow-ups filed for out-of-scope work | FU-1 [#710](https://github.com/auerbachb/claude-code-config/issues/710) (telemetry), FU-2 [#711](https://github.com/auerbachb/claude-code-config/issues/711) (`/wave` symlink). |

--- a/.claude/skills/issue-maker/SKILL.md
+++ b/.claude/skills/issue-maker/SKILL.md
@@ -314,7 +314,9 @@ Default to **Standard** when signals are too sparse to classify confidently (thi
 
 ### Step 9c: Offer a coding chip (default-on, alongside the closing link)
 
-Immediately after logging the issue, offer a one-click coding chip **in addition to**, never in place of, the closing URL line below. This runs unconditionally — including in rapid-fire mode, with no extra confirmation and no opt-out flag today.
+Immediately after logging the issue, offer a one-click coding chip **in addition to**, never in place of, the closing URL line below. This is default-on — including in rapid-fire mode, with no extra confirmation and no opt-out flag today.
+
+**PM-context inline gate (before the chip).** Apply the gate from `.claude/reference/chip-launching.md` "PM-context inline gate". In the rare case this capture thread also carries live PM context (a `## Active Work` table) with a free inline slot, and the freshly-created issue is subagent-fit, **prefer noting it can be picked up inline via `/subagent #N` in the PM thread** over offering a standalone-thread chip (#613). This is a recommendation in the report, not an in-thread action — capture mode still performs no worktree/branch/implementation work (Step 2). In the common case — a dedicated capture thread with no PM context — there is no free inline pipeline to use, so the chip is the right hand-off and Step 9c proceeds unchanged.
 
 Check chip availability per `.claude/reference/chip-launching.md`. The coding-thread prompt is the same regardless of mode:
 
@@ -351,7 +353,7 @@ Why delegate to `/start-issue` instead of a fuller inline template (like `/pm`'s
   Print only the short summary per issue (per `chip-launching.md` "Short-summary transcript format") — never the full block in chip mode.
 - **Fallback mode** (tool absent, or this issue's `spawn_task` call failed): print the full fenced block above and leave `chip_task_id` as `null`. A failed spawn degrades **only that issue** — note the fallback once per batch; the rest keep their chips.
 
-Every created issue ends with exactly one of: a chip, or a printed block — never neither, and never both. (Batches: this repeats once per issue in the loop — see Step 6.)
+Every created issue ends with exactly one of: a chip, a printed block, or — when the PM-context inline gate above routed it — an inline `/subagent` recommendation; never neither, and never two of them. (Batches: this repeats once per issue in the loop — see Step 6.)
 
 If the user asks to "print the full prompt for #N" while in chip mode, re-emit that issue's complete block verbatim (Model line + guard preamble included) — the chip stays offered (`chip-launching.md` "Print-on-demand replay").
 

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -186,12 +186,14 @@ This creates **one canonical planning document** the coding agent can work from.
 
 ## Step 7: Deliver the ready-to-code handoff
 
+**PM-context inline gate (before the chip).** Apply the gate from `.claude/reference/chip-launching.md` "PM-context inline gate". `/start-issue` creates no `## Active Work` table of its own, but when it is invoked *inside* a PM thread that has one — with a free inline slot and a subagent-fit issue — **prefer recommending the issue run inline via `/subagent #N` in that PM thread** over spawning a chip that opens yet another thread (#613); the worktree prepared in Step 6 stays ready if the user would rather code it here instead. In the common case — `/start-issue` as the front door to a fresh coding thread, no PM context — there is no inline pipeline to use, so the chip/handoff below is the right delivery and Step 7 proceeds unchanged. Recommending inline is not launching it (Execution boundary).
+
 **First, check chip availability** per `.claude/reference/chip-launching.md`, then branch. The handoff content is the same in both delivery modes — only how it reaches the user differs:
 
 - **Chip mode** (`mcp__ccd_session__spawn_task` present): call `spawn_task` once for this issue with `title` / `prompt` / `tldr` / `cwd` (shape under "Chip construction" below). Print **only** the short summary — issue, title, `**Model:**` line, one-line rationale — in the reference's exact format. Do **not** also print the fallback block, or the same work is offered twice.
 - **Fallback mode** (tool absent): print the summary block below, unchanged.
 
-**A failed `spawn_task` is treated as unavailable** (per the reference): print the full fallback block instead. Do not retry the spawn. The handoff always ends with exactly one of: a chip, or a printed block — never neither.
+**A failed `spawn_task` is treated as unavailable** (per the reference): print the full fallback block instead. Do not retry the spawn. The handoff always ends with exactly one of: a chip, a printed block, or — when the PM-context inline gate above routed it — an inline `/subagent` recommendation; never neither.
 
 ### Fallback mode output
 

--- a/.claude/skills/wave/SKILL.md
+++ b/.claude/skills/wave/SKILL.md
@@ -14,7 +14,7 @@ Answer one question: **what is the largest set of backlog issues I can start rig
 
 `/wave` ranks nothing itself, launches nothing itself, and writes no code. It selects, caps, and offers.
 
-> **NON-NEGOTIABLE — `/wave` never auto-launches.** Every issue in the wave is *offered* as a chip (or a printed prompt block in fallback mode). **The user's click is the only launch path.** `/wave` does not spawn Agent-tool subagents, does not invoke `/subagent`, and does not treat its own selection as go-ahead. Selecting an issue for the wave is the recommendation; it is not permission. See "Execution boundary" at the end of this file.
+> **NON-NEGOTIABLE — `/wave` never auto-launches.** Every issue in the wave is either *offered* as a chip (or a printed prompt block in fallback mode) or — in a live PM thread with free inline slots — *recommended* for inline execution via `/subagent` (Step 7.0). **The user's action (a chip click, or running `/subagent`) is the only launch path.** `/wave` never spawns Agent-tool subagents and never invokes `/subagent` itself, and does not treat its own selection as go-ahead. Selecting an issue for the wave is the recommendation; it is not permission. See "Execution boundary" at the end of this file.
 
 ---
 
@@ -155,11 +155,13 @@ Take the first `SLOTS` issues from the independent set. Anything past that is ex
 
 ---
 
-## Step 7: Offer the wave as chips
+## Step 7: Offer the wave — inline when PM context is live, else chips
 
-Follow `.claude/reference/chip-launching.md` **verbatim** — availability detection, `spawn_task` shape, model-guard preamble, short-summary format, per-issue fallback on spawn failure. Nothing in this section overrides it.
+**7.0 — PM-context inline gate (before offering any chip).** Apply the gate from `.claude/reference/chip-launching.md` "PM-context inline gate". When this thread already has a `## Active Work` table (PM context) **and** a free inline slot (the `IN_FLIGHT` you computed in Step 2 is below the ceiling), the subagent-fit wave issues should be **recommended for inline parallel execution** — lead with a single `/subagent #{a} #{b} …` line for them rather than spawning chips. Inline runs them in parallel up to the same ceiling, which is exactly what a wave is for, and it keeps them in the one PM thread instead of scattering tabs (#613). Fall through to the chip offer below for issues that are **too big** for a subagent (each carrying its one-line "too big because X" reason), or whenever there is **no PM context** or **no free slot** — a separate thread is the right hand-off there. `/wave` still launches nothing: recommending `/subagent` is not running it (Execution boundary); the user's `/subagent` or click is the only launch path.
 
-For each issue in the final wave:
+**7.1 — Offer the (remaining) wave as chips.** Follow `.claude/reference/chip-launching.md` **verbatim** — availability detection, `spawn_task` shape, model-guard preamble, short-summary format, per-issue fallback on spawn failure. Nothing in this section overrides it.
+
+For each issue still offered as a chip:
 
 - **`prompt`** — the full self-contained thread prompt from `/pm` Step 3.1's template (`**Model:**` line first, model-guard preamble immediately after with no blank line between, then the task / issue body / codebase context / workflow / constraints sections). Reuse that template as written; `/wave` does not define a prompt format of its own.
 - **`title`** — ≤60 chars, starts with a verb, includes the issue number.
@@ -231,7 +233,7 @@ When chip mode is unavailable (CLI, headless, older client), the wave is deliver
 | Rationalization | Reality |
 |---|---|
 | "The user asked for a wave, so they clearly want these running." | They asked for the *set*. Which ones actually run is the click. |
-| "These are all small — running them inline is what `/pm` would do." | `/pm`'s inline default is `/pm`'s. `/wave`'s whole contract is that launch is elective; running them inline deletes the choice this skill exists to give. |
+| "These are all small — I'll just run them inline myself like `/pm` does." | *Recommending* inline via `/subagent` (Step 7.0) is the #613 default in a PM thread — but `/wave` *running them itself* is not. Launch stays elective: which issues run, and how, is the user's action (a chip click or their own `/subagent`), never `/wave`'s. |
 | "I'll just start the top one to save a round-trip." | One auto-launch is the whole violation. There is no partial version of this rule. |
 | "Fallback mode has no chips, so I'll spawn subagents instead." | Fallback prints blocks. Absent chips means fewer delivery options, not a different execution boundary. |
 | "The user said 'go' after seeing the wave." | An explicit user instruction to run specific issues is honored by `/subagent` — invoke that, and only for the issues they named. `/wave` still never launches on its own. |


### PR DESCRIPTION
## **User description**
## What this does

Audit-then-tighten of #613's inline-first routing (Closes #701).

**Ground truth (AC1).** A thread-count proxy over `~/.claude/skill-usage.log`, bucketed at the #613 merge (2026-07-21), confirms the "too many threads" diagnosis for the pre-#613 period and shows #613 working where it's used:

| Metric | pre-#613 | post-#613 |
|--------|----------|-----------|
| Coding-thread lifecycle calls | 118 | 31 |
| Inline `/subagent` calls | 1 | 6 |
| Inline share of execution | ~0.8% | ~16% |
| PM sessions that ran inline | 0/0 | **5/6** |

The residual sprawl is **not** `/pm` misrouting — it's that most work enters thread-first via `/start-issue` **outside** any PM thread, where inline-first never gets consulted. (Proxy, not spend: the log has no model/token data — that's the FU-5 gap, filed as #710.)

**Deployment liveness (AC2).** `~/.claude/skills-worktree` HEAD == `origin/main`; deployed `pm`/`subagent` copies encode inline-first + the three-criterion too-big test + the 3–4 queue.

**Per-surface audit (AC3).** `/pm`, `/prompt`, `/subagent` already conform. `/wave`, `/issue-maker`, `/start-issue` offered chips with no PM-context/slot check — the three gap surfaces.

**Tightening (AC4).** One shared **PM-context inline gate** added to `chip-launching.md` (reference doc — not auto-loaded, no rule-budget impact) and referenced by the three gap surfaces: before offering a standalone-thread chip for subagent-fit work, check for live PM context (`## Active Work` table) + a free inline slot (`IN_FLIGHT` < 3–4 ceiling) + subagent-fit; if all hold, **prefer inline** (`/subagent` or queue). Every slot-available thread offer carries a one-line "too big because X" rationale. The chip **execution boundary is untouched** — the gate only re-frames the recommendation; nothing auto-launches.

**Queue-over-spawn (AC5).** Verified already satisfied in `/pm` (3.1/3.4), `/subagent` (Step 7), and `subagent-orchestration.md` line 66 — **no rule-corpus edit** (corpus stays 11,373 ≤ 11,671 cap).

**Follow-ups (AC6).** #710 (spend/thread-type telemetry pipeline — the real FU-5 fix), #711 (`/wave` missing its global skill symlink).

## Files

- `.claude/reference/pm-routing-audit-2026-07.md` (new) + `.claude/reference/README.md` index entry
- `.claude/reference/chip-launching.md` — canonical PM-context inline gate
- `.claude/skills/{wave,issue-maker,start-issue}/SKILL.md` — reference the gate; reconcile `/wave`'s never-launch invariants and each skill's "chip or block, never neither" terminal with the inline path

## Local review note

Both local CLIs were unavailable this run: **CodeRabbit CLI rate-limited** (free OSS limit; 23-min reset) and **CodeAnt CLI not installed** on this machine. Per `cr-local-review.md`, I did a self-review (which caught and fixed internal invariant contradictions in `/wave`). The GitHub-side reviewers (CodeRabbit App, CodeAnt, BugBot) are the gating review for this PR.

## Test plan

Static verification (against this PR's changes):

- [x] **AC1** — Ground truth attributed (thread-count proxy, caveated) in the audit doc; diagnosis confirmed pre-#613, improving post.
- [x] **AC2** — #613 deployment verified (skills-worktree == `origin/main`; inline-first language encoded).
- [x] **AC3** — Per-surface routing table for all six surfaces in the audit doc.
- [x] **AC4** — Inline gate defined once in `chip-launching.md`; referenced by `/wave`, `/issue-maker`, `/start-issue`; slot-available thread offers require a "too big because X" rationale.
- [x] **AC5** — Queue-over-spawn verified present in `/pm`, `/subagent`, `subagent-orchestration.md`; documented (no rule change).
- [x] **AC6** — Follow-ups #710, #711 filed and cited in the audit doc + README.
- [x] `rule-lint.sh` green (corpus 11,373 ≤ 11,671 cap); `skill-catalog-lint.sh` green (28 commands).
- [x] Execution boundary preserved — no surface auto-launches; gate only re-frames the recommendation.

Runtime validation — post-merge, non-blocking (instruction-level behavior; verify in a live PM session, tracked in the audit doc's next-cadence note. Not blocking AC checkboxes — this PR changes instructions, not runtime code):

- Dry-run `/pm` over a mixed backlog → subagent-fit issues run inline, thread chips only for documented too-big cases.
- With inline slots saturated, the next subagent-fit issue is queued, not offered as a thread.
- One full inline `A→B→C` run from the PM thread reaches merge-ready without a separate thread being opened.


___

## **CodeAnt-AI Description**
**Route subagent-fit work inline when PM context is already live**

### What Changed
- Added a shared check that looks for an active PM thread with free inline capacity before offering a separate coding chip.
- In `/wave`, `/issue-maker`, and `/start-issue`, subagent-fit work in an active PM thread is now steered to inline `/subagent` execution instead of opening another thread.
- Thread offers now include a short “too big because X” reason when a chip is still the right path.
- `/wave` keeps its no-auto-launch rule, but can now recommend inline execution in PM threads when that fits.

### Impact
`✅ Fewer extra coding threads inside PM sessions`
`✅ Shorter handoff from PM to execution`
`✅ Clearer reasons when work still needs a separate thread`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

