### PR TITLE
fix(#759): generalize capability discovery into an explicit CLI ladder

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -80,8 +80,9 @@ Agent tool call:
 
            MINDSET: Before handing off, walk the capability ladder for ANY provider
            CLI (gh, git, vercel, neonctl, railway, cloudinary, or one you've never
-           used): look locally by absolute path (/opt/homebrew/bin/<tool>); if
-           absent, check whether the provider ships a CLI; install it yourself when
+           used): look at what you already have — MCP tools, skills, and the CLI on
+           disk by absolute path (/opt/homebrew/bin/<tool>); if absent, check
+           whether the provider ships a CLI; install it yourself when
            non-interactive and the safety rails hold; else hand off an
            /admin-merge-shaped runbook — exact commands + one-line reason. 'I can't'
            is valid only after the ladder dead-ends, and must name the rung and the

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -78,11 +78,14 @@ Agent tool call:
            commands (rm -rf, rm, git checkout ., git stash, git reset --hard) in the
            root repo directory. Stay in your worktree directory at all times.
 
-           MINDSET: Before handing off, enumerate your actual tools (gh/git/curl/gh
-           api, MCP, skills) — don't trust inherited 'agents can't' prose. Try the
-           CLI-accessible path first. Only hand off for real walls (token-scope 403,
-           branch protection, .env, or a safety.md 'Never' item), structured like
-           /admin-merge: exact command + one-line reason.
+           MINDSET: Before handing off, walk the capability ladder for ANY provider
+           CLI (gh, git, vercel, neonctl, railway, cloudinary, or one you've never
+           used): look locally by absolute path (/opt/homebrew/bin/<tool>); if
+           absent, check whether the provider ships a CLI; install it yourself when
+           non-interactive and the safety rails hold; else hand off an
+           /admin-merge-shaped runbook — exact commands + one-line reason. 'I can't'
+           is valid only after the ladder dead-ends, and must name the rung and the
+           reason.
 
            SKILLS: Before hand-rolling a multi-step task, check whether an existing
            skill already does this job — invoke it via the Skill tool instead of

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -42,7 +42,7 @@ The parent agent provides these values in your prompt:
 - NEVER run destructive commands (`rm -rf`, `rm`, `git checkout .`, `git stash`, `git reset --hard`) in the root repo directory.
 - Stay in your worktree directory at all times.
 - NEVER add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or any linter suppression comment. Fix the actual code.
-- Before treating something as impossible, try the CLI path (`gh`/`git`/`curl`/`gh api`) first — only hand off for real walls, structured per the capability-discovery mindset in `safety.md`.
+- Before treating something as impossible, walk the capability ladder for any provider CLI (`gh`, `git`, `curl`, or a service CLI like `railway`/`vercel`) — check locally by absolute path, check whether the provider ships one, install it when safe; only hand off for real walls, naming the rung you stopped on, per the capability-discovery mindset in `safety.md`.
 
 ## Workflow
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -23,7 +23,7 @@ The parent agent provides:
 - NEVER run destructive commands (`rm -rf`, `rm`, `git checkout .`, `git stash`, `git reset --hard`) in the root repo directory.
 - Stay in your worktree directory at all times.
 - NEVER add linter suppression comments. Fix the actual code.
-- Before treating something as impossible, try the CLI path (`gh`/`git`/`curl`/`gh api`) first — only hand off for real walls, structured per the capability-discovery mindset in `safety.md`.
+- Before treating something as impossible, walk the capability ladder for any provider CLI (`gh`, `git`, `curl`, or a service CLI like `railway`/`vercel`) — check locally by absolute path, check whether the provider ships one, install it when safe; only hand off for real walls, naming the rung you stopped on, per the capability-discovery mindset in `safety.md`.
 
 ## Initialization
 

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -25,7 +25,7 @@ The parent agent provides:
 - Stay in your worktree directory at all times except for `/wrap` helper calls that explicitly target the resolved root repo path.
 - Do not run `gh pr merge` directly. After verification, execute the shared `/wrap` instructions from `.claude/skills/wrap/SKILL.md` so Phase C and `/wrap` cannot drift.
 - Do not delete the running worktree or feature branch. `/wrap` intentionally leaves them in place; stale cleanup is owned by `/pm-update` via `.claude/scripts/stale-cleanup.sh`.
-- Before treating something as impossible, try the CLI path (`gh`/`git`/`curl`/`gh api`) first — only hand off for real walls, structured per the capability-discovery mindset in `safety.md`.
+- Before treating something as impossible, walk the capability ladder for any provider CLI (`gh`, `git`, `curl`, or a service CLI like `railway`/`vercel`) — check locally by absolute path, check whether the provider ships one, install it when safe; only hand off for real walls, naming the rung you stopped on, per the capability-discovery mindset in `safety.md`.
 
 ## Initialization
 

--- a/.claude/reference/capability-discovery-examples.md
+++ b/.claude/reference/capability-discovery-examples.md
@@ -32,7 +32,7 @@ Writing a markdown file full of copy-paste commands **and then saying "you'll ha
 
 ## Rungs 1–3 in practice — the not-installed case
 
-**Rung 1 — look locally, by absolute path.** The Bash tool runs with a minimal PATH, so a bare `which railway` can report nothing for a tool that is in fact installed. Check the real path instead:
+**Rung 1 — look at what you already have.** MCP tools and custom skills count here too: a connected MCP server or an existing skill may already cover the task, in which case no CLI is needed at all. For the CLI itself, check by absolute path — the Bash tool runs with a minimal PATH, so a bare `which railway` can report nothing for a tool that is in fact installed:
 
 ```bash
 ls -l /opt/homebrew/bin/railway || command -v railway

--- a/.claude/reference/capability-discovery-examples.md
+++ b/.claude/reference/capability-discovery-examples.md
@@ -1,8 +1,8 @@
 # Capability Discovery — False Walls vs Real Walls
 
-Extracted from `.claude/rules/safety.md` "Capability Discovery — Try CLI Before Handoff". The rule file keeps the operative rule and the verbatim `MINDSET:` block; this file holds the worked catalog. **Extend the false-walls list as new ones are observed.**
+Extracted from `.claude/rules/safety.md` "Capability Discovery — Try the CLI Before Handoff". The rule file keeps the operative ladder and the verbatim `MINDSET:` block; this file holds the worked catalog. **Extend the false-walls list as new ones are observed.**
 
-## Common false walls (usually doable)
+## Common false walls — GitHub (usually doable)
 
 - Manual Actions run → `gh workflow run <workflow> --ref <branch>`
 - Review approve/reject → `gh pr review --approve|--request-changes`
@@ -14,10 +14,56 @@ Extracted from `.claude/rules/safety.md` "Capability Discovery — Try CLI Befor
 
 An agent's own explicit prohibitions still win (e.g. `phase-c-merger` uses `/wrap`, never `gh pr merge` directly).
 
+## Common false walls — provider CLIs
+
+The ladder is not a GitHub rule. Every provider below is a one-liner, not a dashboard errand. Full command surface and auth notes: `.claude/reference/cli-tool-defaults.md`.
+
+| "I can't…" | Actual command |
+|------------|----------------|
+| set a Railway env var (**the motivating case, issue #759**) | `railway variables --set "{KEY}={value}"` on the linked service |
+| read which Railway env vars already exist | `railway variables` |
+| redeploy or read logs on Railway | `railway redeploy` · `railway logs` |
+| add a Vercel env var | `vercel env add {NAME} {environment}` (value on stdin — never inline it) |
+| ship a Vercel preview or production deploy | `vercel deploy` · `vercel deploy --prod` |
+| create a Neon branch to test a migration | `neonctl branches create --project-id {id} --name {branch}` |
+| upload an asset to Cloudinary | `cloudinary uploader upload {file} public_id={id}` |
+
+Writing a markdown file full of copy-paste commands **and then saying "you'll have to run these"** — on a project where the CLI is installed and linked — is the exact anti-pattern this ladder exists to kill. If you can write the command, you can run it.
+
+## Rungs 1–3 in practice — the not-installed case
+
+**Rung 1 — look locally, by absolute path.** The Bash tool runs with a minimal PATH, so a bare `which railway` can report nothing for a tool that is in fact installed. Check the real path instead:
+
+```bash
+ls -l /opt/homebrew/bin/railway || command -v railway
+```
+
+**Rung 2 — absent? Check whether the provider ships a CLI at all.** Nearly every major service does. Cap this at **one** lookup — a documentation detour mid-task costs more than the handoff it would save. No published CLI, or an inconclusive lookup → rung 4.
+
+**Rung 3 — install it yourself** when the path is non-interactive and every rail in `safety.md` holds: package name confirmed against official docs, no `curl … | sh` of an unvetted URL, no TLS bypass, no `sudo`.
+
+```bash
+brew install railway   # name confirmed against the official Railway docs
+```
+
+Mention the new install in your response. Do **not** edit `cli-tool-defaults.md` as a side effect of unrelated work.
+
 ## Real walls (handoff is correct, but structured)
 
-A token-scope 403 with no workaround, a branch-protection change, a `.env` edit, or anything in `safety.md`'s "Never" lists. Use the `/admin-merge` (#451) pattern: exact copy-paste command, a one-line reason, optional terminal staging — never just a description.
+A token-scope 403 with no workaround, a branch-protection change, a `.env` edit, an install requiring `sudo`, or anything in `safety.md`'s "Never" lists. **Interactive auth is the wall you will actually hit most often** — `brew install railway` is trivial; `railway login` opens a browser, and no agent can complete that.
+
+Use the `/admin-merge` (#451) pattern: exact copy-paste command, a one-line reason, and — when you just installed something — the auth step too. Name the rung you stopped on:
+
+```text
+Stopped at rung 4 (interactive auth): `railway login` opens a browser I can't drive.
+Run these two and I'll set the variables:
+
+  railway login
+  railway link
+```
+
+Never substitute a prose description of what needs doing for the commands themselves.
 
 ## Anti-pattern
 
-Typing "agents can't do X" where X sounds like something `gh` or `git` handles — stop and verify; the default answer is you probably CAN. This doesn't loosen any prohibition: check `safety.md`'s "Never" lists before assuming a capability is off-limits.
+Typing "agents can't do X" where X sounds like something a CLI handles — stop and walk the ladder; the default answer is you probably CAN. A handoff that fails to name the rung it stopped on, with a concrete reason, is not a finished answer. This doesn't loosen any prohibition: check `safety.md`'s "Never" lists before assuming a capability is off-limits.

--- a/.claude/reference/cli-tool-defaults.md
+++ b/.claude/reference/cli-tool-defaults.md
@@ -2,6 +2,8 @@
 
 Four service CLIs are installed on this machine (`vercel` v53.0.1, `neonctl` v2.22.0, `railway` v4.30.5, `cloudinary` v1.14.1). **Default to these CLIs for every operation they support — never direct the user to a web dashboard for something a CLI can do.** Referenced from `.claude/rules/repo-bootstrap.md`.
 
+**These four are examples, not the allowed set.** Any other provider — Supabase, Fly, Stripe, Cloudflare, one you have never used — follows the same capability-discovery ladder in `.claude/rules/safety.md`: look locally by absolute path, check whether the provider ships a CLI, install it when the safety rails hold, and only then hand off a runbook. A provider's absence from this file is not a reason to send the user to a dashboard.
+
 **Secrets:** several commands below print or write credentials (connection strings, pulled env files). Treat that output as secret — never paste it into issues, PRs, commits, or logs (`.claude/rules/safety.md`). Reference env vars by name only (e.g. `CLOUDINARY_URL`), never inline values.
 
 ## Vercel
@@ -104,4 +106,12 @@ cloudinary url {public_id} {transformation}    # e.g. w_200,h_200,c_fill
 
 ## When a CLI is unavailable
 
-Fall back to the web UI **only** when the CLI fails (auth error, outage, missing subcommand) or genuinely lacks the capability. State which CLI command failed and why before suggesting the dashboard. If a CLI is missing entirely, verify with `which {tool}` and report that, rather than assuming the dashboard is the default.
+Fall back to the web UI **only** when the CLI fails (auth error, outage, missing subcommand) or genuinely lacks the capability. State which CLI command failed and why before suggesting the dashboard.
+
+If a CLI looks missing, **verify by absolute path before believing it** — the Bash tool's PATH is minimal, so a bare `which {tool}` under-reports what is installed:
+
+```bash
+ls -l /opt/homebrew/bin/{tool} || command -v {tool}
+```
+
+Genuinely absent is rung 1 of the ladder, not a dead end: continue to rung 2 (does the provider ship a CLI?) and rung 3 (install it, if non-interactive and within the safety rails) before handing anything off. When you do install a CLI, note it in your response — don't append it to this file as a side effect of unrelated work.

--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -52,19 +52,28 @@ commits, or logs. Do NOT pipe untrusted URLs into a shell or disable TLS verific
 Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude/rules/safety.md.
 ```
 
-## Capability Discovery — Try CLI Before Handoff
+## Capability Discovery — Try the CLI Before Handoff
 
-Before handing a task to the user because it "can't" be done, verify against your actual tools — Bash (`gh`/`git`/`curl`/`gh api`), MCP tools, custom skills — not inherited "agents can't" prose. Most `gh`/`git`-shaped "can't do X" claims are **false walls**: workflow runs, PR review, releases, comments, labels are usually one CLI command (catalog: `.claude/reference/capability-discovery-examples.md` — extend it as new false walls appear). An agent's own explicit prohibitions always win. **Real walls** (token-scope 403, branch protection, `.env`, this file's "Never" lists) get a structured handoff per the `/admin-merge` (#451) pattern: exact copy-paste command + one-line reason, never just a description.
+Before telling the user a task "can't" be done, walk this ladder. It covers **any** provider — `gh`, `git`, `vercel`, `neonctl`, `railway`, `cloudinary`, MCP tools, custom skills, or a service you have never used — not just GitHub.
+
+1. **Look locally**, by absolute path (`/opt/homebrew/bin/<tool>`) — the Bash tool's PATH is minimal, so a bare `which` under-reports what is installed.
+2. **Absent? Check whether the provider ships a CLI at all** — most do. One lookup, then move on; a research detour mid-task is not warranted.
+3. **Install it yourself** when a non-interactive path exists and the rails above hold: package name confirmed against official docs, no `curl … | sh` of an unvetted URL, no TLS bypass, no `sudo`. Any rail that blocks — or an install whose auth step opens a browser — drops to rung 4. Note a new install in your response; don't edit the CLI docs as a side effect.
+4. **Hand off a runbook, not a description** — exact copy-paste command(s) plus one line on why it needs a human, in the `/admin-merge` (#451) shape, covering the `<tool> login` step when auth is interactive.
+
+Only a dead-ended ladder licenses "I can't", and the answer must **name the rung it stopped on and the concrete reason** — token-scope 403, browser-only OAuth, a "Never" item above. "I don't think agents can do that" is never a complete answer. Your own agent definition's explicit prohibitions still win (e.g. `phase-c-merger` uses `/wrap`, never `gh pr merge`). Worked examples: `.claude/reference/capability-discovery-examples.md` — extend it as new false walls appear.
 
 ```text
-MINDSET: Before handing off, enumerate your actual tools (gh/git/curl/gh api, MCP,
-skills) — don't trust inherited "agents can't" prose. Try the CLI-accessible path
-first (workflow run, pr review, api dispatches, release create, pr/issue comment
-or edit are usually possible) — but your own agent definition's explicit
-prohibitions always win (e.g. phase-c uses /wrap, never gh pr merge directly).
-Only hand off for real walls (token-scope 403, branch protection, .env, or a
-safety.md "Never" item) — structure it like /admin-merge: exact command + one-line
-reason. Full rules: .claude/rules/safety.md.
+MINDSET: Before handing off, walk the capability ladder for ANY provider CLI
+(gh, git, railway, vercel, neonctl, …): (1) look locally by absolute path
+(/opt/homebrew/bin/<tool>) — minimal PATH makes bare `which` lie; (2) if absent,
+check whether the provider ships one, one lookup max; (3) install it when
+non-interactive and safety rails hold (docs-confirmed name, no curl-pipe-sh, no
+TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped runbook: exact
+commands + one-line reason, incl. interactive auth. Your own definition's
+prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
+valid only after the ladder dead-ends, naming the rung and reason.
+Full rules: .claude/rules/safety.md.
 ```
 
 ## Anthropic Quota & Spend Authority

--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -54,9 +54,9 @@ Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude
 
 ## Capability Discovery — Try the CLI Before Handoff
 
-Before telling the user a task "can't" be done, walk this ladder. It covers **any** provider — `gh`, `git`, `vercel`, `neonctl`, `railway`, `cloudinary`, MCP tools, custom skills, or a service you have never used — not just GitHub.
+Before telling the user a task "can't" be done, walk this ladder. It covers **any** provider — `gh`, `git`, `vercel`, `neonctl`, `railway`, `cloudinary`, or a service you have never used — not just GitHub.
 
-1. **Look locally**, by absolute path (`/opt/homebrew/bin/<tool>`) — the Bash tool's PATH is minimal, so a bare `which` under-reports what is installed.
+1. **Look at what you already have** — MCP tools, custom skills, and the provider's CLI on disk, the last checked by absolute path (`/opt/homebrew/bin/<tool>`): the Bash tool's PATH is minimal, so a bare `which` under-reports what is installed.
 2. **Absent? Check whether the provider ships a CLI at all** — most do. One lookup, then move on; a research detour mid-task is not warranted.
 3. **Install it yourself** when a non-interactive path exists and the rails above hold: package name confirmed against official docs, no `curl … | sh` of an unvetted URL, no TLS bypass, no `sudo`. Any rail that blocks — or an install whose auth step opens a browser — drops to rung 4. Note a new install in your response; don't edit the CLI docs as a side effect.
 4. **Hand off a runbook, not a description** — exact copy-paste command(s) plus one line on why it needs a human, in the `/admin-merge` (#451) shape, covering the `<tool> login` step when auth is interactive.
@@ -65,14 +65,15 @@ Only a dead-ended ladder licenses "I can't", and the answer must **name the rung
 
 ```text
 MINDSET: Before handing off, walk the capability ladder for ANY provider CLI
-(gh, git, railway, vercel, neonctl, …): (1) look locally by absolute path
-(/opt/homebrew/bin/<tool>) — minimal PATH makes bare `which` lie; (2) if absent,
-check whether the provider ships one, one lookup max; (3) install it when
-non-interactive and safety rails hold (docs-confirmed name, no curl-pipe-sh, no
-TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped runbook: exact
-commands + one-line reason, incl. interactive auth. Your own definition's
-prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
-valid only after the ladder dead-ends, naming the rung and reason.
+(gh, git, railway, vercel, neonctl, …): (1) look at what you already have — MCP
+tools, skills, and the CLI on disk by absolute path (/opt/homebrew/bin/<tool>),
+since minimal PATH makes bare `which` lie; (2) if absent, check whether the
+provider ships one, one lookup max; (3) install it when non-interactive and
+safety rails hold (docs-confirmed name, no curl-pipe-sh, no TLS bypass, no
+sudo); (4) else hand off an /admin-merge-shaped runbook: exact commands +
+one-line reason, incl. interactive auth. Your own definition's prohibitions
+still win (phase-c uses /wrap, never gh pr merge). "I can't" is valid only
+after the ladder dead-ends, naming the rung and reason.
 Full rules: .claude/rules/safety.md.
 ```
 

--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -64,16 +64,15 @@ Before telling the user a task "can't" be done, walk this ladder. It covers **an
 Only a dead-ended ladder licenses "I can't", and the answer must **name the rung it stopped on and the concrete reason** — token-scope 403, browser-only OAuth, a "Never" item above. "I don't think agents can do that" is never a complete answer. Your own agent definition's explicit prohibitions still win (e.g. `phase-c-merger` uses `/wrap`, never `gh pr merge`). Worked examples: `.claude/reference/capability-discovery-examples.md` — extend it as new false walls appear.
 
 ```text
-MINDSET: Before handing off, walk the capability ladder for ANY provider CLI
-(gh, git, railway, vercel, neonctl, …): (1) look at what you already have — MCP
-tools, skills, and the CLI on disk by absolute path (/opt/homebrew/bin/<tool>),
-since minimal PATH makes bare `which` lie; (2) if absent, check whether the
-provider ships one, one lookup max; (3) install it when non-interactive and
-safety rails hold (docs-confirmed name, no curl-pipe-sh, no TLS bypass, no
-sudo); (4) else hand off an /admin-merge-shaped runbook: exact commands +
-one-line reason, incl. interactive auth. Your own definition's prohibitions
-still win (phase-c uses /wrap, never gh pr merge). "I can't" is valid only
-after the ladder dead-ends, naming the rung and reason.
+MINDSET: Before handing off, walk the capability ladder for ANY provider
+(gh, git, railway, vercel, …): (1) check what you have — MCP tools, skills, CLI
+on disk by absolute path (/opt/homebrew/bin/<tool>; minimal PATH makes bare
+`which` lie); (2) if absent, check whether the provider ships one (one lookup);
+(3) install it when non-interactive and rails hold (docs-confirmed name, no
+curl-pipe-sh, no TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped
+runbook: exact commands + one-line reason, incl. interactive auth. Your own
+prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
+valid only after the ladder dead-ends, naming the rung and reason.
 Full rules: .claude/rules/safety.md.
 ```
 

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -613,14 +613,16 @@ Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude
 - The verbatim `MINDSET:` block from `.claude/rules/safety.md`:
 
 ```text
-MINDSET: Before handing off, enumerate your actual tools (gh/git/curl/gh api, MCP,
-skills) — don't trust inherited "agents can't" prose. Try the CLI-accessible path
-first (workflow run, pr review, api dispatches, release create, pr/issue comment
-or edit are usually possible) — but your own agent definition's explicit
-prohibitions always win (e.g. phase-c uses /wrap, never gh pr merge directly).
-Only hand off for real walls (token-scope 403, branch protection, .env, or a
-safety.md "Never" item) — structure it like /admin-merge: exact command + one-line
-reason. Full rules: .claude/rules/safety.md.
+MINDSET: Before handing off, walk the capability ladder for ANY provider CLI
+(gh, git, railway, vercel, neonctl, …): (1) look locally by absolute path
+(/opt/homebrew/bin/<tool>) — minimal PATH makes bare `which` lie; (2) if absent,
+check whether the provider ships one, one lookup max; (3) install it when
+non-interactive and safety rails hold (docs-confirmed name, no curl-pipe-sh, no
+TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped runbook: exact
+commands + one-line reason, incl. interactive auth. Your own definition's
+prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
+valid only after the ladder dead-ends, naming the rung and reason.
+Full rules: .claude/rules/safety.md.
 ```
 
 - The verbatim `SKILLS:` block from `.claude/rules/skill-first.md` (`phase-a-fixer` is in the "paste this too" list per `subagent-orchestration.md`'s spawn checklist):

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -614,14 +614,15 @@ Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude
 
 ```text
 MINDSET: Before handing off, walk the capability ladder for ANY provider CLI
-(gh, git, railway, vercel, neonctl, …): (1) look locally by absolute path
-(/opt/homebrew/bin/<tool>) — minimal PATH makes bare `which` lie; (2) if absent,
-check whether the provider ships one, one lookup max; (3) install it when
-non-interactive and safety rails hold (docs-confirmed name, no curl-pipe-sh, no
-TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped runbook: exact
-commands + one-line reason, incl. interactive auth. Your own definition's
-prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
-valid only after the ladder dead-ends, naming the rung and reason.
+(gh, git, railway, vercel, neonctl, …): (1) look at what you already have — MCP
+tools, skills, and the CLI on disk by absolute path (/opt/homebrew/bin/<tool>),
+since minimal PATH makes bare `which` lie; (2) if absent, check whether the
+provider ships one, one lookup max; (3) install it when non-interactive and
+safety rails hold (docs-confirmed name, no curl-pipe-sh, no TLS bypass, no
+sudo); (4) else hand off an /admin-merge-shaped runbook: exact commands +
+one-line reason, incl. interactive auth. Your own definition's prohibitions
+still win (phase-c uses /wrap, never gh pr merge). "I can't" is valid only
+after the ladder dead-ends, naming the rung and reason.
 Full rules: .claude/rules/safety.md.
 ```
 

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -613,16 +613,15 @@ Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude
 - The verbatim `MINDSET:` block from `.claude/rules/safety.md`:
 
 ```text
-MINDSET: Before handing off, walk the capability ladder for ANY provider CLI
-(gh, git, railway, vercel, neonctl, …): (1) look at what you already have — MCP
-tools, skills, and the CLI on disk by absolute path (/opt/homebrew/bin/<tool>),
-since minimal PATH makes bare `which` lie; (2) if absent, check whether the
-provider ships one, one lookup max; (3) install it when non-interactive and
-safety rails hold (docs-confirmed name, no curl-pipe-sh, no TLS bypass, no
-sudo); (4) else hand off an /admin-merge-shaped runbook: exact commands +
-one-line reason, incl. interactive auth. Your own definition's prohibitions
-still win (phase-c uses /wrap, never gh pr merge). "I can't" is valid only
-after the ladder dead-ends, naming the rung and reason.
+MINDSET: Before handing off, walk the capability ladder for ANY provider
+(gh, git, railway, vercel, …): (1) check what you have — MCP tools, skills, CLI
+on disk by absolute path (/opt/homebrew/bin/<tool>; minimal PATH makes bare
+`which` lie); (2) if absent, check whether the provider ships one (one lookup);
+(3) install it when non-interactive and rails hold (docs-confirmed name, no
+curl-pipe-sh, no TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped
+runbook: exact commands + one-line reason, incl. interactive auth. Your own
+prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
+valid only after the ladder dead-ends, naming the rung and reason.
 Full rules: .claude/rules/safety.md.
 ```
 

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -212,16 +212,15 @@ git checkout ., git stash, git reset --hard) in the root repo directory. Stay in
 worktree directory at all times.
 
 ## CAPABILITY DISCOVERY
-MINDSET: Before handing off, walk the capability ladder for ANY provider CLI
-(gh, git, railway, vercel, neonctl, …): (1) look at what you already have — MCP
-tools, skills, and the CLI on disk by absolute path (/opt/homebrew/bin/<tool>),
-since minimal PATH makes bare `which` lie; (2) if absent, check whether the
-provider ships one, one lookup max; (3) install it when non-interactive and
-safety rails hold (docs-confirmed name, no curl-pipe-sh, no TLS bypass, no
-sudo); (4) else hand off an /admin-merge-shaped runbook: exact commands +
-one-line reason, incl. interactive auth. Your own definition's prohibitions
-still win (phase-c uses /wrap, never gh pr merge). "I can't" is valid only
-after the ladder dead-ends, naming the rung and reason.
+MINDSET: Before handing off, walk the capability ladder for ANY provider
+(gh, git, railway, vercel, …): (1) check what you have — MCP tools, skills, CLI
+on disk by absolute path (/opt/homebrew/bin/<tool>; minimal PATH makes bare
+`which` lie); (2) if absent, check whether the provider ships one (one lookup);
+(3) install it when non-interactive and rails hold (docs-confirmed name, no
+curl-pipe-sh, no TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped
+runbook: exact commands + one-line reason, incl. interactive auth. Your own
+prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
+valid only after the ladder dead-ends, naming the rung and reason.
 Full rules: .claude/rules/safety.md.
 
 ## SKILLS-FIRST REFLEX

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -212,14 +212,16 @@ git checkout ., git stash, git reset --hard) in the root repo directory. Stay in
 worktree directory at all times.
 
 ## CAPABILITY DISCOVERY
-MINDSET: Before handing off, enumerate your actual tools (gh/git/curl/gh api, MCP,
-skills) — don't trust inherited "agents can't" prose. Try the CLI-accessible path
-first (workflow run, pr review, api dispatches, release create, pr/issue comment
-or edit are usually possible) — but your own agent definition's explicit
-prohibitions always win (e.g. phase-c uses /wrap, never gh pr merge directly).
-Only hand off for real walls (token-scope 403, branch protection, .env, or a
-safety.md "Never" item) — structure it like /admin-merge: exact command + one-line
-reason. Full rules: .claude/rules/safety.md.
+MINDSET: Before handing off, walk the capability ladder for ANY provider CLI
+(gh, git, railway, vercel, neonctl, …): (1) look locally by absolute path
+(/opt/homebrew/bin/<tool>) — minimal PATH makes bare `which` lie; (2) if absent,
+check whether the provider ships one, one lookup max; (3) install it when
+non-interactive and safety rails hold (docs-confirmed name, no curl-pipe-sh, no
+TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped runbook: exact
+commands + one-line reason, incl. interactive auth. Your own definition's
+prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
+valid only after the ladder dead-ends, naming the rung and reason.
+Full rules: .claude/rules/safety.md.
 
 ## SKILLS-FIRST REFLEX
 SKILLS: Before hand-rolling a multi-step task, check whether an existing skill

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -213,14 +213,15 @@ worktree directory at all times.
 
 ## CAPABILITY DISCOVERY
 MINDSET: Before handing off, walk the capability ladder for ANY provider CLI
-(gh, git, railway, vercel, neonctl, …): (1) look locally by absolute path
-(/opt/homebrew/bin/<tool>) — minimal PATH makes bare `which` lie; (2) if absent,
-check whether the provider ships one, one lookup max; (3) install it when
-non-interactive and safety rails hold (docs-confirmed name, no curl-pipe-sh, no
-TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped runbook: exact
-commands + one-line reason, incl. interactive auth. Your own definition's
-prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
-valid only after the ladder dead-ends, naming the rung and reason.
+(gh, git, railway, vercel, neonctl, …): (1) look at what you already have — MCP
+tools, skills, and the CLI on disk by absolute path (/opt/homebrew/bin/<tool>),
+since minimal PATH makes bare `which` lie; (2) if absent, check whether the
+provider ships one, one lookup max; (3) install it when non-interactive and
+safety rails hold (docs-confirmed name, no curl-pipe-sh, no TLS bypass, no
+sudo); (4) else hand off an /admin-merge-shaped runbook: exact commands +
+one-line reason, incl. interactive auth. Your own definition's prohibitions
+still win (phase-c uses /wrap, never gh pr merge). "I can't" is valid only
+after the ladder dead-ends, naming the rung and reason.
 Full rules: .claude/rules/safety.md.
 
 ## SKILLS-FIRST REFLEX


### PR DESCRIPTION
## Summary

Turns `safety.md`'s "try the CLI first" guidance into an explicit **four-rung ladder** the agent must walk before the words "I can't" are allowed — generalized past `gh`/`git` to any provider.

The motivating case: the agent documented two required Railway env vars in a markdown file with copy-paste commands, then said *"I can't set them — that's on you"*, on a project where it had full Railway CLI access.

1. **Look locally**, by absolute path (`/opt/homebrew/bin/<tool>`) — the Bash tool's PATH is minimal, so a bare `which` under-reports what is installed.
2. **Absent? Check whether the provider ships a CLI at all** — one lookup, then move on.
3. **Install it yourself** when non-interactive and the existing rails hold (docs-confirmed package name, no `curl … | sh` of unvetted URLs, no TLS bypass, no `sudo`).
4. **Hand off a runbook, not a description** — `/admin-merge`-shaped: exact commands + one-line reason, covering the interactive `<tool> login` step.

A handoff must now **name the rung it stopped on and a concrete reason**. Existing prohibitions are untouched — the rails appear as gating conditions, not softened ones; `sudo` is expressed purely as an install-rail condition rather than a new standalone "Never" line.

## Changes

| File | Change |
|------|--------|
| `.claude/rules/safety.md` | Capability Discovery rewritten as the ladder; `MINDSET:` block rewritten to carry it |
| `.claude/skills/subagent/SKILL.md` · `.claude/skills/pr-monitor-and-manage/SKILL.md` | Verbatim `MINDSET:` copies synced byte-for-byte |
| `.claude/agents/README.md` | Abbreviated `MINDSET:` example generalized |
| `.claude/agents/phase-{a-fixer,b-reviewer,c-merger}.md` | One-line reminders now say "any provider CLI" and require naming the rung |
| `.claude/reference/capability-discovery-examples.md` | New provider-CLI false-wall table (led by the Railway case), a worked rungs 1–3 not-installed walk, and interactive-auth as the real wall |
| `.claude/reference/cli-tool-defaults.md` | The four CLIs read as examples, not the allowed set; `which {tool}` replaced with absolute-path detection |

**Budget:** corpus went 11,690 → 11,887 words (+197), under soft 12,000 and the 12,310 ratchet cap. The worked catalog went to un-budgeted `reference/`. `MINDSET:` grew 87 → 110 words (+26%).

## Notes for reviewers

- **A Test Plan item in the issue names a path that does not exist.** `.claude/scripts/rule-lint.sh` isn't real — the linter lives at `.github/scripts/rule-lint.sh`. Verified against the real one. (CodeRabbit's plan flagged this independently.)
- **Local review CLIs were both unavailable, so this was self-reviewed** (`cr-local-review.md` fallback): the CodeRabbit CLI returned a `rate_limit` error record (free OSS quota, 30-min reset) and the CodeAnt CLI is not installed on this machine. Both GitHub App reviewers have independent quotas and still gate this merge.
- Nothing enforces sync across the four `MINDSET:` surfaces, so all copies land in this one commit; the two verbatim ones are byte-identical to the canonical block.

## Test plan

- [x] `bash .github/scripts/rule-lint.sh` prints `rule-lint: OK`
- [x] `{ cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } | wc -w` stays under the ratchet cap in `.claude/rules/.budget-soft-cap`
- [x] No text in `.claude/rules/` still implies capability discovery is `gh`/`git`-only
- [x] The two verbatim `MINDSET:` copies are byte-identical to the canonical block in `safety.md`
- [x] `MINDSET:` stays roughly its prior length (87 → 110 words, +26%) and states all four rungs
- [x] `safety.md` requires naming the stopped-on rung plus a concrete reason
- [x] Rung 3 keeps every install rail (docs-confirmed name, no `curl … | sh`, no TLS bypass, no `sudo`), routing blocked installs to the runbook
- [x] Handoff format is `/admin-merge`-shaped — exact commands + one-line reason, never prose
- [x] `capability-discovery-examples.md` covers provider CLIs including the Railway env-var case
- [x] `cli-tool-defaults.md` states unlisted providers follow the same ladder and uses absolute-path detection


## Review rounds

- **`6dcf34c`** — BugBot (medium): the intro promised the ladder covered MCP tools and custom skills, but rungs 1–4 described only provider CLIs, and the new `MINDSET:` block dropped the MCP/skills mention its predecessor carried. Valid. Rung 1 is now "check what you have — MCP tools, skills, CLI on disk by absolute path", and the catalog notes a connected MCP server or existing skill may cover the task with no CLI at all.
- **`cf85a4d`** — self-caught: that fix pushed `MINDSET:` to 120 words against an original 87 (+38%), too loose to self-certify against the "stays roughly its current length" criterion. Trimmed to 110 (+26%) with no rung, MCP/skills coverage, or name-the-rung requirement dropped.

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)
