### PR TITLE
fix(#723): detect Greptile's comment-based clean pass in merge-gate.sh

### DIFF
--- a/.claude/reference/merge-gate-reviewer-paths.md
+++ b/.claude/reference/merge-gate-reviewer-paths.md
@@ -52,8 +52,10 @@ CR failed, BugBot responded, Greptile never triggered — sticky; see `bugbot.md
 
 Greptile was triggered at any point — both CR and BugBot failed — sticky assignment, see `greptile.md`.
 
+- **Detection channel:** Greptile posts via **issue comments** (`issues/{N}/comments`), not formal PR review objects (`pulls/{N}/reviews`). `merge-gate.sh` detects a clean pass from the latest fresh `greptile-apps[bot]` issue comment with a 👍 reaction (`+1 >= 1`) and zero `greptile-apps[bot]` inline diff comments on the PR. Formal review objects are kept as a supplemental fallback signal. (Issue #723 — observed live on PR #721 where the script missed a clean pass because it only checked the formal-review endpoint.)
+- **Freshness:** the issue comment's `created_at` must be after the last commit's committer date (mirrors the BugBot push-timestamp lesson). A 👍 comment from a previous push does not count.
 - Severity-gated: merge-ready when ANY of these hold:
-  1. **Clean review:** no findings (thumbs-up with no inline comments).
+  1. **Clean review:** fresh `greptile-apps[bot]` issue comment with 👍 AND zero inline diff comments.
   2. **No P0 findings:** only P1/P2 findings present — fix all of them, push, reply to threads; no re-review required.
   3. **P0 fixed + re-review clean:** P0 findings were present, fixed, and a re-triggered `@greptileai` review came back clean.
 - Stay on Greptile — do not switch back to CR or BugBot. Ignore any late CR/BugBot reviews.

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -669,9 +669,15 @@ case "$REVIEWER" in
     #     push-timestamp lesson — repo memory feedback_bugbot_commit_id_stale).
     #   Formal review objects (pulls/{N}/reviews) are kept as supplemental signal.
 
-    # All Greptile inline diff comments on this PR (used in both sub-paths below).
-    G_INLINE_COUNT=$(echo "$PR_COMMENTS_JSON" | jq \
-      '[.[]? | select(.user.login == "greptile-apps[bot]")] | length')
+    # Fresh Greptile inline diff comments (post-push only — mirrors the BugBot
+    # push-timestamp lesson, feedback_bugbot_commit_id_stale). Stale inline comments
+    # from a prior push must NOT count: without this freshness gate, the "no review
+    # yet" guard would skip when stale inline comments exist, and Path B would then
+    # pass cleanly on an empty review body (no fresh Greptile signal on the new HEAD).
+    # G_INLINE_BODIES in Path B is anchored separately to G_ANCHOR_TS.
+    G_INLINE_COUNT=$(echo "$PR_COMMENTS_JSON" | jq --arg after "${LAST_COMMIT_TS:-}" \
+      '[.[]? | select(.user.login == "greptile-apps[bot]")
+              | select(if $after == "" then true else .created_at > $after end)] | length')
 
     # Latest FRESH Greptile issue comment (created after the last push).
     LATEST_G_COMMENT=$(echo "$ISSUE_COMMENTS_JSON" | jq -c --arg after "${LAST_COMMIT_TS:-}" '

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -201,6 +201,12 @@ if [[ -z "$HEAD_SHA" ]]; then
   exit 4
 fi
 
+# Fetch last commit timestamp for Greptile freshness gate (issue #723).
+# Used in the greptile) branch to confirm a 👍 issue comment is post-push.
+# Non-fatal: an empty result disables the freshness filter (comments accepted
+# regardless of age), which is preferable to silently blocking a clean review.
+LAST_COMMIT_TS=$(gh api "repos/$OWNER/$REPO/git/commits/$HEAD_SHA" 2>/dev/null | jq -r '.committer.date // ""' 2>/dev/null || echo "")
+
 # --------------------------------------------------------------------------
 # Fetch data once, reuse everywhere
 # --------------------------------------------------------------------------
@@ -654,42 +660,94 @@ case "$REVIEWER" in
     # Severity-gated. Greptile-specific count handling is intentionally NOT here —
     # the universal unresolved-thread gate above already reports the count for any
     # unresolved thread. This path adds severity context (P0 vs P1/P2) only.
+    #
+    # Greptile posts via issue comments (not formal PR review objects). Detection
+    # (issue #723 — observed live on PR #721):
+    #   Clean pass: latest fresh greptile-apps[bot] issue comment with 👍 (+1)
+    #     reaction AND zero greptile-apps[bot] inline diff comments on the PR.
+    #   Freshness: comment.created_at > LAST_COMMIT_TS (mirrors the BugBot
+    #     push-timestamp lesson — repo memory feedback_bugbot_commit_id_stale).
+    #   Formal review objects (pulls/{N}/reviews) are kept as supplemental signal.
 
-    # Latest Greptile review.
+    # All Greptile inline diff comments on this PR (used in both sub-paths below).
+    G_INLINE_COUNT=$(echo "$PR_COMMENTS_JSON" | jq \
+      '[.[]? | select(.user.login == "greptile-apps[bot]")] | length')
+
+    # Latest FRESH Greptile issue comment (created after the last push).
+    LATEST_G_COMMENT=$(echo "$ISSUE_COMMENTS_JSON" | jq -c --arg after "${LAST_COMMIT_TS:-}" '
+      [.[]?
+        | select(.user.login == "greptile-apps[bot]")
+        | select(if $after == "" then true else .created_at > $after end)]
+      | sort_by(.created_at) | last // empty')
+
+    # Latest Greptile formal review (belt-and-suspenders supplemental signal).
     LATEST_G=$(echo "$REVIEWS_JSON" | jq -c '
       [.[]? | select(.user.login == "greptile-apps[bot]")]
       | sort_by(.submitted_at) | last // empty')
 
-    if [[ -z "$LATEST_G" ]]; then
+    if [[ -z "$LATEST_G" && -z "$LATEST_G_COMMENT" && "$G_INLINE_COUNT" -eq 0 ]]; then
+      # No formal review, no fresh issue comment, no inline findings — nothing to evaluate.
+      # A stale issue comment (created before the last push) does NOT count here;
+      # LATEST_G_COMMENT is already empty when the only comments are pre-push.
       MISSING+=("no Greptile review yet")
     else
-      # Did the latest Greptile review include a P0 finding (in its body or its
-      # inline comments)? Used for severity-gated logic below.
-      G_BODY=$(echo "$LATEST_G" | jq -r '.body // ""')
-      G_SUBMITTED=$(echo "$LATEST_G" | jq -r '.submitted_at // ""')
-      G_INLINE_BODIES=$(echo "$PR_COMMENTS_JSON" | jq -r --arg ts "$G_SUBMITTED" '
-        [.[]? | select(.user.login == "greptile-apps[bot]" and .created_at >= $ts) | .body] | join("\n---\n")')
-      P0_COUNT=$( { echo "$G_BODY"; echo "$G_INLINE_BODIES"; } | grep -oE '\bP0\b' | wc -l | tr -d ' ')
-
-      # Are there unresolved Greptile-authored threads? If so, P0 vs P1/P2 changes
-      # whether a re-review is required after fixing.
-      UNRESOLVED_G=$(echo "$THREADS_JSON" | jq -r '
-        [.data.repository.pullRequest.reviewThreads.nodes[]?
-          | select(.isResolved == false)
-          | select(any(.comments.nodes[]?; .author.login == "greptile-apps[bot]"))]
-        | length')
-
-      if [[ "$UNRESOLVED_G" -gt 0 && "$P0_COUNT" -gt 0 ]]; then
-        # Universal gate already reports the count; add severity-aware advice only.
-        MISSING+=("Greptile threads include P0 finding(s) — need clean re-review after fix")
-      elif [[ "$UNRESOLVED_G" -eq 0 && "$P0_COUNT" -gt 0 ]]; then
-        # Threads are resolved but the latest (most recent) Greptile review had P0.
-        # Since LATEST_G is already the last review by submitted_at, a clean re-review
-        # would BE the latest review and wouldn't have P0. So if we're here, no clean
-        # re-review exists yet — always require one.
-        MISSING+=("latest Greptile review had P0 findings — need clean re-review after fix (trigger @greptileai)")
+      # --- Path A: comment-based clean pass (primary Greptile channel) ---
+      G_COMMENT_CLEAN=false
+      if [[ -n "$LATEST_G_COMMENT" ]]; then
+        G_THUMBSUP=$(echo "$LATEST_G_COMMENT" | jq -r '.reactions["+1"] // 0')
+        # Clean = 👍 present AND no inline findings posted at all.
+        if [[ "$G_THUMBSUP" -gt 0 && "$G_INLINE_COUNT" -eq 0 ]]; then
+          G_COMMENT_CLEAN=true
+        fi
       fi
-      # No unresolved threads + no P0 in latest review → gate is met.
+
+      if [[ "$G_COMMENT_CLEAN" != true ]]; then
+        # --- Path B: severity gate ---
+        # Build a review body from the most-recent Greptile signal (issue comment
+        # or formal review), then check inline bodies anchored at that timestamp.
+        G_ANCHOR_TS=""
+        G_BODY=""
+        if [[ -n "$LATEST_G" ]]; then
+          G_BODY=$(echo "$LATEST_G" | jq -r '.body // ""')
+          G_ANCHOR_TS=$(echo "$LATEST_G" | jq -r '.submitted_at // ""')
+        fi
+        if [[ -n "$LATEST_G_COMMENT" ]]; then
+          G_COMMENT_TS=$(echo "$LATEST_G_COMMENT" | jq -r '.created_at // ""')
+          # Issue comment supersedes formal review when it is more recent.
+          if [[ -z "$G_ANCHOR_TS" || "$G_COMMENT_TS" > "$G_ANCHOR_TS" ]]; then
+            G_BODY=$(echo "$LATEST_G_COMMENT" | jq -r '.body // ""')
+            G_ANCHOR_TS="$G_COMMENT_TS"
+          fi
+        fi
+
+        # Inline bodies associated with the latest Greptile review (by timestamp).
+        G_INLINE_BODIES=$(echo "$PR_COMMENTS_JSON" | jq -r --arg ts "${G_ANCHOR_TS:-}" '
+          [.[]? | select(.user.login == "greptile-apps[bot]")
+                | select(if $ts == "" then true else .created_at >= $ts end) | .body]
+          | join("\n---\n")')
+
+        # Count P0 badges across the review body and inline comments.
+        P0_COUNT=$( { echo "$G_BODY"; echo "$G_INLINE_BODIES"; } | grep -oE '\bP0\b' | wc -l | tr -d ' ')
+
+        # Are there unresolved Greptile-authored threads? If so, P0 vs P1/P2 changes
+        # whether a re-review is required after fixing.
+        UNRESOLVED_G=$(echo "$THREADS_JSON" | jq -r '
+          [.data.repository.pullRequest.reviewThreads.nodes[]?
+            | select(.isResolved == false)
+            | select(any(.comments.nodes[]?; .author.login == "greptile-apps[bot]"))]
+          | length')
+
+        if [[ "$UNRESOLVED_G" -gt 0 && "$P0_COUNT" -gt 0 ]]; then
+          # Universal gate already reports the count; add severity-aware advice only.
+          MISSING+=("Greptile threads include P0 finding(s) — need clean re-review after fix")
+        elif [[ "$UNRESOLVED_G" -eq 0 && "$P0_COUNT" -gt 0 ]]; then
+          # Threads are resolved but P0 in latest review body / inline bodies.
+          # A clean re-review would supersede this — require one.
+          MISSING+=("latest Greptile review had P0 findings — need clean re-review after fix (trigger @greptileai)")
+        fi
+        # Unresolved G > 0 && P0 == 0: universal thread gate already covered.
+        # Unresolved G == 0 && P0 == 0: only P1/P2 all resolved — gate met.
+      fi
     fi
     ;;
 esac

--- a/.claude/scripts/tests/merge-gate-greptile-comment.test.sh
+++ b/.claude/scripts/tests/merge-gate-greptile-comment.test.sh
@@ -168,6 +168,36 @@ check_eq "1"     "$RC"     "stale comment: exit code 1"
 check_eq "yes" "$(missing_has "no Greptile review")" \
   "stale comment: missing says 'no Greptile review yet'"
 
+# --------------------------------------------------------------------------
+# Test 4: Stale inline comments only — no fresh review on the new HEAD.
+# Prior push left greptile-apps[bot] inline comments (now resolved as stale).
+# No fresh issue comment and no formal review exist for the new HEAD.
+# Without the freshness gate on G_INLINE_COUNT the "no review yet" guard would
+# not fire (G_INLINE_COUNT > 0) and Path B would pass on an empty review body.
+# Gate MUST report "no Greptile review yet" — not met.
+# --------------------------------------------------------------------------
+echo "--- Test 4: stale inline comments only (no fresh review) ---"
+
+# Build a stale inline comment (created before the push timestamp).
+greptile_stale_inline() {
+  jq -cn --arg ts "$STALE_TS" \
+    '{id:3001, user:{login:"greptile-apps[bot]"},
+      body:"P1 — minor nit from prior review round.",
+      created_at:$ts,
+      commit_id:"aabbccddeeff0011223344556677889900aabbcc",
+      original_commit_id:"aabbccddeeff0011223344556677889900aabbcc"}'
+}
+
+STALE_INLINE="$(greptile_stale_inline)"
+run_gate "$PUSH_TS" "[]" "[$STALE_INLINE]"
+
+check_eq "false" "$(met)"  "stale inline only: met == false"
+check_eq "1"     "$RC"     "stale inline only: exit code 1"
+# G_INLINE_COUNT freshness gate must exclude the stale comment, so the "no review
+# yet" guard fires and reports exactly this missing entry.
+check_eq "yes" "$(missing_has "no Greptile review")" \
+  "stale inline only: missing says 'no Greptile review yet'"
+
 echo "----------------------------------------"
 echo "merge-gate-greptile-comment.test.sh: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/.claude/scripts/tests/merge-gate-greptile-comment.test.sh
+++ b/.claude/scripts/tests/merge-gate-greptile-comment.test.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# merge-gate-greptile-comment.test.sh — Regression tests for issue #723:
+# merge-gate.sh Greptile path must detect comment-based clean passes.
+#
+# Greptile posts via ISSUE COMMENTS (not formal PR review objects).
+# A clean pass = fresh greptile-apps[bot] issue comment with 👍 reaction +
+# zero inline diff comments on the PR.
+#
+# Tests:
+#   1. Clean 👍 + no inline comments → gate met (primary fix)
+#   2. 👍 + P0-badged inline findings → gate not met (severity gate)
+#   3. 👍 comment created BEFORE last push (stale) → gate not met (freshness)
+#
+# Only `gh` is stubbed; merge-gate.sh, ci-status.sh and check-runs-dedup.sh
+# are the real scripts run in place.
+#
+# Run from repo root: bash .claude/scripts/tests/merge-gate-greptile-comment.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SUT="$REPO_ROOT/.claude/scripts/merge-gate.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# Sandbox HOME: no session-state.json → reviewer resolution uses --reviewer flag.
+export HOME="$TMP/home"; mkdir -p "$HOME/.claude"
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+check_eq() { # expected actual label
+  if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected: $1, got: $2)"; fi
+}
+
+HEAD_SHA="aabbccddeeff0011223344556677889900aabbcc"
+# Last push: commit committer date. Tests set FAKE_COMMIT_TS relative to this.
+PUSH_TS="2026-07-23T13:00:00Z"
+# A timestamp clearly AFTER the push (comment is fresh).
+FRESH_TS="2026-07-23T13:05:00Z"
+# A timestamp clearly BEFORE the push (comment is stale).
+STALE_TS="2026-07-23T12:55:00Z"
+
+# --- Fake gh: stubs the endpoints merge-gate.sh calls. ----------------------
+BIN="$TMP/bin"; mkdir -p "$BIN"
+cat > "$BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  "repo view --json nameWithOwner --jq .nameWithOwner")
+    echo "solo/repo"; exit 0 ;;
+  *"pr view "*headRefOid*)
+    jq -cn \
+      --arg sha  "$HEAD_SHA" \
+      '{number:1, state:"OPEN", headRefOid:$sha, baseRefName:"main",
+        mergeStateStatus:"CLEAN", mergeable:"MERGEABLE", reviewDecision:"APPROVED"}'
+    exit 0 ;;
+  *"git/commits/"*)
+    # Return FAKE_COMMIT_TS as the committer date — used for Greptile freshness.
+    jq -cn --arg d "$FAKE_COMMIT_TS" '{committer:{date:$d}}'
+    exit 0 ;;
+  *check-runs*)
+    # Single passing check so CI gate is met.
+    jq -cn '{check_runs:[{id:1,name:"ci",status:"completed",conclusion:"success",
+               completed_at:"2026-07-23T13:01:00Z",
+               check_suite:{id:1},app:{slug:"gha",id:1}}]}'
+    exit 0 ;;
+  *pulls/*/reviews*)
+    # Greptile never posts formal reviews; return empty.
+    printf '%s' "${FAKE_REVIEWS:-[]}"; exit 0 ;;
+  *pulls/*/comments*)
+    printf '%s' "${FAKE_PR_COMMENTS:-[]}"; exit 0 ;;
+  *issues/*/comments*)
+    printf '%s' "${FAKE_ISSUE_COMMENTS:-[]}"; exit 0 ;;
+  *graphql*)
+    jq -cn '{data:{repository:{pullRequest:{reviewThreads:{nodes:[]}}}}}'; exit 0 ;;
+  *contents/*)
+    echo "Not Found" >&2; exit 1 ;;
+esac
+echo "unexpected gh call: $ARGS" >&2
+exit 1
+GHEOF
+chmod +x "$BIN/gh"
+
+# Export HEAD_SHA so the heredoc-embedded gh stub can see it.
+export HEAD_SHA
+export PUSH_TS
+
+# Helper: build a Greptile issue comment JSON object.
+greptile_comment() { # created_at thumbsup_count
+  local ts="$1" up="$2"
+  jq -cn --arg ts "$ts" --argjson up "$up" \
+    '{id:1001, user:{login:"greptile-apps[bot]"},
+      body:"<h3>Greptile Summary</h3>\nClean review.",
+      created_at:$ts,
+      reactions:{url:"",total_count:$up,"+1":$up,"-1":0}}'
+}
+
+# Helper: build a Greptile inline diff comment with a P0 badge.
+greptile_p0_inline() {
+  jq -cn --arg sha "$HEAD_SHA" \
+    '{id:2001, user:{login:"greptile-apps[bot]"},
+      body:"**P0** — critical issue found",
+      created_at:"'"$FRESH_TS"'",
+      commit_id:$sha, original_commit_id:$sha}'
+}
+
+OUT=""
+RC=0
+run_gate() {
+  # $1 = FAKE_COMMIT_TS, $2 = FAKE_ISSUE_COMMENTS, $3 = FAKE_PR_COMMENTS (optional)
+  local commit_ts="$1" issue_comments="$2" pr_comments="${3:-[]}"
+  OUT=$(PATH="$BIN:$PATH" \
+        FAKE_COMMIT_TS="$commit_ts" \
+        FAKE_ISSUE_COMMENTS="$issue_comments" \
+        FAKE_PR_COMMENTS="$pr_comments" \
+        FAKE_REVIEWS="[]" \
+        "$SUT" 1 --reviewer greptile 2>/dev/null)
+  RC=$?
+}
+
+# Helpers for common assertions.
+met()           { echo "$OUT" | jq -r '.met'; }
+missing_count() { echo "$OUT" | jq -r '.missing | length'; }
+missing_has()   { echo "$OUT" | jq -e --arg s "$1" '[.missing[]? | select(contains($s))] | length > 0' >/dev/null && echo yes || echo no; }
+
+# --------------------------------------------------------------------------
+# Test 1: Clean 👍 pass — primary fix for issue #723.
+# Greptile posted a fresh issue comment with 👍 and no inline findings.
+# merge-gate.sh must report met:true.
+# --------------------------------------------------------------------------
+echo "--- Test 1: clean 👍 pass ---"
+COMMENT1="$(greptile_comment "$FRESH_TS" 1)"
+run_gate "$PUSH_TS" "[$COMMENT1]" "[]"
+
+check_eq "true"  "$(met)"           "clean pass: met == true"
+check_eq "0"     "$(missing_count)" "clean pass: missing array empty"
+check_eq "0"     "$RC"              "clean pass: exit code 0"
+
+# --------------------------------------------------------------------------
+# Test 2: P0-badged inline findings — gate must remain unmet.
+# Greptile issue comment (👍) exists but P0 inline diff comments are present.
+# --------------------------------------------------------------------------
+echo "--- Test 2: P0 findings present ---"
+COMMENT2="$(greptile_comment "$FRESH_TS" 1)"
+INLINE_P0="$(greptile_p0_inline)"
+run_gate "$PUSH_TS" "[$COMMENT2]" "[$INLINE_P0]"
+
+check_eq "false" "$(met)"   "P0 findings: met == false"
+check_eq "yes"   "$(missing_has "P0")" "P0 findings: missing contains P0 message"
+check_eq "1"     "$RC"      "P0 findings: exit code 1"
+
+# --------------------------------------------------------------------------
+# Test 3: Stale 👍 — comment created BEFORE the last push must not count.
+# Gate should report not met (no fresh Greptile review).
+# --------------------------------------------------------------------------
+echo "--- Test 3: stale 👍 before push ---"
+COMMENT3="$(greptile_comment "$STALE_TS" 1)"
+run_gate "$PUSH_TS" "[$COMMENT3]" "[]"
+
+check_eq "false" "$(met)"  "stale comment: met == false"
+check_eq "1"     "$RC"     "stale comment: exit code 1"
+# The stale comment exists but zero fresh comments + no inline findings:
+# missing should say "no Greptile review yet".
+check_eq "yes" "$(missing_has "no Greptile review")" \
+  "stale comment: missing says 'no Greptile review yet'"
+
+echo "----------------------------------------"
+echo "merge-gate-greptile-comment.test.sh: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Fixes `merge-gate.sh` Greptile path missing comment-based clean reviews — script reported `met:false, missing:["no Greptile review yet"]` on a fully clean 👍 pass observed live on PR #721.

**Root cause:** Greptile posts via issue comments (`issues/{N}/comments`), never via formal PR review objects (`pulls/{N}/reviews`). The old greptile branch only checked the formal-review endpoint.

**Fix:**
- Detects the primary Greptile channel: latest fresh `greptile-apps[bot]` issue comment with 👍 (`+1 ≥ 1`) AND zero inline diff comments = clean pass.
- Freshness gate: `comment.created_at > last_commit_committer_date` — mirrors the BugBot push-timestamp lesson.
- Formal review objects kept as supplemental signal (belt-and-suspenders).
- P0 severity gate updated to use both issue comment body and formal review body for badge detection.
- `.claude/reference/merge-gate-reviewer-paths.md` updated to document the issue-comment detection channel.

Closes #723

## Test plan

- [x] A Greptile clean pass (👍 + no inline comments, no formal review object) makes `merge-gate.sh` report the greptile path met on current HEAD
- [x] A Greptile review WITH P0-badged inline findings still fails the gate until fixed per `greptile.md`
- [x] Regression tests cover both, using stubbed endpoint fixtures (`merge-gate-greptile-comment.test.sh` — 9 tests, all passing; existing `merge-gate-ci-dedup.test.sh` — 17 tests, all still passing)
- [x] `.claude/reference/merge-gate-reviewer-paths.md` updated — Greptile section now documents issue-comment channel and freshness requirement

**Local CLI review notes:**
- CodeRabbit CLI: timed out (>2 min, 0 output) — dropped per `cr-local-review.md`
- CodeAnt CLI: not installed — dropped
- Self-review: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Greptile merge checks to recognize fresh 👍 issue comments as successful reviews.
  * Prevented stale reviews and inline comments from affecting merge decisions.
  * Applied severity checks to current review findings, including unresolved P0 issues.

* **Tests**
  * Added coverage for fresh, stale, clean, and P0-containing Greptile review scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->