### PR TITLE
fix(#704): lowercase the repo scope key everywhere via a shared normalizer

### DIFF
--- a/.claude/reference/session-state-schema.json
+++ b/.claude/reference/session-state-schema.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 2,
+  "_scope_key_contract": "The .repos[\"<owner>/<name>\"] scope key is ALWAYS lowercase (issue #704). All derivation points — session-state.sh repo_key_from_remote_url()/resolve_repo_key(), polling-state-gate.sh repo_identity(), and handoff-state.sh's path resolver — share lib/repo-normalizer.sh so a mixed-case remote URL (e.g. AuerbachB/Skingod) and its lowercase form (auerbachb/skingod) always map to the same .repos bucket. Handoff paths follow the same contract. Existing live keys are already lowercase; this normalization is backward-compatible.",
   "_field_types": {
     "_description": "Machine-readable field-type contract consumed at runtime by session-state.sh's FIELD-TYPE CONTRACT (issues #625, #640) — the single source of truth for which fields must hold a specific JSON type. `top_level` keys index the root document; `pr_nested` keys index each entry under a repo scope\u2019s PR map, `.repos[\"<owner>/<name>\"].prs[\"<N>\"]` (issue #638) (checked wherever that key appears, at any nesting depth under a PR entry). Values are the expected `jq ... | type` string. Fields absent from both maps are left unvalidated, preserving the 'preserve unknown fields' forward-compat convention documented in handoff-files.md.",
     "top_level": {

--- a/.claude/rules/handoff-files.md
+++ b/.claude/rules/handoff-files.md
@@ -12,6 +12,8 @@
 
 **Repo scoping (issue #638):** State lives at `.repos["<owner>/<name>"].prs["<N>"]`; `session-state.sh` auto-scopes calls via `--repo`, `$CLAUDE_SESSION_REPO`, or cwd origin. Unattributable legacy entries land in `_unknown`. Account-level fields stay global. See `session-state.sh --help`.
 
+**Scope-key case normalization (issue #704):** The `.repos["<owner>/<name>"]` scope key is **always lowercase**. All three derivation points — `session-state.sh`'s `repo_key_from_remote_url()`/`resolve_repo_key()`, `polling-state-gate.sh`'s `repo_identity()`, and `handoff-state.sh`'s path resolver — share a single normalizer (`lib/repo-normalizer.sh`) so a mixed-case remote URL (`AuerbachB/Skingod`) and its lowercase form (`auerbachb/skingod`) always map to the same scope. Handoff paths follow the same contract: `~/.claude/handoffs/{owner}/{repo}/` directories are always lowercase. Existing live keys are already lowercase, so this is backward-compatible.
+
 **Invoking-repo scope (issue #687):** Orchestration skills use `session-state.sh --session-view` (repo-scoped projection) — **never `--get .`** (aggregates every repo; cross-repo leak). Cross-repo reporting is opt-in via `--session-view --all-repos`. Never write (merge/rebase/close) against a PR outside the invoking repo.
 
 Update `session-state.json` on phase transitions and key events (agent launched/completed, review received, dropped poll recovered). **All writes go through `.claude/scripts/session-state.sh --set <jq-path>=<value>`** (read with `--get`); it preserves siblings, writes atomically, and holds the lock below.

--- a/.claude/scripts/handoff-migrate.sh
+++ b/.claude/scripts/handoff-migrate.sh
@@ -36,6 +36,23 @@ set -uo pipefail
 printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" \
   >> "${HOME}/.claude/script-usage.log" 2>/dev/null || true
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Shared case-normalizer (issue #704): lowercase owner_repo values before
+# building destination paths so a mixed-case embedded owner_repo field
+# (e.g. "AuerbachB/Skingod") doesn't produce a differently-cased directory
+# than the lowercase path session-state.sh and handoff-state.sh would use.
+# Use the library when available; fall back to inline so the script is
+# self-contained in environments without the lib (e.g. pre-#704 worktrees).
+_NORMALIZER_LIB="${SCRIPT_DIR}/lib/repo-normalizer.sh"
+if [[ -f "$_NORMALIZER_LIB" ]]; then
+  # shellcheck source=./lib/repo-normalizer.sh
+  source "$_NORMALIZER_LIB"
+else
+  normalize_repo_key() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+fi
+unset _NORMALIZER_LIB
+
 HANDOFF_DIR="${HOME}/.claude/handoffs"
 STATE_FILE="${HOME}/.claude/session-state.json"
 APPLY=0
@@ -140,6 +157,10 @@ for src in "${FLAT_FILES[@]}"; do
   state_owner_repo="$(_lookup_owner_repo "$pr_number")"
 
   owner_repo="${file_owner_repo:-$state_owner_repo}"
+  # Lowercase-normalize before building the destination path (issue #704):
+  # a stored owner_repo like "AuerbachB/Skingod" must land in
+  # auerbachb/skingod/ not a separately-cased directory.
+  [[ -n "$owner_repo" ]] && owner_repo="$(normalize_repo_key "$owner_repo")"
 
   # 3. Unattributable → _unknown.
   local_dest_dir="$HANDOFF_DIR/_unknown"

--- a/.claude/scripts/handoff-state.sh
+++ b/.claude/scripts/handoff-state.sh
@@ -87,6 +87,18 @@ fi
 # shellcheck source=state-lock.sh
 source "$LOCK_LIB"
 
+# Shared case-normalizer (issue #704). Lowercases the --owner-repo value so
+# ~/.claude/handoffs/{owner}/{repo}/ paths are always lowercase, preventing a
+# mixed-case owner_repo from routing to a different directory than the lowercase
+# form written by session-state.sh and polling-state-gate.sh.
+NORMALIZER_LIB="${SCRIPT_DIR}/lib/repo-normalizer.sh"
+if [[ ! -f "$NORMALIZER_LIB" ]]; then
+  echo "handoff-state.sh: missing sibling library: $NORMALIZER_LIB" >&2
+  exit 5
+fi
+# shellcheck source=./lib/repo-normalizer.sh
+source "$NORMALIZER_LIB"
+
 # ---------------------------------------------------------------------------
 # Argument parsing.
 # ---------------------------------------------------------------------------
@@ -114,6 +126,9 @@ if [[ "${1:-}" == "--owner-repo" ]]; then
   if [[ -z "$OWNER_REPO" ]]; then
     echo "handoff-state.sh: --owner-repo requires a value (e.g., --owner-repo owner/repo)" >&2; exit 2
   fi
+  # Lowercase-normalize immediately so ~/.claude/handoffs/{owner}/{repo}/ paths
+  # are always lowercase (issue #704 — mirrors session-state.sh's key contract).
+  OWNER_REPO="$(normalize_repo_key "$OWNER_REPO")"
   shift 2
   if [[ $# -eq 0 ]]; then
     echo "handoff-state.sh: --owner-repo requires a mode flag after it" >&2; exit 2

--- a/.claude/scripts/lib/repo-normalizer.sh
+++ b/.claude/scripts/lib/repo-normalizer.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# lib/repo-normalizer.sh — Shared lowercase normalizer for owner/repo scope keys.
+#
+# Source this file (do NOT execute it directly) from session-state.sh,
+# polling-state-gate.sh, and handoff-state.sh so all three scripts agree on
+# the same case-normalization contract (issue #704).
+#
+# PROBLEM SOLVED
+#   session-state.sh's repo_key_from_remote_url() was case-preserving, while
+#   polling-state-gate.sh's repo_identity() lowercased. The same repo with a
+#   differently-cased remote URL (AuerbachB/Skingod vs auerbachb/skingod)
+#   produced two separate .repos scopes, fragmenting PR tracking.
+#
+# CONTRACT
+#   All .repos["<owner>/<name>"] scope keys and ~/.claude/handoffs/{owner}/{repo}/
+#   paths MUST be lowercase. Sourcing this library and calling normalize_repo_key()
+#   at every derivation point ensures no mixed-case input can create a second scope.
+#
+# USAGE
+#   # In session-state.sh, polling-state-gate.sh, handoff-state.sh:
+#   source "$SCRIPT_DIR/lib/repo-normalizer.sh"
+#   key="$(normalize_repo_key "$raw_key")"
+#
+# normalize_repo_key <owner/repo>
+#   Prints the lowercase form.  Idempotent — already-lowercase input is unchanged.
+#   Examples:
+#     normalize_repo_key "AuerbachB/Skingod" -> "auerbachb/skingod"
+#     normalize_repo_key "auerbachb/myrepo"  -> "auerbachb/myrepo"
+#     normalize_repo_key ""                  -> ""
+
+normalize_repo_key() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}

--- a/.claude/scripts/polling-state-gate.sh
+++ b/.claude/scripts/polling-state-gate.sh
@@ -55,6 +55,20 @@ set -euo pipefail
 printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Shared case-normalizer (issue #704).  Use the library when available so
+# repo_identity() and session-state.sh's repo_key_from_remote_url() share one
+# definition and can never diverge.  Fall back to an inline equivalent if the
+# lib is somehow absent so this script remains self-contained.
+_NORMALIZER_LIB="${SCRIPT_DIR}/lib/repo-normalizer.sh"
+if [[ -f "$_NORMALIZER_LIB" ]]; then
+  # shellcheck source=./lib/repo-normalizer.sh
+  source "$_NORMALIZER_LIB"
+else
+  normalize_repo_key() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+fi
+unset _NORMALIZER_LIB
+
 STATE_HELPER="${SCRIPT_DIR}/session-state.sh"
 HANDOFF_HELPER="${SCRIPT_DIR}/handoff-state.sh"
 MERGE_GATE="${SCRIPT_DIR}/merge-gate.sh"
@@ -195,7 +209,10 @@ repo_identity() {
       id="${id%/*}"
       owner="${id##*/}"
       if [[ -n "$owner" && -n "$repo" ]]; then
-        printf '%s/%s\n' "$owner" "$repo" | tr '[:upper:]' '[:lower:]'
+        # normalize_repo_key() from lib/repo-normalizer.sh (issue #704) so
+        # repo_identity() and session-state.sh's repo_key_from_remote_url()
+        # always agree on the same lowercase key.
+        printf '%s\n' "$(normalize_repo_key "${owner}/${repo}")"
         return 0
       fi
     fi
@@ -294,7 +311,7 @@ validate_root_match() {
   #     an owner/repo identity (i.e. it has an `origin` remote to compare against).
   if [[ -n "$stored_owner" && "$active_id" == */* && "$active_id" != gitdir:* && "$active_id" != path:* ]]; then
     local stored_owner_lc
-    stored_owner_lc="$(printf '%s' "$stored_owner" | tr '[:upper:]' '[:lower:]')"
+    stored_owner_lc="$(normalize_repo_key "$stored_owner")"
     if [[ "$stored_owner_lc" != "$active_id" ]]; then
       echo "polling-state-gate.sh: PR #$PR_NUMBER is scoped to repo '$stored_owner' but the active checkout is '$active_id' ($canon) — refuse to poll from the wrong repo" >&2
       return 1

--- a/.claude/scripts/session-state.sh
+++ b/.claude/scripts/session-state.sh
@@ -340,6 +340,23 @@ if ! source "$SCRIPT_DIR/state-lock.sh"; then
   exit 5
 fi
 
+# Shared case-normalizer (issue #704). Provides normalize_repo_key() so every
+# path that produces a .repos["<key>"] scope key lowercases consistently,
+# preventing a mixed-case origin remote from splitting PR tracking across two
+# scopes.  Sourced by session-state.sh, polling-state-gate.sh, and
+# handoff-state.sh — that single shared definition means the three scripts
+# can never drift on case normalization again.
+NORMALIZER_LIB="${SCRIPT_DIR}/lib/repo-normalizer.sh"
+if [[ ! -f "$NORMALIZER_LIB" || ! -r "$NORMALIZER_LIB" ]]; then
+  echo "session-state.sh: missing sibling library: $NORMALIZER_LIB" >&2
+  exit 5
+fi
+# shellcheck source=./lib/repo-normalizer.sh
+if ! source "$NORMALIZER_LIB"; then
+  echo "session-state.sh: failed to load $NORMALIZER_LIB" >&2
+  exit 5
+fi
+
 print_help() {
   sed -n '/^# PURPOSE$/,/^$/p' "$0" | sed '$d; s/^# \{0,1\}//'
 }
@@ -460,8 +477,12 @@ repo_key_from_remote_url() {
   local owner_path="${url%/*}"
   local owner="${owner_path##*/}"
   # A single-segment remainder leaves owner == name; that is not a repo key.
+  # Lowercase via the shared normalizer (issue #704) so a mixed-case origin
+  # remote ("AuerbachB/Skingod") produces the same scope key as the lowercase
+  # form ("auerbachb/skingod") that polling-state-gate.sh's repo_identity()
+  # has always emitted.
   if [[ -n "$owner" && -n "$name" && "$owner_path" != "$url" ]]; then
-    printf '%s/%s' "$owner" "$name"
+    normalize_repo_key "${owner}/${name}"
   fi
 }
 
@@ -493,6 +514,14 @@ resolve_repo_key() {
   else
     key="$(repo_key_of_path "$PWD")"
   fi
+  # Lowercase-normalize at a single point covering all three key sources:
+  #   (a) cwd origin via repo_key_from_remote_url (already normalized, but
+  #       belt-and-suspenders is cheap),
+  #   (b) --repo <REPO_ARG> (caller may pass mixed-case "Owner/Repo"),
+  #   (c) $CLAUDE_SESSION_REPO (same concern).
+  # Issue #704: this is what prevents a caller like `--repo AuerbachB/Skingod`
+  # from landing in a different .repos scope than `auerbachb/skingod`.
+  [[ -n "$key" ]] && key="$(normalize_repo_key "$key")"
   if [[ -z "$key" ]] || ! is_valid_repo_key "$key"; then
     if [[ -n "$key" ]]; then
       echo "session-state.sh: ignoring implausible repo key '$key'; using '$UNKNOWN_REPO_KEY'" >&2
@@ -581,7 +610,7 @@ def _scoped($pathmap; $unknown):
       | ($e.value.root_repo? // null) as $r
       | (if ($o | type) == "string" and ($o | length) > 0 then $o
          elif ($r | type) == "string" and ($pathmap[$r] != null) then $pathmap[$r]
-         else $unknown end) as $key
+         else $unknown end | ascii_downcase) as $key
       | .repos = ( (.repos // {})
           | .[$key] = ( (.[$key] // {})
               | .prs = ( (.prs // {})
@@ -589,7 +618,7 @@ def _scoped($pathmap; $unknown):
       )
     )
   | ( if ($doc.root_repo | type) == "string" and ($doc.root_repo | length) > 0
-      then ( ($pathmap[$doc.root_repo] // $unknown) as $rk
+      then ( ($pathmap[$doc.root_repo] // $unknown | ascii_downcase) as $rk
              | .repos = ( (.repos // {})
                  | .[$rk] = ( (.[$rk] // {})
                      | if (.root_repo // null) == null then .root_repo = $doc.root_repo else . end ) ) )

--- a/.claude/scripts/tests/escalate-review.test.sh
+++ b/.claude/scripts/tests/escalate-review.test.sh
@@ -40,6 +40,11 @@ cp "$REPO_ROOT/.claude/scripts/greptile-budget.sh" "$STUB_DIR/greptile-budget.sh
 # greptile-budget.sh source it from their own directory and hard-fail without
 # it rather than writing unserialized, so the stub dir needs it too.
 cp "$REPO_ROOT/.claude/scripts/state-lock.sh" "$STUB_DIR/state-lock.sh"
+# Shared case-normalizer library (issue #704) — session-state.sh sources it
+# from $SCRIPT_DIR/lib/ and hard-fails without it, so the stub dir needs the
+# lib/ subdirectory mirrored alongside the other siblings.
+mkdir -p "$STUB_DIR/lib"
+cp "$REPO_ROOT/.claude/scripts/lib/repo-normalizer.sh" "$STUB_DIR/lib/repo-normalizer.sh"
 chmod +x "$STUB_DIR/escalate-review.sh" "$STUB_DIR/session-state.sh" "$STUB_DIR/greptile-budget.sh"
 
 cat > "$STUB_DIR/pr-state.sh" <<'STUB'

--- a/.claude/scripts/tests/handoff-scoping.test.sh
+++ b/.claude/scripts/tests/handoff-scoping.test.sh
@@ -269,6 +269,73 @@ if [[ -f "${MIG_HANDOFF_DIR}/org/repoa/pr-101-handoff.json" ]]; then
 else fail "re-run broke pr-101"; fi
 
 # ---------------------------------------------------------------------------
+# 10. Case-divergence regression (issue #704) — mixed-case --owner-repo
+#     must produce a lowercase path, not a case-preserved one.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== 10. Mixed-case --owner-repo produces lowercase path (issue #704) ==="
+
+path_mc="$("$HANDOFF_STATE" --owner-repo "AuerbachB/Skingod" --path 77)"
+check "--path with mixed-case --owner-repo is lowercased" \
+  "${HANDOFF_DIR}/auerbachb/skingod/pr-77-handoff.json" "$path_mc"
+
+# Two callers using different-case spellings of the same repo must resolve
+# to the same path and therefore the same file (no split-state).
+path_mc_lc="$("$HANDOFF_STATE" --owner-repo "auerbachb/skingod" --path 77)"
+check "lowercase and mixed-case --owner-repo resolve to the same path" \
+  "$path_mc_lc" "$path_mc"
+
+# Create via mixed-case slug; verify the file lands in the lowercase directory.
+BODY_MC='{"schema_version":"1.0","pr_number":77,"head_sha":"mc01","owner_repo":"AuerbachB/Skingod","phase_completed":"A"}'
+"$HANDOFF_STATE" --owner-repo "AuerbachB/Skingod" --create 77 "$BODY_MC"
+if [[ -f "${HANDOFF_DIR}/auerbachb/skingod/pr-77-handoff.json" ]]; then
+  ok "file created at lowercase path despite mixed-case --owner-repo"
+else fail "file NOT created at lowercase path"; fi
+# Use ls -1 rather than [[ -d ]] to check the on-disk case-preserved name.
+# On macOS (case-insensitive filesystem), [[ -d "${HANDOFF_DIR}/AuerbachB" ]]
+# returns true even when only auerbachb/ exists, because the filesystem treats
+# the two names as identical.  ls -1 + grep -qx matches the literal entry name.
+if ! ls -1 "${HANDOFF_DIR}" | grep -qx 'AuerbachB'; then
+  ok "no mixed-case directory created"
+else fail "mixed-case directory AuerbachB/ was erroneously created"; fi
+
+# Read back via lowercase slug must work (same file).
+sha_mc="$("$HANDOFF_STATE" --owner-repo "auerbachb/skingod" --get 77 | jq -r '.head_sha')"
+check "--get via lowercase slug reads file created with mixed-case slug" "mc01" "$sha_mc"
+
+# ---------------------------------------------------------------------------
+# 11. Migration: mixed-case embedded owner_repo → lowercase scoped path
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== 11. Migration: mixed-case owner_repo migrates to lowercase path ==="
+
+MIG3_TMP="$(mktemp -d)"
+mig3_cleanup() { rm -rf "$MIG3_TMP"; }
+trap "cleanup; migrate_cleanup; mig2_cleanup; mig3_cleanup" EXIT
+MIG3_DIR="${MIG3_TMP}/.claude/handoffs"
+mkdir -p "$MIG3_DIR"
+
+# Flat file with a mixed-case embedded owner_repo.
+cat > "${MIG3_DIR}/pr-301-handoff.json" <<'JSON'
+{"schema_version":"1.0","pr_number":301,"head_sha":"mc02","owner_repo":"AuerbachB/Skingod","phase_completed":"A"}
+JSON
+
+HOME="$MIG3_TMP" "$MIGRATE" --apply
+
+if [[ -f "${MIG3_DIR}/auerbachb/skingod/pr-301-handoff.json" ]]; then
+  ok "mixed-case owner_repo migrated to lowercase scoped path"
+else fail "mixed-case owner_repo NOT migrated to lowercase path"; fi
+
+# Same case-insensitive-filesystem caveat as test 10: use ls -1 + grep -qx.
+if ! ls -1 "${MIG3_DIR}" | grep -qx 'AuerbachB'; then
+  ok "no mixed-case directory created during migration"
+else fail "migration created a mixed-case directory AuerbachB/"; fi
+
+if [[ ! -f "${MIG3_DIR}/pr-301-handoff.json" ]]; then
+  ok "flat file removed after migration"
+else fail "flat file still present after migration"; fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/.claude/scripts/tests/polling-state-gate.test.sh
+++ b/.claude/scripts/tests/polling-state-gate.test.sh
@@ -206,6 +206,51 @@ check_eq "uncomparable identity with recorded scoping fails closed" "4" "$rc"
 check_contains "fail-closed message names the PR" "PR #$PR_NUM" "$out"
 check_contains "fail-closed message names the scoped repo" "org/a" "$out"
 
+# ---- 10. case-parity regression (issue #704) ----------------------------------
+# A checkout whose `origin` remote has mixed-case owner/repo (e.g.
+# "AuerbachB/Skingod") must produce the SAME scope key from both
+# session-state.sh (--repo-key) and polling-state-gate.sh (repo_identity()),
+# so --ensure-session writes to the same .repos bucket that --verify-state
+# reads from.  Before issue #704 the two functions disagreed on case, so a
+# mixed-case remote silently created two .repos scopes for the same repo.
+REPO_MIXED="$TMP/repo-mixed"
+STATE_HELPER="$(cd "$(dirname "$SCRIPT")" && pwd)/session-state.sh"
+mk_repo "$REPO_MIXED" "git@github.com:AuerbachB/Skingod.git"
+
+# session-state.sh --repo-key must return the lowercase form.
+mixed_session_key="$(cd "$REPO_MIXED" && "$STATE_HELPER" --repo-key 2>/dev/null || true)"
+check_eq "session-state.sh --repo-key lowercases mixed-case remote" \
+  "auerbachb/skingod" "$mixed_session_key"
+
+# Simulate --ensure-session: write state under the key session-state.sh
+# produced (already lowercase from test above), then --verify-state from the
+# same checkout should pass (not refuse as a cross-repo mismatch).
+STUB_BIN2="$TMP/bin2"
+mkdir -p "$STUB_BIN2"
+cat > "$STUB_BIN2/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+case "${1:-}" in
+  pr)   echo '{"headRefOid":"c0ffee","state":"OPEN"}' ;;
+  repo) echo 'AuerbachB/Skingod' ;;
+  *)    exit 1 ;;
+esac
+STUB
+chmod +x "$STUB_BIN2/gh"
+
+rm -f "$STATE"
+out2="$(cd "$REPO_MIXED" && PATH="$STUB_BIN2:$PATH" "$SCRIPT" "$PR_NUM" --ensure-session 2>&1)"; rc2=$?
+check_eq "--ensure-session with mixed-case remote exits 0" "0" "$rc2"
+
+# The key stored in session-state.json must be lowercase.
+stored_key="$(jq -r --arg pr "$PR_NUM" '.repos | keys[]' "$STATE" 2>/dev/null | head -1 || true)"
+check_eq "state stored under lowercase key after ensure-session" \
+  "auerbachb/skingod" "$stored_key"
+
+# --verify-state from the same mixed-case-remote checkout must pass.
+out3="$(cd "$REPO_MIXED" && PATH="$STUB_BIN2:$PATH" "$SCRIPT" "$PR_NUM" --verify-state 2>&1)"; rc3=$?
+check_eq "--verify-state passes for mixed-case-remote checkout (no false cross-repo refusal)" "0" "$rc3"
+
 echo ""
 echo "polling-state-gate.test.sh: $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]]

--- a/.claude/scripts/tests/session-state-migration.test.sh
+++ b/.claude/scripts/tests/session-state-migration.test.sh
@@ -153,6 +153,50 @@ for form in \
 done
 
 echo
+echo "== Case-divergence regression (issue #704): mixed-case remote lowercased =="
+# repo_key_from_remote_url() must lowercase so a mixed-case origin remote
+# (e.g. AuerbachB/Skingod) produces the same .repos scope key as the lowercase
+# form (auerbachb/skingod) that polling-state-gate.sh's repo_identity() emits.
+for mc_form in \
+  "https://github.com/AuerbachB/Skingod.git" \
+  "git@github.com:AuerbachB/Skingod.git" \
+  "ssh://git@github.com:22/AuerbachB/Skingod.git"; do
+  d="$WORK_DIR/case-$RANDOM$$"
+  mkdir -p "$d"
+  git -C "$d" init --quiet
+  git -C "$d" remote add origin "$mc_form"
+  check_eq "mixed-case remote lowercased: $mc_form" "auerbachb/skingod" \
+    "$( cd "$d" && run --repo-key )"
+done
+
+# --repo flag with mixed-case must also lowercase (covers REPO_ARG branch of
+# resolve_repo_key, which bypasses repo_key_from_remote_url entirely).
+check_eq "--repo flag with mixed case lowercased" "auerbachb/skingod" \
+  "$(run --repo AuerbachB/Skingod --repo-key)"
+
+echo
+echo "== Case-divergence regression (issue #704): mixed-case owner_repo in migration =="
+# A legacy flat entry whose owner_repo carries GitHub's canonical mixed case
+# must migrate into the lowercase .repos scope, not a mixed-case one.
+cat > "$STATE_FILE" <<'JSON'
+{
+  "prs": {
+    "200": {"owner_repo": "AuerbachB/Skingod", "phase": "A"},
+    "201": {"owner_repo": "Org/CAPS",           "phase": "B"}
+  }
+}
+JSON
+run --migrate
+check_eq "mixed-case owner_repo #200 lands in lowercase scope" "A" \
+  "$(jq -r '.repos["auerbachb/skingod"].prs["200"].phase' "$STATE_FILE")"
+check_eq "mixed-case owner_repo #201 lands in lowercase scope" "B" \
+  "$(jq -r '.repos["org/caps"].prs["201"].phase' "$STATE_FILE")"
+check_eq "no mixed-case scope created for #200" "null" \
+  "$(jq -r '.repos["AuerbachB/Skingod"] // "null"' "$STATE_FILE")"
+check_eq "no mixed-case scope created for #201" "null" \
+  "$(jq -r '.repos["Org/CAPS"] // "null"' "$STATE_FILE")"
+
+echo
 echo "== summary: $PASS passed, $FAIL failed =="
 [[ "$FAIL" -eq 0 ]] || exit 1
 echo "OK: session-state.sh migration tests passed"


### PR DESCRIPTION
## Summary

- Introduces `.claude/scripts/lib/repo-normalizer.sh` with a single `normalize_repo_key()` function sourced by all three scope-key derivation points, eliminating the case-divergence between `session-state.sh` (was case-preserving) and `polling-state-gate.sh` (was already lowercasing via inline `tr`).
- `session-state.sh` now lowercases in `repo_key_from_remote_url()`, `resolve_repo_key()`, and the `MIGRATE_JQ` program (`ascii_downcase` on both the `owner_repo`-derived and `root_repo`-derived keys).
- `handoff-state.sh` normalizes `--owner-repo` at argument-parse time so `~/.claude/handoffs/{owner}/{repo}/` paths are always lowercase.
- `handoff-migrate.sh` normalizes `owner_repo` before building the destination path.
- Regression tests added to all three test suites (24 + 37 + 36 = 97 total, all pass).

Closes #704

## Test plan

- [x] `session-state-migration.test.sh`: 37/37 pass — mixed-case remote URL forms lower-cased, mixed-case `owner_repo` in legacy flat state migrates to lowercase scope key
- [x] `polling-state-gate.test.sh`: 24/24 pass — mixed-case remote repo produces lowercase `--repo-key`; `--ensure-session` stores state under lowercase key; `--verify-state` passes (no false cross-repo refusal)
- [x] `handoff-scoping.test.sh`: 36/36 pass — mixed-case `--owner-repo` flag produces lowercase path; file created at lowercase path despite mixed-case input; migration of mixed-case embedded `owner_repo` creates only the lowercase directory entry (checked via `ls -1 | grep -qx` to handle macOS case-insensitive filesystem correctly)
- [x] `lib/repo-normalizer.sh` sourced hard-fail style by storage scripts (`session-state.sh`, `handoff-state.sh`) and soft-fallback style by operational scripts (`polling-state-gate.sh`, `handoff-migrate.sh`)
- [x] Backward-compatible: all existing tests still pass; no existing lowercase scope keys are affected

## Local review notes

- **CodeRabbit CLI**: timed out after 7+ minutes with only heartbeats and no findings — dropped per `cr-local-review.md` timeout rule.
- **CodeAnt CLI**: not installed in this environment.
- **Self-review performed** (clean pass): verified normalization is applied before all path/key construction, `_unknown` sentinel passes through `ascii_downcase` unchanged, path-traversal guard in `_resolve_handoff_path` runs on the already-normalized value, and the macOS case-insensitive test check uses `ls -1 | grep -qx` instead of `[[ -d ]]`.