### PR TITLE
feat(#769): make zero-coverage local review loud at push time

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -3,5 +3,6 @@
 Cursor auto-memory normally lives under `~/.claude/projects/*/memory/`. This repo tracks durable notes that belong in git.
 
 - [feedback_bugbot_auto_trigger_unreliable.md](feedback_bugbot_auto_trigger_unreliable.md) — Always post `@cursor review` on every PR push (CI + `/fixpr`); BugBot auto-trigger is unreliable; per-seat cost.
+- [feedback_review_clis_down_app_independent.md](feedback_review_clis_down_app_independent.md) — Both CLIs can be simultaneously unavailable (CR rate-limited + CodeAnt not installed), producing `none` coverage; surface loudly in-thread; GitHub App reviewers are unaffected and still gate the merge.
 - [skill_usage_telemetry.md](skill_usage_telemetry.md) — `skill-usage.log` / `skill-usage.csv` live under `~/.claude/`; use `skill-usage-report.sh` for rollups; never log in skills worktree.
 - [token_efficiency_verbosity.md](token_efficiency_verbosity.md) — token burn is structural (fixed context, repetition, fan-out), not stylistic; routine status = one line; playbook in `reference/token-efficiency-audit-2026-07.md`.

--- a/.claude/memory/feedback_review_clis_down_app_independent.md
+++ b/.claude/memory/feedback_review_clis_down_app_independent.md
@@ -1,0 +1,19 @@
+---
+name: Review CLIs down ≠ App reviewers down
+description: When both local CLIs are unavailable, GitHub App reviewers are unaffected — but the zero-coverage state must be surfaced loudly, not silently
+type: feedback
+---
+
+# Review CLIs down ≠ App reviewers down
+
+During PR #763, both local review CLIs were unavailable simultaneously: CodeRabbit CLI returned `{"type":"error","errorType":"rate_limit"}` (OSS quota exhausted) and CodeAnt CLI was not installed (`codeant: command not found`). The both-CLIs-down → self-review fallback ran correctly per `cr-local-review.md`, but the push proceeded with the only signal being a freeform line in the PR body — invisible unless a human happened to read it. GitHub App reviewers then caught a High-severity bug the local layer would plausibly have caught.
+
+**Durable lessons:**
+
+1. **CLI quotas are independent of App reviewer quotas.** A rate-limited or absent CodeRabbit/CodeAnt CLI has zero effect on the CodeRabbit GitHub App or CodeAnt GitHub App. Both Apps continue reviewing PRs normally while their CLIs are dark. A capped CLI never blocks a merge — the App still gates it.
+
+2. **Zero-coverage is a distinct state that must be surfaced loudly.** When both CLIs are unavailable (`coverage: none`), the local review layer contributed nothing while reporting "handled". The fix (Issue #769): classify coverage as `both | cr-only | codeant-only | none` and print `[COVERAGE] none — both CLIs unavailable, self-review only` in-thread before the push decision, plus a labeled line in the PR body. This is never a merge blocker — it is visibility only.
+
+3. **Self-review is risk-reduction, not coverage.** A self-review exits the local loop correctly per the rules but never satisfies the GitHub merge gate. It should be surfaced in-thread, not only as a footnote in the PR body.
+
+**Provenance:** Issue #769, PR #763 incident; related issues #642 (CodeAnt false-clean on API failure), #643 (403 entitlement), #663 (CodeAnt 403 re-auth advice).

--- a/.claude/reference/handoff-file-schema.json
+++ b/.claude/reference/handoff-file-schema.json
@@ -15,5 +15,6 @@
   "files_changed": ["src/foo.ts", "src/bar.ts"],
   "push_timestamp": "2026-03-24T17:00:00Z",
   "stale_bot_reviews_dismissed": ["987654321"],
-  "notes": "CR had 3 findings, all fixed. 1 dismissed as false positive."
+  "local_review_coverage": "none",
+  "notes": "CR had 3 findings, all fixed. 1 dismissed as false positive. Local review coverage: none — CR rate-limited, CodeAnt not installed."
 }

--- a/.claude/reference/local-review-cli-failure-modes.md
+++ b/.claude/reference/local-review-cli-failure-modes.md
@@ -146,6 +146,23 @@ dropped CLI for the session — note it in the PR body; do not retry more than o
 Related: a CodeRabbit *GitHub* check-run can report `success` while its description says
 "Review rate limited" — read the description, not the state.
 
+## Coverage enum — mapping failure states
+
+`cr-local-review.md` defines coverage as `both | cr-only | codeant-only | none`. A CLI contributes to coverage **only** when it produced a verified-successful clean pass. Failures map as:
+
+| Failure state | Coverage contribution |
+|---|---|
+| CodeRabbit `rate_limit` NDJSON error record | CR **not covered** |
+| CodeRabbit `type: "error"` (any `errorType`) | CR **not covered** |
+| CodeRabbit emits only `review_context`/`status` records with no `review` or finding records | CR **not covered** |
+| CodeAnt stderr API Error / 403 daily-cap | CodeAnt **not covered** |
+| CodeAnt `meta.capped == true` (15-file cap) | CodeAnt **not covered** (partial coverage is not full coverage) |
+| CodeAnt `command not found` / not installed | CodeAnt **not covered** |
+| CodeAnt false-clean (stderr error, stdout `{"issues":[]}`) | CodeAnt **not covered** |
+| Either CLI hangs >2 min or errors twice (dropped) | That CLI **not covered** |
+
+Enforcement ownership stays in `cr-local-review.md`. This table only maps failure appearances to the enum.
+
 ## CodeAnt auth storage
 
 `codeant login` is a browser flow (prints a URL, polls every 10s, 10-minute timeout) and

--- a/.claude/rules/cr-local-review.md
+++ b/.claude/rules/cr-local-review.md
@@ -52,7 +52,10 @@ Never add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or equival
 - Per CLI: hangs for more than **2 minutes** or errors out twice → drop that CLI for the session and note it in the PR body. Preserve any findings it already emitted — the remaining CLI gates only after those are resolved or explicitly waived in the PR body. Do not retry a failed CLI more than once.
 - If both CLIs are down, run a **self-review** instead (see self-review fallback rules).
 
+**Coverage classification (determine before every push):** Based on which CLIs produced a verified-successful clean pass (not merely exit 0, applying the false-clean checks above), classify as one of: `both` (both passed) | `cr-only` | `codeant-only` | `none` (both unavailable — self-review only). A rate-limited, stderr-erroring, binary-absent, or no-review-records CLI counts as **not covered** for that CLI. Coverage is visibility-only and never feeds the merge gate (`cr-merge-gate.md`). Failure-state-to-enum mapping: `.claude/reference/local-review-cli-failure-modes.md`.
+
 ### Exit criteria
 
 - **One verified-successful clean pass on both CLIs** (or on the surviving CLI + PR-body note; one clean self-review if both are unavailable). "No findings" alone is not a clean pass.
+- **Determine and record coverage** (see Timeout & fallback above) before committing/pushing. Surface `none` in-thread and in the PR body.
 - Once clean, **immediately** commit, push, create/update the PR (`Closes #N` + Test Plan checkboxes), and enter `cr-github-review.md`. Local review never satisfies `cr-merge-gate.md`.

--- a/.claude/rules/cr-local-review.md
+++ b/.claude/rules/cr-local-review.md
@@ -57,5 +57,5 @@ Never add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or equival
 ### Exit criteria
 
 - **One verified-successful clean pass on both CLIs** (or on the surviving CLI + PR-body note; one clean self-review if both are unavailable). "No findings" alone is not a clean pass.
-- **Determine and record coverage** (see Timeout & fallback above) before committing/pushing. Surface `none` in-thread and in the PR body.
+- **Determine and record coverage** (see Timeout & fallback above) before committing/pushing. Surface any degraded state (`none`, `cr-only`, or `codeant-only`) in-thread and in the PR body.
 - Once clean, **immediately** commit, push, create/update the PR (`Closes #N` + Test Plan checkboxes), and enter `cr-github-review.md`. Local review never satisfies `cr-merge-gate.md`.

--- a/.claude/skills/go-on/SKILL.md
+++ b/.claude/skills/go-on/SKILL.md
@@ -106,6 +106,7 @@ $CR_BIN review --agent
   BASE=$(gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null || echo main)
   git diff "$BASE"...HEAD
   ```
+- **After the local review loop completes**, classify and print coverage: `[COVERAGE] <level> — <reason>` (per `cr-local-review.md` "Coverage classification": `both | cr-only | codeant-only | none`). This flow reaches at most `cr-only` or `none`. For `none`, the line is mandatory before any push.
 
 ---
 
@@ -153,7 +154,7 @@ Pipe with `printf '%s'`, never `echo` — zsh's builtin `echo` interprets the es
     ```bash
     gh issue view $ISSUE_NUM --json title,body 2>/dev/null
     ```
-  - Create the PR with a proper body (including `Closes #N` if issue was found) and a Test plan section. After creation, capture the PR number:
+  - Create the PR with a proper body (including `Closes #N` if issue was found) and a Test plan section. Include a `**Local review coverage:** <level>` labeled line when coverage is anything other than `both` (mandatory for `none` and single-CLI cases). After creation, capture the PR number:
     ```bash
     PR_NUM=$(gh pr view --json number --jq '.number')
     ```

--- a/.claude/skills/go-on/SKILL.md
+++ b/.claude/skills/go-on/SKILL.md
@@ -143,7 +143,7 @@ PR_NUM=$(printf '%s' "$PR_JSON" | jq -r '.number // empty')
 
 Pipe with `printf '%s'`, never `echo` — zsh's builtin `echo` interprets the escape sequences in the PR body and corrupts the JSON, so `jq` errors and `PR_NUM` comes back empty, which reads as "no PR exists" (issue #574).
 
-- If a PR exists and is open: `[DONE]` — PR #$PR_NUM exists.
+- If a PR exists and is open: `[DONE]` — PR #$PR_NUM exists. Additionally, if coverage is not `both`, update (or add) the `**Local review coverage:**` line in the PR body so it reflects the current run's classification — fetch the PR body, replace the line if present or append it if missing, then `gh pr edit "$PR_NUM" --body "$UPDATED_BODY"`.
 - If no PR exists: `[ACTION]` — Create one.
   - Look for an issue number from the branch name (pattern: `issue-N-*`):
     ```bash

--- a/.claude/skills/go-on/SKILL.md
+++ b/.claude/skills/go-on/SKILL.md
@@ -143,7 +143,7 @@ PR_NUM=$(printf '%s' "$PR_JSON" | jq -r '.number // empty')
 
 Pipe with `printf '%s'`, never `echo` — zsh's builtin `echo` interprets the escape sequences in the PR body and corrupts the JSON, so `jq` errors and `PR_NUM` comes back empty, which reads as "no PR exists" (issue #574).
 
-- If a PR exists and is open: `[DONE]` — PR #$PR_NUM exists. Additionally, if coverage is not `both`, update (or add) the `**Local review coverage:**` line in the PR body so it reflects the current run's classification — fetch the PR body, replace the line if present or append it if missing, then `gh pr edit "$PR_NUM" --body "$UPDATED_BODY"`.
+- If a PR exists and is open: `[DONE]` — PR #$PR_NUM exists. Additionally, always update the `**Local review coverage:**` line in the PR body: if coverage is `both`, remove any existing label (clearing stale degraded markers from prior runs); if coverage is degraded, replace the line if present or append it if missing. Fetch the PR body, apply the change, then `gh pr edit "$PR_NUM" --body "$UPDATED_BODY"`.
 - If no PR exists: `[ACTION]` — Create one.
   - Look for an issue number from the branch name (pattern: `issue-N-*`):
     ```bash

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -308,10 +308,12 @@ isn't a fuzzy match. Full rules: .claude/rules/skill-first.md.
      --arg now "$NOW" \
      --argjson files '["{list of files you changed}"]' \
      --arg notes "{brief summary of what was done}" \
+     --arg coverage "{both|cr-only|codeant-only|none}" \
      '{schema_version:"1.0",pr_number:$pr,head_sha:$sha,reviewer:"cr",
        phase_completed:"A",created_at:$now,findings_fixed:[],
        findings_dismissed:[],threads_replied:[],threads_resolved:[],
-       files_changed:$files,push_timestamp:$now,notes:$notes}')"
+       files_changed:$files,push_timestamp:$now,notes:$notes,
+       local_review_coverage:$coverage}')"
    "$HANDOFF_STATE_SH" --create "{PR_NUMBER}" "$HANDOFF_JSON"
    ```
 9. Print the Structured Exit Report as your FINAL output:

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -280,11 +280,13 @@ isn't a fuzzy match. Full rules: .claude/rules/skill-first.md.
    - Run all available CLIs again. Repeat until each remaining CLI has one clean pass.
    - If a CLI hangs >2 minutes or errors twice, drop it for the session, resolve or explicitly waive its pre-drop findings in the PR body, gate on the remaining one, and note the drop.
    - If both are down, do one self-review and note it in the PR body — it exits the local loop but never satisfies the GitHub merge gate.
+   - **Before committing/pushing**, classify coverage: `both | cr-only | codeant-only | none` (per `cr-local-review.md` "Coverage classification"). Print `[COVERAGE] <level> — <reason>` in-thread. For `none`, this line is mandatory and must be visible before the push.
 5. Commit all changes in ONE commit.
 6. Push the branch.
 7. Create the PR via `gh pr create` with:
    - `Closes #{NUMBER}` in the body
    - A **Test plan** section with acceptance criteria checkboxes from the issue
+   - A `**Local review coverage:** <level>` labeled line (e.g. `**Local review coverage:** none — both CLIs unavailable, self-review only`). This is mandatory for `none` and `cr-only`/`codeant-only`; omit only when coverage is `both`.
 8. Write the handoff file via `handoff-state.sh --create` so the write is serialized under
    the shared state-lock.sh advisory lock (issue #682). Never write inline with
    `jq … > tmp && mv tmp` — that bypasses the lock.

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -280,7 +280,7 @@ isn't a fuzzy match. Full rules: .claude/rules/skill-first.md.
    - Run all available CLIs again. Repeat until each remaining CLI has one clean pass.
    - If a CLI hangs >2 minutes or errors twice, drop it for the session, resolve or explicitly waive its pre-drop findings in the PR body, gate on the remaining one, and note the drop.
    - If both are down, do one self-review and note it in the PR body — it exits the local loop but never satisfies the GitHub merge gate.
-   - **Before committing/pushing**, classify coverage: `both | cr-only | codeant-only | none` (per `cr-local-review.md` "Coverage classification"). Print `[COVERAGE] <level> — <reason>` in-thread. For `none`, this line is mandatory and must be visible before the push.
+   - **Before committing/pushing**, classify coverage: `both | cr-only | codeant-only | none` (per `cr-local-review.md` "Coverage classification"). Print `[COVERAGE] <level> — <reason>` in-thread. For any degraded state (`none`, `cr-only`, or `codeant-only`), this line is mandatory and must be visible before the push.
 5. Commit all changes in ONE commit.
 6. Push the branch.
 7. Create the PR via `gh pr create` with:

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -60,11 +60,12 @@ Autonomy does not mean filing blind: every candidate goes through the body-aware
 | **Terse** | *(default)* | Two concise blocks — **Merged** (≤3 sentences) and **Follow-ups** (≤3 sentences, or "No follow-ups opened.") — plus a one-line lessons ack and, only when the sweep left decisions pending, a one-line verdict. Per-phase narration is suppressed. |
 | **Verbose** | `--verbose` | The full report: per-cycle recovery heartbeats, the Session Lessons block, and the multi-section "Wrap-Up Complete" report (Issues filed, Filings suppressed as duplicates, Session sweep, Verdict, Lessons). |
 
-**Verbosity is additive and human-facing only.** Every phase — inference, the merge-gate recovery loop, `/fixpr` delegation, the follow-up + full-session sweep, and the lessons/memory write — executes **identically** in both modes; only narration differs (the `babysit-pr --silent` "work continues, output suppressed" model). Three things always print regardless of mode:
+**Verbosity is additive and human-facing only.** Every phase — inference, the merge-gate recovery loop, `/fixpr` delegation, the follow-up + full-session sweep, and the lessons/memory write — executes **identically** in both modes; only narration differs (the `babysit-pr --silent` "work continues, output suppressed" model). Four things always print regardless of mode:
 
 - **State-changing blockers and stop conditions** — a merge that can't proceed, `CONFLICTING`, human `CHANGES_REQUESTED`, no PR found, the recovery cap — surface as a short one-line reason even in terse mode (Step 4.3 **Blocker path**). Terseness never swallows a blocker.
 - **The `[INFERRED]` merge-safety checkpoint** (Step 1.1). It is the user's only catch point for a mis-inferred **merge**, so it is a safety guardrail rather than phase chatter — it prints in both modes (it fires only on the inference path, never on the normal branch path, so it barely affects terseness).
 - **The CLAUDE.md 5-minute heartbeat** during long `/fixpr` waits. Terse mode suppresses the *routine* per-cycle recovery heartbeat, but never the obligation to break silence during a long-running operation.
+- **`[COVERAGE]` when local review was degraded** (`cr-only`, `codeant-only`, or `none`). When the session-sweep or per-PR detection surfaces that the pre-push local review ran with less than full CLI coverage, emit one line in the follow-up report: e.g. `[COVERAGE] none — both CLIs unavailable, self-review only`. Full coverage (`both`) is terse-suppressible routine state.
 
 When `/wrap` is invoked by a phase-C subagent, the machine **`EXIT_REPORT`** block (per `phase-protocols.md`) is emitted **identically regardless of verbosity** — `--verbose` governs only the prose report, never the structured exit contract.
 


### PR DESCRIPTION
## Summary

Closes #769

When both local review CLIs are unavailable (e.g. CR rate-limited + CodeAnt not installed), the local review layer was silently degraded — only a freeform line in the PR body indicated it. GitHub App reviewers on PR #763 caught a High-severity bug the local layer would plausibly have caught, but the local gate contributed nothing while appearing to report "handled."

This PR introduces:
- A formal `both | cr-only | codeant-only | none` coverage enum derived from verified-clean CLI passes (not exit-0 alone)
- A mandatory `[COVERAGE]` in-thread signal before push when coverage is `none` (or degraded)
- A labeled `**Local review coverage:**` line in the PR body for any non-`both` case
- Coverage as a fourth always-print item in `/wrap`'s terse output mode (alongside blockers, `[INFERRED]`, and heartbeat)
- Coverage threading through the `subagent`, `go-on` push flows
- `local_review_coverage` field in the handoff schema (visibility-only, never feeds merge gate)
- Durable memory lesson documenting CLI/App quota independence

## Distinct from Issue #663

Issue #663 covered the CodeAnt CLI's misleading re-auth advice on a 403 (a specific error response). Issue #769 is the broader case where *neither* CLI produces any review at all — zero coverage. No reconciliation action needed; #663 is closed.

## Changes

| File | Change |
|------|--------|
| `.claude/rules/cr-local-review.md` | Adds coverage enum + "Coverage classification" paragraph in Timeout & fallback; mandates surfacing `none` in Exit criteria |
| `.claude/reference/local-review-cli-failure-modes.md` | Adds coverage-enum mapping table; adds CR-emits-only-status-records row |
| `.claude/skills/wrap/SKILL.md` | Adds `[COVERAGE]` as 4th always-print item in terse mode |
| `.claude/skills/subagent/SKILL.md` | Phase A: coverage print before push + labeled PR-body line |
| `.claude/skills/go-on/SKILL.md` | Step 2: coverage print; Step 4: labeled PR-body line |
| `.claude/reference/handoff-file-schema.json` | Adds `local_review_coverage` field |
| `.claude/memory/feedback_review_clis_down_app_independent.md` | New durable lesson |
| `.claude/memory/MEMORY.md` | Index pointer for new memory file |

**Local review coverage: none** — CR CLI hung >2 min (dropped per `cr-local-review.md`), CodeAnt CLI not installed. Self-review performed; no issues found. GitHub App reviewers (CodeRabbit, CodeAnt) are unaffected and will review this PR normally. The irony of this fix being pushed under exactly the zero-coverage condition it addresses is duly noted.

## Test plan

- [x] Zero-coverage push produces the visible marker: `cr-local-review.md` mandates `[COVERAGE] none — both CLIs unavailable, self-review only` in-thread before push, and a `**Local review coverage:**` labeled line in the PR body
- [x] Single-CLI coverage (`cr-only` or `codeant-only`) does NOT trigger `none` treatment — it emits an advisory line only
- [x] Coverage is machine-checkable: the `**Local review coverage:**` PR-body label is a stable, parseable string; the handoff `local_review_coverage` field is a closed enum value
- [x] Rule-lint passes: corpus at 11,095 words (ratchet cap 11,749, headroom 654)
- [x] All doc lints green: `rule-lint.sh`, `skill-catalog-lint.sh`, `verbatim-block-lint.sh`
- [x] 142 Python unit tests pass; bash hook test suite passes
- [x] `local-review-cli-failure-modes.md` coverage table maps all documented failure states including CR-emits-only-status-records (no `review` records = not covered)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added explicit local review coverage reporting with `both`, `cr-only`, `codeant-only`, and `none` statuses.
  - Coverage status is now shown in workflow output and recorded in pull request descriptions when review coverage is incomplete.
  - Added handoff metadata to preserve local review coverage state.

- **Documentation**
  - Clarified how review failures affect coverage classification.
  - Documented that unavailable local review tools should be surfaced prominently and do not replace required app-based merge reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
