### PR TITLE
feat(#715): default to babysitting in-flight PRs — never ask permission to monitor

### DIFF
--- a/.claude/rules/monitor-mode.md
+++ b/.claude/rules/monitor-mode.md
@@ -2,7 +2,7 @@
 
 > **Always:** Enter monitor mode when subagents are active. Timestamp every message (see CLAUDE.md #1). Heartbeat every ≤5 min (see CLAUDE.md #3). Report subagent failures immediately. Recover state after compaction.
 > **Ask first:** Breaking monitor mode for explicit user requests — warn about paused monitoring first.
-> **Never:** Do substantive work while subagents are active. Go >5 min without a user-visible message. Let a stalled PR go unreported.
+> **Never:** Do substantive work while subagents are active. Go >5 min without a user-visible message. Let a stalled PR go unreported. Ask permission to monitor — babysitting an in-flight PR is the default (`CLAUDE.md`).
 
 ## Dedicated Monitor Mode (MANDATORY for parent agents)
 

--- a/.claude/rules/scheduling-reliability.md
+++ b/.claude/rules/scheduling-reliability.md
@@ -1,6 +1,6 @@
 # Scheduling Reliability
 
-> **Always:** Use `/loop` for user-facing "poll/check/watch every N" requests. Run the pre-exit checklist. Record polling state in `session-state.json`.
+> **Always:** Use `/loop` for user-facing "poll/check/watch every N" requests — including the default in-flight-PR watch (`CLAUDE.md`). Run the pre-exit checklist. Record polling state in `session-state.json`.
 > **Ask first:** Never — scheduling reliability is autonomous.
 > **Never:** Hand-roll a chain of one-shot `ScheduleWakeup` (or equivalent) calls for a recurring user-facing poll. Promise to "check back in N minutes" without backing it with an active `/loop` or `CronCreate` job. Exit a wake-up turn without confirming the next tick is scheduled.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ The workflow is fully autonomous. At every phase transition — local review, pu
 - Merging (except `/wrap` / `/merge` / `/pr-monitor-and-manage` — see above)
 - Respawning a failed subagent
 
+**Monitoring is never a permission-gated action — babysitting an in-flight PR is the default, never a question.** When a PR is open and not yet merge-ready, arm the watch yourself and report it; never present a "watch it / babysit / review it yourself — which?" menu, and never wait for the user to say "watch it" first. A CodeRabbit timeout or rate-limit is not a stop-and-ask — it routes autonomously into the reviewer-escalation chain (BugBot → Greptile → self-review, `cr-github-review.md`). Keep it token-safe: arm `/loop` (or `CronCreate` for durable/fleet) so it pauses between ticks and widens on stable-state backoff — never a continuous poll (`scheduling-reliability.md`). Use the existing skills (`/babysit-pr`, `/pr-monitor-and-manage`); add no new machinery. The only authorization left in the babysit→merge loop is the **merge** itself (see "PR MERGE AUTHORIZATION" above and issue #674).
+
 If you catch yourself composing a "should I...?" question about any workflow step, stop — the answer is always yes. Just do it.
 
 ---


### PR DESCRIPTION
## What & why

Being asked to authorize monitoring is pure friction — you always want an in-flight PR watched, so the "watch it / babysit / review yourself — which?" menu just adds a round-trip before anything happens. This makes **babysitting an in-flight PR the default**: the thread arms a token-safe watch itself and reports it, never presenting a menu and never waiting for you to say "watch it" first. Only **merge** still needs authorization (governed by `CLAUDE.md` "PR MERGE AUTHORIZATION" / issue #674).

The "menu" was **emergent behavior**, not hardcoded text — a grep of `.claude/rules` + `.claude/skills` + `CLAUDE.md` found no literal menu/ask-to-monitor phrasing to delete. So the fix is a single authoritative reflex in `CLAUDE.md` plus two one-line consistency pointers. **No new machinery** — it routes into the existing `/babysit-pr` and `/pr-monitor-and-manage` skills.

`CLAUDE.md` is one file (the user-global `~/.claude/CLAUDE.md` is a symlink to the repo copy via the skills-worktree), so a single repo edit satisfies "global + project."

## Changes
- **`CLAUDE.md`** — new reflex in the *AUTONOMOUS WORKFLOW EXECUTION — DO NOT ASK PERMISSION* section: monitoring is never permission-gated; arm the watch yourself, no menu, no "watch it" gate; a CR timeout/rate-limit routes autonomously into the BugBot → Greptile → self-review escalation chain (`cr-github-review.md`); the watch uses `/loop`/`CronCreate` with stable-state backoff, never a continuous poll (`scheduling-reliability.md`); only merge stays gated (issue #674).
- **`.claude/rules/monitor-mode.md`** — banner `Never` line: never ask permission to monitor; babysitting is the default.
- **`.claude/rules/scheduling-reliability.md`** — banner `Always` line: the default in-flight-PR watch is a canonical `/loop` consumer.

## Test plan
- [x] `CLAUDE.md` makes arming a watch the **default** for an in-flight PR — no "watch it / babysit / review yourself — which?" menu; no "say 'watch it'" gate (`CLAUDE.md` AUTONOMOUS WORKFLOW EXECUTION).
- [x] Monitoring authorization explicitly removed from the permission set; text is unambiguous that only **merge** authorization remains (cross-refs issue #674).
- [x] "CR timeout / rate-limit → keep babysitting" stated as default: routes into the escalation chain (BugBot → Greptile → self-review) autonomously, not a user prompt.
- [x] Token-safety guardrail spelled out: default watch uses `/loop` (or `CronCreate` for durable/fleet) with pause-between-ticks + stable-state backoff — never a continuous poll; `scheduling-reliability.md`'s backoff contract is **referenced, not duplicated**.
- [x] No "check back in N minutes" phrasing exists that isn't backed by `/loop` (grep clean — only `scheduling-reliability.md`'s own prohibition).
- [x] `monitor-mode.md` and `scheduling-reliability.md` read consistently with the new default (one-line pointers back to the reflex; existing `Ask first` clause still governs *pausing* monitor mode, not *starting* it).
- [x] Rule corpus within limits and `rule-lint.sh` passes: **11,618 / 11,671** ratchet cap (net +156 words); `.github/scripts/rule-lint.sh` exits 0.
- [x] Grep audit for "say 'watch it'", "tell me which", "which do you want", "authorize … monitor", "want it watched" — only hits are the new *prohibitions*; no lingering ask-to-monitor prompts.
- [x] Merge gate unweakened: `# PR MERGE AUTHORIZATION` intact; removing the monitoring prompt did not touch the merge prompt.

## Reviewer notes
- **Local CodeRabbit CLI raised 1 finding** (CLAUDE.md:41) asking to replace the reflex with a one-line pointer to the rule files. **Declined with reasoning:** that directly contradicts AC #1–#3 (which require the default/no-menu/CR-timeout behavior to be stated *in CLAUDE.md*) and CR's own merged plan (Design Choice 2 chose "global reflex in CLAUDE.md plus pointers to the skills"). The reflex is not duplicated elsewhere — the rule files only point back to it; mechanics are deferred by reference per AC #4. Budget passes, so there's no forcing reason to cut.
- **CodeAnt CLI is not installed locally**, so only the CodeRabbit CLI ran for local review. The CodeAnt **GitHub App** is unaffected and still gates this PR.

Closes #715


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified monitoring guidance for active pull requests, including status updates, stalled-work reporting, and monitoring permissions.
  * Added reliability requirements for recurring checks, including pre-exit verification and persisted polling state.
  * Clarified automatic monitoring, escalation for timeouts or rate limits, and merge authorization requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->