### PR TITLE
fix(#712): exclude _unknown from --session-view's other-repo PR claims

### DIFF
--- a/.claude/scripts/session-state.sh
+++ b/.claude/scripts/session-state.sh
@@ -1005,15 +1005,18 @@ migrate(\$__pathmap; \$__unknown)"
     #      write sites needs no change here.
     #   2. Else keep an entry with no .pr (unattributable).
     #   3. Else correlate by PR number: keep UNLESS .pr is tracked by some OTHER
-    #      repo ($otherpr = every PR key under a repo != this one). That drops
-    #      other-repo agents AND, conservatively, the ambiguous case where the
-    #      same PR number is tracked by two repos — a scoped view that
-    #      under-shows a thread is safer than one that leaks another repo's. The
-    #      entry stays visible via --all-repos. Numeric .pr is stringified to
-    #      compare against the string PR-map keys.
+    #      repo ($otherpr = every PR key under a real repo != this one). The
+    #      _unknown bucket is excluded from $otherpr (issue #712): it holds
+    #      unattributed/legacy entries and is not a real repo, so a PR number
+    #      there is not evidence the PR belongs to someone else. That drops
+    #      genuine other-repo agents AND, conservatively, the ambiguous case
+    #      where the same PR number is tracked by two real repos — a scoped
+    #      view that under-shows a thread is safer than one that leaks another
+    #      repo's. The entry stays visible via --all-repos. Numeric .pr is
+    #      stringified to compare against the string PR-map keys.
     SV_PROGRAM="$SV_PROGRAM
 | (.repos[\$__rk] // {}) as \$mine
-| ([ (.repos // {}) | to_entries[] | select(.key != \$__rk) | (.value.prs // {}) | keys[] ]) as \$otherpr
+| ([ (.repos // {}) | to_entries[] | select(.key != \$__rk and .key != \$__unknown) | (.value.prs // {}) | keys[] ]) as \$otherpr
 | .prs = (\$mine.prs // {})
 | .root_repo = (\$mine.root_repo // null)
 | .active_agents = ((.active_agents // [])

--- a/.claude/scripts/tests/session-state.test.sh
+++ b/.claude/scripts/tests/session-state.test.sh
@@ -319,6 +319,38 @@ check_eq "empty file: active_agents defaults to []" "[]" "$(jq -c '.active_agent
 check_eq "empty file: root_repo is null" "null" "$(jq -c '.root_repo' <<<"$VIEW_EMPTY")"
 
 echo
+echo "== --session-view: _unknown does not mask PR attribution (issue #712) =="
+# Three cases for active_agents entries (no owner_repo, correlated by .pr):
+#   PR 501 — lives ONLY under _unknown         → agent retained (unattributed)
+#   PR 502 — lives under a real other repo     → agent dropped  (other repo wins)
+#   PR 503 — lives under BOTH _unknown and a   → agent dropped  (real repo wins
+#              real other repo                    even when _unknown also has it)
+cat > "$STATE_FILE" <<'JSON'
+{
+  "active_agents": [
+    {"id":"only-unknown","pr":501},
+    {"id":"real-other","pr":502},
+    {"id":"both-unknown-and-real","pr":503}
+  ],
+  "repos": {
+    "org/invoking": {"prs": {"600": {"phase":"A"}}},
+    "org/other":    {"prs": {"502": {"phase":"B"}, "503": {"phase":"C"}}},
+    "_unknown":     {"prs": {"501": {"phase":"A"}, "503": {"phase":"A"}}}
+  }
+}
+JSON
+VIEW_712="$(run --repo org/invoking --session-view)"
+check_eq "#712: agent with PR only in _unknown is retained" '["only-unknown"]' \
+  "$(jq -c '[.active_agents[].id]' <<<"$VIEW_712")"
+check_eq "#712: agent with PR in a real other repo is dropped" "0" \
+  "$(jq '[.active_agents[].id] | map(select(. == "real-other")) | length' <<<"$VIEW_712")"
+check_eq "#712: agent with PR in both _unknown and a real other repo is dropped" "0" \
+  "$(jq '[.active_agents[].id] | map(select(. == "both-unknown-and-real")) | length' <<<"$VIEW_712")"
+# Confirm the invoking repo's own PRs still scope correctly alongside.
+check_eq "#712: invoking repo prs unaffected" '{"600":{"phase":"A"}}' \
+  "$(jq -c '.prs' <<<"$VIEW_712")"
+
+echo
 echo "== summary: $PASS passed, $FAIL failed =="
 if [[ "$FAIL" -eq 0 ]]; then
   echo "OK: session-state.sh field-type contract tests passed"


### PR DESCRIPTION
## Summary

The `$otherpr` set in `--session-view`'s `active_agents` filter was built from every `.repos` key except the invoking repo. The `_unknown` bucket is not a real repo — it holds unattributed/legacy entries — but its key differed from `$__rk`, so PR numbers parked there leaked into `$otherpr`. An agent legitimately working a PR whose number also sits in `_unknown` was incorrectly filtered out of its own repo's session view.

**Fix:** one-clause jq change in `session-state.sh` — extend the `select()` predicate in the `$otherpr` builder to also exclude `$__unknown` (already bound in `SV_ARGS`, no new plumbing needed):

```diff
-| ([ (.repos // {}) | to_entries[] | select(.key != \$__rk) | (.value.prs // {}) | keys[] ]) as \$otherpr
+| ([ (.repos // {}) | to_entries[] | select(.key != \$__rk and .key != \$__unknown) | (.value.prs // {}) | keys[] ]) as \$otherpr
```

The "number in both `_unknown` and a real other repo" case still drops correctly — the real repo's entry still populates `$otherpr`. The exclusion is additive and cannot weaken the existing cross-repo guarantee from issue #687.

Closes #712

## Test plan

- [ ] `$otherpr` excludes the `_unknown` scope, so an unattributed entry never masquerades as another repo's claim on a PR number
- [ ] An agent whose `.pr` appears **only** under `_unknown` is retained in the invoking repo's `--session-view`
- [ ] An agent whose `.pr` is tracked by a genuine other repo is still dropped (the #687 guarantee is unchanged)
- [ ] Regression test covers all three cases: number in `_unknown` only, number in a real other repo, number in both

All 4 new assertions pass; full suite: 96/96 tests pass.

## Notes

- CodeAnt CLI not installed in this environment (exit 127) — dropped for this session. CodeRabbit CLI: 0 findings on both changed files.
- Does not implement reattribution (issue #670) — this is view-filter only per issue #712 scope.
