### PR TITLE
fix(pr-state): classify Greptile clean-pass summary as acknowledgment

### DIFF
--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -431,8 +431,10 @@ CONVO=$(run_gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per
 #         finding pattern — otherwise the finding pattern swallows BugBot clean summaries.
 #      4. Finding patterns (severity/badges/phrases/suggestions) come next.
 #      5. Weak-ack fallback (lgtm variants) next, so it can't hide a real finding.
-#      6. CR walkthrough/summary marker ("<!-- ... summarize by coderabbit.ai -->") is the LAST
-#         override, immediately above the default — deliberately NOT in the tier-1 group above (#575).
+#      6. Greptile clean-pass summary ("Greptile Summary" heading, placed after severity
+#         checks but before the generic "issues? found" finding phrase — #743) sits with the
+#         CR walkthrough/summary marker as the LAST overrides, immediately above the default
+#         — deliberately NOT in the tier-1 group above (#575, #743).
 #         This is a different trigger from #557's rate-limit/usage-limit family: the walkthrough is
 #         the boilerplate CR posts on nearly every PR, and it matched no branch at all, so it fell
 #         through to default → finding and produced phantom findings.
@@ -442,6 +444,12 @@ CONVO=$(run_gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per
 #         which is strictly worse than the phantom-finding noise it fixes. Every finding pattern must
 #         be evaluated first and win. Ordering alone supplies that guard, so no AND-not guard (of the
 #         BugBot zero-issue kind) is needed here.
+#         Greptile's issue-comment summary (#743) follows the same late-placement rule for the
+#         walkthrough half of this tier; the Greptile branch itself sits just above the generic
+#         "issues? found" phrase because clean summaries say "no issues found" — caught by that
+#         phrase if the Greptile branch were any later. The branch requires the summary heading
+#         and either no "issues found" prose or the explicit "no issues found" clean-pass wording,
+#         so a summary that reports N>0 issues still reaches the finding phrase below.
 #      7. Default is finding — under-classifying is the failure mode this skill prevents.
 # ----------------------------------------------------------------------
 NEW_SINCE="null"
@@ -469,6 +477,7 @@ if [[ -n "$SINCE" ]]; then
       elif test("\\b(critical|major|minor|nitpick|p[0-2])\\b"; "i") then {class: "finding", reason: "severity keyword"}
       elif test("🔴|🟠|🟡"; "") then {class: "finding", reason: "severity badge"}
       elif test("actionable comments posted"; "i") then {class: "finding", reason: "actionable phrase"}
+      elif (test("Greptile Summary"; "i") and ((test("issues? found"; "i") | not) or test("no issues found"; "i"))) then {class: "acknowledgment", reason: "Greptile clean-pass summary"}
       elif test("potential[_ ]issue|issues? found|findings?:"; "i") then {class: "finding", reason: "finding phrase"}
       elif test("Prompt for AI Agent"; "i") then {class: "finding", reason: "CR fix prompt"}
       elif test("```suggestion"; "m") then {class: "finding", reason: "suggestion block"}

--- a/.claude/scripts/tests/pr-state-classify.test.sh
+++ b/.claude/scripts/tests/pr-state-classify.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Unit test for the `classify` jq function inside `pr-state.sh --since`
-# (issues #535, #557, #575, #669).
+# (issues #535, #557, #575, #669, #743).
 #
 # Verifies that comment bodies observed misclassified in the wild are now correctly
 # classified as acknowledgments, and that existing patterns are not regressed:
@@ -588,6 +588,62 @@ class="${result%%|*}"
   || fail "Bug8a: finding quoting CR auto-reply prose — expected finding, got $class"
 
 # ---------------------------------------------------------------------------
+# Bug 9: Greptile clean-pass summary comment (issue #743)
+#
+# Greptile posts a "Greptile Summary" issue comment on nearly every PR. Pre-fix,
+# it matched no branch and fell through to default → finding, inflating /wrap
+# Phase 1 finding_count on PRs where Greptile had a fully clean pass.
+# Was: default → finding; Should be: Greptile clean-pass summary → acknowledgment
+#
+# Fixture: faithful reproduction of PR #742's clean-pass summary shape.
+# ---------------------------------------------------------------------------
+BODY='<h3>Greptile Summary</h3> This PR condenses the auto-loaded rule corpus.
+
+<h3>Confidence Score: 5/5</h3> Safe to merge — no issues found.'
+result=$(classify_body "$BODY")
+class="${result%%|*}"; reason="${result##*|}"
+if [[ "$class" == "acknowledgment" && "$reason" == "Greptile clean-pass summary" ]]; then
+  pass "Bug9: Greptile clean-pass summary → acknowledgment"
+else
+  fail "Bug9: Greptile clean-pass summary — expected acknowledgment/Greptile clean-pass summary, got $class/$reason"
+fi
+
+# ---------------------------------------------------------------------------
+# Bug9a: MASKING GUARD — Greptile summary heading + severity keyword stays a finding.
+# Same rationale as Bug6a/Bug6b: the summary can mention findings it summarizes.
+# ---------------------------------------------------------------------------
+BODY='<h3>Greptile Summary</h3>
+
+Summary of changes, including one nitpick raised against the retry loop.'
+result=$(classify_body "$BODY")
+class="${result%%|*}"
+[[ "$class" == "finding" ]] && pass "Bug9a: Greptile summary + severity keyword 'nitpick' → finding (real findings not masked)" \
+  || fail "Bug9a: Greptile summary + severity keyword — expected finding, got $class"
+
+# ---------------------------------------------------------------------------
+# Bug9b: genuine Greptile inline finding with P0 badge stays a finding (no regression).
+# Uses the <img alt="P0"> format Greptile actually emits (issue #729).
+# ---------------------------------------------------------------------------
+BODY='<img alt="P0" src="badge.svg" /> Critical issue found in auth flow.'
+result=$(classify_body "$BODY")
+class="${result%%|*}"
+[[ "$class" == "finding" ]] && pass "Bug9b: Greptile P0 inline badge → finding (unchanged behavior)" \
+  || fail "Bug9b: Greptile P0 inline badge — expected finding, got $class"
+
+# ---------------------------------------------------------------------------
+# Bug9c: MASKING GUARD — Greptile summary + non-zero "issues found" stays a finding.
+# The #743 override requires either no "issues found" prose or the explicit
+# "no issues found" clean-pass wording; a summary reporting N>0 must not ack.
+# ---------------------------------------------------------------------------
+BODY='<h3>Greptile Summary</h3>
+
+3 issues found in the diff.'
+result=$(classify_body "$BODY")
+class="${result%%|*}"
+[[ "$class" == "finding" ]] && pass "Bug9c: Greptile summary + '3 issues found' → finding (non-clean summary not masked)" \
+  || fail "Bug9c: Greptile summary + issue count — expected finding, got $class"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""
@@ -595,4 +651,4 @@ echo "Results: $PASS passed, $FAIL failed"
 if [[ "$FAIL" -gt 0 ]]; then
   exit 1
 fi
-echo "OK: pr-state.sh classify — all fixtures and regressions passed (issues #535, #557, #575, #669)"
+echo "OK: pr-state.sh classify — all fixtures and regressions passed (issues #535, #557, #575, #669, #743)"


### PR DESCRIPTION
## **User description**
## Summary

- Add a Greptile clean-pass branch to `pr-state.sh`'s bot-comment classifier so `Greptile Summary` issue comments classify as `acknowledgment`, not `finding`
- Place the branch after severity checks but before the generic `issues? found` finding phrase (clean summaries say "no issues found", which that phrase would otherwise swallow)
- Add regression tests (Bug9/Bug9a/Bug9b/Bug9c) covering the PR #742 summary shape, masking guards, and inline P0 findings

Closes #743

## Test plan

- [x] `bash .claude/scripts/tests/pr-state-classify.test.sh` — all 47 fixtures pass (Bug9 clean summary → acknowledgment; Bug9a severity masking; Bug9b P0 inline → finding; Bug9c non-clean summary → finding)
- [x] Greptile clean-pass summary with `Confidence Score: 5/5` / `Safe to merge — no issues found` classifies as `acknowledgment`
- [x] Genuine Greptile inline P0 badge still classifies as `finding`
- [x] Classifier default fallback remains last; no reordering of tier-1 overrides
- [ ] Manual: on a PR with a clean Greptile pass, `/wrap` Phase 1 reports `WRAP_PHASE1_FINDINGS: 0` (requires live PR)


Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Classify clean Greptile summary comments as acknowledgments**

### What Changed
- Clean Greptile summary comments with a “no issues found” result are now treated as acknowledgments instead of findings
- Greptile summaries that mention real issues, severity words, or a non-zero issue count still count as findings
- Added regression coverage for the clean summary case and for summary comments that still report actual problems

### Impact
`✅ Fewer false findings on clean PRs`
`✅ Fewer unnecessary fix/review cycles`
`✅ Cleaner wrap-up results for Greptile scans`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
