### PR TITLE
fix(#729): count Greptile P0s by severity badge, not prose mentions

### DIFF
--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -732,8 +732,10 @@ case "$REVIEWER" in
                 | select(if $ts == "" then true else .created_at >= $ts end) | .body]
           | join("\n---\n")')
 
-        # Count P0 badges across the review body and inline comments.
-        P0_COUNT=$( { echo "$G_BODY"; echo "$G_INLINE_BODIES"; } | grep -oE '\bP0\b' | wc -l | tr -d ' ')
+        # Count P0 severity badges across the review body and inline comments.
+        # Match only formal Greptile badges (<img alt="P0">) — not bare-word prose
+        # mentions like "no P0" which inflate the count (issue #729).
+        P0_COUNT=$( { echo "$G_BODY"; echo "$G_INLINE_BODIES"; } | grep -oF 'alt="P0"' | wc -l | tr -d ' ')
 
         # Are there unresolved Greptile-authored threads? If so, P0 vs P1/P2 changes
         # whether a re-review is required after fixing.

--- a/.claude/scripts/tests/merge-gate-greptile-comment.test.sh
+++ b/.claude/scripts/tests/merge-gate-greptile-comment.test.sh
@@ -99,11 +99,12 @@ greptile_comment() { # created_at thumbsup_count
       reactions:{url:"",total_count:$up,"+1":$up,"-1":0}}'
 }
 
-# Helper: build a Greptile inline diff comment with a P0 badge.
+# Helper: build a Greptile inline diff comment with a formal P0 severity badge.
+# Uses the <img alt="P0"> format Greptile actually emits (issue #729).
 greptile_p0_inline() {
   jq -cn --arg sha "$HEAD_SHA" \
     '{id:2001, user:{login:"greptile-apps[bot]"},
-      body:"**P0** — critical issue found",
+      body:"<img alt=\"P0\" src=\"badge.svg\" /> Critical issue found.",
       created_at:"'"$FRESH_TS"'",
       commit_id:$sha, original_commit_id:$sha}'
 }
@@ -197,6 +198,44 @@ check_eq "1"     "$RC"     "stale inline only: exit code 1"
 # yet" guard fires and reports exactly this missing entry.
 check_eq "yes" "$(missing_has "no Greptile review")" \
   "stale inline only: missing says 'no Greptile review yet'"
+
+# --------------------------------------------------------------------------
+# Test 5: Prose "no P0" must NOT count as a P0 badge (regression for #729).
+# A Greptile issue comment whose body contains the words "no P0" but no
+# <img alt="P0"> badge must yield P0_COUNT=0 — the severity gate passes.
+# Before the fix, grep -oE '\bP0\b' would match "P0" in "no P0" and wrongly
+# inflate P0_COUNT, flipping the gate to "P0 present" on a P1/P2-only review.
+# --------------------------------------------------------------------------
+echo "--- Test 5: prose 'no P0' must not count as badge ---"
+# A fresh Greptile issue comment with thumbsup=0 and prose "no P0".
+# thumbsup=0 → G_COMMENT_CLEAN=false → Path B; P0 prose in G_BODY must not count.
+COMMENT5="$(jq -cn \
+  '{id:4001, user:{login:"greptile-apps[bot]"},
+    body:"P1: minor nit — there are no P0 issues, this is purely a style concern.",
+    created_at:"'"$FRESH_TS"'",
+    reactions:{url:"",total_count:0,"+1":0,"-1":0}}')"
+run_gate "$PUSH_TS" "[$COMMENT5]" "[]"
+
+check_eq "true" "$(met)"           "prose no-P0: met == true (P0_COUNT=0)"
+check_eq "0"    "$(missing_count)" "prose no-P0: no missing entries"
+check_eq "0"    "$RC"              "prose no-P0: exit code 0"
+
+# --------------------------------------------------------------------------
+# Test 6: Formal <img alt="P0"> badge must be detected and fail the gate.
+# An inline comment whose body contains <img alt="P0"> must yield P0_COUNT>=1,
+# so the severity gate blocks merge until a clean re-review (regression for #729).
+# --------------------------------------------------------------------------
+echo "--- Test 6: formal P0 badge is detected ---"
+P0_BADGE="$(jq -cn --arg sha "$HEAD_SHA" \
+  '{id:5001, user:{login:"greptile-apps[bot]"},
+    body:"<img alt=\"P0\" src=\"badge.svg\" /> Critical: null pointer dereference in handler.",
+    created_at:"'"$FRESH_TS"'",
+    commit_id:$sha, original_commit_id:$sha}')"
+run_gate "$PUSH_TS" "[]" "[$P0_BADGE]"
+
+check_eq "false" "$(met)"              "P0 badge: met == false"
+check_eq "yes"   "$(missing_has "P0")" "P0 badge: missing contains P0 message"
+check_eq "1"     "$RC"                 "P0 badge: exit code 1"
 
 echo "----------------------------------------"
 echo "merge-gate-greptile-comment.test.sh: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

`merge-gate.sh:736` used `grep -oE '\bP0\b'` to count P0 findings, which matched bare-word "P0" anywhere in Greptile comment/review bodies — including prose like "no P0 issues found" in a P1 finding explanation. This inflated `P0_COUNT` and flipped the severity gate to "P0 present" on P1/P2-only reviews. PR #727's own Phase B review hit this exact case and required manual adjudication.

**Fix:** match only formal Greptile severity badges (`alt="P0"` in `<img>` tags), the channel Greptile actually uses for severity classification. Change is one line in `merge-gate.sh`; two regression tests added.

Closes #729

## Test plan

- [x] P0 detection matches severity badges (`alt="P0"`), not prose
- [x] A P1/P2-only review whose text mentions "no P0" passes the severity gate
- [x] A genuine P0 badge still fails the gate until fixed + re-reviewed per `greptile.md`
- [x] Regression tests added to `merge-gate-greptile-comment.test.sh` covering both

Tests verified locally: `bash .claude/scripts/tests/merge-gate-greptile-comment.test.sh` → 18 passed, 0 failed (up from 12).

**Local CLI note:** CodeRabbit CLI hit OSS rate limit; CodeAnt CLI not installed. Self-review performed per `cr-local-review.md` both-CLIs-down fallback — change is a targeted one-line fix with tight regression coverage.