### PR TITLE
feat(#680): make the auto-file dedup check repo-wide across every autonomous issue filer

### DIFF
--- a/.claude/agents/pm-worker.md
+++ b/.claude/agents/pm-worker.md
@@ -30,7 +30,31 @@ When creating a new GitHub issue:
 
 Write the title, body, acceptance criteria, and relevant context.
 
-### 2. Create the issue
+### 2. Dedup check (MANDATORY before filing)
+
+Run `.claude/scripts/issue-dedup.sh` (try the three standard paths in order):
+
+```bash
+for DEDUP in \
+  "$HOME/.claude/skills-worktree/.claude/scripts/issue-dedup.sh" \
+  "$HOME/.claude/scripts/issue-dedup.sh" \
+  ".claude/scripts/issue-dedup.sh"; do
+  [ -x "$DEDUP" ] && break; DEDUP=""; done
+```
+
+If the helper is found, run it with a 2–6 keyword phrase from the issue title:
+
+```bash
+DEDUP_JSON=$("$DEDUP" "<keywords from issue title>" 2>/dev/null) || DEDUP_RC=$?
+```
+
+Classify the top candidate per `.claude/reference/autofile-dedup.md`:
+
+- **Strong match** (open issue, same primary artifact, a quotable covering criterion, `coverage ≥ 0.6`) → **do not file**. Post the finding as a comment on the existing issue using the template in `autofile-dedup.md`. Record in your exit report: `"<title>" — appended to #<N> instead of filing`. Proceed to the exit report (Step 4 is skipped).
+- **Weak / ambiguous match** → file as normal (Step 3), and include `Possibly duplicates #<N> — <one line on the overlap>` in the issue body.
+- **No match** or helper not found → file as normal (Step 3). If the helper was missing, note the degraded check once in your exit report.
+
+### 3. Create the issue
 
 ```bash
 gh issue create --title "<title>" --body "<body>" --label "<labels>"
@@ -38,7 +62,7 @@ gh issue create --title "<title>" --body "<body>" --label "<labels>"
 
 A GitHub Actions workflow automatically comments `@coderabbitai plan` on new issues — you do not need to trigger it manually.
 
-### 3. If starting work immediately — Issue Planning Flow
+### 4. If starting work immediately — Issue Planning Flow
 
 1. Wait for CR's plan via `.claude/scripts/cr-plan.sh` — it encapsulates the canonical substantive-plan filter (`cr-plan-filter.py`: `coderabbitai` author, reject issue-enrichment/Issue-Planner boilerplate and "actions performed" ack lines, then require >200 chars of stripped content plus a heading or numbered step — issue #541) and the 60s polling loop:
    ```bash
@@ -99,7 +123,7 @@ PHASE_COMPLETE: pm
 PR_NUMBER: <PR number if a PR was created or referenced, else "none">
 HEAD_SHA: <current HEAD SHA if applicable, else "none">
 REVIEWER: <cr, bugbot, greptile, or none>
-OUTCOME: <issue_created|repo_bootstrapped|blocked|exhaustion>
+OUTCOME: <issue_created|issue_deferred|repo_bootstrapped|blocked|exhaustion>
 FILES_CHANGED: <comma-separated paths, or empty>
 NEXT_PHASE: none
 HANDOFF_FILE: none
@@ -108,6 +132,7 @@ HANDOFF_FILE: none
 **Valid OUTCOME values for pm-worker:**
 
 - `issue_created` — a GitHub issue was created (include issue number in your output before the exit report)
+- `issue_deferred` — dedup check found a strong match; finding was commented on the existing issue instead of filing (include the target issue number and a one-line summary in your output before the exit report)
 - `repo_bootstrapped` — a required workflow file was added or branch-protection gap reported
 - `blocked` — a task requires user confirmation (e.g., branch protection changes) or cannot proceed autonomously
 - `exhaustion` — token budget low, partial work applied

--- a/.claude/agents/pm-worker.md
+++ b/.claude/agents/pm-worker.md
@@ -45,12 +45,14 @@ for DEDUP in \
 If the helper is found, run it with a 2–6 keyword phrase from the issue title:
 
 ```bash
-DEDUP_JSON=$("$DEDUP" "<keywords from issue title>" 2>/dev/null) || DEDUP_RC=$?
+if [ -n "$DEDUP" ]; then
+  DEDUP_JSON=$("$DEDUP" "<keywords from issue title>" 2>/dev/null) || DEDUP_RC=$?
+fi
 ```
 
 Classify the top candidate per `.claude/reference/autofile-dedup.md`:
 
-- **Strong match** (open issue, same primary artifact, a quotable covering criterion, `coverage ≥ 0.6`) → **do not file**. Post the finding as a comment on the existing issue using the template in `autofile-dedup.md`. Record in your exit report: `"<title>" — appended to #<N> instead of filing`. Proceed to the exit report (Step 4 is skipped).
+- **Strong match** (open issue, same primary artifact, a quotable covering criterion, `coverage ≥ 0.6`) → **do not file**. Post the finding as a comment on the existing issue using the template in `autofile-dedup.md`. Record in your exit report: `"<title>" — appended to #<N> instead of filing`. Proceed to the exit report (Steps 3 and 4 are skipped).
 - **Weak / ambiguous match** → file as normal (Step 3), and include `Possibly duplicates #<N> — <one line on the overlap>` in the issue body.
 - **No match** or helper not found → file as normal (Step 3). If the helper was missing, note the degraded check once in your exit report.
 

--- a/.claude/reference/autofile-dedup.md
+++ b/.claude/reference/autofile-dedup.md
@@ -1,6 +1,26 @@
 # Auto-file dedup — thresholds and the comment-vs-file decision
 
-Canonical rules for any skill that opens GitHub issues **without a human in the loop** (`/wrap` Phase 3 Parts A and B today; the same rules apply to any future autonomous filer). Mechanical recall lives in `.claude/scripts/issue-dedup.sh`; the judgment described here is the caller's.
+This is a **repo-wide contract** that applies to every code path that can call `gh issue create` without a human confirmation step. It is not a per-skill rule. Mechanical recall lives in `.claude/scripts/issue-dedup.sh`; the judgment described here is the caller's.
+
+## Filer inventory
+
+Run `grep -rn "gh issue create" .claude/` to reproduce this list. Every site must be classified; adding a new autonomous filer requires updating this table before merging.
+
+| Site | Classification | Dedup behavior |
+|------|---------------|----------------|
+| `.claude/skills/wrap/SKILL.md` (Phase 3, Parts A + B) | **Autonomous** | Strong/weak/none — suppress + report (wired since PR #661) |
+| `.claude/agents/pm-worker.md` (Task: Issue Creation) | **Autonomous** | Strong/weak/none — suppress + report (wired since PR #680) |
+| `.claude/skills/issue-maker/SKILL.md` (Step 4) | **Human-in-the-loop** | Surface-only — never auto-suppress (wired since PR #661) |
+| `.claude/skills/start-issue/SKILL.md` (Step 1a) | **Human-in-the-loop** | Surface strong matches, pause for confirmation (wired since PR #680) |
+| `.claude/agents/researcher.md` | **Non-filer** | `gh issue create` appears in the agent's forbidden-command list |
+| `.claude/skills/pm-clean/SKILL.md` | **Non-filer** | Confirmed — only calls `gh issue close`, never `gh issue create` |
+| `.claude/rules/issue-planning.md` | **Documentation** | Describes the human-driven issue-creation flow; not itself a filer |
+
+### Asymmetry rule
+
+**Autonomous filers** (no human confirmation step): apply the full strong/weak/none suppression logic and always report suppressed filings — naming the issue deferred to, never silently.
+
+**Human-present callers**: run the same helper and surface strong matches to the user for confirmation; do not auto-suppress. A human can judge context that the script cannot.
 
 ## Why this exists
 
@@ -32,7 +52,7 @@ All four must hold:
 
 If you cannot quote the covering criterion, it is **not** a strong match — drop to weak. Criterion 3 is the load-bearing one; the numeric floor in 4 is a guard against thin matches, not a substitute for reading the issue.
 
-Action: `gh issue comment <N>` with the finding, using the template below. Record it in the sweep report as a **suppressed filing naming the target issue** — never silently.
+Action: `gh issue comment <N>` with the finding, using the template below. Record it in the run report as a **suppressed filing naming the target issue** — never silently.
 
 ### Weak / ambiguous match → file anyway, with the pointer
 
@@ -44,7 +64,7 @@ Action: file as normal, and include in the body, immediately under the title con
 Possibly duplicates #<N> — <one line on the overlap and what is unclear>.
 ```
 
-Flag it in the sweep report too, so the ambiguity is visible in two places rather than buried in an issue body.
+Flag it in the run report too, so the ambiguity is visible in two places rather than buried in an issue body.
 
 ### No match → file normally
 
@@ -52,29 +72,33 @@ Behavior is unchanged from before this check existed.
 
 ## Same-run batch self-check
 
-Before filing, compare the candidate against issues **this run** already filed (`WRAP_FILED_ISSUES` in `/wrap`), not just against the repo. Two findings in one sweep that duplicate each other collapse into one issue; the second is recorded as suppressed, naming the first. Pass the run's already-filed numbers as `--exclude` so they cannot also come back as repo candidates and be double-counted.
+Before filing, compare the candidate against issues **this run** already filed (tracked in a run-scoped registry such as `WRAP_FILED_ISSUES` in `/wrap`), not just against the repo. Two findings in one sweep that duplicate each other collapse into one issue; the second is recorded as suppressed, naming the first. Pass the run's already-filed numbers as `--exclude` so they cannot also come back as repo candidates and be double-counted.
 
-## Never silent
+## Never silent (shared obligation for every autonomous caller)
 
-Every suppressed filing appears in the report with the issue it deferred to, in one of two shapes:
+Every suppressed filing from any autonomous caller appears in that caller's run/sweep report with the issue it deferred to, in one of two shapes:
 
 - `Appended to #638 instead of filing — "<finding summary>"`
 - `Collapsed into #660 (filed earlier this run) — "<finding summary>"`
 
-A finding that is neither filed nor reported is the outcome this whole mechanism exists to prevent.
+A finding that is neither filed nor reported is the outcome this whole mechanism exists to prevent. `/wrap`'s "Filings suppressed as duplicates" report section is the reference shape; every other autonomous caller must produce an equivalent — same content, its own format.
 
 ## Comment template (strong match)
 
 ```markdown
-Additional observation from a /wrap session sweep on PR #<PR_NUMBER>:
+Additional observation from an automated filing:
 
 <finding summary and context>
 
 Filed here rather than as a new issue: this restates <the covering criterion>.
 
-_Appended by /wrap._
+_Auto-filed by <caller name>._
 ```
 
 ## Tuning
 
 `--min-coverage` (default `0.34`) controls **recall** — how many candidates you get to look at. Lowering it surfaces more candidates and costs only reading time; it does not by itself suppress anything, because suppression requires the four strong-match criteria. Raising it risks hiding the one candidate you needed to see. If in doubt, lower it.
+
+## Reconciliation — Issue #677
+
+Issue #677 ("improve /issue-maker title-only dedup") was closed as stale before this PR. Its premise — that `/issue-maker` used only title-matching — was superseded by PR #661, which pointed `/issue-maker` Step 4 at the shared body-aware `issue-dedup.sh` helper. Issue #677 covered no other autonomous filers (those are the subject of PR #680). There is no remaining work from #677 to carry forward.

--- a/.claude/scripts/issue-dedup.sh
+++ b/.claude/scripts/issue-dedup.sh
@@ -43,8 +43,10 @@
 #   4  gh / network / environment error (gh or python3 missing or failing, or
 #      unparseable gh output)
 #
-# Callers: .claude/skills/wrap/SKILL.md (Steps 3.3 / 3.7),
-#          .claude/skills/issue-maker/SKILL.md (Step 4).
+# Callers: .claude/skills/wrap/SKILL.md (Steps 3.3 / 3.7) — autonomous,
+#          .claude/skills/issue-maker/SKILL.md (Step 4) — human-in-the-loop,
+#          .claude/agents/pm-worker.md (Step 2) — autonomous,
+#          .claude/skills/start-issue/SKILL.md (Step 1a) — human-in-the-loop.
 # Thresholds and the comment-vs-file decision: .claude/reference/autofile-dedup.md
 
 set -euo pipefail

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -26,12 +26,25 @@ Only when a description was provided.
 1. **Draft locally** (do NOT post yet):
    - Title: concise version of the description (≤70 chars)
    - Body: one paragraph of context plus an `## Acceptance Criteria` section with placeholder checkbox items derived from the description
-2. **Create the issue:**
+2. **Dedup surface check** (human-in-the-loop — surface only, never auto-suppress):
+   Run `.claude/scripts/issue-dedup.sh` with a 2–6 keyword phrase from the draft title. Try the three standard paths:
+   ```bash
+   for DEDUP in \
+     "$HOME/.claude/skills-worktree/.claude/scripts/issue-dedup.sh" \
+     "$HOME/.claude/scripts/issue-dedup.sh" \
+     ".claude/scripts/issue-dedup.sh"; do
+     [ -x "$DEDUP" ] && break; DEDUP=""; done
+   ```
+   If the helper is found and returns candidates, classify the top candidate per `.claude/reference/autofile-dedup.md`:
+   - **Strong match** (open issue, same primary artifact, a quotable covering criterion, `coverage ≥ 0.6`) → surface it to the user: "This may duplicate #N — `<title>`. Should I file a new issue anyway, or add context to #N instead?" Wait for confirmation before creating.
+   - **Weak match** → note it once ("Similar open issue: #N — `<title>`") and continue to Step 3.
+   - **No match** or helper not found → continue to Step 3.
+3. **Create the issue:**
    ```bash
    ISSUE_URL=$(gh issue create --title "<title>" --body "<body>")
    ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
    ```
-3. The repo's `cr-plan-on-issue.yml` workflow will auto-post `@coderabbitai plan` within ~30s. Record `ISSUE_CREATED_AT=$(date -u +%s)` so Step 3 knows to use the "< 10 min" polling path.
+4. The repo's `cr-plan-on-issue.yml` workflow will auto-post `@coderabbitai plan` within ~30s. Record `ISSUE_CREATED_AT=$(date -u +%s)` so Step 3 knows to use the "< 10 min" polling path.
 
 ## Step 2: Read the issue
 
@@ -255,7 +268,7 @@ Stop after delivering the handoff. Do NOT start coding automatically — the use
 - **Issue already has a branch / worktree:** if `git worktree list` shows an existing worktree for `issue-$ISSUE_NUMBER-*`, stop and report the path instead of creating a duplicate (see Step 6).
 - **Issue is closed:** stop in Step 2.
 - **CR plan is an "Actions performed" ack only** (no actual plan content): treat as "no plan" and proceed.
-- **New issue description matches an existing open issue** (e.g. duplicate title): the skill will still create a new issue. It does not dedupe — that is the user's responsibility.
+- **New issue description matches an existing open issue**: Step 1a runs `issue-dedup.sh` and surfaces any strong match before creating. The user decides whether to file or defer to the existing issue.
 - **Empty argument:** stop and ask the user for input.
 - **`gh` not authenticated or repo lookup fails:** stop and report the underlying `gh` error to the user.
 - **Launched thread's running model mismatches its `**Model:**` line:** guard rules live in `chip-launching.md`, not here — the launched thread stops on any mismatch as its first action and waits for the user, per the model-guard preamble. `/start-issue` only has to ensure the preamble is present in the block; it does not itself detect or resolve mismatches.

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -44,7 +44,7 @@ Only when a description was provided.
    ISSUE_URL=$(gh issue create --title "<title>" --body "<body>")
    ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
    ```
-4. The repo's `cr-plan-on-issue.yml` workflow will auto-post `@coderabbitai plan` within ~30s. Record `ISSUE_CREATED_AT=$(date -u +%s)` so Step 3 knows to use the "< 10 min" polling path.
+4. The repo's `cr-plan-on-issue.yml` workflow will auto-post `@coderabbitai plan` within ~30s. Record `ISSUE_CREATED_AT=$(date -u +%s)` so the outer **Step 3: Handle CR implementation plan** knows to use the "< 10 min" polling path.
 
 ## Step 2: Read the issue
 


### PR DESCRIPTION
## Summary

Closes #680

PR #661 shipped `issue-dedup.sh` and the strong/weak/none threshold contract for `/wrap` and `/issue-maker`. This PR makes the dedup check a property of the repo, not of one skill — every autonomous `gh issue create` path runs the same check.

### Key finding: `/pm-clean` is a non-filer

The issue premise said `/pm-clean` needed wiring. After an actual `grep -rn "gh issue create" .claude/` sweep, `/pm-clean` only calls `gh issue close` — it never creates issues. The real autonomous filers that needed wiring were `pm-worker` (agent) and `/start-issue` (human-in-the-loop).

### Changes

**`.claude/reference/autofile-dedup.md`** — rewired as a repo-wide contract:
- States explicitly that the rule applies to every `gh issue create` path, not per-skill
- Adds a grep-verifiable filer inventory table classifying all sites (autonomous vs. human-in-the-loop vs. non-filer)
- Makes the asymmetry rule explicit: autonomous filers suppress + report; human-present callers surface only
- Generalises the "never silent" obligation to every autonomous caller (not `/wrap`-specific)
- Generalises the comment template (removes `/wrap` branding)
- Adds Issue #677 reconciliation note

**`.claude/agents/pm-worker.md`** — adds dedup Step 2 (autonomous path):
- Runs `issue-dedup.sh` with the three-path fallback before `gh issue create`
- Strong match: comments on the existing issue, does NOT file, reports suppression
- Weak match: files with `Possibly duplicates #N` pointer
- No match / helper missing: files normally (notes degraded check once)
- Adds `issue_deferred` to the OUTCOME enum and exit-report template

**`.claude/skills/start-issue/SKILL.md`** — adds surface-only dedup in Step 1a (human-in-the-loop):
- Strong match: surfaces the candidate to the user and waits for confirmation
- Weak match: notes it once and continues
- Removes the stale edge-case note "does not dedupe — that is the user's responsibility"

**`.claude/scripts/issue-dedup.sh`** — updates callers comment to list all four callers with their classifications.

### Deferred (pinned scope)

The question of extending the same check to PRs-in-flight (the PR-layer duplicate that triggered Issues #661/#673) is explicitly deferred by Issue #680 as a candidate follow-up ticket.

### Reviewer availability note

Both local review CLIs unavailable: CodeRabbit CLI returned exit 127 (not installed), CodeAnt CLI not installed. Self-review performed. CodeAnt GitHub App is unaffected and will cover the GitHub-side review.

## Test plan

- [ ] Inventory every path that can call `gh issue create` without a confirmation step; list them in `.claude/reference/autofile-dedup.md`
- [ ] `/pm-clean` (and any other autonomous filer found in the inventory) runs `issue-dedup.sh` before filing, applying the strong/weak/none rules unchanged
- [ ] Each such caller reports suppressed filings the way `/wrap` does — naming the issue deferred to, never silently
- [ ] `.claude/reference/autofile-dedup.md` states the rule applies repo-wide, not per-skill
- [ ] Reconcile with #677 — decide whether it is subsumed, still needed, or should be closed as stale
- [ ] A `/pm-clean` run proposing a ticket that duplicates an open issue defers to it instead of filing
- [ ] The same run with no match files normally
- [ ] Suppressed filings appear in that skill's report with the target issue named
- [ ] Inventory in `autofile-dedup.md` matches an actual grep for `gh issue create` across `.claude/skills/`