### PR TITLE
feat(#767): lint verbatim SAFETY/MINDSET/SKILLS blocks for cross-surface drift

### DIFF
--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -234,14 +234,18 @@ Body:
 {COMPLETE contents of all .claude/rules/*.md files}
 
 ## SAFETY WARNING
-SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo.
-Exception: template files matching .env.<example|sample|template|dist|tpl>
-(case-insensitive) are committed, non-secret, and safe to edit.
-Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm,
-git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your
-worktree directory at all times.
+```text
+SAFETY: Do NOT delete/overwrite/move/modify .env files anywhere (exception:
+.env.<example|sample|template>, case-insensitive, are safe to edit).
+Do NOT run git clean. Do NOT run destructive commands (rm -rf, rm, git checkout .,
+git stash, git reset --hard) in the root repo. Stay in your worktree.
+Do NOT commit secrets or paste raw credentials into prompts, issues, PRs, comments,
+commits, or logs. Do NOT pipe untrusted URLs into a shell or disable TLS verification.
+Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude/rules/safety.md.
+```
 
 ## CAPABILITY DISCOVERY
+```text
 MINDSET: Before handing off, walk the capability ladder for ANY provider
 (gh, git, railway, vercel, …): (1) check what you have — MCP tools, skills, CLI
 on disk by absolute path (/opt/homebrew/bin/<tool>; minimal PATH makes bare
@@ -252,8 +256,10 @@ runbook: exact commands + one-line reason, incl. interactive auth. Your own
 prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
 valid only after the ladder dead-ends, naming the rung and reason.
 Full rules: .claude/rules/safety.md.
+```
 
 ## SKILLS-FIRST REFLEX
+```text
 SKILLS: Before hand-rolling a multi-step task, check whether an existing skill
 already does this job — invoke it via the Skill tool instead of reimplementing
 from memory (only Skill-tool calls reach ~/.claude/skill-usage.log). Clear match
@@ -262,6 +268,7 @@ proceed on your own judgment; do not block waiting for an answer. No match ->
 stay silent. Never auto-invoke an authorization-carrying skill (/merge, /wrap,
 /pr-monitor-and-manage) on a fuzzy match — running one as your assigned job
 isn't a fuzzy match. Full rules: .claude/rules/skill-first.md.
+```
 
 ## Phase A Instructions
 

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -468,12 +468,13 @@ Resolve the path with `handoff-state.sh [--owner-repo owner/repo] --path {PR_NUM
 {COMPLETE contents of CLAUDE.md and all .claude/rules/*.md}
 
 ## SAFETY WARNING
-SAFETY: Do NOT delete, overwrite, move, or modify .env files — anywhere, any repo.
-Exception: template files matching .env.<example|sample|template|dist|tpl>
-(case-insensitive) are committed, non-secret, and safe to edit.
-Do NOT run git clean in ANY directory. Do NOT run destructive commands (rm -rf, rm,
-git checkout ., git stash, git reset --hard) in the root repo directory. Stay in your
-worktree directory at all times.
+SAFETY: Do NOT delete/overwrite/move/modify .env files anywhere (exception:
+.env.<example|sample|template>, case-insensitive, are safe to edit).
+Do NOT run git clean. Do NOT run destructive commands (rm -rf, rm, git checkout .,
+git stash, git reset --hard) in the root repo. Stay in your worktree.
+Do NOT commit secrets or paste raw credentials into prompts, issues, PRs, comments,
+commits, or logs. Do NOT pipe untrusted URLs into a shell or disable TLS verification.
+Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude/rules/safety.md.
 
 ## Phase C Instructions
 

--- a/.github/scripts/tests/verbatim-block-lint.test.sh
+++ b/.github/scripts/tests/verbatim-block-lint.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Unit tests for verbatim-block-lint.sh (issue #767)
+#
+# Covers three required cases per the acceptance criteria:
+#   (a) clean repo passes with exit 0
+#   (b) a drifted verbatim copy fails naming the specific file/block
+#   (c) a missing copy file fails
+# Plus a bonus case:
+#   (d) a missing block within a copy file fails
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LINT="${REPO_ROOT}/.github/scripts/verbatim-block-lint.sh"
+
+TMP_ROOT=$(mktemp -d -t verbatim-block-lint.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+case_num=0
+
+make_fixture() {
+  local dir="$1"
+  mkdir -p \
+    "$dir/.claude/rules" \
+    "$dir/.claude/skills/subagent" \
+    "$dir/.claude/skills/pr-monitor-and-manage"
+  cp "$REPO_ROOT/.claude/rules/safety.md" "$dir/.claude/rules/"
+  cp "$REPO_ROOT/.claude/rules/skill-first.md" "$dir/.claude/rules/"
+  cp "$REPO_ROOT/.claude/skills/subagent/SKILL.md" \
+     "$dir/.claude/skills/subagent/"
+  cp "$REPO_ROOT/.claude/skills/pr-monitor-and-manage/SKILL.md" \
+     "$dir/.claude/skills/pr-monitor-and-manage/"
+}
+
+expect() {
+  local name="$1" want="$2" want_re="$3"; shift 3
+  case_num=$(( case_num + 1 ))
+  local dir="${TMP_ROOT}/case${case_num}"
+  make_fixture "$dir"
+  ( cd "$dir" && "$@" )
+
+  local out got
+  out=$(cd "$dir" && bash "$LINT" 2>&1) && got=0 || got=$?
+
+  if (( got != want )); then
+    echo "FAIL — ${name}: expected exit ${want}, got ${got}"
+    echo "$out" | sed 's/^/       /'
+    failures=$(( failures + 1 ))
+    return
+  fi
+
+  if ! grep -qE "$want_re" <<< "$out"; then
+    echo "FAIL — ${name}: exit ${got} as expected, but output did not match /${want_re}/"
+    echo "$out" | sed 's/^/       /'
+    failures=$(( failures + 1 ))
+    return
+  fi
+
+  echo "ok   — ${name}"
+}
+
+noop() { :; }
+
+# (a) Clean repo passes
+expect "well-formed repo passes" 0 'verbatim-block-lint: OK' noop
+
+# (b) Drifted verbatim copy fails naming the file and block
+expect "drifted MINDSET in subagent SKILL.md fails naming file and block" 1 \
+  'MINDSET.*drifted|drifted.*MINDSET' \
+  sed -i.bak 's/capability ladder/DRIFTED ladder/' \
+    .claude/skills/subagent/SKILL.md
+
+# (c) Missing copy file fails
+expect "missing copy file fails" 1 \
+  'Required file not found' \
+  rm -f .claude/skills/subagent/SKILL.md
+
+# (d) Missing block within a copy file fails
+expect "missing SKILLS block in subagent SKILL.md fails" 1 \
+  'Missing SKILLS|SKILLS.*not found' \
+  sed -i.bak 's/^SKILLS: /REMOVED: /' \
+    .claude/skills/subagent/SKILL.md
+
+# Final: real repo conformance
+if (cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1); then
+  echo "ok   — real repo conformance is intact"
+else
+  echo "FAIL — lint does not pass against the real repo"
+  (cd "$REPO_ROOT" && bash "$LINT" 2>&1 | sed 's/^/       /') || true
+  failures=$(( failures + 1 ))
+fi
+
+if (( failures > 0 )); then
+  echo "verbatim-block-lint.test: ${failures} failure(s)"
+  exit 1
+fi
+
+echo "OK: verbatim-block-lint tests passed (${case_num} fixtures)"

--- a/.github/scripts/verbatim-block-lint.sh
+++ b/.github/scripts/verbatim-block-lint.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Lint verbatim SAFETY/MINDSET/SKILLS block conformance across declared copies (issue #767).
+#
+# Validates that every declared verbatim copy of a canonical block is byte-identical
+# to the canonical block extracted from its rule file.
+#
+# Canonical sources:
+#   SAFETY:  → .claude/rules/safety.md
+#   MINDSET: → .claude/rules/safety.md
+#   SKILLS:  → .claude/rules/skill-first.md
+#
+# Verbatim-copy surfaces (byte-compared):
+#   .claude/skills/subagent/SKILL.md
+#   .claude/skills/pr-monitor-and-manage/SKILL.md
+#
+# Paraphrased surfaces (out of scope for byte comparison — intentionally excluded):
+#   .claude/agents/README.md
+#   .claude/agents/phase-a-fixer.md
+#   .claude/agents/phase-b-reviewer.md
+#   .claude/agents/phase-c-merger.md
+#   .claude/agents/pm-worker.md
+#   These files carry abbreviated/reworded versions of the blocks as prompt examples
+#   and cannot be byte-compared without false positives.
+#
+# Extraction: each block is delimited by its marker line (^BLOCK:) as the start
+# anchor and the next line that is exactly ``` as the end anchor (excluded). This
+# works uniformly for the canonical rule files (inside ```text…``` fences) and for
+# the copy files that use the same fence format.
+#
+# Companion to rule-lint.sh / chip-model-guard-lint.sh. Run from repo root.
+# Output uses GitHub Actions annotations. Exits 1 on any error.
+# Compatible with bash 3.2+ (no associative arrays).
+
+set -euo pipefail
+
+errors=0
+
+usage() {
+  cat <<'EOF'
+Usage: .github/scripts/verbatim-block-lint.sh
+
+  Verifies SAFETY/MINDSET/SKILLS verbatim blocks have not drifted from canonical.
+  No options. Run from the repo root. Exits 1 on any error.
+EOF
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "::error::Unknown argument: $1"
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# ---------------------------------------------------------------------------
+# Canonical source map: block name → canonical rule file (bash 3.2 compatible).
+# One-line change to remap a block to a different canonical source.
+# ---------------------------------------------------------------------------
+canonical_src() {
+  local block="$1"
+  case "$block" in
+    SAFETY|MINDSET) printf '%s\n' ".claude/rules/safety.md" ;;
+    SKILLS)         printf '%s\n' ".claude/rules/skill-first.md" ;;
+    *) printf '::error::Internal error: no canonical source registered for block %s\n' "$block" >&2
+       return 1 ;;
+  esac
+}
+
+# All distinct canonical source files (for the pre-flight existence check).
+CANONICAL_FILES=(
+  ".claude/rules/safety.md"
+  ".claude/rules/skill-first.md"
+)
+
+# ---------------------------------------------------------------------------
+# Verbatim-copy surface list: "BLOCK|copy_file" pairs.
+# One-line change to add or remove a copy surface.
+# ---------------------------------------------------------------------------
+VERBATIM_COPIES=(
+  "SAFETY|.claude/skills/subagent/SKILL.md"
+  "MINDSET|.claude/skills/subagent/SKILL.md"
+  "SKILLS|.claude/skills/subagent/SKILL.md"
+  "SAFETY|.claude/skills/pr-monitor-and-manage/SKILL.md"
+  "MINDSET|.claude/skills/pr-monitor-and-manage/SKILL.md"
+  "SKILLS|.claude/skills/pr-monitor-and-manage/SKILL.md"
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+require_file() {
+  local f="$1"
+  if [[ ! -f "$f" ]]; then
+    echo "::error file=${f}::Required file not found"
+    errors=$(( errors + 1 ))
+    return 1
+  fi
+  return 0
+}
+
+# Extract a verbatim block from a file.
+# Arguments: BLOCK_MARKER  FILE
+# Output: all lines from the first line matching ^BLOCK_MARKER: through all
+# subsequent lines up to (but NOT including) the next line that is exactly ```.
+# Returns nothing and exits non-zero if the block is not found.
+extract_block() {
+  local marker="$1" file="$2"
+  awk -v m="^${marker}:" '
+    !found && $0 ~ m { found = 1 }
+    found {
+      if ($0 == "```") { exit }
+      print
+    }
+  ' "$file"
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight: verify canonical source files exist
+# ---------------------------------------------------------------------------
+for cf in "${CANONICAL_FILES[@]}"; do
+  require_file "$cf" || true
+done
+
+# ---------------------------------------------------------------------------
+# Main: compare each declared verbatim copy against its canonical block
+# ---------------------------------------------------------------------------
+for entry in "${VERBATIM_COPIES[@]}"; do
+  block="${entry%%|*}"
+  copy_file="${entry##*|}"
+
+  # Guard against missing copy file
+  require_file "$copy_file" || continue
+
+  # Resolve canonical source file
+  canon_file=""
+  RC=0; canon_file="$(canonical_src "$block")" || RC=$?
+  if (( RC != 0 )) || [[ -z "$canon_file" ]]; then
+    echo "::error::Internal error: no canonical source registered for block ${block}"
+    errors=$(( errors + 1 ))
+    continue
+  fi
+
+  # Guard against missing canonical file (already checked above, but be safe)
+  if [[ ! -f "$canon_file" ]]; then
+    continue  # error already recorded above
+  fi
+
+  # Extract canonical block
+  canonical_block="$(extract_block "$block" "$canon_file")"
+  if [[ -z "$canonical_block" ]]; then
+    echo "::error file=${canon_file}::${block}: block not found in canonical source ${canon_file}"
+    errors=$(( errors + 1 ))
+    continue
+  fi
+
+  # Extract block from copy file
+  copy_block="$(extract_block "$block" "$copy_file")"
+  if [[ -z "$copy_block" ]]; then
+    echo "::error file=${copy_file}::Missing ${block}: block not found in declared copy ${copy_file}"
+    errors=$(( errors + 1 ))
+    continue
+  fi
+
+  # Byte-compare
+  RC=0
+  diff_out="$(diff <(printf '%s\n' "$canonical_block") <(printf '%s\n' "$copy_block") 2>&1)" || RC=$?
+  if (( RC != 0 )); then
+    echo "::error file=${copy_file}::${block} block has drifted from canonical (${canon_file})"
+    printf '%s\n' "$diff_out" | sed 's/^/  /'
+    errors=$(( errors + 1 ))
+  fi
+done
+
+if (( errors > 0 )); then
+  echo "verbatim-block-lint: ${errors} error(s) found"
+  exit 1
+fi
+
+echo "verbatim-block-lint: OK (${#VERBATIM_COPIES[@]} copy surfaces)"

--- a/.github/workflows/rule-lint.yml
+++ b/.github/workflows/rule-lint.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Run skill-catalog-lint
         run: bash .github/scripts/skill-catalog-lint.sh
+
+      - name: Run verbatim-block-lint
+        run: bash .github/scripts/verbatim-block-lint.sh


### PR DESCRIPTION
## Summary

- Adds `verbatim-block-lint.sh`: extracts canonical SAFETY/MINDSET/SKILLS blocks from rule files via awk fence-boundary anchoring and byte-compares every declared verbatim copy surface
- Adds `verbatim-block-lint.test.sh`: 4 fixture cases (clean pass, drifted copy, missing file, missing block) + real-repo conformance; auto-discovered by `hook-scripts.yml`
- Wires lint into CI via new step in `rule-lint.yml` (inherits the required-status gate; `rule-lint.sh` is config-protected per `config-protection.py`, so the step belongs in the workflow per its own comment — issue #591)
- Fixes drift found in `subagent/SKILL.md`: SAFETY block had different wording and was missing 3 lines (secrets/TLS/packages); wraps all three blocks in \`\`\`text fences so the awk extractor works uniformly

**Drift found and fixed:** `subagent/SKILL.md` SAFETY block was drifted — different wording, 3 lines missing. `pmm/SKILL.md` was already canonical, no changes needed.

**Note on rule-lint.sh wiring:** `config-protection.py` blocks all writes to `.github/scripts/rule-lint.sh`. The new lint step is added directly to `rule-lint.yml` instead, which the workflow's own comment explicitly directs: _"New doc lints belong here as steps so they inherit that gate (issue #591)"_.

Closes #767

## Test plan

- [x] `verbatim-block-lint.sh` exits 0 against the real repo (6 copy surfaces checked)
- [x] `verbatim-block-lint.sh` exits 1 when a block drifts, naming the file and block in the error
- [x] `verbatim-block-lint.sh` exits 1 when a copy file is missing
- [x] `verbatim-block-lint.sh` exits 1 when a declared block is absent from a copy file
- [x] `verbatim-block-lint.test.sh` passes all 4 fixture cases + real-repo conformance
- [x] `verbatim-block-lint.test.sh` auto-discovered by `hook-scripts.yml` (no workflow edit for test wiring)
- [x] Wired into CI: `rule-lint.yml` new "Run verbatim-block-lint" step; `bash .github/scripts/rule-lint.sh` still prints `rule-lint: OK`
- [x] `subagent/SKILL.md` SAFETY block now byte-matches canonical (`.claude/rules/safety.md`)
- [x] `subagent/SKILL.md` MINDSET block now byte-matches canonical (`.claude/rules/safety.md`)
- [x] `subagent/SKILL.md` SKILLS block now byte-matches canonical (`.claude/rules/skill-first.md`)
- [x] `pmm/SKILL.md` all three blocks already canonical — no changes, lint passes