### PR TITLE
feat(#773): one-line status contract, delta-aware PMM table, silence-detector time dedupe

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -68,7 +68,7 @@ Enforces the 5-minute heartbeat rule. If the agent goes >5 minutes without sendi
 
 **How it works:** Two hooks work together:
 - **`silence-detector-ack.sh`** (Stop hook): Fires when Claude finishes a response. Touches a heartbeat file in `/tmp` to record the timestamp.
-- **`silence-detector.sh`** (PostToolUse hook, all tools): After every tool call, checks the heartbeat file's mtime. If >5 min elapsed, injects a warning via `additionalContext` that the agent sees.
+- **`silence-detector.sh`** (PostToolUse hook, all tools): After every tool call, checks the heartbeat file's mtime. If >5 min elapsed, injects a warning via `additionalContext` that the agent sees. Below the threshold it injects `Current system time` at most once per `SILENCE_TIME_INJECT_S` (default 60s; marker `/tmp/claude-time-injected-$SESSION_ID`) and emits `{}` otherwise, so tool-call bursts don't re-inject a near-identical timestamp on every call (issue #773).
 
 The heartbeat file is session-scoped (`/tmp/claude-heartbeat-$CLAUDE_SESSION_ID`) and cleaned up automatically by the OS.
 

--- a/.claude/hooks/silence-detector.sh
+++ b/.claude/hooks/silence-detector.sh
@@ -95,7 +95,10 @@ TIME_INJECT_S="${SILENCE_TIME_INJECT_S:-60}"
 
 emit_time_if_due() {
   # Dedupe (issue #773): skip the time injection when one landed < TIME_INJECT_S ago.
-  if [[ -f "$TIME_FILE" ]]; then
+  # $1 = "force": bypass the dedupe check — new-session paths must always emit,
+  # even when a marker from a prior same-id session (e.g. the shared "default"
+  # id) survives in /tmp.
+  if [[ "${1:-}" != "force" && -f "$TIME_FILE" ]]; then
     local last_inject inject_age
     last_inject=$(file_mtime "$TIME_FILE")
     if [[ -n "$last_inject" ]]; then
@@ -128,7 +131,7 @@ touch "$ACTIVE_FILE" 2>/dev/null || true
 # If heartbeat file doesn't exist, create it (first tool call in session)
 if [[ ! -f "$HEARTBEAT_FILE" ]]; then
   touch "$HEARTBEAT_FILE"
-  emit_time_if_due
+  emit_time_if_due force
   exit 0
 fi
 last_ack=$(file_mtime "$HEARTBEAT_FILE")
@@ -136,7 +139,7 @@ last_ack=$(file_mtime "$HEARTBEAT_FILE")
 # Fallback if stat failed
 if [[ -z "$last_ack" ]]; then
   touch "$HEARTBEAT_FILE"
-  emit_time_if_due
+  emit_time_if_due force
   exit 0
 fi
 

--- a/.claude/hooks/silence-detector.sh
+++ b/.claude/hooks/silence-detector.sh
@@ -100,7 +100,8 @@ emit_time_if_due() {
     last_inject=$(file_mtime "$TIME_FILE")
     if [[ -n "$last_inject" ]]; then
       inject_age=$(( $(date +%s) - last_inject ))
-      if (( inject_age < TIME_INJECT_S )); then
+      # Negative age = future-dated marker (clock rollback) — treat as stale, re-inject.
+      if (( inject_age >= 0 && inject_age < TIME_INJECT_S )); then
         echo '{}'
         return
       fi

--- a/.claude/hooks/silence-detector.sh
+++ b/.claude/hooks/silence-detector.sh
@@ -107,7 +107,12 @@ emit_time_if_due() {
       fi
     fi
   fi
-  touch "$TIME_FILE" 2>/dev/null || true
+  if ! touch "$TIME_FILE" 2>/dev/null; then
+    # Deliberate fail-open: an unwritable marker degrades to the pre-dedupe
+    # behavior (inject every call) rather than losing time context. Surface it
+    # so the condition is visible in hook logs instead of silent.
+    echo "silence-detector: cannot write $TIME_FILE — time-injection dedupe disabled this call" >&2
+  fi
   emit_context "Current system time: ${current_time}"
 }
 LOG_DIR="$HOME/.claude/logs"

--- a/.claude/hooks/silence-detector.sh
+++ b/.claude/hooks/silence-detector.sh
@@ -3,6 +3,11 @@
 # Checks if >5 minutes have passed since the agent last sent a visible message.
 # If so, injects an additionalContext warning into the agent's context.
 #
+# Steady-state time injection is deduped (issue #773): the "Current system
+# time" context is emitted at most once per SILENCE_TIME_INJECT_S (default
+# 60s), so bursts of tool calls don't re-inject a near-identical value into
+# the transcript on every call. The >5-min warning path always emits.
+#
 # Acknowledgment is handled automatically by the companion Stop hook
 # (silence-detector-ack.sh), which touches the heartbeat file whenever
 # Claude finishes a response.
@@ -81,9 +86,29 @@ SESSION_ID="${SESSION_ID//[^[:alnum:]_.-]/_}"
 HEARTBEAT_FILE="/tmp/claude-heartbeat-${SESSION_ID}"
 WARNED_FILE="/tmp/claude-silence-warned-${SESSION_ID}"
 ACTIVE_FILE="/tmp/claude-active-${SESSION_ID}"
+TIME_FILE="/tmp/claude-time-injected-${SESSION_ID}"
 THRESHOLD=300  # 5 minutes in seconds
 COOLDOWN_S="${SILENCE_WARN_COOLDOWN_S:-90}"
 [[ "$COOLDOWN_S" =~ ^[0-9]+$ ]] || COOLDOWN_S=90
+TIME_INJECT_S="${SILENCE_TIME_INJECT_S:-60}"
+[[ "$TIME_INJECT_S" =~ ^[0-9]+$ ]] || TIME_INJECT_S=60
+
+emit_time_if_due() {
+  # Dedupe (issue #773): skip the time injection when one landed < TIME_INJECT_S ago.
+  if [[ -f "$TIME_FILE" ]]; then
+    local last_inject inject_age
+    last_inject=$(file_mtime "$TIME_FILE")
+    if [[ -n "$last_inject" ]]; then
+      inject_age=$(( $(date +%s) - last_inject ))
+      if (( inject_age < TIME_INJECT_S )); then
+        echo '{}'
+        return
+      fi
+    fi
+  fi
+  touch "$TIME_FILE" 2>/dev/null || true
+  emit_context "Current system time: ${current_time}"
+}
 LOG_DIR="$HOME/.claude/logs"
 LOG_FILE="$LOG_DIR/silence.log"
 LOG_MAX_SIZE=$((10 * 1024 * 1024))
@@ -97,7 +122,7 @@ touch "$ACTIVE_FILE" 2>/dev/null || true
 # If heartbeat file doesn't exist, create it (first tool call in session)
 if [[ ! -f "$HEARTBEAT_FILE" ]]; then
   touch "$HEARTBEAT_FILE"
-  emit_context "Current system time: ${current_time}"
+  emit_time_if_due
   exit 0
 fi
 last_ack=$(file_mtime "$HEARTBEAT_FILE")
@@ -105,7 +130,7 @@ last_ack=$(file_mtime "$HEARTBEAT_FILE")
 # Fallback if stat failed
 if [[ -z "$last_ack" ]]; then
   touch "$HEARTBEAT_FILE"
-  emit_context "Current system time: ${current_time}"
+  emit_time_if_due
   exit 0
 fi
 
@@ -127,9 +152,10 @@ if [[ $elapsed -ge $THRESHOLD ]]; then
   elapsed_min=$((elapsed / 60))
   ( write_log "$elapsed" ) || true
   touch "$WARNED_FILE"
+  touch "$TIME_FILE" 2>/dev/null || true  # warning carries a fresh time — restart the dedupe window
   emit_context "Current system time: ${current_time}. HEARTBEAT WARNING: No visible message to user in ${elapsed_min}+ minutes (${elapsed}s). Per the 5-minute heartbeat rule, you MUST send a status update to the user NOW — before making any more tool calls. Include: what you are doing, what is pending, any blockers. Use the timestamp above as your prefix."
 else
-  emit_context "Current system time: ${current_time}"
+  emit_time_if_due
 fi
 
 exit 0

--- a/.claude/hooks/tests/silence-detector-time-dedupe.test.sh
+++ b/.claude/hooks/tests/silence-detector-time-dedupe.test.sh
@@ -73,6 +73,14 @@ CTX=$(run_hook "$SID" | context_of)
 CTX=$(run_hook "$SID" | context_of)
 [[ -z "$CTX" ]] || fail "warned-cooldown call should emit no context, got: '$CTX'"
 
+# --- 5b. New session with a leftover marker still gets its first timestamp ---
+# Simulates same-session-id reuse (e.g. the shared "default" id): heartbeat
+# file absent, fresh time marker present — the first call must force-emit.
+touch "/tmp/claude-time-injected-${SID}"          # fresh marker, deterministically
+rm -f "/tmp/claude-heartbeat-${SID}" "/tmp/claude-silence-warned-${SID}"
+CTX=$(run_hook "$SID" | context_of)
+[[ "$CTX" == Current\ system\ time:* ]] || fail "new session with leftover marker should force-inject, got: '$CTX'"
+
 # --- 6. Env override is respected --------------------------------------------
 SID2="dedupe-test-env-$$-$RANDOM"
 rm -f $(tmp_files "$SID2")

--- a/.claude/hooks/tests/silence-detector-time-dedupe.test.sh
+++ b/.claude/hooks/tests/silence-detector-time-dedupe.test.sh
@@ -4,8 +4,17 @@
 # does not touch real session state.
 set -euo pipefail
 
+# Isolate from caller environment — default-window assertions must not inherit
+# a CI/user override; test 6 passes the env var explicitly.
+unset SILENCE_TIME_INJECT_S
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 HOOK="$REPO_ROOT/.claude/hooks/silence-detector.sh"
+
+# Relative timestamps (BSD/macOS then GNU date) — never a hard-coded calendar
+# date, which flips future/past depending on when the test runs.
+PAST_STAMP=$(date -v-2H +%Y%m%d%H%M 2>/dev/null || date -d '2 hours ago' +%Y%m%d%H%M)
+FUTURE_STAMP=$(date -v+2H +%Y%m%d%H%M 2>/dev/null || date -d '2 hours' +%Y%m%d%H%M)
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
@@ -41,14 +50,19 @@ CTX=$(printf '%s' "$OUT" | context_of)
 printf '%s' "$OUT" | python3 -c "import json,sys; json.load(sys.stdin)" || fail "deduped output is not valid JSON"
 
 # --- 3. An aged marker re-injects --------------------------------------------
-touch -t 202601010000 "/tmp/claude-time-injected-${SID}"
+touch -t "$PAST_STAMP" "/tmp/claude-time-injected-${SID}"
 CTX=$(run_hook "$SID" | context_of)
 [[ "$CTX" == Current\ system\ time:* ]] || fail "aged marker should re-inject time, got: '$CTX'"
 
+# --- 3b. A future-dated marker (clock rollback) re-injects -------------------
+touch -t "$FUTURE_STAMP" "/tmp/claude-time-injected-${SID}"
+CTX=$(run_hook "$SID" | context_of)
+[[ "$CTX" == Current\ system\ time:* ]] || fail "future-dated marker should be treated as stale and re-inject, got: '$CTX'"
+
 # --- 4. Warning path fires with time even inside the dedupe window -----------
-# Fresh time marker (just injected in step 3) + stale heartbeat => warning must
+# Fresh time marker (just injected in step 3b) + stale heartbeat => warning must
 # still be emitted and must carry the timestamp.
-touch -t 202601010000 "/tmp/claude-heartbeat-${SID}"
+touch -t "$PAST_STAMP" "/tmp/claude-heartbeat-${SID}"
 rm -f "/tmp/claude-silence-warned-${SID}"
 CTX=$(run_hook "$SID" | context_of)
 [[ "$CTX" == *"HEARTBEAT WARNING"* ]] || fail "stale heartbeat should warn, got: '$CTX'"

--- a/.claude/hooks/tests/silence-detector-time-dedupe.test.sh
+++ b/.claude/hooks/tests/silence-detector-time-dedupe.test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Tests for silence-detector.sh steady-state time-injection dedupe (issue #773).
+# Uses a unique session id per test so the /tmp marker files are isolated;
+# does not touch real session state.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK="$REPO_ROOT/.claude/hooks/silence-detector.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+run_hook() {
+  local sid="$1"
+  printf '{"session_id": "%s", "tool_name": "Bash", "cwd": "/tmp"}' "$sid" | "$HOOK"
+}
+
+context_of() {
+  python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('hookSpecificOutput',{}).get('additionalContext',''))"
+}
+
+# Session-scoped tmp files the hook derives from the session id
+tmp_files() {
+  local sid="$1"
+  echo "/tmp/claude-heartbeat-${sid}" "/tmp/claude-silence-warned-${sid}" \
+       "/tmp/claude-active-${sid}" "/tmp/claude-time-injected-${sid}"
+}
+
+SID="dedupe-test-$$-$RANDOM"
+cleanup() { rm -f $(tmp_files "$SID"); }
+trap cleanup EXIT
+cleanup
+
+# --- 1. First call in a session injects the time -----------------------------
+CTX=$(run_hook "$SID" | context_of)
+[[ "$CTX" == Current\ system\ time:* ]] || fail "first call should inject time, got: '$CTX'"
+
+# --- 2. Immediate second call is deduped to {} -------------------------------
+OUT=$(run_hook "$SID")
+CTX=$(printf '%s' "$OUT" | context_of)
+[[ -z "$CTX" ]] || fail "second call within SILENCE_TIME_INJECT_S should emit no context, got: '$CTX'"
+printf '%s' "$OUT" | python3 -c "import json,sys; json.load(sys.stdin)" || fail "deduped output is not valid JSON"
+
+# --- 3. An aged marker re-injects --------------------------------------------
+touch -t 202601010000 "/tmp/claude-time-injected-${SID}"
+CTX=$(run_hook "$SID" | context_of)
+[[ "$CTX" == Current\ system\ time:* ]] || fail "aged marker should re-inject time, got: '$CTX'"
+
+# --- 4. Warning path fires with time even inside the dedupe window -----------
+# Fresh time marker (just injected in step 3) + stale heartbeat => warning must
+# still be emitted and must carry the timestamp.
+touch -t 202601010000 "/tmp/claude-heartbeat-${SID}"
+rm -f "/tmp/claude-silence-warned-${SID}"
+CTX=$(run_hook "$SID" | context_of)
+[[ "$CTX" == *"HEARTBEAT WARNING"* ]] || fail "stale heartbeat should warn, got: '$CTX'"
+[[ "$CTX" == Current\ system\ time:* ]] || fail "warning should include current time, got: '$CTX'"
+
+# --- 5. Warned-cooldown path still emits {} ----------------------------------
+# Heartbeat still stale, warned file fresh from step 4 => cooldown suppression.
+CTX=$(run_hook "$SID" | context_of)
+[[ -z "$CTX" ]] || fail "warned-cooldown call should emit no context, got: '$CTX'"
+
+# --- 6. Env override is respected --------------------------------------------
+SID2="dedupe-test-env-$$-$RANDOM"
+rm -f $(tmp_files "$SID2")
+run_hook "$SID2" >/dev/null                      # seeds marker
+sleep 1
+CTX=$(printf '{"session_id": "%s", "tool_name": "Bash", "cwd": "/tmp"}' "$SID2" | SILENCE_TIME_INJECT_S=1 "$HOOK" | context_of)
+rm -f $(tmp_files "$SID2")
+[[ "$CTX" == Current\ system\ time:* ]] || fail "SILENCE_TIME_INJECT_S=1 after 1s sleep should re-inject, got: '$CTX'"
+
+echo "PASS: silence-detector time-dedupe tests"

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -4,3 +4,4 @@ Cursor auto-memory normally lives under `~/.claude/projects/*/memory/`. This rep
 
 - [feedback_bugbot_auto_trigger_unreliable.md](feedback_bugbot_auto_trigger_unreliable.md) — Always post `@cursor review` on every PR push (CI + `/fixpr`); BugBot auto-trigger is unreliable; per-seat cost.
 - [skill_usage_telemetry.md](skill_usage_telemetry.md) — `skill-usage.log` / `skill-usage.csv` live under `~/.claude/`; use `skill-usage-report.sh` for rollups; never log in skills worktree.
+- [token_efficiency_verbosity.md](token_efficiency_verbosity.md) — token burn is structural (fixed context, repetition, fan-out), not stylistic; routine status = one line; playbook in `reference/token-efficiency-audit-2026-07.md`.

--- a/.claude/memory/token_efficiency_verbosity.md
+++ b/.claude/memory/token_efficiency_verbosity.md
@@ -1,0 +1,7 @@
+# Token burn is structural, not stylistic
+
+**Finding (issue #773, 2026-07):** heavy sessions exhausted the 5h quota in 3–4h. Research across four reports converged: output verbosity is a minority cost (~8.5% measured, not the advertised ~65%); the dominant taxes are fixed always-loaded context, transcript repetition (per-tool-call injections, every-tick tables), subagent fan-out (~15× chat), and giant invoked skills (5K/skill post-compaction re-injection cap).
+
+**Why:** every API call re-transmits history, so per-turn junk compounds ~quadratically; caching discounts price, not window share.
+
+**How to apply:** before adding any recurring output (hook injection, per-tick table, heartbeat prose), ask what it costs *per session*, not per message. Routine status = one line; full detail only on change/blocker/failure — hard stops always print in full. Optimize tokens-to-verified-outcome, never tokens-per-response. Full verdicts + deferred cuts: `.claude/reference/token-efficiency-audit-2026-07.md`.

--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -60,6 +60,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `graphite-stacked-prs-research-2026-05.md` — stacked PR economics (#418 / #433)
 - `codeant-code-quality-eval-2026-06.md` — deeper CodeAnt Code Quality integration eval; verdict: keep advisory (#444)
 - `instruction-set-audit-2026-07.md` — 1-month instruction-set size & optimization re-check; verdict: keep caps (#462)
+- `token-efficiency-audit-2026-07.md` — token-efficiency playbook: adopt/skip/adapt verdicts, ranked cuts, shipped v1 (one-line heartbeats, delta PMM table, silence-detector dedupe) + FU-1…FU-7 (#773)
 - `pm-routing-audit-2026-07.md` — thread-vs-inline routing effectiveness audit of #613; ground-truth attribution + the shared PM-context inline gate for chip surfaces (#701)
 
 ### Diagrams (mermaid stubs and indexes)

--- a/.claude/reference/token-efficiency-audit-2026-07.md
+++ b/.claude/reference/token-efficiency-audit-2026-07.md
@@ -1,0 +1,174 @@
+# Token-Efficiency Audit & Playbook — July 2026
+
+**Issue:** [#773](https://github.com/auerbachb/claude-code-config/issues/773) (stretch Claude sessions toward the 5h limit)
+
+**Date:** 2026-07-28
+
+**Related precedent:** [instruction-set-audit-2026-07.md](instruction-set-audit-2026-07.md) (#462, size caps), [harness-model-audit-2026-06.md](harness-model-audit-2026-06.md) (#49), [skill-repo-diff.md](skill-repo-diff.md) (#417 pattern mining), [pm-routing-audit-2026-07.md](pm-routing-audit-2026-07.md) (#710 telemetry gap)
+
+**Method:** Four independent deep-research reports (two general syntheses, one evidence-tiered field guide, one harness-specific decision memo) consolidated into one playbook, then audited against this harness. Each pattern gets an explicit **adopt / skip / adapt** call. This doc is the durable record; the shipped changes are in the PR closing #773.
+
+---
+
+## Verdict (read this first)
+
+**The dominant token costs are structural, not stylistic.** Output verbosity — what most "token efficiency" advice targets — is a minority cost (independent A/B: concise-output styles measured ~8.5%, not the advertised ~65%). The four bigger taxes for this harness:
+
+1. **Fixed-context:** ~12K *words* of always-loaded CLAUDE.md + 18 unscoped rules, reprocessed every turn.
+2. **Repetition:** rituals accumulating in the transcript — per-tool-call time injection, every-tick full fleet tables, multi-line heartbeats. Every API call re-transmits history, so per-turn junk compounds ~quadratically (20 turns × 2K/turn ≈ 420K cumulative processed).
+3. **Fan-out:** subagents reloading the instruction hierarchy (multi-agent ≈ 15× chat tokens, Anthropic-measured), everything defaulting to Opus.
+4. **Workflow payload:** giant invoked skills (`pr-monitor-and-manage` ≈ 1,100 lines; post-compaction re-injection caps at 5K tokens/skill, so most of it doesn't even survive).
+
+Right objective: **tokens to verified outcome**, not tokens per response. Trim noise (helps cost *and* quality); never trim signal (rules that prevent retries, reasoning on hard problems, hard-stop visibility).
+
+**Shipped for #773 (v1):** one-line-by-default status/heartbeat contract (CLAUDE.md #2/#3 + `monitor-mode.md`), delta-aware PMM fleet table (full table only when something changed or an action fires), and a "repeat less" cut — `silence-detector.sh` stops injecting `Current system time` on every tool call (≥1/min max in steady state). Everything else is ranked below and deferred to follow-ups.
+
+---
+
+## The five cost surfaces (mental model)
+
+| Surface | What it is | This harness today |
+|---|---|---|
+| 1. Fixed startup context | CLAUDE.md, unscoped rules, skill descriptions, MCP schemas loaded before the first task | ~12K-word rule corpus (budgeted, ratchet-capped); dozens of MCP servers/skills in some sessions; documented community floor 20–30K tokens before "hi" |
+| 2. Per-turn accumulation | Full history re-sent every call; cache discounts price (~10% reads) but not window share | Per-tool-call hook injections, every-tick tables, heartbeat prose |
+| 3. Retained/re-injected | What survives compaction: root CLAUDE.md + unscoped rules reload; invoked skills capped 5K/skill, 25K total; MEMORY.md truncates 200 lines/25KB; path-scoped rules vanish until re-touched | 951+-line skills assume their procedure survives compaction — it doesn't |
+| 4. Fan-out | Each subagent reloads baseline context | Custom agents embed rule copies *and* (per research — verify, FU-1) also inherit the hierarchy → double-pay; Opus default everywhere |
+| 5. Generated output | Narration, recaps, thinking tokens | The minority cost; already partially addressed by terse skill outputs |
+
+Overlay: **context rot** — accuracy degrades well before the technical window limit (verified across 18 models, Chroma eval). Anthropic's framing: *smallest set of high-signal tokens that maximizes the likelihood of the desired outcome* — not minimum tokens.
+
+---
+
+## Adopt / skip / adapt — pattern verdicts
+
+Evidence tiers: **A** = Anthropic primary/measured · **B** = community, reproducible mechanism · **C** = folklore.
+
+### Monitoring & status chatter (this issue's core)
+
+| Pattern | Tier | Call | This-harness note |
+|---|---|---|---|
+| One-line routine heartbeats; full detail only on change/blocker/failure | B | **ADOPT — shipped** | CLAUDE.md #2/#3 + `monitor-mode.md` now define the one-line format; monitor declaration folds into the line |
+| Delta-only fleet reporting (no unchanged-table reprints) | B | **ADOPT — shipped** | PMM Step 4 reuses the Step 6 fleet digest; table prints only on change/action/first tick |
+| Unchanged tick ⇒ no model-visible prose *at all* (event-driven wake) | B | **ADAPT — partial** | Full version needs a script-side poller that skips the model call entirely; v1 keeps the 5-min non-silence guarantee (one line). Poller-pattern rewrite = FU-2 |
+| Kill per-tool-call hook injections that repeat static/near-static values | A (Anthropic warns hook-injected timestamps go stale) | **ADOPT — shipped** | `silence-detector.sh` steady-state time injection now ≥60s apart (`SILENCE_TIME_INJECT_S`), warning path untouched |
+| Move time/monitor state to statusline (renders outside context, zero tokens) | A/B | **ADAPT — FU-3** | Statusline shows ET time · branch · agents; the user-facing timestamp *prefix* rule stays (user preference), but injection reliance shrinks |
+| Heartbeat exists to prove liveness ⇒ delete it | C | **SKIP** | The 5-min heartbeat is a deliberate UX contract here; we shorten it, never drop it |
+
+### Fixed context (rules, CLAUDE.md, MCP, skills)
+
+| Pattern | Tier | Call | This-harness note |
+|---|---|---|---|
+| Tiny universal kernel; procedures live in invoked skills | B | **ADAPT — FU-5** | Direction already house style ("keep growth out of the corpus", reference/ offload); a kernel rewrite is #768/#770 territory, not this PR |
+| Magic CLAUDE.md token target (e.g. <500) | C | **SKIP** | "Minimal ≠ short" (Anthropic). We keep the word-budget ratchet instead — remove *inferable* content, keep load-bearing constraints |
+| Path-scope rules via `paths:` frontmatter (−41% one case) | B | **ADAPT — FU-5** | Most of our 18 rules are genuinely global workflow rules; audit which are branch-phase-specific. Caveat: path-scoped rules vanish post-compaction until a matching file is touched |
+| Splitting one file into many files = lazy loading | C (misconception) | **SKIP** | All unscoped rules load at startup regardless of file count; only `paths:` gates loading |
+| `disable-model-invocation: true` on operator-only skills | B | **SKIP for now** | Repo memory `feedback_skill_frontmatter.md`: it also hides the skill from user autocomplete — unacceptable UX cost until upstream fixes it |
+| Giant skill → dispatcher (50–150 lines) + `references/` + `scripts/` | A/B (5K/skill re-injection cap makes >5K skills partially dead weight) | **ADAPT — FU-2** | PMM (~1,100 lines) is the target; its scripts already exist (`pr-state.sh`, `merge-gate.sh`, `merge-sequence.sh`) — the prose around them is what needs the split |
+| MCP per-repo pruning; Tool Search Tool for schema deferral (~85% cut, accuracy ↑) | A | **ADOPT — FU-6** | Session-dependent (many idle MCP servers observed in desktop sessions); needs `/context` baseline first (#710) |
+| Prefer CLI over MCP where equivalent | B | **ADOPT (already house style)** | `gh`, scripts, absolute-path CLIs are the norm here |
+| `permissions.deny` for junk dirs (`.claudeignore` is advisory-only) | A (docs) | **ADOPT — FU-6** | Cheap; bundle with the measurement pass |
+| HTML comments in rules are stripped before injection (free maintainer notes) | B | **ADOPT — use as needed** | Zero-cost documentation channel |
+
+### Fan-out & models
+
+| Pattern | Tier | Call | This-harness note |
+|---|---|---|---|
+| Fix the subagent-inheritance assumption ("subagents do NOT auto-load rules" may be wrong on current harness → embedded rule copies double-pay) | B | **VERIFY then adapt — FU-1** | Contradicts `subagent-orchestration.md`; `skill-first.md` already documents snapshot-at-spawn (PR #585). Verify on current version, then de-duplicate `.claude/agents/*` embedded copies. Ties into #770 |
+| Model routing: Haiku for polling/formatting, Sonnet for implementation, Opus by escalation | A/B (pricing: Haiku $1/$5, Sonnet $3/$15, Opus $5/$25 per MTok) | **ADAPT — FU-4** | We already route A/B=opus, C/pm-worker=sonnet (`subagent-orchestration.md`); the candidate cut is Haiku for pure poll/classify ticks. Needs an eval — misrouting a hard bug to Haiku is false economy |
+| Never switch models/effort/MCP set mid-session (per-model caches; cold re-read often costs more) | A | **ADOPT (already policy-adjacent)** | Set at session/spawn start; document in FU-4 |
+| Explore/Plan agents for read-only recon (skip global instructions) | A | **ADOPT (already available)** | Use Explore for repo sweeps instead of custom agents |
+| Parallel-agent fan-out as free savings | C | **SKIP** | Multi-agent ≈ 15× tokens (Anthropic); fan out for quality/wall-clock, on purpose, never "to save tokens" |
+
+### Tool results, compaction, state
+
+| Pattern | Tier | Call | This-harness note |
+|---|---|---|---|
+| Filter at source (grep/head/jq projections; counts not dumps) | A/B (tool I/O >60% of context; reads 76% of tokens on SWE-bench mini) | **ADOPT (mostly house style)** | Scripts already emit compact summaries; FU-7 audits the noisiest remaining pipelines |
+| Offload bulky output to disk; pass path + summary | A | **ADOPT (house style)** | Also built-in now: >50K-char tool results auto-spill to disk |
+| Universal lossy tool-output interception (RTK/Headroom-style) | B/C | **SKIP** | Fragile: subagent hook bypass, over-minified errors, blind spots; selective wrappers only |
+| External state as primary memory (session-state.json, handoffs, issues/PR bodies) | A | **ADOPT (already built)** | This harness's strongest asset; keep building on it |
+| `/clear` at phase boundaries; compact only mid-task with a preservation contract; never reactively at the limit | A/B | **ADOPT — practice** | Preservation list: issue/PR numbers, branch/SHA, AC status, reviewed SHA, gate state, next command |
+| Arbitrary compaction thresholds ("compact at 50%") | C | **SKIP** | Task-boundary discipline instead |
+| Concise-output styles / "no preamble" / fragments-only | C→B (measured down to 4–12%) | **SKIP beyond the one contract** | One paragraph shipped in CLAUDE.md #3; stripping reasoning measurably increases retries |
+
+---
+
+## Ranked recommendations (savings × risk)
+
+| # | Change | Expected savings | Correctness risk | Status |
+|---|---|---|---|---|
+| 1 | Silence-detector steady-state dedupe (per-tool-call → ≥60s) | High — fires on *every* tool call in *every* session; each injection also re-transmits with all later turns | **Very low** — warning path untouched; turn-start injector untouched | **Shipped (#773)** |
+| 2 | Delta-aware PMM table + one-line heartbeats | High in monitor-heavy sessions (the #773 complaint) | **Low** — table still prints before any action; critical states always full | **Shipped (#773)** |
+| 3 | Subagent inheritance verify + de-dup embedded rules | Very high if confirmed (every spawn pays the corpus twice) | Medium — changes agent definitions; needs verification first | **FU-1** (ties #770) |
+| 4 | PMM dispatcher/references/scripts split | High (invocation + selection + compaction-survival) | Medium — big refactor of a load-bearing skill | **FU-2** |
+| 5 | Statusline for time/branch/agents | Medium — removes injection reliance, zero-context display | Low | **FU-3** |
+| 6 | Haiku routing for pure poll/classify ticks | Medium ($ more than tokens) | Medium — needs eval; escalation path must stay | **FU-4** |
+| 7 | Rule-corpus kernel shrink + path-scoping audit | High per-turn | Medium-high — literal-following models misfire on botched cuts; #768/#770 own it | **FU-5** |
+| 8 | MCP pruning + `/context`/`ccusage` measurement baseline | High in MCP-heavy sessions | Low | **FU-6** (ties #710) |
+| 9 | Tool-result JSON contracts for remaining noisy pipelines | Medium on long sessions | Low | **FU-7** |
+| — | Concise-output styling beyond the shipped contract | Low (4–12% measured) | Medium (retry inflation) | **Rejected** |
+| — | `disable-model-invocation` on operator skills | Medium | High (autocomplete gotcha) | **Blocked** — revisit on harness fix |
+| — | Universal output interception layer | Medium | High | **Rejected** |
+
+## What NOT to change (guardrails for every future cut)
+
+- **Hard stops and merge-gate failures print in full, always:** failing/incomplete CI, human `CHANGES_REQUESTED`, unresolved threads, unchecked AC, branch-protection blocks, authorship refusals. Never summarized into a status line.
+- **`safety.md` prohibitions and their subagent blocks:** verbatim, never compressed.
+- **The 5-minute non-silence guarantee and timestamp prefix:** cadence and prefix stay; only the *body* got shorter. The silence-detector *warning* path is untouched.
+- **Structured exit reports, handoff files, session-state writes:** these are the external memory that makes context cheap — cutting them is anti-efficiency.
+- **Reviewer-chain and polling exit criteria:** "0 unresolved right now" is still not an exit; brevity never relaxes the gate.
+
+---
+
+## Cargo-cult list (measured down or wrong — do not ship)
+
+Magic CLAUDE.md token numbers · "no preamble" as a saver (redundant with the system prompt) · mid-session CLAUDE.md edits (no effect until restart, cache-neutral but pure downside) · mid-session model downgrades (per-model caches → often costs more) · worktrees/subagents as free savings (each reloads baseline) · believing `.claudeignore` blocks reads (advisory; use `permissions.deny`) · fearing statuslines eat context (they render outside it) · many-files-as-lazy-loading (only `paths:` gates) · `@imports`-as-progressive-disclosure (fully expand at launch) · everything-pack skill installs (SWE-Skills-Bench: 39/49 skills no gain, overhead to +451%, 3 harmful) · arbitrary compaction percentages · heartbeats that exist to prove liveness · answering every incident with a permanent rule instead of a test/guard/script · trusting pre-2026 guides (no `/context`, MCP toggling, Tool Search, or context-editing = stale).
+
+## Key measured numbers (for future arguments)
+
+| Claim | Number | Tier |
+|---|---|---|
+| Context editing (tool-result clearing) | +29% benchmark alone; +39% with memory tool; −84% tokens on 100-turn eval | A |
+| Multi-agent overhead | ~4× chat per agent; ~15× multi-agent; token usage explains ~80% of perf variance | A |
+| Tool Search Tool | ~85% schema-overhead cut (77K→8.7K); Opus tool-selection 49→74% | A |
+| MCP schema cost | ~1K+/tool; 10–20K/server; 55K observed for 5 servers | B |
+| Tool I/O share | >60% of used context; file reads 76.1% of tokens (SWE-bench Verified, mini-agent) | B |
+| Session floor | 20–30K tokens before first message | B |
+| Concise-output styles | ~65% claimed → 8.5% independent A/B; 4–12% repo-reported | C→B |
+| Cache pricing | reads ≈10% of input price; writes 1.25× (5-min TTL) / 2× (1-hr) | A |
+| Skill re-injection post-compaction | 5K/skill, 25K total; MEMORY.md 200 lines/25KB | A |
+
+Headline "60–91% savings" figures across the ecosystem come from deliberately bad baselines — treat as ceilings, measure our own delta (FU-6).
+
+---
+
+## Sources
+
+**Anthropic (Tier A):** [Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) · [Managing context on the Claude Developer Platform](https://www.anthropic.com/news/context-management) · [How we built our multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system) · [Introducing advanced tool use (Tool Search)](https://www.anthropic.com/engineering/advanced-tool-use) · [Effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) · [Code execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp) · [Claude Code docs](https://code.claude.com/docs) (memory, costs, sub-agents, skills, hooks).
+
+**Research:** AGENTS.md runtime study ([arXiv 2601.20404](https://arxiv.org/abs/2601.20404): −28.6% runtime, −16.6% output tokens) · context-file eval ([arXiv 2602.11988](https://arxiv.org/abs/2602.11988): generic context files add >20% cost, no success gain) · SWE-Skills-Bench ([arXiv 2603.15401](https://arxiv.org/abs/2603.15401)) · [Chroma context-rot eval](https://research.trychroma.com/context-rot).
+
+**Community (Tier B/C, mechanisms sound, multipliers marketing):** [ccusage](https://github.com/ryoppippi/ccusage) (longitudinal token telemetry) · [drona23/claude-token-efficient](https://github.com/drona23/claude-token-efficient) (candid own-benchmark: 4–12%, full file sometimes net-negative) · [agentskills.io](https://agentskills.io) (progressive-disclosure standard) · Caveman-style concise output + independent A/B (~8.5%) · RTK / Headroom / Context-Mode interception teardowns (why universal interception is fragile) · compaction-cascade reverse-engineering (openedclaude, y-agent, finisky, decodeclaude).
+
+---
+
+## Follow-ups (deferred cuts — file as issues at wrap)
+
+- **FU-1:** Verify subagent instruction inheritance on the current harness version; if the hierarchy loads into custom agents, strip duplicated rule blocks from `.claude/agents/*` (keep role-specific prompts + safety blocks). Ties #770.
+- **FU-2:** Split `pr-monitor-and-manage` into dispatcher (≤150 lines) + `references/` + existing scripts; add script-side no-change short-circuit so an unchanged tick costs ~no model tokens.
+- **FU-3:** Statusline (ET time · branch · active agents · watchers) to replace injection reliance for time display.
+- **FU-4:** Poller model-routing eval (Haiku for classify-only ticks) + "set model/effort at spawn, never mid-session" note in `subagent-orchestration.md`.
+- **FU-5:** Rule-corpus kernel/path-scoping audit (with #768/#770).
+- **FU-6:** Measurement baseline: `/context` + `ccusage` per repo, MCP prune list, `permissions.deny` junk-dir blocks (ties #710).
+- **FU-7:** Compact-JSON output contracts for the remaining noisy `gh`/log pipelines.
+
+## AC coverage (#773)
+
+| AC | Where |
+|---|---|
+| Research note, ≥5 sources, adopt/skip/adapt | This doc (Sources + verdict tables) |
+| Ranked recommendations, savings vs risk | "Ranked recommendations" table |
+| Status/progress rules tightened | CLAUDE.md #2/#3, `monitor-mode.md` User Heartbeat, PMM Step 4, babysit T7 |
+| ≥1 cut beyond verbosity | `silence-detector.sh` steady-state time-injection dedupe (+ tests) |
+| Word budget respected | `rule-lint.sh` run in PR; edits net-negative |
+| No hidden hard stops | "What NOT to change" section; critical signals carved out as always-full |

--- a/.claude/rules/monitor-mode.md
+++ b/.claude/rules/monitor-mode.md
@@ -1,6 +1,6 @@
 # Monitor Mode, Heartbeats & Recovery
 
-> **Always:** Enter monitor mode when subagents are active. Timestamp every message (see CLAUDE.md #1). Heartbeat every ≤5 min (see CLAUDE.md #3). Report subagent failures immediately. Recover state after compaction.
+> **Always:** Enter monitor mode when subagents are active. Timestamp every message and heartbeat ≤5 min (CLAUDE.md #1/#3). Report subagent failures immediately. Recover state after compaction.
 > **Ask first:** Breaking monitor mode for explicit user requests — warn about paused monitoring first.
 > **Never:** Do substantive work while subagents are active. Go >5 min without a user-visible message. Let a stalled PR go unreported. Ask permission to monitor — babysitting an in-flight PR is the default (`CLAUDE.md`).
 
@@ -18,7 +18,7 @@ Every ~60s, in order:
 1. Process completed subagents and parse exit reports.
 2. Execute phase transitions via `phase-protocols.md`; also launch transitions stalled in `session-state.json`.
 3. For every session PR still on `reviewer == cr`, run `.claude/scripts/escalate-review.sh <PR_NUMBER>` and act on its `STATUS=` verdict before sleeping.
-4. Send heartbeat if due (≤5 min; include active agents, PR phases, pending transitions, blockers).
+4. Send any due heartbeat (one line — User Heartbeat below).
 5. Investigate stale agents: >15 min Phase A, >10 min Phase B, >5 min Phase C.
 
 ## Subagent Health Monitoring (MANDATORY)
@@ -29,11 +29,15 @@ Respawn permissions: crash asks, exhaustion auto (`phase-protocols.md`).
 
 ## User Heartbeat (MANDATORY)
 
-CLAUDE.md #3 is canonical (timestamped status ≤5 min). In monitor mode it is part of each loop; outside it, send status before/after multi-step operations; if the silence hook warns, message immediately. Between-turn polling: `scheduling-reliability.md`.
+CLAUDE.md #3 is canonical for the one-line default and for when full detail is owed. Routine-beat format:
+
+`[<ET timestamp>] <state / what's running> · next: <action or cadence> — monitoring N PR(s) (#a, #b)`
+
+No tables, plan restating, or rule quoting on routine beats. If the silence hook warns, message immediately. Between-turn polling: `scheduling-reliability.md`.
 
 ## File-Write Status Updates (MANDATORY)
 
-For operations touching 4+ files, emit one-line status after every 3 writes/edits. Batches of 1-3 need no extra message. Applies to parent agents and subagents.
+Operations touching 4+ files: one-line status every 3 writes/edits; batches of 1–3 need none. Applies to parents and subagents.
 
 ## Post-Compaction Recovery (MANDATORY)
 

--- a/.claude/rules/scheduling-reliability.md
+++ b/.claude/rules/scheduling-reliability.md
@@ -14,7 +14,7 @@ The 5-minute heartbeat rule catches silence during turns; this file covers betwe
 | ≥3 concurrent polls or cross-session durability | **`CronCreate`** | Durable fleet job |
 | One-shot "wake me in N minutes" | `ScheduleWakeup` | Single tick only |
 
-> **Default recurring user-facing poll: `/loop`.** Use `CronCreate` only for ≥3 concurrent polls, cross-session durability, or fleet jobs. Never hand-roll "do work, then schedule the next one-shot wakeup" chains — a forgotten re-arm silently kills the poll; `/loop` re-arms itself.
+> Why the "Never" above: a forgotten re-arm silently kills a hand-rolled one-shot chain; `/loop` re-arms itself.
 
 ## PM Monitoring Primitive
 
@@ -35,7 +35,7 @@ Before any polling turn ends (`/loop`, `CronCreate`, or legacy one-shot), verify
    - `/loop`: verify it is active/re-armed.
    - `CronCreate`: confirm with `CronList`; prior `CronDelete` or 7-day expiry may remove it.
    - Legacy `ScheduleWakeup`: confirm this turn made the next-tick call and it returned cleanly. If skipped/errored, switch to `/loop`.
-2. **User heartbeat sent this turn?** Timestamped visible message summarizing what happened and what is next.
+2. **User heartbeat sent this turn?** Timestamped one-liner: what happened, what's next.
 3. **Monitoring state recorded?** Update `~/.claude/session-state.json` with tick time, next expected tick, and watermarks (last review ID, last HEAD SHA, etc.). See `handoff-files.md`.
 
 ## Stable-State Backoff

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-monitor-and-manage
-description: Thread-level PR fleet manager. Rediscovers your open PRs every tick, prints a status table, and auto-dispatches the per-PR decision tree (rebase / parallel phase-a-fixer / sequential /wrap) until the fleet is clean, hard-blocked, or idle. Auto-pauses when idle; resume with /pr-monitor-and-manage-wake. Triggers on "/pr-monitor-and-manage", "/pmm", "manage PRs", "PR fleet", "watch PRs".
+description: Thread-level PR fleet manager. Rediscovers your open PRs every tick, prints a delta-aware status table (one-line heartbeat when nothing changed), and auto-dispatches the per-PR decision tree (rebase / parallel phase-a-fixer / sequential /wrap) until the fleet is clean, hard-blocked, or idle. Auto-pauses when idle; resume with /pr-monitor-and-manage-wake. Triggers on "/pr-monitor-and-manage", "/pmm", "manage PRs", "PR fleet", "watch PRs".
 triggers:
   - pr-monitor-and-manage
   - pmm
@@ -225,7 +225,7 @@ PMM does **not** launch Phase B/C after Phase A — it only fixes and pushes. St
 HARD_BLOCK_JSON=$(.claude/scripts/session-state.sh --get '.pmm_hard_block // {}' 2>/dev/null || echo '{}')
 ```
 
-This step is **side-effect-free**: it gathers state and computes a verdict per PR, but performs **no** rebases or dispatches. Actions happen in **Step 5**, after the table prints (Step 4). This ordering is required so the heartbeat table always shows the classification *before* any long-running dispatch.
+This step performs no PR mutations or dispatches: it gathers state, computes verdicts, and may persist orchestration bookkeeping (e.g. Step 3.6's `.pmm_merge_holds`). PR mutations and dispatches happen in **Step 5**, after the heartbeat/table prints (Step 4). This ordering is required so the classification is always visible *before* any long-running dispatch.
 
 For **each** PR number, gather state. Run the per-PR fetches **in parallel across PRs** (one batch of background jobs, then collect), since they are independent network calls.
 
@@ -414,14 +414,31 @@ Evaluate the `jq` first and pass the resulting JSON as the value — never a raw
 
 ---
 
-## Step 4: Print the status table (the per-tick heartbeat — EVERY tick, BEFORE any action)
+## Step 4: Heartbeat + status table (EVERY tick, BEFORE any action — table only when it carries news)
 
-The table is this skill's heartbeat. Print it **every tick** and **before** Step 5 runs any rebase or dispatch, so the classification is visible even if a dispatch is long-running. Lead with an Eastern-time timestamp (per `CLAUDE.md` #1):
+A heartbeat prints **every tick**, **before** Step 5 runs any rebase or dispatch — but the **full table only when something changed or is about to happen** (issue #773; `monitor-mode.md` one-line default). Compute two digests **here** (Step 6 reuses and persists them):
+
+- `FLEET_TUPLE_SORTED` — Step 3's per-PR state tuples `(number, head_sha, merge_state, review_decision, ci_blocking_count, unresolved_threads)`, sorted by PR number. Drives backoff (Step 6) and quiet-tick detection.
+- `ROW_TUPLE_SORTED` — everything the table *displays* per PR: `(number, issue_ref, merge_state, conflicting_flag, review_decision, ci_summary, unresolved_threads, refined_verdict, subagent_cell)`, sorted by PR number. Catches display-only changes the state tuple misses (verdict refinements like `rate-limited` → `waiting`, subagent `spawned` → `working`, `mergeable` flips) so a quiet tick can never mask them.
 
 ```bash
+DIGEST=$(printf '%s' "$FLEET_TUPLE_SORTED" | sha256sum | awk '{print $1}')
+ROW_DIGEST=$(printf '%s' "$ROW_TUPLE_SORTED" | sha256sum | awk '{print $1}')
+PREV=$(.claude/scripts/session-state.sh --get '.pmm_digest' 2>/dev/null || echo null)       # read-only here —
+ROW_PREV=$(.claude/scripts/session-state.sh --get '.pmm_row_digest' 2>/dev/null || echo null) # Step 6 owns the persist
 TS=$(TZ='America/New_York' date +'%a %b %-d %I:%M %p ET')
 echo "[$TS] PMM tick — $PR_COUNT PR(s) in fleet (author:$PMM_AUTHOR)"
 ```
+
+Print the **full table** (below the lead line) when ANY of:
+
+- (a) this is the arm-mode immediate tick or the first tick after a resume;
+- (b) `DIGEST != PREV` or `ROW_DIGEST != ROW_PREV` (or either previous value is null);
+- (c) any PR's verdict this tick is actionable — `rebase`, `fixpr`, `wrap`, or `batch(#A)` — so the classification is always visible before Step 5 acts;
+- (d) Step 2.5 processed any subagent outcome, or `HARD_BLOCK[]` gained a new entry this tick;
+- (e) Step 3.6 held or batched anything (the merge-sequence annotation must stay visible).
+
+**Quiet tick** (none of a–e): append `— no change` plus the PR numbers to the lead line (e.g. `… (author:x) — no change (#101 #102)`) and print **only that line** — no table. Hard blocks, gate failures, and terminations are never quiet: they hit (b)/(c)/(d) by construction.
 
 | Issue | PR | State | Reviews | CI | Unresolved Threads | Verdict | Subagent |
 |-------|----|-------|---------|----|--------------------|---------|----------|
@@ -450,7 +467,7 @@ Merge sequence: holding #101, #102 until #100 lands — they share `.claude/skil
 
 Omit the line entirely when nothing is held or batched — a fleet with no overlap gets no annotation and no behavioural change. When `SEQ`'s `excluded_prs[]` is non-empty, add one short line naming the count and reason (e.g. "1 PR excluded from sequencing: not yours") so a collaborator's PR silently sitting out is visible rather than invisible.
 
-Only after the table is printed does Step 5 execute the actions.
+Only after the heartbeat (and the table, when any of a–e fired) is printed does Step 5 execute the actions. A quiet tick has no actionable verdicts by construction (condition c); if Step 5.0 pre-flight nonetheless acts on a quiet tick (draft flip, reviewer trigger), its own timestamped output lines report it.
 
 ---
 
@@ -874,15 +891,15 @@ Initialize `MERGED_THIS_SESSION='[]'` on the first tick in Step 0/Step 1.
 
 ## Step 6: Stable-state backoff + idle streak (per `scheduling-reliability.md`)
 
-Compute a **per-tick fleet digest** and track a streak so an idle fleet stops hammering the API. Hash the per-PR tuple `(number, head_sha, merge_state, review_decision, ci_blocking_count, unresolved_threads)` across the whole fleet (sorted by PR number for stability):
+Track a streak over the fleet digest so an idle fleet stops hammering the API. `DIGEST`/`PREV` and `ROW_DIGEST`/`ROW_PREV` were already computed in Step 4 this tick (hashed once) — reuse them, do not recompute. **Only the state digest feeds the streak**: `ROW_DIGEST` exists solely for Step 4's table decision, so a display-only change (verdict refinement, subagent cell) never resets backoff or the idle counter.
 
 ```bash
-DIGEST=$(printf '%s' "$FLEET_TUPLE_SORTED" | sha256sum | awk '{print $1}')
-PREV=$(.claude/scripts/session-state.sh --get '.pmm_digest' 2>/dev/null || echo null)
+# DIGEST/PREV + ROW_DIGEST/ROW_PREV come from Step 4 (read pre-persist).
 STREAK=$(.claude/scripts/session-state.sh --get '.pmm_digest_streak' 2>/dev/null || echo 0)
 [ "$STREAK" = null ] && STREAK=0
 if [ "$DIGEST" = "$PREV" ]; then STREAK=$((STREAK+1)); else STREAK=0; fi
-.claude/scripts/session-state.sh --set ".pmm_digest=\"$DIGEST\"" --set ".pmm_digest_streak=$STREAK"
+.claude/scripts/session-state.sh --set ".pmm_digest=\"$DIGEST\"" --set ".pmm_digest_streak=$STREAK" \
+  --set ".pmm_row_digest=\"$ROW_DIGEST\""
 
 # Resolve the effective cadence from the streak (used by Step 7's loop re-arm).
 if [ "$STREAK" -ge 3 ]; then EFFECTIVE_CADENCE="15m"; else EFFECTIVE_CADENCE="$PMM_CADENCE"; fi
@@ -966,8 +983,8 @@ NOW=$(date -u +%FT%TZ)
 **Pre-exit checklist (run before ending every polling turn — `scheduling-reliability.md`):**
 
 1. **Next tick scheduled?** Confirm `/loop` is active/re-armed at `$EFFECTIVE_CADENCE` (or stopped/paused per the routing above).
-2. **Heartbeat sent?** The Step 4 timestamped table is the heartbeat — never end a tick silently.
-3. **State recorded?** `pmm_active`, cadence, watermarks, `pmm_in_flight`, `active_agents`, `pmm_digest(_streak)`, `pmm_idle_streak` written to `session-state.json`.
+2. **Heartbeat sent?** The Step 4 timestamped line (plus the table when it carried news) is the heartbeat — never end a tick silently.
+3. **State recorded?** `pmm_active`, cadence, watermarks, `pmm_in_flight`, `active_agents`, `pmm_digest(_streak)`, `pmm_row_digest`, `pmm_idle_streak` written to `session-state.json`.
 
 ---
 

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -440,7 +440,7 @@ Print the **full table** (below the lead line) when ANY of:
 - (d) Step 2.5 processed any subagent outcome, or `HARD_BLOCK[]` gained a new entry this tick;
 - (e) Step 3.6 held or batched anything (the merge-sequence annotation must stay visible).
 
-**Quiet tick** (none of a–e): append `— no change` plus the PR numbers to the lead line, and when `HARD_BLOCK[]` is non-empty append the standing blocks with reasons (e.g. `… (author:x) — no change (#101 #102; hard-blocked: #99 human-CR)`); print **only that line** — no table. **New** hard blocks, gate failures, and terminations always get the full table on the tick they appear ((b)/(c)/(d)); already-reported blocks stay visible via the hard-blocked suffix on every quiet line — never silently dropped. Terminal snapshots (Pause / Stop & Clean Exit) always print the full table regardless of quiet-tick status.
+**Quiet tick** (none of a–e): append `— no change` plus the PR numbers to the lead line; when `HARD_BLOCK[]` is non-empty append the standing blocks with reasons, and when any PR is refined `queued (cap)` or `held(#A)` append those too (e.g. `… (author:x) — no change (#101 #102; hard-blocked: #99 human-CR; queued (cap): #103)`); print **only that line** — no table. **New** hard blocks, gate failures, and terminations always get the full table on the tick they appear ((b)/(c)/(d)); already-reported blocks stay visible via the hard-blocked suffix on every quiet line — never silently dropped. Terminal snapshots (Pause / Stop & Clean Exit) always print the full table regardless of quiet-tick status.
 
 | Issue | PR | State | Reviews | CI | Unresolved Threads | Verdict | Subagent |
 |-------|----|-------|---------|----|--------------------|---------|----------|

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -38,7 +38,9 @@ if [ "$PAUSED_AT" != null ] && [ -n "$PAUSED_AT" ]; then
   #    session-state after step 3 has run (it will be null by then).
   SAVED=$(.claude/scripts/session-state.sh --get '.pmm.config_at_pause' 2>/dev/null || echo '{}')
   # 2. Delete auto-wake cron (fail-closed — see pr-monitor-and-manage-wake Step 3)
-  # 3. Clear pause marker + reset pmm_idle_streak=0 + set pmm_active=true (atomic batch)
+  # 3. Clear pause marker + reset pmm_idle_streak=0 + set pmm_active=true
+  #    + null .pmm_digest and .pmm_row_digest (atomic batch) — the digest reset
+  #    forces Step 4's full table on the first post-resume tick (condition a/b)
   # 4. Merge flags: explicit $ARGUMENTS override $SAVED (the step-1 variable, not
   #    session-state — that field is already cleared by step 3 at this point)
   echo "[PMM] Resuming from pause (paused_at=$PAUSED_AT) — flags on this invocation override saved config."
@@ -49,7 +51,7 @@ Resume logic is shared with `/pr-monitor-and-manage-wake` — see `.claude/skill
 
 A stale marker left by a killed session is safely reconciled here: the next `/pr-monitor-and-manage` invocation reads it, resumes (or the user runs `/pmm-stop`), and re-runs discovery from scratch.
 
-On the **first** invocation in a thread (and after any resume), acknowledge the mode up front so the constraints are explicit and survive context compaction:
+On the **first** invocation in a thread (and after any resume), null the table digests — `session-state.sh --set '.pmm_digest=null' --set '.pmm_row_digest=null'` — so Step 4's first tick always prints the full table, and acknowledge the mode up front so the constraints are explicit and survive context compaction:
 
 > **PR-fleet-manager mode active.** My only job in **this parent thread** is to watch and manage your open PRs as a fleet — rediscover them each tick, print a status table, and dispatch rebase / parallel `phase-a-fixer` subagents (fix work, including merge conflicts) / sequential `/wrap` (merge-ready) per the decision tree. Merge-ready PRs are landed autonomously via inline `/wrap` dispatch (unless `--confirm-merges` is set). I will not edit feature code **directly in this thread**, start issues, or do unrelated work here — but I **will** dispatch subagents that edit code, resolve conflicts, fix findings, push, and reply/resolve threads.
 
@@ -418,7 +420,7 @@ Evaluate the `jq` first and pass the resulting JSON as the value — never a raw
 
 A heartbeat prints **every tick**, **before** Step 5 runs any rebase or dispatch — but the **full table only when something changed or is about to happen** (issue #773; `monitor-mode.md` one-line default). Compute two digests **here** (Step 6 reuses and persists them):
 
-- `FLEET_TUPLE_SORTED` — Step 3's per-PR state tuples `(number, head_sha, merge_state, review_decision, ci_blocking_count, unresolved_threads)`, sorted by PR number. Drives backoff (Step 6) and quiet-tick detection.
+- `FLEET_TUPLE_SORTED` — Step 3's per-PR state tuples `(number, head_sha, merge_state, review_decision, ci_failing_count, unresolved_threads)`, sorted by PR number, where `ci_failing_count` is Step 3's `CI_FAILING` (`.ci_status.failing` from the gate JSON). Drives backoff (Step 6) and quiet-tick detection.
 - `ROW_TUPLE_SORTED` — everything the table *displays* per PR: `(number, issue_ref, merge_state, conflicting_flag, review_decision, ci_summary, unresolved_threads, refined_verdict, subagent_cell)`, sorted by PR number. Catches display-only changes the state tuple misses (verdict refinements like `rate-limited` → `waiting`, subagent `spawned` → `working`, `mergeable` flips) so a quiet tick can never mask them.
 
 ```bash
@@ -432,13 +434,13 @@ echo "[$TS] PMM tick — $PR_COUNT PR(s) in fleet (author:$PMM_AUTHOR)"
 
 Print the **full table** (below the lead line) when ANY of:
 
-- (a) this is the arm-mode immediate tick or the first tick after a resume;
+- (a) this is the first tick of a fresh invocation (Step 0 mode entry) or the first tick after a resume (Step 0a) — both null `.pmm_digest`/`.pmm_row_digest`, so (b) also fires mechanically;
 - (b) `DIGEST != PREV` or `ROW_DIGEST != ROW_PREV` (or either previous value is null);
 - (c) any PR's verdict this tick is actionable — `rebase`, `fixpr`, `wrap`, or `batch(#A)` — so the classification is always visible before Step 5 acts;
 - (d) Step 2.5 processed any subagent outcome, or `HARD_BLOCK[]` gained a new entry this tick;
 - (e) Step 3.6 held or batched anything (the merge-sequence annotation must stay visible).
 
-**Quiet tick** (none of a–e): append `— no change` plus the PR numbers to the lead line (e.g. `… (author:x) — no change (#101 #102)`) and print **only that line** — no table. Hard blocks, gate failures, and terminations are never quiet: they hit (b)/(c)/(d) by construction.
+**Quiet tick** (none of a–e): append `— no change` plus the PR numbers to the lead line, and when `HARD_BLOCK[]` is non-empty append the standing blocks with reasons (e.g. `… (author:x) — no change (#101 #102; hard-blocked: #99 human-CR)`); print **only that line** — no table. **New** hard blocks, gate failures, and terminations always get the full table on the tick they appear ((b)/(c)/(d)); already-reported blocks stay visible via the hard-blocked suffix on every quiet line — never silently dropped.
 
 | Issue | PR | State | Reviews | CI | Unresolved Threads | Verdict | Subagent |
 |-------|----|-------|---------|----|--------------------|---------|----------|

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -440,7 +440,7 @@ Print the **full table** (below the lead line) when ANY of:
 - (d) Step 2.5 processed any subagent outcome, or `HARD_BLOCK[]` gained a new entry this tick;
 - (e) Step 3.6 held or batched anything (the merge-sequence annotation must stay visible).
 
-**Quiet tick** (none of a–e): append `— no change` plus the PR numbers to the lead line, and when `HARD_BLOCK[]` is non-empty append the standing blocks with reasons (e.g. `… (author:x) — no change (#101 #102; hard-blocked: #99 human-CR)`); print **only that line** — no table. **New** hard blocks, gate failures, and terminations always get the full table on the tick they appear ((b)/(c)/(d)); already-reported blocks stay visible via the hard-blocked suffix on every quiet line — never silently dropped.
+**Quiet tick** (none of a–e): append `— no change` plus the PR numbers to the lead line, and when `HARD_BLOCK[]` is non-empty append the standing blocks with reasons (e.g. `… (author:x) — no change (#101 #102; hard-blocked: #99 human-CR)`); print **only that line** — no table. **New** hard blocks, gate failures, and terminations always get the full table on the tick they appear ((b)/(c)/(d)); already-reported blocks stay visible via the hard-blocked suffix on every quiet line — never silently dropped. Terminal snapshots (Pause / Stop & Clean Exit) always print the full table regardless of quiet-tick status.
 
 | Issue | PR | State | Reviews | CI | Unresolved Threads | Verdict | Subagent |
 |-------|----|-------|---------|----|--------------------|---------|----------|
@@ -996,7 +996,7 @@ Reached from Step 7 when the fleet is empty or idle. Unlike Stop & Clean Exit, P
 
 ### 1. Final heartbeat
 
-Print the Step 4 status table one last time, then a one-line reason:
+Print the **full** Step 4 status table one last time — terminal snapshots (Pause here, Stop & Clean Exit) are an explicit exception to Step 4's quiet-tick suppression, so the user always gets a final fleet snapshot even when the pause tick itself was quiet — then a one-line reason:
 
 ```text
 [$TS] PMM pausing — reason: <empty fleet | N idle ticks>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ Do not merge or commit to `main` outside this path unless the user explicitly ov
 These apply to EVERY message the parent agent sends to the user. No exceptions, no degradation over time, no skipping after context compaction.
 
 1. **Timestamp prefix.** Start every message with Eastern time (`Mon Mar 16 02:34 AM ET`). **Windows (Git Bash):** `TZ=America/New_York` is often wrong — use PowerShell `TimeZoneInfo` for ET first; **Linux/macOS:** `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`. Never estimate — run a command; for elapsed time, compare two outputs.
-2. **Active monitoring declaration.** If monitoring background agents, state how many and which PRs at the end of every message.
-3. **5-minute heartbeat.** Never go >5 minutes without a status message. During operations touching 4+ files, emit a one-line status after every 3 writes/edits (see `monitor-mode.md` "User Heartbeat" and "File-Write Status Updates" for details).
+2. **Active monitoring declaration.** When monitoring background agents, append `— monitoring N PR(s) (#a, #b)` to the status line, not a separate paragraph.
+3. **5-minute heartbeat — one line by default.** Never go >5 minutes without a status message; routine ones are one line (format: `monitor-mode.md` "User Heartbeat"). Multi-line detail only for state changes, dispatches, blockers, failures, and final reports — hard stops (CI red, `CHANGES_REQUESTED`, safety) always in full. Don't restate the task or narrate routine tool use. During operations touching 4+ files, emit a one-line status after every 3 writes/edits (`monitor-mode.md`).
 4. **`/loop` for recurring polls.** Back any "poll/check/watch every N" request with `/loop` (or `CronCreate` for ≥3 concurrent polls / cross-session durability) — never a hand-rolled chain of one-shot wake-ups. Decision tree + pre-exit checklist: `scheduling-reliability.md`.
 5. **Dedicated monitor mode.** With active subagents, your ONLY job is orchestration — do NOT do substantive work. See `monitor-mode.md` "Dedicated Monitor Mode" for full rules.
 


### PR DESCRIPTION
## **User description**
Closes #773

## Summary

Applies the token-efficiency deep research (four-report consolidated playbook, supplied in-thread) to the harness. Core diagnosis: token burn is structural (fixed context, transcript repetition, fan-out), not stylistic — so v1 ships the highest-ROI, lowest-risk cuts and defers the rest as ranked follow-ups.

**Phase 1 — research landed:** `.claude/reference/token-efficiency-audit-2026-07.md` — five-surface cost model, **adopt/skip/adapt** verdict per pattern with this-harness fit, recommendations **ranked by savings vs. correctness risk**, "What NOT to change" guardrails, measured-numbers table, cargo-cult list, 14+ linked sources, FU-1…FU-7 deferred cuts, AC-coverage table. Indexed in `reference/README.md`; pointer memory added (`.claude/memory/token_efficiency_verbosity.md`).

**Phase 2 — concise status rules:** `CLAUDE.md` #2/#3 + `monitor-mode.md`: routine status/heartbeats are **one line by default**; the active-monitor declaration folds into the line as a suffix; multi-line detail is reserved for state changes, dispatches, blockers, failures, and final reports — **hard stops (CI red, `CHANGES_REQUESTED`, safety) always print in full**. Offsetting dedup trims in `monitor-mode.md`/`scheduling-reliability.md` keep the corpus under budget. (`babysit-pr` T7 already conformed to the one-line format — no change needed there.)

**Phase 2b — delta-aware PMM heartbeat:** `pr-monitor-and-manage` Step 4 now prints the full fleet table only when it carries news — first tick, state-digest or display-row-digest change, actionable verdict (table-before-action invariant preserved), subagent outcome, or new hard block. Quiet ticks emit one line. Two digests (state tuple for backoff, rendered-row tuple for display changes) so a quiet tick can never mask a verdict/subagent/`CONFLICTING` flip; Step 6 reuses and persists both, and only the state digest feeds backoff/idle streaks.

**Phase 3 — "repeat less" cut beyond verbosity:** `silence-detector.sh` no longer injects `Current system time` into context on **every tool call** — steady-state injections are deduped to once per `SILENCE_TIME_INJECT_S` (default 60s, session-scoped marker). The ≥5-min HEARTBEAT WARNING path is untouched and always carries a fresh timestamp; first-call/stat-fallback paths still inject. In active sessions tool calls cluster seconds apart, so this removes the large majority of these per-call context messages (each of which otherwise re-transmits with every later turn).

## Local review

- **CodeRabbit CLI:** run 1 verified-successful — 5 findings: 4 fixed (2 doc dedups, PMM display-digest gap → `ROW_DIGEST`, stale "side-effect-free" claim), 1 declined with reason (MEMORY.md path is a backtick code span in house repo-root-relative style, not a resolvable link). Runs 2–3 returned `Rate limit exceeded` → CR CLI dropped for the session per `cr-local-review.md` (max one retry).
- **CodeAnt CLI:** not installed on this machine → dropped for the session per `cr-local-review.md`; the CodeAnt GitHub App still reviews this PR and can satisfy the merge gate.
- **Self-review fallback performed** (both CLIs down): full-diff pass, cross-reference sweep of every `Step 4`/table mention in PMM, `bash -n` + bash-3.2 compat check on the hook, and a regression-direction check — the new test **fails against the pre-change hook** (at the dedupe assertion) and passes against the new one.

## Word budget

Corpus 11,957 → **11,975** words (soft warn 12,000; ratchet cap 12,310; hard 13,000). The +18 net buys the one-line contract + always-full hard-stop carve-out, offset by dedup trims. `rule-lint.sh` passes.

## Test plan

- [x] Research note landed in `.claude/reference/` covering ≥5 external sources with links and an adopt/skip/adapt call per pattern
- [x] Recommendations explicitly ranked by expected token savings vs. risk to workflow correctness
- [x] Status/progress rules tightened: routine updates one line by default (CLAUDE.md #2/#3, `monitor-mode.md`, PMM Step 4)
- [x] ≥1 research-backed cut shipped beyond verbosity (`silence-detector.sh` steady-state time-injection dedupe)
- [x] Hook regression test passes against the new hook and fails against the pre-change hook (`.claude/hooks/tests/silence-detector-time-dedupe.test.sh`)
- [x] All pre-existing hook tests still pass (script-bypass-detector, skill-command-tracker, stale-worktree-warn)
- [x] `rule-lint.sh` passes and corpus word count ≤ soft/ratchet caps
- [x] No change hides hard stops, merge-gate failures, or safety prohibitions (hard stops carved out as always-full-detail; PMM quiet tick provably cannot mask a displayed change — row digest; warning path untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Reduce repeated monitoring output while preserving important alerts

### What Changed
- Routine heartbeats now use a single status line, while full details remain visible for changes, actions, blockers, failures, and final reports
- PR fleet monitoring prints the full status table only on the first tick or when fleet state, displayed results, actions, subagent outcomes, or hard blocks change; quiet ticks show a concise line with standing blockers
- Pause, stop, and resume operations still provide a complete fleet snapshot
- The silence detector injects the current time at most once per minute by default, while 5-minute warnings always include the time and remain unchanged
- Added coverage for time-injection deduplication, clock changes, warning behavior, cooldowns, and configuration overrides
- Added guidance and research documenting the monitoring and token-efficiency rules

### Impact
`✅ Fewer repeated heartbeat messages`
`✅ Lower transcript growth during PR monitoring`
`✅ Alerts and final fleet status remain visible`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
