### PR TITLE
fix(#720): print the plain --admin merge when enforce_admins is off but strict blocks a clean-BEHIND PR

### DIFF
--- a/.claude/scripts/admin-merge.sh
+++ b/.claude/scripts/admin-merge.sh
@@ -32,10 +32,13 @@
 #                      the clipboard (pbcopy), and echo a marker line in the new
 #                      terminal. Never auto-executes the command. Falls back to
 #                      --print behaviour on Linux/Windows with a clear message.
-#   --execute          USER-INVOKED ONLY. Run the toggle-merge-toggle dance with a
-#                      trap that re-enables enforce_admins on any failure, then
-#                      verify protection is restored and the PR merged. A clean-
-#                      BEHIND bypass (#631) is revalidated just before the dance.
+#   --execute          USER-INVOKED ONLY. Toggle shape: run the toggle-merge-toggle
+#                      dance with a trap that re-enables enforce_admins on any
+#                      failure, then verify protection is restored and the PR merged.
+#                      Plain shape (enforce_admins=false + strict=true + clean-BEHIND):
+#                      run a bare `gh pr merge --squash --admin` with no protection
+#                      changes. Both shapes revalidate the clean-BEHIND state (#631)
+#                      just before executing.
 #
 # Options:
 #   --repo-path <path>  Absolute path of the local clone to cd into (default:
@@ -52,7 +55,9 @@
 #   3 — PR not found / not open
 #   4 — gh / network / jq error
 #   5 — refused: repo is not solo-owned (would skip a real review)
-#   6 — refused: no enforce_admins protection block detected (nothing to bypass)
+#   6 — refused: enforce_admins is disabled and strict+clean-BEHIND bypass does
+#        not apply — no bypass path detected (inspect branch protection for the
+#        actual blocker)
 #   7 — execute-mode failure (merge failed; trap re-enabled protection)
 
 set -uo pipefail

--- a/.claude/scripts/admin-merge.sh
+++ b/.claude/scripts/admin-merge.sh
@@ -335,12 +335,24 @@ if [[ -z "$PROTECTION_JSON" ]] || ! echo "$PROTECTION_JSON" | jq -e . >/dev/null
   exit 4
 fi
 ENFORCE_ADMINS=$(echo "$PROTECTION_JSON" | jq -r '.enforce_admins.enabled // false')
+STRICT=$(echo "$PROTECTION_JSON" | jq -r '.required_status_checks.strict // false')
+
+# Default bypass shape: the existing disable→merge→re-enable toggle chain.
+BYPASS_MODE=toggle
 
 if [[ "$ENFORCE_ADMINS" != "true" ]]; then
-  echo "REFUSED: enforce_admins is not enabled on $OWNER/$REPO@$BRANCH — no admin bypass needed." >&2
-  echo "If the merge is still blocked, the blocker is something else; inspect:" >&2
-  echo "  gh api repos/$OWNER/$REPO/branches/$BRANCH/protection" >&2
-  exit 6
+  # enforce_admins is off — still a legitimate admin bypass when the branch is
+  # clean-BEHIND and required_status_checks.strict blocks a normal merge.
+  # gh pr merge --squash --admin bypasses the strict up-to-date constraint
+  # without touching any protection settings.
+  if [[ "$STRICT" == "true" && "$CLEAN_BEHIND_OK" == "true" ]]; then
+    BYPASS_MODE=plain
+  else
+    echo "REFUSED: enforce_admins is not enabled on $OWNER/$REPO@$BRANCH — no admin bypass needed." >&2
+    echo "If the merge is still blocked, the blocker is something else; inspect:" >&2
+    echo "  gh api repos/$OWNER/$REPO/branches/$BRANCH/protection" >&2
+    exit 6
+  fi
 fi
 
 # Surface adjacent (non-enforce_admins) protection settings as informational notes.
@@ -352,28 +364,41 @@ EXTRA_NOTES=()
 
 # --------------------------------------------------------------------------
 # Build the bypass command (single source of truth for the command shape).
-# NOTE: the re-enable POST is sent with NO body. GitHub returns HTTP 422
+# Toggle shape: the re-enable POST is sent with NO body. GitHub returns HTTP 422
 # ("enabled is not a permitted key") if a body is supplied (verified on PR #535).
+# Plain shape: no protection calls at all — just gh pr merge --squash --admin.
 # --------------------------------------------------------------------------
 DELETE_CALL="gh api -X DELETE repos/$OWNER/$REPO/branches/$BRANCH/protection/enforce_admins"
 MERGE_CALL="gh pr merge $PR_NUMBER --squash --admin"
 REENABLE_CALL="gh api -X POST repos/$OWNER/$REPO/branches/$BRANCH/protection/enforce_admins"
 
-BYPASS_CMD=$(printf 'cd %q && \\\n%s && \\\n%s && \\\n%s' \
-  "$REPO_PATH" "$DELETE_CALL" "$MERGE_CALL" "$REENABLE_CALL")
+if [[ "$BYPASS_MODE" == "plain" ]]; then
+  # Plain shape: ordinary --admin merge, no protection toggles.
+  BYPASS_CMD=$(printf 'cd %q && \\\n%s' "$REPO_PATH" "$MERGE_CALL")
+else
+  # Toggle shape: disable enforce_admins → merge → re-enable.
+  BYPASS_CMD=$(printf 'cd %q && \\\n%s && \\\n%s && \\\n%s' \
+    "$REPO_PATH" "$DELETE_CALL" "$MERGE_CALL" "$REENABLE_CALL")
+fi
 
 print_warning_block() {
   echo "# ───────────────────────────────────────────────────────────────────"
   echo "# /admin-merge bypass for PR #$PR_NUMBER ($OWNER_REPO @ $BRANCH)"
-  echo "# Claude CANNOT run this — modifying branch protection is prohibited by"
-  echo "# Claude's safety rules. You (the repo admin) must run it yourself."
-  echo "# It: (1) disables enforce_admins, (2) squash-merges with --admin,"
-  echo "#     (3) re-enables enforce_admins (bare POST, no body)."
-  echo "# WARNING: this is chained with '&&'. If the merge fails, the final"
-  echo "# re-enable is skipped and enforce_admins stays OFF until you re-run:"
-  echo "#   $REENABLE_CALL"
-  echo "# (Use 'bash .claude/scripts/admin-merge.sh $PR_NUMBER --execute' instead"
-  echo "#  to run a trap-protected version that always re-enables protection.)"
+  if [[ "$BYPASS_MODE" == "plain" ]]; then
+    echo "# Ordinary --admin squash-merge: the PR is clean-BEHIND and"
+    echo "# required_status_checks.strict prevents a normal merge — --admin"
+    echo "# bypasses that constraint. No protection settings are modified."
+  else
+    echo "# Claude CANNOT run this — modifying branch protection is prohibited by"
+    echo "# Claude's safety rules. You (the repo admin) must run it yourself."
+    echo "# It: (1) disables enforce_admins, (2) squash-merges with --admin,"
+    echo "#     (3) re-enables enforce_admins (bare POST, no body)."
+    echo "# WARNING: this is chained with '&&'. If the merge fails, the final"
+    echo "# re-enable is skipped and enforce_admins stays OFF until you re-run:"
+    echo "#   $REENABLE_CALL"
+    echo "# (Use 'bash .claude/scripts/admin-merge.sh $PR_NUMBER --execute' instead"
+    echo "#  to run a trap-protected version that always re-enables protection.)"
+  fi
   echo "# $SOLO_NOTE"
   [[ -n "$REPO_PATH_NOTE" ]] && echo "# $REPO_PATH_NOTE"
   for n in "${EXTRA_NOTES[@]:-}"; do [[ -n "$n" ]] && echo "# note: $n"; done
@@ -473,6 +498,29 @@ if [[ "$MODE" == "execute" ]]; then
     fi
   fi
 
+  # Plain shape (no protection toggles): just run the admin merge directly.
+  if [[ "$BYPASS_MODE" == "plain" ]]; then
+    print_warning_block
+    echo "[admin-merge] squash-merging PR #$PR_NUMBER with --admin (strict up-to-date + clean-BEHIND) ..."
+    if ! $MERGE_CALL; then
+      echo "ERROR: 'gh pr merge --admin' failed." >&2
+      exit 7
+    fi
+    FINAL_MERGED="unknown"
+    for _attempt in 1 2 3; do
+      FINAL_MERGED=$(gh pr view "$PR_NUMBER" --json state --jq '(.state == "MERGED")' 2>/dev/null || echo "unknown")
+      [[ "$FINAL_MERGED" == "true" ]] && break
+      (( _attempt < 3 )) && sleep 2
+    done
+    echo "[admin-merge] done: PR merged=$FINAL_MERGED"
+    if [[ "$FINAL_MERGED" != "true" ]]; then
+      echo "WARNING: PR does not report state=MERGED after retrying — verify manually: gh pr view $PR_NUMBER --json state,mergedAt" >&2
+      exit 7
+    fi
+    exit 0
+  fi
+
+  # Toggle shape (enforce_admins=true): disable → merge → re-enable.
   ENFORCE_DISABLED=0
   ENFORCE_REENABLED=0
 

--- a/.claude/scripts/tests/admin-merge.test.sh
+++ b/.claude/scripts/tests/admin-merge.test.sh
@@ -177,6 +177,36 @@ FAKE_GATE_EXIT=1 FAKE_CBC_EXIT=1 \
 expect_rc 1 "non-clean BEHIND stays a hard blocker (exit 1)"
 grep_absent "gh pr merge 1 --squash --admin" "no admin-merge command printed for non-clean BEHIND"
 
+# 13. Plain shape: enforce_admins=false + strict=true + clean-BEHIND → exit 0,
+#     prints plain --admin merge command exactly once, no protection toggle calls.
+FAKE_GATE_EXIT=1 FAKE_CBC_EXIT=0 \
+  FAKE_GATE_MISSING='["branch is BEHIND base — rebase + force-push before merging"]' \
+  FAKE_PROTECTION='{"enforce_admins":{"enabled":false},"required_status_checks":{"strict":true}}' \
+  run 1 --print --repo-path "$CLONE" --branch main
+expect_rc 0 "plain shape: enforce_admins=false + strict=true + clean-BEHIND exits 0"
+grep_ok "gh pr merge 1 --squash --admin" "plain shape: plain --admin merge command printed"
+grep_absent "protection/enforce_admins" "plain shape: no protection toggle calls in output"
+PLAIN_COUNT=$(printf '%s\n' "$OUT" | grep -c "gh pr merge 1 --squash --admin" 2>/dev/null || echo 0)
+if [[ "$PLAIN_COUNT" -eq 1 ]]; then ok "plain shape: merge command appears exactly once"; else bad "plain shape: merge command should appear exactly once (found $PLAIN_COUNT: $OUT)"; fi
+
+# 14. Gate-not-met (non-BEHIND hard blocker) with enforce_admins=false → exit 1;
+#     gate short-circuits before the protection check, no bypass or protection call printed.
+FAKE_GATE_EXIT=1 \
+  FAKE_GATE_MISSING='["1 unresolved review thread(s) — resolve via GraphQL before merge"]' \
+  FAKE_PROTECTION='{"enforce_admins":{"enabled":false}}' \
+  run 1 --print --repo-path "$CLONE" --branch main
+expect_rc 1 "gate-not-met (non-BEHIND) with enforce_admins=false still refuses (exit 1)"
+grep_absent "gh pr merge" "no merge command when gate not met with enforce_admins=false"
+grep_absent "protection/enforce_admins" "no protection API call when gate not met with enforce_admins=false"
+
+# 15. Regression: enforce_admins=true path unchanged — toggle chain still printed.
+FAKE_GATE_EXIT=0 FAKE_GATE_MISSING='[]' \
+  FAKE_PROTECTION='{"enforce_admins":{"enabled":true}}' \
+  run 1 --print --repo-path "$CLONE" --branch main
+expect_rc 0 "enforce_admins=true toggle path unchanged (regression, exit 0)"
+grep_ok "gh api -X DELETE repos/solo/repo/branches/main/protection/enforce_admins" "enforce_admins=true: DELETE toggle call still present"
+grep_ok "gh api -X POST repos/solo/repo/branches/main/protection/enforce_admins" "enforce_admins=true: POST re-enable call still present"
+
 echo "----------------------------------------"
 echo "admin-merge.test.sh: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/.claude/skills/admin-merge/SKILL.md
+++ b/.claude/skills/admin-merge/SKILL.md
@@ -49,15 +49,15 @@ The script, before printing anything:
 
 1. **Verifies merge-readiness** via `merge-gate.sh` — CI green, primary reviewer (CR/CodeAnt) APPROVED on HEAD, all threads resolved, no human `CHANGES_REQUESTED`, not CONFLICTING. It steps over exactly two protection-mechanical blockers: the branch-protection `reviewDecision` (the thing the bypass addresses) and a **clean `BEHIND`** — a `mergeStateStatus: BEHIND` that `.claude/scripts/clean-behind-check.sh` confirms is safe (gate green except BEHIND, `mergeable != CONFLICTING`, AC verified, and the base delta's changed line ranges do **not** intersect the PR's changed line ranges at hunk level; conservative file-level fallback when patches are unavailable; issues #631, #667). A non-clean BEHIND (overlapping hunks at hunk level, or file-level overlap when patch data is absent) or any other missing reason is a hard blocker → the script refuses and points back to the rebase → re-run path.
 2. **Confirms solo-owner** (heuristic above).
-3. **Diagnoses the protection blocker** — confirms `enforce_admins` is actually enabled and tailors the command to it (it does **not** print a generic "disable everything" command).
+3. **Diagnoses the protection blocker and selects the bypass shape** — if `enforce_admins` is enabled, it builds the toggle chain (disable → merge → re-enable); if `enforce_admins` is off but `required_status_checks.strict` is blocking a clean-BEHIND branch, it uses a plain `--admin` merge (no protection changes); otherwise it refuses with exit 6. It does **not** print a generic "disable everything" command.
 4. **Resolves the local clone's absolute path** and prepends `cd "<abs-path>" && ` so the command runs from any cwd.
 
 Handle the exit code — **do not** print a bypass yourself when the script refused:
 
-- `0` → command printed. Relay the script's full output (warning block + command) to the user verbatim. Proceed to Step 4.
+- `0` → command printed. Relay the script's full output (warning block + command) to the user verbatim. The printed command is either the protection-toggle chain (`enforce_admins=true` shape: DELETE + merge + POST) or a plain `gh pr merge --squash --admin` (`enforce_admins=false` + `required_status_checks.strict=true` + clean-BEHIND shape); relay whichever was printed without substituting. Proceed to Step 4.
 - `1` → not merge-ready. Surface the script's listed blockers; tell the user to fix them (run `/fixpr`) first. **Do not** generate any bypass. Stop.
 - `5` → not solo-owned. Tell the user the bypass is refused because it would skip a real review; point to the standard review flow. Stop.
-- `6` → `enforce_admins` is not enabled — the merge is blocked by something else. Tell the user to inspect `gh api repos/<owner>/<repo>/branches/<branch>/protection`. Stop.
+- `6` → `enforce_admins` is off **and** the blocker is not an explainable `strict` + clean-BEHIND case — the merge is blocked by something else. Tell the user to inspect `gh api repos/<owner>/<repo>/branches/<branch>/protection`. Stop.
 - `3` → PR not found/closed. Stop.
 - `2`/`4` → usage or gh/network error. Surface stderr and stop.
 
@@ -73,9 +73,10 @@ On macOS this opens a new **iTerm2** window (preferred when installed, else **Te
 
 ### Step 4: One-line warning to the user
 
-Along with the printed command, tell the user plainly: *"Claude can't run this — modifying branch protection is prohibited by Claude's safety rules. Run the command above yourself; it disables `enforce_admins`, squash-merges with `--admin`, then re-enables `enforce_admins`."*
+Along with the printed command, tell the user what the command does — the framing depends on which shape was printed (the warning block in the script's output identifies it):
 
-Note the inline `&&` failure mode loudly: if the merge fails, the final re-enable is skipped and protection stays OFF until the user re-runs the bare `POST`. Offer the trap-protected alternative the script prints: `bash .claude/scripts/admin-merge.sh <PR> --execute` (the **user** runs this in their terminal — never Claude).
+- **Toggle shape** (command includes DELETE + POST calls, `enforce_admins=true`): *"Claude can't run this — modifying branch protection is prohibited by Claude's safety rules. Run the command above yourself; it disables `enforce_admins`, squash-merges with `--admin`, then re-enables `enforce_admins`."* Note the inline `&&` failure mode: if the merge fails, the final re-enable is skipped and protection stays OFF until the user re-runs the bare `POST`. Offer the trap-protected alternative the script prints: `bash .claude/scripts/admin-merge.sh <PR> --execute` (the **user** runs this — never Claude).
+- **Plain shape** (command is just `gh pr merge --squash --admin`, no protection calls): *"Run the command above; it does an ordinary admin squash-merge that bypasses the strict up-to-date requirement on a verified clean-BEHIND branch. No protection settings are modified."*
 
 ### Step 5: Confirm the merge, then run `/wrap` follow-ups
 
@@ -85,7 +86,7 @@ After the user reports running the command (or you detect it), poll until the PR
 gh pr view "$PR_NUM" --json state --jq '{state}'
 ```
 
-Once `state: MERGED`, also confirm protection was restored:
+Once `state: MERGED`, if the **toggle shape** was used (the command included protection changes), confirm protection was restored:
 
 ```bash
 # owner/repo/branch come from the PR; <branch> is the PR base branch


### PR DESCRIPTION
## Summary

Fixes the dead-end in the `#631` clean-BEHIND escape hatch: when `enforce_admins=false` but `required_status_checks.strict=true`, a clean-BEHIND PR is still blocked from a normal merge, yet `admin-merge.sh --print` was exiting 6 ("no admin bypass needed"). Observed live on PR #719, 2026-07-22.

**Root cause:** the script assumed the only admin-bypass-worthy blocker was `enforce_admins=true`. The `strict=true + clean-BEHIND` shape is equally real and equally solvable with `gh pr merge --squash --admin` — no protection toggles required.

**Fix:** introduce `BYPASS_MODE` (`toggle`/`plain`). When `enforce_admins` is off but `strict=true` and the PR is clean-BEHIND (pre-flight already verified), set `BYPASS_MODE=plain` and emit the bare merge command instead of exiting 6. All three modes (`--print`, `--launch-terminal`, `--execute`) branch on the flag. The existing exit-6 path is preserved for genuinely unexplained cases.

CodeAnt CLI not installed — noted per local-review rules.

Closes #720

## Test plan

- [x] `enforce_admins=false` + `strict=true` + clean-BEHIND → script prints the plain `--admin` squash-merge command (exit 0)
- [x] `enforce_admins=false` + gate NOT met → still refuses (exit 1, no bypass printed)
- [x] `enforce_admins=true` path unchanged (existing toggle-chain output)
- [x] Regression tests in the offline test suite cover all three shapes (31 tests total, 0 failed)
- [x] `.claude/skills/admin-merge/SKILL.md` exit-code table and Steps 2/4/5 updated to match
