### PR TITLE
fix(hooks): ignore protected paths in quoted Bash payload

### DIFF
--- a/.claude/hooks/config-protection.py
+++ b/.claude/hooks/config-protection.py
@@ -163,6 +163,100 @@ BARE_REDIRECT_RE = re.compile(r'^(?:\d*>{1,2}\|?|&>{1,2})$')
 EMBEDDED_REDIRECT_RE = re.compile(r'(?:\d*>{1,2}\|?|&>{1,2})([^<>&].*)$')
 WRITE_FLAG_TOKENS = frozenset({'--write', '--fix', '-w', '-inplace'})
 COPY_MOVE_BINS = frozenset({'cp', 'mv'})
+# Commands whose regular arguments are payload text, not file targets. A
+# protected path that appears only inside a quoted argument to one of these
+# is prose/data (issue #744), not a write target.
+PAYLOAD_COMMAND_BINS = frozenset({'echo', 'printf', 'gh'})
+
+
+def _extract_quoted_literal_contents(segment: str) -> frozenset[str]:
+    """Return inner text of single- and double-quoted literals in segment."""
+    contents: set[str] = set()
+    quote: str | None = None
+    buf: list[str] = []
+    i = 0
+    n = len(segment)
+    while i < n:
+        ch = segment[i]
+        if quote:
+            if ch == quote:
+                contents.add(''.join(buf))
+                buf = []
+                quote = None
+            elif quote == '"' and ch == '\\' and i + 1 < n:
+                buf.append(segment[i + 1])
+                i += 1
+            else:
+                buf.append(ch)
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            quote = ch
+            buf = []
+            i += 1
+            continue
+        i += 1
+    return frozenset(contents)
+
+
+def _here_string_data_tokens(tokens: list[str]) -> frozenset[str]:
+    """Tokens that are here-string (<<<) payload, never file targets."""
+    data: set[str] = set()
+    after_op = False
+    for tok in tokens:
+        if after_op:
+            data.add(tok)
+            after_op = False
+            continue
+        if tok == '<<<':
+            after_op = True
+            continue
+        if tok.startswith('<<<') and len(tok) > 3:
+            data.add(tok[3:])
+    return frozenset(data)
+
+
+def _resolve_executable_bin(tokens: list[str]) -> str | None:
+    """Best-effort executable basename, skipping env assignments and wrappers."""
+    expect_command_name = True
+    current_wrapper: str | None = None
+    expect_wrapper_flag_value = False
+    for tok in tokens:
+        base = tok.rsplit('/', 1)[-1]
+        if expect_command_name:
+            if expect_wrapper_flag_value:
+                expect_wrapper_flag_value = False
+            elif ENV_ASSIGNMENT_RE.match(tok):
+                pass
+            elif base in COMMAND_WRAPPER_BINS:
+                current_wrapper = base
+            elif tok.startswith('-'):
+                if current_wrapper and tok in WRAPPER_VALUE_FLAGS.get(current_wrapper, ()):
+                    expect_wrapper_flag_value = True
+            else:
+                return base
+        else:
+            break
+    return None
+
+
+def _non_target_data_tokens(segment: str, tokens: list[str]) -> frozenset[str]:
+    """Tokens that carry quoted/heredoc payload text, not write targets.
+
+    Issue #744: a protected path mentioned only inside quoted text or a
+    here-string must not be treated as the command's write target."""
+    data = set(_here_string_data_tokens(tokens))
+    quoted_contents = _extract_quoted_literal_contents(segment)
+    if not quoted_contents:
+        return frozenset(data)
+
+    executable = _resolve_executable_bin(tokens)
+    if executable in PAYLOAD_COMMAND_BINS:
+        for tok in tokens:
+            if tok in quoted_contents:
+                data.add(tok)
+
+    return frozenset(data)
 
 
 def _split_into_command_segments(cmd: str) -> list[str]:
@@ -326,7 +420,11 @@ def should_block_edit(path: str, cwd: str | None = None) -> bool:
     return path_exists(path, cwd)
 
 
-def _scan_command_segment(tokens: list[str], cwd: str | None) -> str | None:
+def _scan_command_segment(
+    segment: str,
+    tokens: list[str],
+    cwd: str | None,
+) -> str | None:
     """Scan one separator-free command segment for a write targeting a
     protected path. Every piece of state here is local to this single
     segment — nothing from an earlier or later `;`/`&&`/`|`-separated
@@ -352,6 +450,7 @@ def _scan_command_segment(tokens: list[str], cwd: str | None) -> str | None:
     expect_redirect_target = False
 
     protected_in_cmd: list[str] = []
+    data_tokens = _non_target_data_tokens(segment, tokens)
 
     for tok in tokens:
         if expect_redirect_target:
@@ -419,7 +518,7 @@ def _scan_command_segment(tokens: list[str], cwd: str | None) -> str | None:
             has_write_op = True
             last_copy_move = None
             continue
-        if is_protected_path(tok):
+        if is_protected_path(tok) and tok not in data_tokens:
             normalized = normalize_path(tok)
             protected_in_cmd.append(normalized)
             if last_copy_move in COPY_MOVE_BINS:
@@ -460,7 +559,7 @@ def bash_targets_protected(cmd: str, cwd: str | None = None) -> str | None:
             tokens = segment_str.split()
         if not tokens:
             continue
-        blocked = _scan_command_segment(tokens, cwd)
+        blocked = _scan_command_segment(segment_str, tokens, cwd)
         if blocked:
             return blocked
     return None

--- a/tests/test_config_protection.py
+++ b/tests/test_config_protection.py
@@ -527,6 +527,70 @@ class ConfigProtectionBashTests(unittest.TestCase):
                 with self.subTest(cmd=cmd):
                     self.assertEqual(config_protection.bash_targets_protected(cmd), str(target))
 
+    def test_bash_allows_protected_path_mentioned_in_quoted_text(self) -> None:
+        # issue #744: a protected path mentioned only inside quoted payload
+        # text must not be blocked when the actual write goes elsewhere.
+        with tempfile.TemporaryDirectory() as tmp:
+            rule_lint = pathlib.Path(tmp) / '.github' / 'scripts'
+            rule_lint.mkdir(parents=True)
+            protected = rule_lint / 'rule-lint.sh'
+            protected.write_text('#!/bin/sh\n', encoding='utf-8')
+            protected_path = str(protected)
+            rel_path = '.github/scripts/rule-lint.sh'
+            scratch = pathlib.Path(tmp) / 'out.md'
+            allow_cmds = [
+                f"echo 'see {rel_path} for the budget limit' > {scratch}",
+                f'echo "docs mention {rel_path} in prose" > {scratch}',
+                f"printf '%s' 'text about {rel_path}' > {scratch}",
+                f"tee {scratch} <<< '{rel_path}'",
+                f"tee {scratch} <<<'mention {rel_path} in prose'",
+                f"gh issue create --body 'See {rel_path} for details'",
+                (
+                    f"cat > {scratch} <<'EOF'\n"
+                    f"the soft-warning limit in `{rel_path}`\n"
+                    f"EOF"
+                ),
+            ]
+            for cmd in allow_cmds:
+                with self.subTest(cmd=cmd):
+                    self.assertIsNone(
+                        config_protection.bash_targets_protected(cmd, cwd=str(tmp))
+                    )
+
+    def test_bash_allows_issue_repro_heredoc_shape(self) -> None:
+        # issue #744: exact reported shape — write to scratchpad, protected
+        # path only in heredoc prose, then gh issue create.
+        with tempfile.TemporaryDirectory() as tmp:
+            rule_lint = pathlib.Path(tmp) / '.github' / 'scripts'
+            rule_lint.mkdir(parents=True)
+            protected = rule_lint / 'rule-lint.sh'
+            protected.write_text('#!/bin/sh\n', encoding='utf-8')
+            rel_path = '.github/scripts/rule-lint.sh'
+            cmd = (
+                f"cat > {tmp}/issue-body.md <<'EOF'\n"
+                f"the 12,000-word soft-warning limit in `{rel_path}`\n"
+                f"EOF\n"
+                f'gh issue create --title "test" --body-file {tmp}/issue-body.md'
+            )
+            self.assertIsNone(config_protection.bash_targets_protected(cmd, cwd=str(tmp)))
+
+    def test_bash_still_blocks_real_writes_after_quote_fix(self) -> None:
+        # issue #744 regression guard: genuine writes must stay blocked.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = pathlib.Path(tmp) / '.eslintrc.json'
+            target.write_text('existing: true\n', encoding='utf-8')
+            rel = str(target)
+            block_cmds = [
+                f"echo x > {rel}",
+                f"sed -i 's/x/y/' {rel}",
+                f"tee {rel}",
+                f"tee {rel} <<<'harmless stdin'",
+                f"rm -f '{rel}'",
+            ]
+            for cmd in block_cmds:
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(config_protection.bash_targets_protected(cmd), rel)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## **User description**
## Summary

- Fix false positives in `config-protection.py` when a protected path appears only inside quoted text or a here-string (`<<<`) payload, not as an actual write target
- Add helpers to classify payload/data tokens vs file targets: here-string content, and quoted literals passed to payload commands (`echo`, `printf`, `gh`)
- Add regression tests for heredoc-body mentions, single/double-quoted mentions, and genuine redirect/`sed -i`/`tee`/`rm` writes

Closes #744

## Test plan

- [x] Command whose only reference to a protected path is inside a quoted string or heredoc body is **not** blocked
- [x] Genuine write to a protected path (redirect, `mv`/`cp`/`rm`/`sed -i`/`tee`) is still blocked
- [x] Read-only access remains allowed (#624, #668 behavior preserved)
- [x] Test cases cover: heredoc-body mention, single/double-quoted mention, redirect write, `sed -i` write
- [x] Hook remains importable and correct on Python 3.9 — verified via `python3 -m unittest tests.test_config_protection`

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Ignore protected paths when they only appear inside quoted text or here-string content**

### What Changed
- Protected paths mentioned only inside quoted prose, `printf`/`echo` output, `gh issue create` text, or here-string input are no longer treated as write targets
- Commands that still perform a real write to a protected path, such as redirects, `sed -i`, `tee`, and `rm`, continue to be blocked
- Added regression coverage for the reported issue shape and for the existing write-blocking cases

### Impact
`✅ Fewer false blocks on issue bodies and shell text`
`✅ Safer protected-file checks during scratch-file writes`
`✅ Preserved blocking for real edits and deletions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
