### PR TITLE
fix(#696): rank dedup candidates by score first and keep numeric tokens

### DIFF
--- a/.claude/scripts/issue-dedup.sh
+++ b/.claude/scripts/issue-dedup.sh
@@ -192,7 +192,7 @@ def tokenize(text):
     terms = []
     for t in raw:
         t = t.strip("./-")
-        if len(t) < 3 or t in STOPWORDS or t.isdigit():
+        if len(t) < 3 or t in STOPWORDS:
             continue
         if t not in terms:
             terms.append(t)
@@ -259,7 +259,7 @@ def score_all():
         })
     # Open issues outrank closed ones at equal score: only an open issue can
     # absorb a finding as a comment.
-    candidates.sort(key=lambda c: (c["state"] == "OPEN", c["score"], c["title_hits"], -c["number"]), reverse=True)
+    candidates.sort(key=lambda c: (c["score"], c["state"] == "OPEN", c["title_hits"], -c["number"]), reverse=True)
     return candidates[:max_results]
 
 # An unexpected exception must not exit 1: exit 1 is the documented "searched,

--- a/.claude/scripts/tests/issue-dedup.test.sh
+++ b/.claude/scripts/tests/issue-dedup.test.sh
@@ -224,6 +224,134 @@ assert_eq "unknown option → exit 2" "2" "$rc_badopt"
 assert_eq "non-numeric limit → exit 2" "2" "$rc_badnum"
 assert_eq "--help → exit 0" "0" "$rc_help"
 
+# ---- regression #696: fix 1 — score-first ranking ----------------------------
+echo "== regression #696: high-score closed beats low-score open (score-first ranking) =="
+# Before the fix, (state=="OPEN") led the sort key, so every open issue
+# outranked every closed one regardless of score.  A perfect-1.0 closed match
+# was pushed past position 5 by five lower-scoring open issues and silently
+# dropped by --max-results 5 — the #638/#647 mechanism.
+# After the fix, score is the primary key; OPEN is only the tiebreak at equal
+# score, matching what the sort comment already promised.
+#
+# Fixture: 5 open issues each matching 2/5 terms (coverage 0.40, score 0.40),
+# plus 1 closed issue matching all 5 (coverage 1.0, score 1.0).
+cat > "$WORK/open_rank.json" <<'JSON'
+[
+  {"number": 101, "title": "Unrelated issue one",   "url": "https://github.com/o/r/issues/101", "state": "OPEN",   "body": "xyzzy quuxbaz"},
+  {"number": 102, "title": "Unrelated issue two",   "url": "https://github.com/o/r/issues/102", "state": "OPEN",   "body": "xyzzy quuxbaz"},
+  {"number": 103, "title": "Unrelated issue three", "url": "https://github.com/o/r/issues/103", "state": "OPEN",   "body": "xyzzy quuxbaz"},
+  {"number": 104, "title": "Unrelated issue four",  "url": "https://github.com/o/r/issues/104", "state": "OPEN",   "body": "xyzzy quuxbaz"},
+  {"number": 105, "title": "Unrelated issue five",  "url": "https://github.com/o/r/issues/105", "state": "OPEN",   "body": "xyzzy quuxbaz"}
+]
+JSON
+cat > "$WORK/closed_rank.json" <<'JSON'
+[
+  {"number": 999, "title": "Another unrelated", "url": "https://github.com/o/r/issues/999",
+   "state": "CLOSED", "body": "xyzzy quuxbaz frobble wibble narf"}
+]
+JSON
+cat > "$WORK/bin/gh" <<EOF
+#!/usr/bin/env bash
+state="open"
+for a in "\$@"; do case "\$prev" in --state) state="\$a" ;; esac; prev="\$a"; done
+case "\$state" in
+  open)   cat "$WORK/open_rank.json" ;;
+  closed) cat "$WORK/closed_rank.json" ;;
+  *)      echo "[]" ;;
+esac
+EOF
+chmod +x "$WORK/bin/gh"
+run "xyzzy quuxbaz frobble wibble narf"
+assert_eq "exit 0 (candidates found)" "0" "$RC"
+assert_eq "closed #999 (score 1.0) ranks first over five open issues (score 0.40)" "999" "$(top_number)"
+if has_number 101; then
+  ok "low-score open #101 still surfaces (not suppressed)"
+else
+  fail "open #101 should still surface"
+fi
+
+echo "== regression #696: open still wins at equal score (tiebreak preserved) =="
+# This guards the /wrap use-case: a closed issue does not suppress an open one
+# at the same match quality, because the open one can still absorb a comment.
+cat > "$WORK/open_tie.json" <<'JSON'
+[
+  {"number": 200, "title": "Open full match", "url": "https://github.com/o/r/issues/200",
+   "state": "OPEN", "body": "xyzzy quuxbaz frobble wibble narf"}
+]
+JSON
+cat > "$WORK/closed_tie.json" <<'JSON'
+[
+  {"number": 201, "title": "Closed full match", "url": "https://github.com/o/r/issues/201",
+   "state": "CLOSED", "body": "xyzzy quuxbaz frobble wibble narf"}
+]
+JSON
+cat > "$WORK/bin/gh" <<EOF
+#!/usr/bin/env bash
+state="open"
+for a in "\$@"; do case "\$prev" in --state) state="\$a" ;; esac; prev="\$a"; done
+case "\$state" in
+  open)   cat "$WORK/open_tie.json" ;;
+  closed) cat "$WORK/closed_tie.json" ;;
+  *)      echo "[]" ;;
+esac
+EOF
+chmod +x "$WORK/bin/gh"
+run "xyzzy quuxbaz frobble wibble narf"
+assert_eq "exit 0" "0" "$RC"
+assert_eq "open #200 ranks first at equal score (tiebreak preserved)" "200" "$(top_number)"
+if has_number 201; then
+  ok "closed #201 also surfaces"
+else
+  fail "closed #201 should also surface"
+fi
+
+# ---- regression #696: fix 2 — numeric tokens kept ---------------------------
+echo "== regression #696: numeric token '403' contributes to terms_matched and coverage =="
+# Before the fix, t.isdigit() silently dropped '403' from the term set.
+# For keywords "codeant 403 re-authenticate daily cap":
+#   OLD (4 terms, 403 gone): issue matching only "codeant" scores 1/4 = 0.25 — below
+#     the 0.34 floor, filtered out.
+#   NEW (5 terms, 403 kept): same issue also matches "403", scoring 2/5 = 0.40 —
+#     above the floor, surfaces.
+# The len < 3 guard already drops noisy short numbers; removing isdigit() only
+# affects identifiers of length ≥ 3 such as error codes and PR/issue numbers.
+cat > "$WORK/open_403.json" <<'JSON'
+[]
+JSON
+cat > "$WORK/closed_403.json" <<'JSON'
+[
+  {"number": 643, "title": "Unexpected error from review CLI",
+   "url": "https://github.com/o/r/issues/643", "state": "CLOSED",
+   "body": "codeant 403 error response unauthorized"}
+]
+JSON
+cat > "$WORK/bin/gh" <<EOF
+#!/usr/bin/env bash
+state="open"
+for a in "\$@"; do case "\$prev" in --state) state="\$a" ;; esac; prev="\$a"; done
+case "\$state" in
+  open)   cat "$WORK/open_403.json" ;;
+  closed) cat "$WORK/closed_403.json" ;;
+  *)      echo "[]" ;;
+esac
+EOF
+chmod +x "$WORK/bin/gh"
+# Keywords produce 5 terms: codeant, 403, re-authenticate, daily, cap.
+# Issue #643 body matches "codeant" and "403" → 2/5 = 0.40 ≥ 0.34 floor.
+run "codeant 403 re-authenticate daily cap"
+assert_eq "exit 0 (numeric token raises coverage above 0.34 floor)" "0" "$RC"
+if printf '%s' "$OUT" | jq -e '.[0].terms_matched | contains(["403"])' >/dev/null 2>&1; then
+  ok "'403' appears in terms_matched"
+else
+  fail "'403' missing from terms_matched"
+fi
+if awk -v c="$(printf '%s' "$OUT" | jq -r '.[0].coverage // 0')" \
+       'BEGIN { exit !(c >= 0.34) }'; then
+  ok "coverage is at or above the 0.34 floor (numeric token contributed)"
+else
+  fail "coverage below 0.34 — got $(printf '%s' "$OUT" | jq -r '.[0].coverage // 0')"
+fi
+
 echo
 echo "passed: $PASS  failed: $FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Two independent mechanical defects in `.claude/scripts/issue-dedup.sh`'s embedded Python that caused both duplicate pairs that motivated the helper to be missed:

1. **Ranking**: Sort key led with `(c["state"] == "OPEN", ...)` so every open issue outranked every closed one regardless of match quality. A perfect-1.0 closed match (#638) ranked 7th and was truncated by `--max-results 5`. Fixed to `(c["score"], c["state"] == "OPEN", ...)` — score first, state as tiebreak only.

2. **Numeric tokens discarded**: `t.isdigit()` dropped `403` etc. from the term set. For a "codeant 403" finding, issue #643 matched only `codeant` → coverage 0.25, below the 0.34 floor → filtered out. With `isdigit()` removed, it matches both tokens → coverage 0.40 → surfaces. The `len(t) < 3` guard still drops noisy short numbers.

Both are one-token edits. The coverage-weighting redesign mentioned in the issue's Notes remains out of scope and open for a future discussion.

Closes #696

---

## Probe before/after

Results against `auerbachb/claude-code-config` at default settings:

| Probe | Target | Before (from issue) | After (actual run) |
|-------|--------|---------------------|--------------------|
| `session-state.json root_repo polling-state-gate.sh concurrent` | **#638** | `[651,670,682,655,647]` — miss | `[696,647,625,**638**,651]` — rank 4 ✓ |
| `codeant 403 re-authenticate daily cap` | **#643** | `[675,664,642,663,470]` — miss | `[696,664,663,642,**643**]` — rank 5 ✓ |

(Issue #696 itself appears first in the post-fix output because its body describes exactly these terms — expected behavior.)

---

## Local review

- **CodeRabbit CLI**: clean pass, 0 findings
- **CodeAnt CLI**: not installed — noted; CodeAnt GitHub App unaffected and will review on the PR

---

## Acceptance criteria

- [ ] The sort key orders by `score` first, with `state` retained as a tiebreak so an open issue still wins at equal score (the behavior the current comment already documents)
- [ ] The `t.isdigit()` clause is removed from `tokenize()`; the `len(t) < 3` guard is retained
- [ ] A finding phrased like #647 returns **#638** within the default `--max-results 5`
- [ ] A finding phrased like #663 returns **#643** within the default `--max-results 5`
- [ ] All existing tests in `.claude/scripts/tests/issue-dedup.test.sh` still pass
- [ ] A regression test asserts a **closed** candidate at full coverage is not truncated out by lower-scoring **open** candidates at the default `--max-results` — the case the current suite does not cover
- [ ] A regression test asserts a numeric token (e.g. `403`) contributes to `terms_matched` and to `coverage`
- [ ] The sort comment still matches the code after the change

## Test plan

- [ ] `bash .claude/scripts/tests/issue-dedup.test.sh` → 33+ passing, 0 failing
- [ ] `issue-dedup.sh "session-state.json root_repo polling-state-gate.sh concurrent"` → #638 present in default output
- [ ] `issue-dedup.sh "codeant 403 re-authenticate daily cap"` → #643 present in default output
- [ ] `issue-dedup.sh "codeant 403" --max-results 20 | jq '.[] | select(.number==643) | .terms_matched'` → includes `"403"`
- [ ] Equal-score open vs closed candidates → open still ranks first (tiebreak preserved, no regression to `/wrap`'s suppression rule)
- [ ] `--min-coverage` / `--max-results` / `--exclude` behavior unchanged
- [ ] `/wrap` and `/issue-maker` still parse the output unchanged (field names and shape untouched)
