### PR TITLE
fix(#748): treat Greptile summary updated_at as fresh after in-place re-review

### DIFF
--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -718,11 +718,16 @@ case "$REVIEWER" in
       '[.[]? | select(.user.login == "greptile-apps[bot]")
               | select(if $after == "" then true else .created_at > $after end)] | length')
 
-    # Latest FRESH Greptile issue comment (created after the last push).
+    # Latest FRESH Greptile issue comment (created OR updated after the last push).
+    # Greptile edits its summary comment in-place on re-review rather than posting a
+    # new one (observed on PR #734 — rebased + force-pushed; re-review updated the
+    # existing summary comment at updated_at 03:05:28Z after the 02:50:10Z push while
+    # created_at stayed at the original post time). Accept the comment as fresh when
+    # either timestamp is post-push (issue #748).
     LATEST_G_COMMENT=$(echo "$ISSUE_COMMENTS_JSON" | jq -c --arg after "${LAST_COMMIT_TS:-}" '
       [.[]?
         | select(.user.login == "greptile-apps[bot]")
-        | select(if $after == "" then true else .created_at > $after end)]
+        | select(if $after == "" then true else (.created_at > $after or .updated_at > $after) end)]
       | sort_by(.created_at) | last // empty')
 
     # Latest Greptile formal review (belt-and-suspenders supplemental signal).
@@ -757,7 +762,10 @@ case "$REVIEWER" in
           G_ANCHOR_TS=$(echo "$LATEST_G" | jq -r '.submitted_at // ""')
         fi
         if [[ -n "$LATEST_G_COMMENT" ]]; then
-          G_COMMENT_TS=$(echo "$LATEST_G_COMMENT" | jq -r '.created_at // ""')
+          # Prefer updated_at over created_at: Greptile edits its summary in-place
+          # (issue #748), so updated_at is the effective review timestamp after a
+          # re-review. Falls back to created_at for comments without updated_at.
+          G_COMMENT_TS=$(echo "$LATEST_G_COMMENT" | jq -r '(.updated_at // .created_at) // ""')
           # Issue comment supersedes formal review when it is more recent.
           if [[ -z "$G_ANCHOR_TS" || "$G_COMMENT_TS" > "$G_ANCHOR_TS" ]]; then
             G_BODY=$(echo "$LATEST_G_COMMENT" | jq -r '.body // ""')

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -773,10 +773,15 @@ case "$REVIEWER" in
           fi
         fi
 
-        # Inline bodies associated with the latest Greptile review (by timestamp).
-        G_INLINE_BODIES=$(echo "$PR_COMMENTS_JSON" | jq -r --arg ts "${G_ANCHOR_TS:-}" '
+        # Inline bodies associated with the latest Greptile review (fresh post-push).
+        # Use LAST_COMMIT_TS (push time) rather than G_ANCHOR_TS (summary updated_at):
+        # when Greptile posts inlines before editing its summary in-place (issue #748),
+        # G_ANCHOR_TS > inline.created_at and those inlines would be excluded from P0
+        # scanning — identical asymmetry to the BugBot commit_id lesson. Using the push
+        # timestamp keeps G_INLINE_BODIES consistent with G_INLINE_COUNT (same filter).
+        G_INLINE_BODIES=$(echo "$PR_COMMENTS_JSON" | jq -r --arg ts "${LAST_COMMIT_TS:-}" '
           [.[]? | select(.user.login == "greptile-apps[bot]")
-                | select(if $ts == "" then true else .created_at >= $ts end) | .body]
+                | select(if $ts == "" then true else .created_at > $ts end) | .body]
           | join("\n---\n")')
 
         # Count P0 severity badges across the review body and inline comments.

--- a/.claude/scripts/tests/merge-gate-greptile-comment.test.sh
+++ b/.claude/scripts/tests/merge-gate-greptile-comment.test.sh
@@ -43,6 +43,8 @@ PUSH_TS="2026-07-23T13:00:00Z"
 FRESH_TS="2026-07-23T13:05:00Z"
 # A timestamp clearly BEFORE the push (comment is stale).
 STALE_TS="2026-07-23T12:55:00Z"
+# A timestamp AFTER FRESH_TS — simulates a summary edited later than its inlines.
+LATE_FRESH_TS="2026-07-23T13:10:00Z"
 
 # --- Fake gh: stubs the endpoints merge-gate.sh calls. ----------------------
 BIN="$TMP/bin"; mkdir -p "$BIN"
@@ -274,6 +276,33 @@ check_eq "false" "$(met)"  "both-stale comment: met == false"
 check_eq "1"     "$RC"     "both-stale comment: exit code 1"
 check_eq "yes" "$(missing_has "no Greptile review")" \
   "both-stale comment: missing says 'no Greptile review yet'"
+
+# --------------------------------------------------------------------------
+# Test 9: P0 inline posted BEFORE in-place summary edit must still be caught.
+# Reproduces the BugBot finding from PR #751: G_INLINE_BODIES was anchored to
+# G_ANCHOR_TS (summary updated_at), which could be LATER than the inline's
+# created_at, silently excluding the P0 from badge scanning.
+#
+# Timeline:
+#   PUSH_TS (13:00) < FRESH_TS (13:05, inline created) < LATE_FRESH_TS (13:10, summary updated_at)
+#
+# G_INLINE_COUNT must count the inline (created_at > PUSH_TS ✓).
+# G_INLINE_BODIES must include the inline (created_at > PUSH_TS ✓) — not gate
+# on G_ANCHOR_TS=LATE_FRESH_TS, which would exclude it.
+# P0_COUNT must be 1 → gate remains unmet.
+# --------------------------------------------------------------------------
+echo "--- Test 9: P0 inline created before in-place summary edit ---"
+COMMENT9="$(greptile_comment "$STALE_TS" 0 "$LATE_FRESH_TS")"
+INLINE_P0_EARLY="$(jq -cn --arg sha "$HEAD_SHA" \
+  '{id:6001, user:{login:"greptile-apps[bot]"},
+    body:"<img alt=\"P0\" src=\"badge.svg\" /> Critical: use-after-free in destructor.",
+    created_at:"'"$FRESH_TS"'",
+    commit_id:$sha, original_commit_id:$sha}')"
+run_gate "$PUSH_TS" "[$COMMENT9]" "[$INLINE_P0_EARLY]"
+
+check_eq "false" "$(met)"              "P0 inline pre-summary-edit: met == false"
+check_eq "yes"   "$(missing_has "P0")" "P0 inline pre-summary-edit: missing contains P0 message"
+check_eq "1"     "$RC"                 "P0 inline pre-summary-edit: exit code 1"
 
 echo "----------------------------------------"
 echo "merge-gate-greptile-comment.test.sh: $PASS passed, $FAIL failed"

--- a/.claude/scripts/tests/merge-gate-greptile-comment.test.sh
+++ b/.claude/scripts/tests/merge-gate-greptile-comment.test.sh
@@ -95,12 +95,16 @@ export HEAD_SHA
 export PUSH_TS
 
 # Helper: build a Greptile issue comment JSON object.
-greptile_comment() { # created_at thumbsup_count
-  local ts="$1" up="$2"
-  jq -cn --arg ts "$ts" --argjson up "$up" \
+# Third arg (updated_at) is optional — defaults to created_at.
+# GitHub's API always includes updated_at; we default it here so existing tests
+# continue to produce a comment that has updated_at == created_at (pre-push when
+# created_at is pre-push), preserving the stale-comment test expectations.
+greptile_comment() { # created_at thumbsup_count [updated_at]
+  local ts="$1" up="$2" upd="${3:-$1}"
+  jq -cn --arg ts "$ts" --argjson up "$up" --arg upd "$upd" \
     '{id:1001, user:{login:"greptile-apps[bot]"},
       body:"<h3>Greptile Summary</h3>\nClean review.",
-      created_at:$ts,
+      created_at:$ts, updated_at:$upd,
       reactions:{url:"",total_count:$up,"+1":$up,"-1":0}}'
 }
 
@@ -241,6 +245,35 @@ run_gate "$PUSH_TS" "[]" "[$P0_BADGE]"
 check_eq "false" "$(met)"              "P0 badge: met == false"
 check_eq "yes"   "$(missing_has "P0")" "P0 badge: missing contains P0 message"
 check_eq "1"     "$RC"                 "P0 badge: exit code 1"
+
+# --------------------------------------------------------------------------
+# Test 7: In-place re-review — created_at pre-push, updated_at post-push.
+# Greptile edits its summary comment in-place on re-review (observed on PR #734).
+# The original created_at pre-dates the force-push; updated_at is post-push.
+# merge-gate.sh must treat updated_at as sufficient freshness and report met:true.
+# This is the primary regression test for issue #748.
+# --------------------------------------------------------------------------
+echo "--- Test 7: in-place re-review — created_at pre-push, updated_at post-push ---"
+COMMENT7="$(greptile_comment "$STALE_TS" 1 "$FRESH_TS")"
+run_gate "$PUSH_TS" "[$COMMENT7]" "[]"
+
+check_eq "true"  "$(met)"           "in-place re-review: met == true"
+check_eq "0"     "$(missing_count)" "in-place re-review: missing array empty"
+check_eq "0"     "$RC"              "in-place re-review: exit code 0"
+
+# --------------------------------------------------------------------------
+# Test 8: Both created_at and updated_at pre-push — truly stale, gate must fail.
+# A comment that was both created and last edited before the push is not a fresh
+# review signal and must not satisfy the gate (no Greptile review yet).
+# --------------------------------------------------------------------------
+echo "--- Test 8: both created_at and updated_at pre-push — truly stale ---"
+COMMENT8="$(greptile_comment "$STALE_TS" 1 "$STALE_TS")"
+run_gate "$PUSH_TS" "[$COMMENT8]" "[]"
+
+check_eq "false" "$(met)"  "both-stale comment: met == false"
+check_eq "1"     "$RC"     "both-stale comment: exit code 1"
+check_eq "yes" "$(missing_has "no Greptile review")" \
+  "both-stale comment: missing says 'no Greptile review yet'"
 
 echo "----------------------------------------"
 echo "merge-gate-greptile-comment.test.sh: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Greptile edits its summary issue comment **in-place** on re-review rather than posting a new one. The prior freshness filter in `merge-gate.sh` only checked `created_at > LAST_COMMIT_TS`, so a re-reviewed PR would still report "no Greptile review yet" even when the update happened post-push.

**Observed on PR #734:** rebased + force-pushed at 02:50:10Z; Greptile re-reviewed and updated the existing summary comment at `updated_at` 03:05:28Z (👍, Confidence 5/5, no inline findings), while `created_at` remained at the original pre-push timestamp. `merge-gate.sh` incorrectly returned "no Greptile review yet."

## Changes

**`merge-gate.sh`** (Greptile path):
- `LATEST_G_COMMENT` filter extended from `.created_at > $after` to `(.created_at > $after or .updated_at > $after)` — accepts the summary comment as fresh when either timestamp is post-push.
- `G_COMMENT_TS` in Path B updated to use `(.updated_at // .created_at)` — the effective review timestamp after an in-place edit, used to anchor `G_INLINE_BODIES` for P0 badge counting.

**`merge-gate-greptile-comment.test.sh`**:
- `greptile_comment()` helper extended with optional 3rd arg `updated_at` (defaults to `created_at`) so fixture comments now include the `updated_at` field GitHub's API always provides.
- **Test 7** (primary regression): `created_at` pre-push + `updated_at` post-push + 👍 + no inline → `met:true`.
- **Test 8** (stale guard): both `created_at` and `updated_at` pre-push → `met:false`, "no Greptile review yet".

## Inline-comment design choice

`G_INLINE_COUNT` was **intentionally not** extended with `or .updated_at > $after`. Inline diff comments are per-commit findings posted at review time; if a human replies to one, `updated_at` advances but it is still the same old finding — not a fresh finding from the re-review. Extending `updated_at` here would cause stale findings (replied to post-push) to count as fresh, breaking the stale-inline guard that Test 4 verifies. The issue body used "if applicable" for this side; it is not applicable.

## Test plan

- [x] Rebase a Greptile-owned PR; confirm Greptile updates existing summary in-place — cited live observation on PR #734 (rebased + force-pushed at 02:50:10Z; `updated_at` on the summary comment was 03:05:28Z; `created_at` was pre-push). This is the root cause; no additional live rebase needed for this fix.
- [x] `merge-gate.sh` exits 0 when `updated_at` is post-push even if `created_at` is pre-push — covered by **Test 7** (24/24 pass).
- [x] Stale pre-push comments with no post-push `updated_at` still fail the gate — covered by **Test 3** (stale `created_at`, `updated_at` defaults to `created_at` = stale, gate fails) and **Test 8** (both timestamps explicitly pre-push, gate fails).

### Fixture test matrix (all in `merge-gate-greptile-comment.test.sh`)

| Test | created_at | updated_at | 👍 | inline | Expected |
|------|-----------|-----------|-----|--------|----------|
| 7 (new) | pre-push | post-push | yes | none | met:true |
| 8 (new) | pre-push | pre-push | yes | none | met:false |
| 3 (existing) | pre-push | (defaults to pre-push) | yes | none | met:false |
| 1 (existing) | post-push | (defaults to post-push) | yes | none | met:true |

**24/24 tests pass** (was 18).

## Local review notes

- **CodeRabbit CLI**: clean pass, 0 findings on 2 reviewed files.
- **CodeAnt CLI**: not installed in this environment — noted per `cr-local-review.md` timeout & fallback.

Closes #748