### PR TITLE
feat(#803): hard 20-minute ceiling on chat silence while background work runs

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -111,6 +111,24 @@ Replace `/absolute/path/to/claude-code-config` with the actual path to your clon
 
 - All hook scripts must be executable: `chmod +x .claude/hooks/silence-detector*.sh`
 
+## bgwork-ceiling-arm.sh + bgwork-ceiling-guard.sh
+
+Puts a hard ceiling on chat silence while background work runs (issue #803). The pair above enforces the 5-minute heartbeat *within* a turn; this pair covers what happens *after* one ends — a thread that spawns a subagent, ends its turn, and waits makes no tool calls, so no PostToolUse hook can ever fire for it.
+
+**How it works:** the measurement is not re-implemented. `/tmp/claude-heartbeat-$SESSION_ID` already means "last user-visible message"; what these hooks add is an observer of it that can force a turn, plus a gate making that observer non-optional.
+
+- **`bgwork-ceiling-arm.sh`** (PostToolUse, all tools): records background work — an `Agent` spawn, a `Workflow`, a `Monitor`, or a `Bash` call with `run_in_background: true` — and, while the ceiling is unarmed, injects the exact arming call into context. Arming is recognised by the `--tick` sentinel in the command text, so the ceiling watch is never miscounted as new background work. **Advisory only.**
+- **`bgwork-ceiling-guard.sh`** (Stop): returns `decision: block` when background work is in flight and the ceiling is unarmed, so the turn cannot end silently. **This is the enforcement.** Blocking is bounded at 2 consecutive turns (`CLAUDE_BGWORK_MAX_BLOCKS`); past the bound it stands down loudly — stderr, `~/.claude/logs/bgwork-ceiling.log`, and an unguarded marker the arm hook resurfaces on every later tool call.
+
+The armed watch is a `Monitor` running `bgwork-ceiling.sh --tick` on a loop. It prints nothing unless the heartbeat file is genuinely stale, so a thread sending normal heartbeats never sees a message from it, and `persistent: true` means the ceiling is armed **once per session** rather than once per spawn.
+
+All state lives in `/tmp` markers (overridable as a set via `CLAUDE_BGWORK_MARKER_DIR`, which is what the test suites use) and in `.claude/scripts/bgwork-ceiling.sh`, which owns the ceiling duration — no rule file states it. Rationale, the `Monitor`-vs-`ScheduleWakeup`-vs-`CronCreate` call, and the derived-timing invariant: `.claude/reference/bgwork-ceiling.md`.
+
+### Prerequisites
+
+- `jq` must be installed
+- `.claude/scripts/bgwork-ceiling.sh` must be present and executable — both hooks exit 0 silently without it, so a checkout missing it degrades rather than breaks
+
 ## skill-usage-tracker.sh + skill-command-tracker.sh
 
 Records every skill invocation to `~/.claude/skill-usage.log` (and the aggregate `~/.claude/skill-usage.csv`), which `.claude/scripts/skill-usage-report.sh` rolls up.

--- a/.claude/hooks/bgwork-ceiling-arm.sh
+++ b/.claude/hooks/bgwork-ceiling-arm.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Background-work ceiling — arming half (PostToolUse hook, all tools).
+#
+# Two jobs, both driven off the tool call that just ran:
+#
+#   1. Notice that the thread started background work it will wait on — a
+#      subagent spawn, a backgrounded Bash command, a Workflow, or a Monitor —
+#      and record it via bgwork-ceiling.sh --note-started.
+#   2. While background work is in flight and the ceiling watch is NOT armed,
+#      inject the exact arming call into the agent's context, so arming happens
+#      as part of the same step rather than as a separate thing to remember.
+#
+# Arming itself is recognised by the `--tick` sentinel in the command text, so
+# the ceiling watch is never miscounted as new background work (which would
+# leave the guard permanently unsatisfiable).
+#
+# The companion Stop hook (bgwork-ceiling-guard.sh) is what makes this
+# non-optional: this hook only advises, it cannot stop a turn from ending.
+
+STDIN_JSON=$(cat)
+
+emit_context() {
+  jq -n --arg message "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: $message
+    }
+  }'
+}
+
+json_field() {
+  printf '%s' "$STDIN_JSON" | jq -r "$1 // empty" 2>/dev/null
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CEILING_SH="${SCRIPT_DIR%/hooks}/scripts/bgwork-ceiling.sh"
+[[ -x "$CEILING_SH" ]] || exit 0
+
+SESSION_ID=$(json_field '.session_id')
+SESSION_ID="${SESSION_ID:-${CLAUDE_SESSION_ID:-default}}"
+
+TOOL_NAME=$(json_field '.tool_name')
+COMMAND=$(json_field '.tool_input.command')
+BACKGROUNDED=$(json_field '.tool_input.run_in_background')
+
+# --- 1. Is this call arming the ceiling watch? -------------------------------
+# Matched on the command text rather than the tool name, so arming still
+# registers if the watch is started some other way (e.g. a backgrounded Bash).
+#
+# The match is against the WHOLE generated command, not just a `--tick`
+# substring: in this repo plenty of commands merely mention the sentinel (a
+# grep, a docs edit, a test run), and treating one of those as "armed" would
+# satisfy the Stop hook with no watch actually running — a guard defeated by
+# talking about it. Regenerating the expected command here also keeps detection
+# in step with --arm-command automatically if its shape ever changes.
+if [[ "$COMMAND" == *bgwork-ceiling.sh* ]]; then
+  EXPECTED_ARM=$("$CEILING_SH" --arm-command --session "$SESSION_ID" 2>/dev/null)
+  if [[ -n "$EXPECTED_ARM" && "$COMMAND" == *"$EXPECTED_ARM"* ]]; then
+    "$CEILING_SH" --record-armed --session "$SESSION_ID" || true
+    echo '{}'
+    exit 0
+  fi
+fi
+
+# --- 2. Did this call start background work the thread will wait on? --------
+started=0
+case "$TOOL_NAME" in
+  Agent|Workflow|Monitor)
+    started=1
+    ;;
+  Bash)
+    [[ "$BACKGROUNDED" == "true" ]] && started=1
+    ;;
+esac
+
+if (( started == 1 )); then
+  "$CEILING_SH" --note-started "$TOOL_NAME" --session "$SESSION_ID" || true
+fi
+
+# --- 3. Advise arming while in flight and unarmed ----------------------------
+if "$CEILING_SH" --check --session "$SESSION_ID"; then
+  echo '{}'
+  exit 0
+fi
+
+ARM_COMMAND=$("$CEILING_SH" --arm-command --session "$SESSION_ID" 2>/dev/null)
+if [[ -z "$ARM_COMMAND" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+MARKER_DIR="${CLAUDE_BGWORK_MARKER_DIR:-/tmp}"
+SAFE_ID="${SESSION_ID//[^[:alnum:]_.-]/_}"
+SAFE_ID="${SAFE_ID:-default}"
+
+UNGUARDED_NOTE=""
+if [[ -f "${MARKER_DIR}/claude-bgceiling-unguarded-${SAFE_ID}" ]]; then
+  UNGUARDED_NOTE="This thread is currently UNGUARDED — the Stop hook already blocked twice and stood down. Arm it now. "
+fi
+
+# The call that STARTED the work always gets the advisory — that is the step
+# arming belongs in. Every later call while still unarmed is a reminder, and
+# reminders are rate-limited so a burst of tool calls cannot replay this whole
+# paragraph into context on each one. The Stop hook, not repetition, is what
+# makes arming actually happen.
+#
+# The rate limit deliberately does NOT apply once the guard has stood down: at
+# that point the thread really is unguarded, and quietly throttling the only
+# remaining signal would be the same silent degradation this whole change
+# exists to remove (feedback_guard_must_fail_closed.md).
+ADVISED_FILE="${MARKER_DIR}/claude-bgceiling-advised-${SAFE_ID}"
+COOLDOWN_S="${CLAUDE_BGWORK_ADVISE_COOLDOWN_S:-60}"
+[[ "$COOLDOWN_S" =~ ^[0-9]+$ ]] || COOLDOWN_S=60
+
+if (( started == 0 )) && [[ -z "$UNGUARDED_NOTE" ]] && [[ -f "$ADVISED_FILE" ]]; then
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    last_advice=$(stat -f %m "$ADVISED_FILE" 2>/dev/null)
+  else
+    last_advice=$(stat -c %Y "$ADVISED_FILE" 2>/dev/null)
+  fi
+  if [[ -n "$last_advice" ]]; then
+    advice_age=$(( $(date +%s) - last_advice ))
+    # A negative age means a future-dated marker (clock rollback) — treat it as
+    # stale and re-advise rather than suppressing indefinitely.
+    if (( advice_age >= 0 && advice_age < COOLDOWN_S )); then
+      echo '{}'
+      exit 0
+    fi
+  fi
+fi
+touch "$ADVISED_FILE" 2>/dev/null || true
+
+emit_context "BACKGROUND WORK CEILING NOT ARMED. ${UNGUARDED_NOTE}This thread has background work in flight, so it can end its turn and go silent with no tool call left to warn it. Arm the ceiling in THIS step, before ending the turn: call the Monitor tool with persistent: true, description \"background-work silence ceiling\", and command: ${ARM_COMMAND} — the watch stays silent unless the thread actually goes quiet, so a thread sending normal heartbeats will never see a message from it. Do not announce the arming to the user; it is bookkeeping, not status."
+
+exit 0

--- a/.claude/hooks/bgwork-ceiling-guard.sh
+++ b/.claude/hooks/bgwork-ceiling-guard.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Background-work ceiling — enforcement half (Stop hook).
+#
+# The companion PostToolUse hook (bgwork-ceiling-arm.sh) only advises, and
+# advice is exactly what the current bug is made of: the model can end its turn
+# without arming anything and nothing notices. This hook is the turn boundary
+# where that becomes impossible — when background work is in flight and the
+# ceiling watch is unarmed, it returns `decision: block`, so the turn does not
+# end silently and the agent gets another step in which to arm it.
+#
+# Fail-closed, bounded, never silent. An unbounded block would hang the thread,
+# so consecutive blocks are capped. Past the cap the hook stands down, but it
+# stands down LOUDLY: a breach marker is written, the event is logged, and the
+# reason goes to stderr. The arm hook then resurfaces the unguarded state on
+# every subsequent tool call. A silent no-op here would re-create the very bug
+# this guard exists to close (feedback_guard_must_fail_closed.md).
+
+STDIN_JSON=$(cat)
+
+json_field() {
+  printf '%s' "$STDIN_JSON" | jq -r "$1 // empty" 2>/dev/null
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CEILING_SH="${SCRIPT_DIR%/hooks}/scripts/bgwork-ceiling.sh"
+[[ -x "$CEILING_SH" ]] || exit 0
+
+SESSION_ID=$(json_field '.session_id')
+SESSION_ID="${SESSION_ID:-${CLAUDE_SESSION_ID:-default}}"
+SAFE_ID="${SESSION_ID//[^[:alnum:]_.-]/_}"
+SAFE_ID="${SAFE_ID:-default}"
+
+MARKER_DIR="${CLAUDE_BGWORK_MARKER_DIR:-/tmp}"
+BLOCKS_FILE="${MARKER_DIR}/claude-bgceiling-blocks-${SAFE_ID}"
+BREACH_FILE="${MARKER_DIR}/claude-bgceiling-unguarded-${SAFE_ID}"
+MAX_BLOCKS="${CLAUDE_BGWORK_MAX_BLOCKS:-2}"
+[[ "$MAX_BLOCKS" =~ ^[0-9]+$ ]] || MAX_BLOCKS=2
+
+# Nothing to guard, or already armed — clear any block counter and get out of
+# the way. The counter is per-stretch-of-unarmed-work, not per-session.
+if "$CEILING_SH" --check --session "$SESSION_ID"; then
+  rm -f "$BLOCKS_FILE" 2>/dev/null || true
+  exit 0
+fi
+
+blocks=0
+if [[ -f "$BLOCKS_FILE" ]]; then
+  blocks=$(cat "$BLOCKS_FILE" 2>/dev/null)
+  [[ "$blocks" =~ ^[0-9]+$ ]] || blocks=0
+fi
+
+ARM_COMMAND=$("$CEILING_SH" --arm-command --session "$SESSION_ID" 2>/dev/null)
+
+if (( blocks >= MAX_BLOCKS )); then
+  # Stand down — but loudly, and leave evidence the arm hook keeps resurfacing.
+  printf '%s' "$(date -u +%FT%TZ)" > "$BREACH_FILE" 2>/dev/null || true
+  printf 'bgwork-ceiling-guard: STOOD DOWN after %s blocked turns — background work is in flight with NO silence ceiling armed for session %s. Chat silence in this thread is now unbounded.\n' \
+    "$blocks" "$SAFE_ID" >&2
+  log_dir="${CLAUDE_BGWORK_LOG_DIR:-$HOME/.claude/logs}"
+  mkdir -p "$log_dir" 2>/dev/null || true
+  printf '%s\t%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$SAFE_ID" "guard-stood-down" "blocks=${blocks}" \
+    >> "$log_dir/bgwork-ceiling.log" 2>/dev/null || true
+  echo '{}'
+  exit 0
+fi
+
+blocks=$(( blocks + 1 ))
+if ! printf '%s' "$blocks" > "$BLOCKS_FILE" 2>/dev/null; then
+  # Cannot count blocks -> cannot bound them. Refuse to start an unbounded
+  # block loop; surface instead. (feedback_guard_must_fail_closed.md — the
+  # failure is reported, never swallowed into a silent pass.)
+  printf 'bgwork-ceiling-guard: cannot write %s — refusing to block unbounded; background work is UNGUARDED for session %s.\n' \
+    "$BLOCKS_FILE" "$SAFE_ID" >&2
+  echo '{}'
+  exit 0
+fi
+
+REASON="Do not end this turn yet. Background work is in flight and this thread has no silence ceiling armed, so it can now go quiet indefinitely with no tool call left to warn it — the exact failure this guard exists to prevent. Arm it now: call the Monitor tool with persistent: true, description \"background-work silence ceiling\", and command: ${ARM_COMMAND} — then finish the turn as you intended. The watch stays silent unless the thread actually goes quiet, so it adds no noise to a healthy thread. Do not report the arming to the user; it is bookkeeping, not status."
+
+printf 'bgwork-ceiling-guard: blocking turn end (%s/%s) — background work in flight with no ceiling armed for session %s.\n' \
+  "$blocks" "$MAX_BLOCKS" "$SAFE_ID" >&2
+
+jq -n --arg reason "$REASON" '{decision: "block", reason: $reason}'
+exit 0

--- a/.claude/hooks/tests/bgwork-ceiling-hooks.test.sh
+++ b/.claude/hooks/tests/bgwork-ceiling-hooks.test.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Tests for the background-work silence ceiling hooks (issue #803):
+#   bgwork-ceiling-arm.sh    PostToolUse — detect background work, advise arming
+#   bgwork-ceiling-guard.sh  Stop        — fail closed when it was not armed
+#
+# Markers and logs are redirected into a temp dir, so the suite never touches
+# real session state in /tmp or ~/.claude.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ARM="$REPO_ROOT/.claude/hooks/bgwork-ceiling-arm.sh"
+GUARD="$REPO_ROOT/.claude/hooks/bgwork-ceiling-guard.sh"
+CEILING="$REPO_ROOT/.claude/scripts/bgwork-ceiling.sh"
+
+TMP_DIR="$(mktemp -d)"
+export CLAUDE_BGWORK_MARKER_DIR="$TMP_DIR/markers"
+export CLAUDE_BGWORK_LOG_DIR="$TMP_DIR/logs"
+mkdir -p "$CLAUDE_BGWORK_MARKER_DIR" "$CLAUDE_BGWORK_LOG_DIR"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+unset CLAUDE_BGWORK_CEILING_S CLAUDE_BGWORK_MAX_BLOCKS
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "ok   — $*"; }
+
+# Each block of assertions gets its own session id so markers never leak
+# between cases.
+new_sid() { printf 'bgceil-hooks-%s-%s-%s' "$$" "$RANDOM" "$1"; }
+
+run_arm() {
+  local sid="$1" tool="$2" cmd="${3:-}" bg="${4:-false}"
+  jq -nc --arg sid "$sid" --arg tool "$tool" --arg cmd "$cmd" --argjson bg "$bg" \
+    '{session_id: $sid, tool_name: $tool,
+      tool_input: ({} | if $cmd == "" then . else .command = $cmd end
+                      | if $bg then .run_in_background = true else . end)}' \
+    | bash "$ARM"
+}
+
+run_guard() {
+  printf '{"session_id":"%s","stop_hook_active":%s}' "$1" "${2:-false}" | bash "$GUARD" 2>/dev/null
+}
+
+context_of() { jq -r '.hookSpecificOutput.additionalContext // ""'; }
+started_kinds() { "$CEILING" --status --session "$1" | jq -r '.background_work | join(",")'; }
+
+# --- 1. A foreground read is not background work -----------------------------
+SID=$(new_sid readonly)
+OUT=$(run_arm "$SID" Read)
+[[ "$(printf '%s' "$OUT" | context_of)" == "" ]] || fail "a Read call should inject no context"
+[[ "$(started_kinds "$SID")" == "" ]] || fail "a Read call should not record background work"
+ok "an ordinary foreground tool call records nothing and injects nothing"
+
+# --- 2. Each background-starting tool shape is detected ----------------------
+SID=$(new_sid agent);    run_arm "$SID" Agent    >/dev/null
+[[ "$(started_kinds "$SID")" == "Agent" ]] || fail "Agent spawn should record background work"
+SID=$(new_sid workflow); run_arm "$SID" Workflow >/dev/null
+[[ "$(started_kinds "$SID")" == "Workflow" ]] || fail "Workflow should record background work"
+SID=$(new_sid monitor);  run_arm "$SID" Monitor "tail -f app.log" >/dev/null
+[[ "$(started_kinds "$SID")" == "Monitor" ]] || fail "a non-ceiling Monitor should record background work"
+SID=$(new_sid bashbg);   run_arm "$SID" Bash "sleep 600" true >/dev/null
+[[ "$(started_kinds "$SID")" == "Bash" ]] || fail "a backgrounded Bash should record background work"
+ok "Agent / Workflow / Monitor / backgrounded Bash all register as background work"
+
+# --- 3. A foreground Bash does NOT ------------------------------------------
+SID=$(new_sid bashfg)
+run_arm "$SID" Bash "ls -la" false >/dev/null
+[[ "$(started_kinds "$SID")" == "" ]] || fail "a foreground Bash should not record background work"
+ok "a foreground Bash is not treated as background work"
+
+# --- 4. The advisory names the arming call ----------------------------------
+SID=$(new_sid advise)
+CTX=$(run_arm "$SID" Agent | context_of)
+[[ "$CTX" == *"CEILING NOT ARMED"* ]] || fail "unarmed background work should inject a warning, got: '$CTX'"
+[[ "$CTX" == *"Monitor"* ]] || fail "the advisory must name the Monitor tool, got: '$CTX'"
+[[ "$CTX" == *"bgwork-ceiling.sh --tick"* ]] || fail "the advisory must carry the arm command, got: '$CTX'"
+[[ "$CTX" == *"persistent: true"* ]] || fail "the advisory must specify a persistent watch, got: '$CTX'"
+ok "the advisory carries the exact arming call, not a description of it"
+
+# --- 4b. The spawning call always advises; later reminders are rate-limited --
+SID=$(new_sid cooldown)
+[[ -n "$(run_arm "$SID" Agent | context_of)" ]] || fail "the spawning call must always advise"
+[[ -z "$(run_arm "$SID" Read | context_of)" ]] || \
+  fail "a follow-up call inside the cooldown should not replay the advisory"
+[[ -n "$(CLAUDE_BGWORK_ADVISE_COOLDOWN_S=0 run_arm "$SID" Read | context_of)" ]] || \
+  fail "the reminder should return once the cooldown lapses"
+# A second spawn is the step arming belongs in, so it advises regardless.
+[[ -n "$(run_arm "$SID" Agent | context_of)" ]] || \
+  fail "a later spawn must advise even inside the cooldown"
+ok "the spawning call always advises; follow-up reminders are rate-limited"
+
+# --- 5. Arming is recognised, and is not itself counted as background work ---
+SID=$(new_sid armmon)
+ARM_CMD=$("$CEILING" --arm-command --session "$SID")
+OUT=$(run_arm "$SID" Monitor "$ARM_CMD")
+[[ "$(printf '%s' "$OUT" | context_of)" == "" ]] || fail "arming should inject no further advice"
+[[ "$(started_kinds "$SID")" == "" ]] || \
+  fail "the ceiling watch must not be counted as background work (that would leave the gate unsatisfiable)"
+"$CEILING" --check --session "$SID" || fail "--check should pass after the ceiling Monitor is seen"
+ok "the ceiling watch registers as arming, never as new background work"
+
+# --- 5b. Merely MENTIONING the sentinel must not count as arming ------------
+# A guard that can be satisfied by talking about it is not a guard. In this
+# repo especially, commands referencing the watch are routine.
+SID=$(new_sid mention)
+run_arm "$SID" Agent >/dev/null
+for decoy in "grep -rn 'bgwork-ceiling.sh --tick' ." \
+             "bash .claude/scripts/tests/bgwork-ceiling.test.sh" \
+             "$CEILING --tick --session $SID"; do
+  run_arm "$SID" Bash "$decoy" >/dev/null
+  "$CEILING" --check --session "$SID" && \
+    fail "a command that only mentions the watch must not satisfy the gate: $decoy"
+done
+ok "mentioning the sentinel does not arm — only the generated watch command does"
+
+# --- 6. Arming is matched on the command, not the tool name -----------------
+SID=$(new_sid armbash)
+run_arm "$SID" Agent >/dev/null
+ARM_CMD=$("$CEILING" --arm-command --session "$SID")
+run_arm "$SID" Bash "$ARM_CMD" true >/dev/null
+"$CEILING" --check --session "$SID" || fail "arming via a backgrounded Bash should also satisfy --check"
+ok "arming is detected by the sentinel, whichever tool starts the watch"
+
+# --- 7. Stop hook is transparent when there is nothing to guard -------------
+SID=$(new_sid guardclean)
+OUT=$(run_guard "$SID")
+[[ "$(printf '%s' "$OUT" | jq -r '.decision // ""' 2>/dev/null)" != "block" ]] || \
+  fail "the Stop hook must not block when no background work has started"
+ok "the Stop hook is transparent when there is nothing to guard"
+
+# --- 8. Stop hook fails CLOSED: unarmed background work blocks the turn ------
+SID=$(new_sid guardblock)
+run_arm "$SID" Agent >/dev/null
+OUT=$(run_guard "$SID")
+[[ "$(printf '%s' "$OUT" | jq -r '.decision')" == "block" ]] || \
+  fail "unarmed background work must block the turn end, got: '$OUT'"
+REASON=$(printf '%s' "$OUT" | jq -r '.reason')
+[[ "$REASON" == *"bgwork-ceiling.sh --tick"* ]] || \
+  fail "the block reason must carry the arm command so the next step can act, got: '$REASON'"
+ok "the Stop hook blocks the turn when background work is in flight and unarmed"
+
+# --- 9. Blocking is bounded, and standing down is LOUD, never silent --------
+SID=$(new_sid guardbound)
+run_arm "$SID" Agent >/dev/null
+D1=$(run_guard "$SID" | jq -r '.decision // ""')
+D2=$(run_guard "$SID" true | jq -r '.decision // ""')
+[[ "$D1" == "block" && "$D2" == "block" ]] || fail "the first two turn ends should block, got '$D1' / '$D2'"
+ERR=$(printf '{"session_id":"%s","stop_hook_active":true}' "$SID" | bash "$GUARD" 2>&1 >/dev/null)
+D3=$(run_guard "$SID" true | jq -r '.decision // ""')
+[[ "$D3" != "block" ]] || fail "blocking must be bounded — the third turn end should stand down"
+[[ "$ERR" == *"STOOD DOWN"* ]] || fail "standing down must be announced on stderr, got: '$ERR'"
+[[ -f "$CLAUDE_BGWORK_MARKER_DIR/claude-bgceiling-unguarded-$SID" ]] || \
+  fail "standing down must leave an unguarded marker behind"
+grep -q "guard-stood-down" "$CLAUDE_BGWORK_LOG_DIR/bgwork-ceiling.log" || \
+  fail "standing down must be logged"
+ok "blocking is bounded, and standing down is loud on stderr, in state, and in the log"
+
+# --- 10. Once unguarded, every later tool call resurfaces it ----------------
+CTX=$(run_arm "$SID" Read | context_of)
+[[ "$CTX" == *"UNGUARDED"* ]] || fail "an unguarded thread should be resurfaced on later tool calls, got: '$CTX'"
+ok "an unguarded thread is resurfaced on every subsequent tool call"
+
+# --- 11. Arming clears the block counter and the unguarded marker ----------
+ARM_CMD=$("$CEILING" --arm-command --session "$SID")
+run_arm "$SID" Monitor "$ARM_CMD" >/dev/null
+[[ -f "$CLAUDE_BGWORK_MARKER_DIR/claude-bgceiling-unguarded-$SID" ]] && \
+  fail "arming should clear the unguarded marker"
+OUT=$(run_guard "$SID")
+[[ "$(printf '%s' "$OUT" | jq -r '.decision // ""')" != "block" ]] || \
+  fail "the Stop hook should pass once armed"
+[[ "$(printf '%s' "$(run_arm "$SID" Read)" | context_of)" == "" ]] || \
+  fail "an armed thread should get no further advisories"
+ok "arming clears the block counter, the unguarded marker, and all advisories"
+
+# --- 12. A later spawn is already covered — arm once, not once per spawn ----
+run_arm "$SID" Agent >/dev/null
+OUT=$(run_guard "$SID")
+[[ "$(printf '%s' "$OUT" | jq -r '.decision // ""')" != "block" ]] || \
+  fail "a second spawn under an armed persistent watch must not re-block"
+ok "the persistent watch covers later spawns — arming is once per session"
+
+# --- 13. Hooks degrade quietly when the enforcement script is absent --------
+SANDBOX="$TMP_DIR/sandbox"
+mkdir -p "$SANDBOX/hooks" "$SANDBOX/scripts"
+cp "$ARM" "$GUARD" "$SANDBOX/hooks/"
+SID=$(new_sid noscript)
+OUT=$(printf '{"session_id":"%s","tool_name":"Agent","tool_input":{}}' "$SID" | bash "$SANDBOX/hooks/bgwork-ceiling-arm.sh" 2>&1)
+RC=$?
+[[ $RC -eq 0 ]] || fail "the arm hook should exit 0 when bgwork-ceiling.sh is missing, got $RC"
+[[ -z "$OUT" ]] || fail "the arm hook should stay quiet when bgwork-ceiling.sh is missing, got: '$OUT'"
+OUT=$(printf '{"session_id":"%s"}' "$SID" | bash "$SANDBOX/hooks/bgwork-ceiling-guard.sh" 2>&1)
+RC=$?
+[[ $RC -eq 0 ]] || fail "the guard hook should exit 0 when bgwork-ceiling.sh is missing, got $RC"
+[[ -z "$OUT" ]] || fail "the guard hook should stay quiet when bgwork-ceiling.sh is missing, got: '$OUT'"
+ok "both hooks degrade quietly in a checkout without the enforcement script"
+
+# --- 14. Both hooks emit well-formed JSON or nothing at all ----------------
+SID=$(new_sid json)
+for payload in '{"session_id":"'"$SID"'","tool_name":"Read","tool_input":{}}' \
+               '{"session_id":"'"$SID"'","tool_name":"Agent","tool_input":{}}'; do
+  printf '%s' "$payload" | bash "$ARM" | jq -e . >/dev/null || fail "arm hook emitted invalid JSON for: $payload"
+done
+run_guard "$SID" | jq -e . >/dev/null || fail "guard hook emitted invalid JSON"
+ok "both hooks emit well-formed JSON"
+
+# --- 15. End-to-end: the exact failing case from issue #803 ----------------
+# Parent spawns a subagent, ends its turn, and waits on the completion
+# notification with ZERO intervening tool calls. Replayed in order, with no
+# hook invocation at all between arming and the breach — which is the whole
+# point: nothing in-turn can fire, so only the out-of-turn watch can speak.
+SID=$(new_sid e2e)
+HB="$CLAUDE_BGWORK_MARKER_DIR/claude-heartbeat-$SID"
+
+touch "$HB"                                              # parent's last message
+run_arm "$SID" Agent >/dev/null                          # spawn a subagent
+OUT=$(run_guard "$SID")                                  # try to end the turn
+[[ "$(printf '%s' "$OUT" | jq -r '.decision')" == "block" ]] || \
+  fail "ending the turn right after a spawn must be blocked while unarmed"
+
+ARM_CMD=$(printf '%s' "$OUT" | jq -r '.reason' | sed -n 's/.*command: \(.*\) — then finish.*/\1/p')
+[[ -n "$ARM_CMD" ]] || fail "the block reason must yield a runnable arm command"
+run_arm "$SID" Monitor "$ARM_CMD" >/dev/null             # arm as instructed
+OUT=$(run_guard "$SID")                                  # now the turn may end
+[[ "$(printf '%s' "$OUT" | jq -r '.decision // ""')" != "block" ]] || \
+  fail "the turn should be allowed to end once the ceiling is armed"
+
+# The thread is now idle: no tool calls, no turns, nothing in-context running.
+# `--tick` is exactly what the armed watch loop runs, so calling it directly
+# reproduces the watch without spawning a real background loop in the suite.
+OUT=$("$CEILING" --tick --session "$SID")
+[[ -z "$OUT" ]] || fail "a freshly-quiet thread should not breach yet, got: '$OUT'"
+touch -t "$(date -v-25M +%Y%m%d%H%M 2>/dev/null || date -d '25 minutes ago' +%Y%m%d%H%M)" "$HB"
+OUT=$("$CEILING" --tick --session "$SID")
+[[ "$OUT" == *"CEILING BREACH"* ]] || \
+  fail "the armed watch must break the silence with zero intervening tool calls, got: '$OUT'"
+ok "end-to-end: spawn → blocked → armed → turn ends → watch breaks the silence unaided"
+
+echo "OK: bgwork-ceiling hook tests passed"

--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -40,6 +40,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `pm-handoff-chips-decision.md` — decision record: `/pm-handoff` intentionally does not offer task chips; its portable prompt text is the deliverable (#562)
 - `chip-model-guard-decision.md` — decision record: the chip model-guard preamble rides in both the chip `prompt` and the fallback block, redefining the fallback baseline (#601)
 - `scheduling-failure-modes.md` — recurring poll failure analysis
+- `bgwork-ceiling.md` — why background work arms a turn-independent silence ceiling, why `Monitor` over `ScheduleWakeup`/`CronCreate`, and why the number stays unpublished (#803)
 - `skill-sync-hooks.md` — skills worktree sync and hook registration narrative
 - `skill-symlink-setup.md` — why a dedicated worktree, session-start bootstrap, symlink install, and migration commands (`skill-symlinks.md`)
 - `trust-dialog-repair.md` — why `~/.claude.json` re-prompts per worktree, the three flags, and repair-script behavior (`trust-dialog-fix.md`)

--- a/.claude/reference/bgwork-ceiling.md
+++ b/.claude/reference/bgwork-ceiling.md
@@ -1,0 +1,96 @@
+# Background-Work Silence Ceiling — Mechanism & Rationale
+
+> Reference material for `.claude/rules/scheduling-reliability.md`, `.claude/rules/monitor-mode.md`, and `.claude/rules/subagent-orchestration.md`. Not auto-loaded. Issue #803.
+
+## The hole this closes
+
+`CLAUDE.md` #3 promises a user-visible message at least every 5 minutes. Three pieces of machinery existed to back that promise, and none of them covered the case where it matters most — a thread that spawns a subagent, ends its turn, and waits.
+
+| Piece | What it does | Why it missed this case |
+|-------|--------------|-------------------------|
+| `silence-detector.sh` | PostToolUse; injects a warning once the heartbeat file is >5 min stale | Fires **after a tool call**. A thread waiting on a completion notification makes none. |
+| `silence-detector-ack.sh` | Stop hook; touches `/tmp/claude-heartbeat-<id>` on every visible response | Records the measurement; cannot act on it. |
+| `silence-watchdog.sh` | launchd; reads the same file out-of-turn | Can only raise an **OS notification** — it has no path back into the thread. It also `continue`s when `/tmp/claude-active-<id>` is absent, and the Stop hook removes that marker, so it **deliberately skips the ended-its-turn-and-waiting state**. |
+
+The single underlying cause: **printing a message requires a turn, and nothing in the spawn path guaranteed a turn would ever happen.** The rules were strict about this for user-facing polls — never promise "I'll check back in N minutes" without a real timer — but monitoring background work was never classified as polling, so spawning a subagent armed nothing.
+
+## What was added
+
+Nothing re-measures silence. `/tmp/claude-heartbeat-<session-id>` already means "time of last user-visible message", and it stays the single source of truth. What was missing was a **turn-independent observer of it that can force a turn**, plus a gate that makes arming that observer non-optional.
+
+- **`.claude/scripts/bgwork-ceiling.sh`** — sole owner of the ceiling number, the derived trip point and poll interval, and the session markers. Full contract: `bgwork-ceiling.sh --help`.
+- **`.claude/hooks/bgwork-ceiling-arm.sh`** (PostToolUse, all tools) — records background work, and injects the exact arming call while the ceiling is unarmed. Advisory.
+- **`.claude/hooks/bgwork-ceiling-guard.sh`** (Stop) — returns `decision: block` when background work is in flight and the ceiling is unarmed, so the turn cannot end silently. Enforcement.
+
+## Why `Monitor`, and not `ScheduleWakeup` or `CronCreate`
+
+The issue left this open. All three create turn boundaries; only one satisfies every constraint at once.
+
+| Primitive | Verdict |
+|-----------|---------|
+| `ScheduleWakeup` | **Rejected.** It is the `/loop` dynamic-mode scheduler — its `prompt` parameter is the /loop input to re-fire. It is not available in a plain coding thread, which is exactly where the hole is. |
+| `CronCreate` | **Rejected.** It fires on wall-clock cadence whether or not the thread is actually silent, so a healthy thread already emitting 5-minute heartbeats would get spurious ceiling messages. Its jitter (up to 10% of the period) eats into the ceiling, it only fires while the REPL is idle, and `durable: true` is a documented no-op — it is session-only regardless. |
+| `Monitor` | **Chosen.** An out-of-turn process whose stdout lines become chat events. |
+
+`Monitor` wins on four properties the other two cannot supply together:
+
+1. **Turn-independent.** The watch is an OS process, not a scheduled prompt. It runs while the thread has no turn at all — the failing case.
+2. **Conditional.** The loop prints *nothing* unless the heartbeat file is genuinely stale, so a thread heartbeating normally never sees a ceiling message. A cron-based ceiling would have to fire unconditionally and then reason about whether to speak.
+3. **Armed once per session.** `persistent: true` covers the whole session, so the ceiling is armed on the first background work and every later spawn is already covered. This also sidesteps having to detect *completion* of background work — the watch stays correct whatever the cause of silence.
+4. **Out of reach of stable-state backoff.** `scheduling-reliability.md` widens polls to 5m/15m and calls `CronDelete` at streak ≥9. Those operate on cron jobs; a `Monitor` is stopped only by `TaskStop`. Backoff therefore *structurally* cannot push silence past the ceiling — no prose carve-out required.
+
+## Why the number is not published
+
+The ceiling is a backstop that must never read as a target. Publishing two cadences invites the looser one to become the norm: a rule saying "no longer than 20 minutes" quietly authorises 19 minutes of silence, which is worse than what the rules say today. So `CEILING_S_DEFAULT` lives in `bgwork-ceiling.sh` and nowhere else, and every rule file says "the ceiling" or names the script. `CLAUDE.md` #3's 5-minute cadence stays the single published number.
+
+## Derived timing, not three independent knobs
+
+```
+CEILING_S = 1200   # the guarantee
+CEILING_MARGIN_S = 90
+CEILING_POLL_S = 30
+TRIP_S = CEILING_S - CEILING_MARGIN_S = 1110
+```
+
+The watch trips at `TRIP_S`, not at the ceiling. Worst case, a breach begins just after a poll, so it is detected `TRIP_S + CEILING_POLL_S = 1140s` in — leaving 60s for the model to compose the message and still land inside the ceiling. Deriving the trip point from the ceiling keeps that invariant true for any `CLAUDE_BGWORK_CEILING_S` override; the test suite asserts `trip + poll <= ceiling` rather than asserting the literals, so the invariant survives retuning.
+
+## Fail-closed, bounded, never silent
+
+`feedback_guard_must_fail_closed.md`: a guard that no-ops on failure turns a bounded operation into an unbounded one. Applied here:
+
+- The **default** is to block. An unarmed turn end does not merely warn.
+- Blocking is **bounded** at `CLAUDE_BGWORK_MAX_BLOCKS` (2) consecutive turns — an unbounded block would hang the thread.
+- Past the bound the guard **stands down loudly**: stderr line, `~/.claude/logs/bgwork-ceiling.log` entry, and a `claude-bgceiling-unguarded-<id>` marker that the PostToolUse hook resurfaces on *every* later tool call. The thread is never quietly unguarded.
+- If the block counter itself cannot be written, the guard refuses to start an unbounded block loop and says so on stderr rather than silently passing.
+- `bgwork-ceiling.sh --note-started` exits 5 on an unwritable marker instead of degrading. This is the deliberate opposite of `silence-detector.sh`'s time-injection dedupe, which fails *open* — that one loses a convenience, this one loses the guarantee.
+- The arm advisory is rate-limited to keep a burst of tool calls from replaying it into context — but the rate limit is **bypassed** once the guard has stood down. Throttling the only remaining signal on an already-unguarded thread would be the same silent degradation the change exists to remove.
+
+### Arming is matched on the whole command, not a substring
+
+The arm hook recognises the watch by regenerating `--arm-command` and requiring the tool's command to *contain that entire string*, rather than by looking for a `--tick` substring. A guard that can be satisfied by talking about it is not a guard: in this repo, commands that merely mention the watch are routine (a grep, a docs edit, a test run), and any of them would otherwise have marked the session armed with no watch actually running. Regenerating the expected command also keeps detection in step with `--arm-command` automatically if its shape changes.
+
+## Session markers
+
+All under `/tmp` (per `feedback_hook_storage_location.md`: ephemeral per-session sentinels), overridable as a set via `CLAUDE_BGWORK_MARKER_DIR` so the test suites never touch live state.
+
+| Marker | Meaning | Written by |
+|--------|---------|-----------|
+| `claude-heartbeat-<id>` | Last user-visible message | `silence-detector-ack.sh` (read-only here) |
+| `claude-bgwork-<id>` | Background work has started; one line per kind | `--note-started` |
+| `claude-bgceiling-armed-<id>` | The ceiling watch is armed | `--record-armed` |
+| `claude-bgceiling-emitted-<id>` | Heartbeat mtime of the last reported breach | `--tick` |
+| `claude-bgceiling-advised-<id>` | Last time the arm advisory was injected | arm hook |
+| `claude-bgceiling-blocks-<id>` | Consecutive blocked turn ends | guard hook |
+| `claude-bgceiling-unguarded-<id>` | The guard stood down; thread is unguarded | guard hook |
+
+Breach reporting is deduped on the heartbeat's mtime, so a single stretch of silence produces one message rather than one per poll. When the agent finally speaks, the Stop hook re-stamps the heartbeat, the mtime changes, and the next genuine breach is reportable again — the same shape as `silence-watchdog.sh`'s `already_alerted` state.
+
+## Compaction
+
+Neither half lives in context: the watch is a process, the state is `/tmp` markers. A thread that compacts mid-wait keeps both, so the ceiling holds across compaction with no recovery step. This is why the ceiling is *not* recorded in `session-state.json` — putting it there would add a reconciliation path that the design does not need.
+
+## Known limits
+
+- **Session-scoped.** The watch dies with the session. That is the right scope — a dead session has no chat to go silent in — but it means the ceiling is not a cross-session guarantee.
+- **The arm hook advises; only the Stop hook enforces.** A harness that ignored `decision: block` on Stop hooks would reduce this to the advisory layer. The bounded-block behavior is written so that outcome is loud rather than silent.
+- **`silence-watchdog.sh` is unchanged.** Upgrading the launchd watchdog to inject into a session — covering the case where the ceiling was never armed at all — needs harness support that does not exist today. Left as the issue filed it: a possible follow-up, not part of this change.

--- a/.claude/reference/diagrams/hook-lifecycle.md
+++ b/.claude/reference/diagrams/hook-lifecycle.md
@@ -13,9 +13,11 @@ sequenceDiagram
   CC->>H: PreToolUse
   Note over H: worktree-guard.sh, env-guard.py, script-bypass-detector.sh
   CC->>H: PostToolUse
-  Note over H: session-start-sync.sh, post-merge-pull.sh, polling-backoff-warn.sh, skill-usage-tracker.sh, silence-detector.sh
+  Note over H: session-start-sync.sh, post-merge-pull.sh, polling-backoff-warn.sh, skill-usage-tracker.sh, silence-detector.sh, bgwork-ceiling-arm.sh
   CC->>H: Stop
-  Note over H: silence-detector-ack.sh, trust-flag-repair.sh, dirty-main-warn.sh
+  Note over H: silence-detector-ack.sh, bgwork-ceiling-guard.sh, trust-flag-repair.sh, dirty-main-warn.sh
 ```
+
+The silence machinery straddles both events twice over (#803). `silence-detector.sh` / `silence-detector-ack.sh` cover silence *within* a turn; `bgwork-ceiling-arm.sh` / `bgwork-ceiling-guard.sh` cover silence *after* one ends, which is the case no PostToolUse hook can see — a thread waiting on a subagent makes no tool calls. The arm hook advises; only the Stop hook enforces, by returning `decision: block` so an unarmed turn cannot end. See `.claude/reference/bgwork-ceiling.md`.
 
 Skill telemetry straddles two of these events (#584): `skill-command-tracker.sh` catches user-typed slash commands at UserPromptSubmit — they arrive pre-expanded and never produce a `Skill` tool call — while `skill-usage-tracker.sh` catches model-initiated calls at PostToolUse. Both write through `.claude/hooks/lib/skill-usage-recorder.sh`, which dedupes so an invocation seen by both paths still counts once. See `.claude/memory/skill_usage_telemetry.md`.

--- a/.claude/reference/scheduling-failure-modes.md
+++ b/.claude/reference/scheduling-failure-modes.md
@@ -50,6 +50,18 @@ The common thread: **between-turn scheduling has no in-turn observer.** Once the
 
 **Fix.** Apply `scheduling-reliability.md` "Stable-State Backoff & Auto-Pause": compute the digest, increment `digest_streak`, widen to 5m at streak 3, widen to 15m at streak 6, and pause at streak 9. If `blocker_kind == "user_input"` or the blocker text says the agent is awaiting the user's direction, pause after the first visible message. When deleting or promoting the cron, also cancel sibling `ScheduleWakeup` jobs.
 
+## Pattern 6 — Background Work With No Armed Observer
+
+**Symptom.** The thread hands work to a subagent (or starts a long background process, or arms a watcher), ends its turn, and goes silent. The last chat message is 15–25 minutes old. Nothing is wrong with the subagent — it is simply still running — but the transcript cannot distinguish "grinding away" from "wedged" from "dead", and the user has to ask "status?" to learn anything.
+
+**Root cause.** Printing a message requires a turn, and nothing in the spawn path guaranteed a turn would happen. The in-context nag (`silence-detector.sh`) is a PostToolUse hook, and a thread waiting on a completion notification makes no tool calls; the launchd watchdog notices the stall but can only raise an OS notification, and it skips sessions whose `claude-active-<id>` marker is gone — which is precisely the ended-its-turn state. The deeper miss: monitoring background work was never *classified* as polling, so none of this file's discipline was applied to it.
+
+**Fix.** `scheduling-reliability.md` now classifies a thread with background work in flight as a polling context, and starting that work arms a turn-independent ceiling watch (`bgwork-ceiling.sh --arm-command` → `Monitor`). The Stop hook blocks a turn that would end unarmed, so this pattern cannot recur through forgetfulness.
+
+**It is mitigation, not an absolute guarantee.** Blocking is bounded at 2 consecutive turns; past that the guard stands down and an unarmed turn *is* allowed to end. That fallback is deliberately loud — stderr, `~/.claude/logs/bgwork-ceiling.log`, and an unguarded marker resurfaced on every later tool call — so a thread that ends up without a ceiling says so, rather than looking identical to a healthy one. Mechanism: `.claude/reference/bgwork-ceiling.md` (#803).
+
+**Note the shape difference from Patterns 1–4.** Those are *dropped* ticks — a schedule existed and stopped. This one is a schedule that was never armed at all, because nobody recognised the situation as scheduling. Detection heuristics keyed on "a polling context with no live job" therefore missed it entirely: there was no polling context recorded to check against.
+
 ## Detection Heuristics
 
 Treat any of these as a scheduling failure until proven otherwise:

--- a/.claude/rules/monitor-mode.md
+++ b/.claude/rules/monitor-mode.md
@@ -1,6 +1,6 @@
 # Monitor Mode, Heartbeats & Recovery
 
-> **Always:** Enter monitor mode when subagents are active. Timestamp every message and heartbeat ≤5 min (CLAUDE.md #1/#3). Report subagent failures immediately. Recover state after compaction.
+> **Always:** Enter monitor mode when subagents are active. Timestamp every message and heartbeat ≤5 min (CLAUDE.md #1/#3). Arm the silence ceiling when background work starts (`scheduling-reliability.md`). Report subagent failures immediately. Recover state after compaction.
 > **Ask first:** Breaking monitor mode for explicit user requests — warn about paused monitoring first.
 > **Never:** Do substantive work while subagents are active. Go >5 min without a user-visible message. Let a stalled PR go unreported. Ask permission to monitor — babysitting an in-flight PR is the default (`CLAUDE.md`).
 
@@ -20,6 +20,7 @@ Every ~60s, in order:
 3. For every session PR still on `reviewer == cr`, run `.claude/scripts/escalate-review.sh <PR_NUMBER>` and act on its `STATUS=` verdict before sleeping.
 4. Send any due heartbeat (one line — User Heartbeat below).
 5. Investigate stale agents: >15 min Phase A, >10 min Phase B, >5 min Phase C.
+6. Before ending the turn, confirm the ceiling is still armed: `bgwork-ceiling.sh --check`.
 
 ## Subagent Health Monitoring (MANDATORY)
 

--- a/.claude/rules/scheduling-reliability.md
+++ b/.claude/rules/scheduling-reliability.md
@@ -2,9 +2,9 @@
 
 > **Always:** Use `/loop` for user-facing "poll/check/watch every N" requests — including the default in-flight-PR watch (`CLAUDE.md`). Run the pre-exit checklist. Record polling state in `session-state.json`.
 > **Ask first:** Never — scheduling reliability is autonomous.
-> **Never:** Hand-roll a chain of one-shot `ScheduleWakeup` (or equivalent) calls for a recurring user-facing poll. Promise to "check back in N minutes" without backing it with an active `/loop` or `CronCreate` job. Exit a wake-up turn without confirming the next tick is scheduled.
+> **Never:** Hand-roll a chain of one-shot `ScheduleWakeup` (or equivalent) calls for a recurring user-facing poll. Promise to "check back in N minutes" without backing it with an active `/loop` or `CronCreate` job. Exit a wake-up turn without confirming the next tick is scheduled. Leave background work running with no ceiling armed.
 
-The 5-minute heartbeat rule catches silence during turns; this file covers between-turn polling.
+The 5-minute heartbeat rule catches silence during turns; this file covers between-turn polling. **Background work in flight is a polling context** — that wait is between turns too.
 
 ## Tool Selection Decision Tree
 
@@ -13,6 +13,7 @@ The 5-minute heartbeat rule catches silence during turns; this file covers betwe
 | Recurring: "poll/check/watch every N", "keep running /skill" | **`/loop`** | Runtime owns cadence |
 | ≥3 concurrent polls or cross-session durability | **`CronCreate`** | Durable fleet job |
 | One-shot "wake me in N minutes" | `ScheduleWakeup` | Single tick only |
+| Background work in flight (subagent, background process, watcher) | **ceiling watch** — `bgwork-ceiling.sh --arm-command` → `Monitor` | Backstop, not a poll — still `/loop` if status is due |
 
 > Why the "Never" above: a forgotten re-arm silently kills a hand-rolled one-shot chain; `/loop` re-arms itself.
 
@@ -29,18 +30,19 @@ Skill-owned polling turns update `session-state.json` per that skill's contract;
 
 ## Mandatory Pre-Exit Checklist for Polling Turns
 
-Before any polling turn ends (`/loop`, `CronCreate`, or legacy one-shot), verify all three:
+Before any polling turn ends (`/loop`, `CronCreate`, legacy one-shot, or a turn ending with background work in flight), verify all three:
 
 1. **Next tick scheduled?**
    - `/loop`: verify it is active/re-armed.
    - `CronCreate`: confirm with `CronList`; prior `CronDelete` or 7-day expiry may remove it.
    - Legacy `ScheduleWakeup`: confirm this turn made the next-tick call and it returned cleanly. If skipped/errored, switch to `/loop`.
+   - Background work: `bgwork-ceiling.sh --check` passes; if not, arm it (`--arm-command` → `Monitor`). The Stop hook blocks the turn otherwise.
 2. **User heartbeat sent this turn?** Timestamped one-liner: what happened, what's next.
 3. **Monitoring state recorded?** Update `~/.claude/session-state.json` with tick time, next expected tick, and watermarks (last review ID, last HEAD SHA, etc.). See `handoff-files.md`.
 
 ## Stable-State Backoff
 
-Each tick hash `(head_sha, cr_state, bugbot_state, greptile_state, ci_blocking_conclusions_sorted, blocker_kind)` into `prs.{N}.digest_streak` (free-text `blocker` excluded). Widen at streak ≥3→5m, ≥6→15m; `CronDelete` at ≥9 or `blocker_kind == "user_input"`. Resume at base cadence after user message or changed digest. `polling-backoff-warn.sh` enforces this.
+Each tick hash `(head_sha, cr_state, bugbot_state, greptile_state, ci_blocking_conclusions_sorted, blocker_kind)` into `prs.{N}.digest_streak` (free-text `blocker` excluded). Widen at streak ≥3→5m, ≥6→15m; `CronDelete` at ≥9 or `blocker_kind == "user_input"`. Resume at base cadence after user message or changed digest. `polling-backoff-warn.sh` enforces this. Backoff cannot reach the ceiling watch: it widens and deletes cron jobs; the watch is a `Monitor`.
 
 ## Failure Recovery
 
@@ -48,4 +50,4 @@ If the user reports a dropped tick: re-establish with `/loop` (never a one-shot 
 
 ## Related
 
-`monitor-mode.md` (in-turn heartbeat/monitor loop) · `.claude/reference/scheduling-failure-modes.md` (observed failure modes) · `handoff-files.md` (`session-state.json` schema).
+`monitor-mode.md` (in-turn heartbeat/monitor loop) · `.claude/reference/scheduling-failure-modes.md` (observed failure modes) · `.claude/reference/bgwork-ceiling.md` (ceiling mechanism + rationale) · `handoff-files.md` (`session-state.json` schema).

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -1,6 +1,6 @@
 # Subagent Context
 
-> **Always:** Spawn subagents via custom agent definitions in `.claude/agents/` (see "How to Spawn Subagents" below). Use `mode: "bypassPermissions"` on every Agent tool call. Set `model` explicitly at every call site per the Model Selection policy (see below). Use phase decomposition (A/B/C). Timestamp every message (see `monitor-mode.md`). Write handoff files on phase completion (see `handoff-files.md`). Print Structured Exit Report before every subagent exit (see `phase-protocols.md`). Only fall back to manually passing all rule files if `.claude/agents/` is unavailable in the current repo.
+> **Always:** Spawn subagents via custom agent definitions in `.claude/agents/` (see "How to Spawn Subagents" below). Use `mode: "bypassPermissions"` on every Agent tool call. Set `model` explicitly at every call site per the Model Selection policy (see below). Use phase decomposition (A/B/C). Timestamp every message (see `monitor-mode.md`). Write handoff files on phase completion (see `handoff-files.md`). Print Structured Exit Report before every subagent exit (see `phase-protocols.md`). Arm the silence ceiling in the same step as the spawn (`scheduling-reliability.md`). Only fall back to manually passing all rule files if `.claude/agents/` is unavailable in the current repo.
 > **Ask first:** Respawning a crashed/no-handoff subagent — tell the user what happened first; exhaustion with valid handoff auto-respawns ("Always do").
 > **Never:** Summarize rules for subagents. Spawn subagents without `mode: "bypassPermissions"`. Spawn without an explicit `model` parameter. Fire-and-forget subagents.
 
@@ -14,6 +14,7 @@ Use `.claude/agents/` definitions; they embed phase rules. Every Agent call must
 5. The verbatim `SAFETY:` block from `safety.md`.
 6. The verbatim `MINDSET:` block from `safety.md` (try CLI before handoff — see "Capability Discovery").
 7. The verbatim `SKILLS:` block from `skill-first.md` — **skip for `phase-c-merger`** (no `Skill` tool).
+8. Same step, but not part of the call: arm the silence ceiling — `bgwork-ceiling.sh --arm-command` → `Monitor` (`persistent: true`). The Stop hook blocks the turn otherwise.
 
 See `.claude/agents/README.md` for the full placeholder reference and spawning examples.
 

--- a/.claude/scripts/bgwork-ceiling.sh
+++ b/.claude/scripts/bgwork-ceiling.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# bgwork-ceiling.sh — hard ceiling on chat silence while background work runs.
+#
+# PURPOSE
+#   The 5-minute heartbeat rule (CLAUDE.md #3) is enforced in-turn by
+#   silence-detector.sh, a PostToolUse hook. That hook cannot fire when the
+#   thread spawns a subagent (or any background work), ends its turn, and waits
+#   for a completion notification — there are no tool calls to hook. The
+#   launchd watchdog (silence-watchdog.sh) reads the same heartbeat file
+#   out-of-turn but can only raise an OS notification, and it deliberately
+#   skips sessions whose /tmp/claude-active-<id> marker is absent — which is
+#   exactly the "ended its turn and is waiting" state. Result: silence with no
+#   ceiling and no observer that can force a turn.
+#
+#   This script is the enforcement layer for that gap and the SOLE OWNER of the
+#   ceiling number. Rule files describe the behavior ("arm the ceiling") and
+#   never state a duration — CLAUDE.md #3's 5-minute cadence stays the only
+#   published number, so a looser backstop can never read as a target.
+#
+#   Measurement is NOT re-implemented here: /tmp/claude-heartbeat-<session-id>,
+#   touched by the silence-detector-ack.sh Stop hook on every visible response,
+#   already means "time of last user-visible message". This script only adds an
+#   out-of-turn observer of it plus the state a fail-closed guard needs.
+#
+# USAGE
+#   bgwork-ceiling.sh --note-started <kind> [--session ID]
+#   bgwork-ceiling.sh --record-armed        [--session ID]
+#   bgwork-ceiling.sh --check               [--session ID]
+#   bgwork-ceiling.sh --tick                [--session ID]
+#   bgwork-ceiling.sh --arm-command         [--session ID]
+#   bgwork-ceiling.sh --status              [--session ID]
+#   bgwork-ceiling.sh --clear               [--session ID]
+#   bgwork-ceiling.sh --ceiling-seconds
+#   bgwork-ceiling.sh --help | -h
+#
+# MODES
+#   --note-started  Record that background work the thread will wait on has
+#                   started (subagent spawn, backgrounded Bash, Workflow,
+#                   Monitor). <kind> is a free-form label recorded for the
+#                   status view. Idempotent.
+#   --record-armed  Record that the ceiling watch is armed for this session.
+#                   Resets the guard's consecutive-block counter and clears any
+#                   degraded-guard breach record.
+#   --check         Gate used by the Stop hook. Exit 0 when there is nothing to
+#                   guard (no background work started) or the watch is armed;
+#                   exit 1 when background work is in flight and unarmed.
+#   --tick          What the armed watch runs on a loop. Prints ONE breach line
+#                   when the heartbeat file is stale past the trip point, and
+#                   prints nothing otherwise, so a thread emitting healthy
+#                   5-minute heartbeats never produces a ceiling message.
+#                   Deduped per heartbeat mtime: one breach line per silence,
+#                   not one per poll. Always exits 0 — a watch that exits stops
+#                   watching.
+#   --arm-command   Print the exact shell command to hand to the Monitor tool.
+#                   The command embeds this script's absolute path and the
+#                   resolved session id, and contains the `--tick` sentinel the
+#                   PostToolUse hook matches to detect arming.
+#   --status        Print a single-line JSON snapshot on stdout.
+#   --clear         Remove this session's markers (test/teardown helper).
+#
+# WHY Monitor AND NOT ScheduleWakeup / CronCreate
+#   ScheduleWakeup is the /loop dynamic-mode scheduler and is unavailable in a
+#   plain coding thread — exactly where the hole is. CronCreate fires on a
+#   wall-clock cadence regardless of whether the thread is actually silent, so
+#   a healthy thread would get spurious ceiling messages, and its jitter (up to
+#   10% of the period) eats into the ceiling. A Monitor runs an out-of-turn
+#   process whose stdout lines become chat events: turn-independent, silent
+#   unless there is a real breach, persistent for the session (so the ceiling is
+#   armed once, not once per spawn), and reachable only by TaskStop — the
+#   stable-state backoff in scheduling-reliability.md widens and deletes CRON
+#   jobs, so it structurally cannot widen or delete this watch.
+#
+# TUNING
+#   CLAUDE_BGWORK_CEILING_S  Override the ceiling, in seconds. Must be a
+#                            positive integer > CEILING_MARGIN_S; anything else
+#                            falls back to the default and warns on stderr.
+#   The poll interval and trip point are DERIVED from the ceiling, never set
+#   independently: the watch must emit early enough that poll granularity plus
+#   the time the model needs to compose the message still lands inside the
+#   ceiling. Deriving them keeps that invariant true for any override.
+#
+# OUTPUT
+#   stdout: mode-dependent (breach line, JSON status, arm command, or nothing).
+#   stderr: one-line diagnostics. State-write failures are always surfaced —
+#           this guard fails CLOSED, so a marker it cannot write is reported
+#           rather than swallowed (feedback_guard_must_fail_closed.md).
+#
+# EXIT STATUS
+#   0  Success (and, for --check, nothing to guard or watch armed).
+#   1  --check only: background work is in flight and the ceiling is unarmed.
+#   2  Usage error (missing/unknown mode, bad flag value).
+#   5  State write failed (unwritable marker directory, disk full, ...).
+
+set -uo pipefail
+
+CEILING_S_DEFAULT=1200   # 20 minutes — the guarantee. Not published in rules.
+CEILING_MARGIN_S=90      # poll granularity + time for the model to reply
+CEILING_POLL_S=30        # how often the armed watch re-checks the heartbeat
+
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+LOG_DIR="${CLAUDE_BGWORK_LOG_DIR:-$HOME/.claude/logs}"
+LOG_FILE="$LOG_DIR/bgwork-ceiling.log"
+MARKER_DIR="${CLAUDE_BGWORK_MARKER_DIR:-/tmp}"
+
+usage() {
+  sed -n '2,/^$/p' "$SCRIPT_PATH" | sed 's/^# \{0,1\}//'
+}
+
+die_usage() {
+  printf 'bgwork-ceiling.sh: %s\n' "$1" >&2
+  printf 'Run with --help for usage.\n' >&2
+  exit 2
+}
+
+resolve_ceiling() {
+  local raw="${CLAUDE_BGWORK_CEILING_S:-}"
+  if [[ -z "$raw" ]]; then
+    printf '%s' "$CEILING_S_DEFAULT"
+    return
+  fi
+  if [[ ! "$raw" =~ ^[0-9]+$ ]] || (( raw <= CEILING_MARGIN_S )); then
+    printf 'bgwork-ceiling.sh: ignoring invalid CLAUDE_BGWORK_CEILING_S=%s (need integer > %s); using %s\n' \
+      "$raw" "$CEILING_MARGIN_S" "$CEILING_S_DEFAULT" >&2
+    printf '%s' "$CEILING_S_DEFAULT"
+    return
+  fi
+  printf '%s' "$raw"
+}
+
+file_mtime() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    stat -f %m "$1" 2>/dev/null
+  else
+    stat -c %Y "$1" 2>/dev/null
+  fi
+}
+
+# Fail closed: a marker we cannot write means the guard cannot do its job, so
+# say so loudly and exit non-zero rather than degrading into a silent no-op.
+write_marker() {
+  local path="$1" body="${2:-}"
+  if ! printf '%s' "$body" > "$path" 2>/dev/null; then
+    printf 'bgwork-ceiling.sh: cannot write %s — ceiling state not recorded\n' "$path" >&2
+    return 1
+  fi
+  return 0
+}
+
+log_event() {
+  local event="$1" detail="${2:-}"
+  mkdir -p "$LOG_DIR" 2>/dev/null || return 0
+  printf '%s\t%s\t%s\t%s\n' \
+    "$(date -u +%FT%TZ)" "$SESSION_ID" "$event" "$detail" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+MODE=""
+KIND=""
+SESSION_ID="${CLAUDE_SESSION_ID:-}"
+
+while (( $# > 0 )); do
+  case "$1" in
+    --note-started)
+      [[ -n "$MODE" ]] && die_usage "only one mode may be given (already have --$MODE)"
+      MODE="note-started"
+      if (( $# < 2 )) || [[ "$2" == --* ]]; then
+        die_usage "--note-started requires a <kind> argument"
+      fi
+      KIND="$2"
+      shift
+      ;;
+    --record-armed|--check|--tick|--arm-command|--status|--clear|--ceiling-seconds)
+      [[ -n "$MODE" ]] && die_usage "only one mode may be given (already have --$MODE)"
+      MODE="${1#--}"
+      ;;
+    --session)
+      (( $# >= 2 )) || die_usage "--session requires an argument"
+      SESSION_ID="$2"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die_usage "unknown argument: $1"
+      ;;
+  esac
+  shift
+done
+
+[[ -n "$MODE" ]] || die_usage "no mode given"
+
+CEILING_S="$(resolve_ceiling)"
+TRIP_S=$(( CEILING_S - CEILING_MARGIN_S ))
+
+if [[ "$MODE" == "ceiling-seconds" ]]; then
+  printf '%s\n' "$CEILING_S"
+  exit 0
+fi
+
+# Match the session-id sanitising the silence hooks apply, so this script and
+# silence-detector-ack.sh derive the SAME heartbeat path from the same raw id.
+SESSION_ID="${SESSION_ID:-default}"
+SESSION_ID="${SESSION_ID//[^[:alnum:]_.-]/_}"
+SESSION_ID="${SESSION_ID:-default}"
+
+HEARTBEAT_FILE="${MARKER_DIR}/claude-heartbeat-${SESSION_ID}"
+BGWORK_FILE="${MARKER_DIR}/claude-bgwork-${SESSION_ID}"
+ARMED_FILE="${MARKER_DIR}/claude-bgceiling-armed-${SESSION_ID}"
+EMITTED_FILE="${MARKER_DIR}/claude-bgceiling-emitted-${SESSION_ID}"
+BLOCKS_FILE="${MARKER_DIR}/claude-bgceiling-blocks-${SESSION_ID}"
+BREACH_FILE="${MARKER_DIR}/claude-bgceiling-unguarded-${SESSION_ID}"
+ADVISED_FILE="${MARKER_DIR}/claude-bgceiling-advised-${SESSION_ID}"
+
+case "$MODE" in
+  note-started)
+    if [[ -f "$BGWORK_FILE" ]] && grep -qxF "$KIND" "$BGWORK_FILE" 2>/dev/null; then
+      exit 0   # already recorded — idempotent
+    fi
+    if ! printf '%s\n' "$KIND" >> "$BGWORK_FILE" 2>/dev/null; then
+      printf 'bgwork-ceiling.sh: cannot write %s — background work not tracked\n' "$BGWORK_FILE" >&2
+      exit 5
+    fi
+    log_event "note-started" "$KIND"
+    ;;
+
+  record-armed)
+    write_marker "$ARMED_FILE" "$(date -u +%FT%TZ)" || exit 5
+    rm -f "$BLOCKS_FILE" "$BREACH_FILE" "$ADVISED_FILE" 2>/dev/null || true
+    log_event "armed" "ceiling_s=${CEILING_S}"
+    ;;
+
+  check)
+    # Nothing started -> nothing to guard.
+    [[ -f "$BGWORK_FILE" ]] || exit 0
+    # Armed once, armed for the session: the watch is persistent and its trip
+    # point is silence-based, so it covers every later spawn too.
+    [[ -f "$ARMED_FILE" ]] && exit 0
+    exit 1
+    ;;
+
+  tick)
+    # No heartbeat file yet means the session has not produced a visible
+    # message for the hooks to stamp; there is nothing to measure from.
+    [[ -f "$HEARTBEAT_FILE" ]] || exit 0
+    last_ack="$(file_mtime "$HEARTBEAT_FILE")"
+    [[ -n "$last_ack" ]] || exit 0
+
+    age=$(( $(date +%s) - last_ack ))
+    (( age >= TRIP_S )) || exit 0
+
+    # Dedupe on the heartbeat's mtime: one breach line per stretch of silence.
+    # When the agent finally speaks, the Stop hook re-touches the heartbeat, the
+    # mtime changes, and the next genuine breach is reportable again.
+    if [[ -f "$EMITTED_FILE" ]]; then
+      emitted="$(cat "$EMITTED_FILE" 2>/dev/null)"
+      [[ "$emitted" == "$last_ack" ]] && exit 0
+    fi
+    printf '%s' "$last_ack" > "$EMITTED_FILE" 2>/dev/null || \
+      printf 'bgwork-ceiling.sh: cannot write %s — breach line may repeat\n' "$EMITTED_FILE" >&2
+
+    log_event "breach" "age_s=${age}"
+    printf 'CEILING BREACH: no user-visible message in %dm (%ds) while background work is in flight. Send the one-line timestamped heartbeat NOW (monitor-mode.md "User Heartbeat"): [<ET timestamp>] <state> · next: <action>. "Still running, nothing new" is a complete and correct heartbeat — say that rather than staying silent.\n' \
+      "$(( age / 60 ))" "$age"
+    ;;
+
+  arm-command)
+    # The `--tick` substring is the sentinel bgwork-ceiling-arm.sh matches to
+    # recognise this call as ARMING rather than as new background work.
+    printf 'while true; do %s --tick --session %s; sleep %s; done\n' \
+      "$SCRIPT_PATH" "$SESSION_ID" "$CEILING_POLL_S"
+    ;;
+
+  status)
+    started="[]"
+    if [[ -f "$BGWORK_FILE" ]]; then
+      started="$(sort -u "$BGWORK_FILE" 2>/dev/null | jq -Rsc 'split("\n") | map(select(length > 0))' 2>/dev/null || printf '[]')"
+    fi
+    armed=false
+    [[ -f "$ARMED_FILE" ]] && armed=true
+    silence=-1
+    if [[ -f "$HEARTBEAT_FILE" ]]; then
+      hb="$(file_mtime "$HEARTBEAT_FILE")"
+      [[ -n "$hb" ]] && silence=$(( $(date +%s) - hb ))
+    fi
+    blocks=0
+    [[ -f "$BLOCKS_FILE" ]] && blocks="$(cat "$BLOCKS_FILE" 2>/dev/null)"
+    [[ "$blocks" =~ ^[0-9]+$ ]] || blocks=0
+    unguarded=false
+    [[ -f "$BREACH_FILE" ]] && unguarded=true
+
+    jq -nc \
+      --arg session "$SESSION_ID" \
+      --argjson started "$started" \
+      --argjson armed "$armed" \
+      --argjson ceiling_s "$CEILING_S" \
+      --argjson trip_s "$TRIP_S" \
+      --argjson poll_s "$CEILING_POLL_S" \
+      --argjson silence_s "$silence" \
+      --argjson blocks "$blocks" \
+      --argjson unguarded "$unguarded" \
+      '{session: $session, background_work: $started, armed: $armed,
+        ceiling_s: $ceiling_s, trip_s: $trip_s, poll_s: $poll_s,
+        silence_s: $silence_s, consecutive_blocks: $blocks, unguarded: $unguarded}'
+    ;;
+
+  clear)
+    rm -f "$BGWORK_FILE" "$ARMED_FILE" "$EMITTED_FILE" "$BLOCKS_FILE" "$BREACH_FILE" \
+          "$ADVISED_FILE" 2>/dev/null || true
+    ;;
+
+  *)
+    die_usage "unhandled mode: $MODE"
+    ;;
+esac
+
+exit 0

--- a/.claude/scripts/tests/bgwork-ceiling.test.sh
+++ b/.claude/scripts/tests/bgwork-ceiling.test.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Tests for bgwork-ceiling.sh — the hard ceiling on chat silence while
+# background work runs (issue #803).
+#
+# Every marker this script touches is redirected into a temp dir via
+# CLAUDE_BGWORK_MARKER_DIR, and the log via CLAUDE_BGWORK_LOG_DIR, so the suite
+# never reads or writes real session state in /tmp or ~/.claude.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/.claude/scripts/bgwork-ceiling.sh"
+
+TMP_DIR="$(mktemp -d)"
+export CLAUDE_BGWORK_MARKER_DIR="$TMP_DIR/markers"
+export CLAUDE_BGWORK_LOG_DIR="$TMP_DIR/logs"
+mkdir -p "$CLAUDE_BGWORK_MARKER_DIR" "$CLAUDE_BGWORK_LOG_DIR"
+cleanup() { chmod -R u+w "$TMP_DIR" 2>/dev/null || true; rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+# Isolate from a caller-set override — the default-ceiling assertions below
+# must not silently inherit a different number from the environment.
+unset CLAUDE_BGWORK_CEILING_S
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "ok   — $*"; }
+
+SID="ceiling-test-$$-$RANDOM"
+hb() { printf '%s/claude-heartbeat-%s' "$CLAUDE_BGWORK_MARKER_DIR" "$SID"; }
+
+# Relative timestamps (BSD/macOS then GNU date) — never a hard-coded calendar
+# date, which flips future/past depending on when the suite runs.
+stamp_minutes_ago() {
+  date -v-"$1"M +%Y%m%d%H%M 2>/dev/null || date -d "$1 minutes ago" +%Y%m%d%H%M
+}
+
+# --- 1. The ceiling number lives here and nowhere else ------------------------
+CEILING=$("$SCRIPT" --ceiling-seconds)
+[[ "$CEILING" == "1200" ]] || fail "--ceiling-seconds should be 1200 (20 min), got '$CEILING'"
+ok "--ceiling-seconds reports the 20-minute ceiling"
+
+# --- 2. Derived timing invariant: a breach is always REPORTED inside the
+#        ceiling, poll granularity included. This is the property that makes
+#        the guarantee true; trip/poll are derived from the ceiling, never
+#        tuned independently. --------------------------------------------------
+STATUS=$("$SCRIPT" --status --session "$SID")
+TRIP=$(printf '%s' "$STATUS" | jq -r '.trip_s')
+POLL=$(printf '%s' "$STATUS" | jq -r '.poll_s')
+(( TRIP < CEILING )) || fail "trip point ($TRIP) must be below the ceiling ($CEILING)"
+(( TRIP + POLL <= CEILING )) || \
+  fail "worst-case detection ($((TRIP + POLL))s = trip $TRIP + poll $POLL) must not exceed the ceiling ($CEILING)"
+ok "trip + poll ($((TRIP + POLL))s) stays inside the ceiling (${CEILING}s)"
+
+# --- 3. --check: nothing started means nothing to guard -----------------------
+"$SCRIPT" --check --session "$SID"
+[[ $? -eq 0 ]] || fail "--check should exit 0 when no background work has started"
+ok "--check passes when no background work has started"
+
+# --- 4. --check fails closed once background work is in flight ---------------
+"$SCRIPT" --note-started Agent --session "$SID" || fail "--note-started should succeed"
+"$SCRIPT" --check --session "$SID"
+[[ $? -eq 1 ]] || fail "--check should exit 1 with background work in flight and no armed ceiling"
+ok "--check fails (exit 1) with background work in flight and unarmed"
+
+# --- 5. --note-started is idempotent -----------------------------------------
+"$SCRIPT" --note-started Agent --session "$SID"
+"$SCRIPT" --note-started Agent --session "$SID"
+KINDS=$("$SCRIPT" --status --session "$SID" | jq -r '.background_work | length')
+[[ "$KINDS" == "1" ]] || fail "repeated --note-started Agent should record one kind, got $KINDS"
+ok "--note-started is idempotent per kind"
+
+# --- 6. Arming satisfies the gate --------------------------------------------
+"$SCRIPT" --record-armed --session "$SID" || fail "--record-armed should succeed"
+"$SCRIPT" --check --session "$SID"
+[[ $? -eq 0 ]] || fail "--check should pass once the ceiling is armed"
+ok "--record-armed satisfies --check"
+
+# --- 7. The arm command carries the sentinel the arm hook matches ------------
+ARM_CMD=$("$SCRIPT" --arm-command --session "$SID")
+[[ "$ARM_CMD" == *"bgwork-ceiling.sh --tick"* ]] || \
+  fail "arm command must contain the '--tick' sentinel, got: $ARM_CMD"
+[[ "$ARM_CMD" == *"--session $SID"* ]] || \
+  fail "arm command must pin the resolved session id, got: $ARM_CMD"
+[[ "$ARM_CMD" == *"sleep $POLL"* ]] || \
+  fail "arm command must poll at the derived interval ($POLL), got: $ARM_CMD"
+ok "--arm-command embeds the sentinel, session id, and derived poll interval"
+
+# --- 8. --tick is silent with no heartbeat to measure from -------------------
+OUT=$("$SCRIPT" --tick --session "$SID")
+[[ -z "$OUT" ]] || fail "--tick with no heartbeat file should print nothing, got: '$OUT'"
+ok "--tick is silent when there is no heartbeat to measure from"
+
+# --- 9. --tick is silent for a healthy thread (the no-spurious-message case) --
+touch "$(hb)"
+OUT=$("$SCRIPT" --tick --session "$SID")
+[[ -z "$OUT" ]] || fail "--tick on a fresh heartbeat should print nothing, got: '$OUT'"
+# ...and still silent just under the trip point.
+touch -t "$(stamp_minutes_ago 15)" "$(hb)"
+OUT=$("$SCRIPT" --tick --session "$SID")
+[[ -z "$OUT" ]] || fail "--tick below the trip point should print nothing, got: '$OUT'"
+ok "--tick stays silent while the thread is heartbeating normally"
+
+# --- 10. --tick breaches past the trip point, in heartbeat format ------------
+touch -t "$(stamp_minutes_ago 25)" "$(hb)"
+OUT=$("$SCRIPT" --tick --session "$SID")
+[[ "$OUT" == *"CEILING BREACH"* ]] || fail "--tick past the trip point should breach, got: '$OUT'"
+[[ "$OUT" == *"User Heartbeat"* ]] || \
+  fail "breach line must point at the monitor-mode.md one-line heartbeat format, got: '$OUT'"
+[[ "$OUT" == *"nothing new"* ]] || \
+  fail "breach line must authorise a nothing-new heartbeat, got: '$OUT'"
+LINES=$(printf '%s' "$OUT" | wc -l | tr -d ' ')
+[[ "$LINES" -le 1 ]] || fail "breach output should be a single line, got $LINES newlines"
+ok "--tick emits a single one-line heartbeat instruction on breach"
+
+# --- 11. Breaches are deduped per stretch of silence ------------------------
+OUT=$("$SCRIPT" --tick --session "$SID")
+[[ -z "$OUT" ]] || fail "second --tick at the same heartbeat mtime should be deduped, got: '$OUT'"
+ok "--tick emits once per stretch of silence, not once per poll"
+
+# --- 12. A new stretch of silence is reportable again -----------------------
+touch "$(hb)"                                   # agent spoke; Stop hook re-stamps
+OUT=$("$SCRIPT" --tick --session "$SID")
+[[ -z "$OUT" ]] || fail "--tick after the agent spoke should be silent, got: '$OUT'"
+touch -t "$(stamp_minutes_ago 30)" "$(hb)"      # goes quiet again
+OUT=$("$SCRIPT" --tick --session "$SID")
+[[ "$OUT" == *"CEILING BREACH"* ]] || fail "a fresh stretch of silence should breach again, got: '$OUT'"
+ok "dedupe resets once the agent speaks, so the next silence still breaches"
+
+# --- 13. --tick never exits non-zero (a watch that exits stops watching) -----
+"$SCRIPT" --tick --session "$SID" >/dev/null
+[[ $? -eq 0 ]] || fail "--tick must always exit 0 so the watch loop survives"
+ok "--tick always exits 0"
+
+# --- 14. Ceiling override is honoured, and derived timing follows it ---------
+OVR=$(CLAUDE_BGWORK_CEILING_S=600 "$SCRIPT" --status --session "$SID")
+[[ "$(printf '%s' "$OVR" | jq -r '.ceiling_s')" == "600" ]] || fail "override should set ceiling_s=600"
+OVR_TRIP=$(printf '%s' "$OVR" | jq -r '.trip_s')
+OVR_POLL=$(printf '%s' "$OVR" | jq -r '.poll_s')
+(( OVR_TRIP + OVR_POLL <= 600 )) || fail "derived timing must respect an overridden ceiling"
+ok "CLAUDE_BGWORK_CEILING_S override keeps the timing invariant"
+
+# --- 15. A nonsense override warns and falls back, never silently applies ----
+ERR=$(CLAUDE_BGWORK_CEILING_S=abc "$SCRIPT" --status --session "$SID" 2>&1 >/dev/null)
+[[ "$ERR" == *"ignoring invalid"* ]] || fail "invalid override should warn on stderr, got: '$ERR'"
+VAL=$(CLAUDE_BGWORK_CEILING_S=abc "$SCRIPT" --status --session "$SID" 2>/dev/null | jq -r '.ceiling_s')
+[[ "$VAL" == "1200" ]] || fail "invalid override should fall back to the default, got '$VAL'"
+# A value at or below the margin would invert the trip point — reject it too.
+VAL=$(CLAUDE_BGWORK_CEILING_S=10 "$SCRIPT" --status --session "$SID" 2>/dev/null | jq -r '.ceiling_s')
+[[ "$VAL" == "1200" ]] || fail "an override below the margin should fall back, got '$VAL'"
+ok "invalid ceiling overrides warn and fall back to the default"
+
+# --- 16. Usage errors exit 2 -------------------------------------------------
+"$SCRIPT" >/dev/null 2>&1;                       [[ $? -eq 2 ]] || fail "no mode should exit 2"
+"$SCRIPT" --nope >/dev/null 2>&1;                [[ $? -eq 2 ]] || fail "unknown flag should exit 2"
+"$SCRIPT" --check --status >/dev/null 2>&1;      [[ $? -eq 2 ]] || fail "two modes should exit 2"
+"$SCRIPT" --note-started >/dev/null 2>&1;        [[ $? -eq 2 ]] || fail "--note-started without kind should exit 2"
+"$SCRIPT" --note-started --check >/dev/null 2>&1; [[ $? -eq 2 ]] || fail "--note-started must not swallow the next flag as its kind"
+ok "usage errors exit 2"
+
+# --- 17. --clear resets the session ------------------------------------------
+"$SCRIPT" --clear --session "$SID"
+"$SCRIPT" --check --session "$SID"
+[[ $? -eq 0 ]] || fail "--check should pass after --clear"
+ok "--clear resets session markers"
+
+# --- 18. An unwritable marker dir fails CLOSED (exit 5), never silently -----
+RO_DIR="$TMP_DIR/readonly"
+mkdir -p "$RO_DIR"
+chmod a-w "$RO_DIR"
+# The probe runs in a subshell so the redirection failure itself is captured —
+# `: > file 2>/dev/null` still lets bash print its own "Permission denied".
+if ( : > "$RO_DIR/probe" ) 2>/dev/null; then
+  rm -f "$RO_DIR/probe"
+  echo "skip — running with write access to a mode-555 dir (root?); cannot test the unwritable path"
+else
+  ERR=$(CLAUDE_BGWORK_MARKER_DIR="$RO_DIR" "$SCRIPT" --note-started Agent --session "$SID" 2>&1 >/dev/null)
+  RC=$?
+  [[ $RC -eq 5 ]] || fail "unwritable marker dir should exit 5 (fail closed), got $RC"
+  [[ "$ERR" == *"cannot write"* ]] || fail "unwritable marker dir should say so on stderr, got: '$ERR'"
+  ok "an unwritable marker dir fails closed (exit 5) and is visible on stderr"
+fi
+chmod u+w "$RO_DIR"
+
+echo "OK: bgwork-ceiling.sh tests passed"

--- a/global-settings.json
+++ b/global-settings.json
@@ -41,6 +41,11 @@
           },
           {
             "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/bgwork-ceiling-guard.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "/path/to/claude-code-config/.claude/hooks/trust-flag-repair.sh",
             "timeout": 10
           },
@@ -165,6 +170,11 @@
           {
             "type": "command",
             "command": "/path/to/claude-code-config/.claude/hooks/silence-detector.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/bgwork-ceiling-arm.sh",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
Closes #803

## What this fixes

`CLAUDE.md` #3 promises a user-visible message at least every 5 minutes. That promise silently stopped applying in the one situation where it matters most: a thread spawns a subagent, ends its turn, and waits. The in-context nag is a **PostToolUse** hook, and a thread waiting on a completion notification makes no tool calls — so nothing checked and nothing warned. The launchd watchdog saw the stall but could only raise an OS notification, and it `continue`s when `/tmp/claude-active-<id>` is absent — a marker the Stop hook removes — so it **deliberately skipped the ended-its-turn-and-waiting state**.

One cause underneath both: printing a message requires a turn, and nothing in the spawn path guaranteed a turn would ever happen.

## Approach

Measurement is not re-implemented. `/tmp/claude-heartbeat-<session-id>` already means "time of last user-visible message" and stays the single source of truth. What was missing is a **turn-independent observer of it that can force a turn**, plus a gate that makes arming that observer non-optional.

- **`.claude/scripts/bgwork-ceiling.sh`** — sole owner of the ceiling duration and the derived trip point / poll interval. Full contract in `--help`.
- **`.claude/hooks/bgwork-ceiling-arm.sh`** (PostToolUse) — records background work (`Agent`, `Workflow`, `Monitor`, backgrounded `Bash`) and injects the exact arming call. **Advisory.**
- **`.claude/hooks/bgwork-ceiling-guard.sh`** (Stop) — returns `decision: block` when background work is in flight and the ceiling is unarmed, so the turn cannot end silently. **This is the enforcement.**

### Which primitive arms it — the issue's open question, resolved

| Primitive | Verdict |
|-----------|---------|
| `ScheduleWakeup` | **Rejected** — it is the `/loop` dynamic-mode scheduler, unavailable in a plain coding thread, which is exactly where the hole is. |
| `CronCreate` | **Rejected** — fires on wall-clock cadence whether or not the thread is silent, so a healthy thread would get spurious ceiling messages; jitter eats into the ceiling; `durable: true` is a documented no-op. |
| `Monitor` | **Chosen** — an out-of-turn process whose stdout lines become chat events. |

`Monitor` is the only option that is turn-independent *and* conditional (silent unless the thread really goes quiet) *and* armed once per session via `persistent: true` *and* out of reach of stable-state backoff — backoff widens and deletes **cron** jobs, and a `Monitor` is stopped only by `TaskStop`, so the issue's "must survive backoff" requirement is met structurally rather than by a prose carve-out.

Arming once per session also sidesteps detecting *completion* of background work: the watch stays correct whatever the cause of silence.

### Why the number is not published

A backstop must never read as a target — "no longer than 20 minutes" quietly authorises 19 minutes of silence. The constant lives in `bgwork-ceiling.sh`; every rule file says "the ceiling" or names the script. `CLAUDE.md` #3's 5-minute cadence stays the only published number.

### Fail-closed, bounded, never silent

Per `feedback_guard_must_fail_closed.md`, the default is to **block**, not warn. Blocking is bounded at 2 consecutive turns (an unbounded block would hang the thread); past the bound the guard stands down **loudly** — stderr, `~/.claude/logs/bgwork-ceiling.log`, and an unguarded marker the arm hook resurfaces on every later tool call. The advisory rate-limit deliberately does **not** apply once unguarded: throttling the only remaining signal would be the same silent degradation this change removes.

## Test plan

- [x] Spawning background work and ending the turn produces a heartbeat inside the ceiling, unprompted — the end-to-end case is replayed in `bgwork-ceiling-hooks.test.sh` #15 (spawn → blocked → armed → turn ends → watch breaks the silence with **zero** intervening hook invocations). The timing guarantee is asserted as the invariant `trip + poll <= ceiling` rather than by waiting out a real 20 minutes, so it holds for any retuning.
- [x] Identical behaviour for a background `Bash` process instead of a subagent — `bgwork-ceiling-hooks.test.sh` #2 covers `Agent` / `Workflow` / `Monitor` / `Bash(run_in_background)`; #3 confirms a foreground `Bash` is *not* treated as background work.
- [x] A thread producing normal 5-minute heartbeats never triggers the ceiling path — `bgwork-ceiling.test.sh` #9 (silent on a fresh heartbeat and below the trip point) and #11 (one breach per stretch of silence, not one per poll).
- [x] The ceiling survives context compaction — verified structurally rather than by forcing a compaction: neither half lives in context (the watch is an OS process, the state is `/tmp` markers), and the suites exercise that state across independent process invocations. Called out under "Known limits" in the reference doc.
- [x] No stated 20-minute cadence in `CLAUDE.md` or any rule file — `grep -rnE '\b20[- ]?(min|minute)' CLAUDE.md .claude/rules/` returns nothing, and the literal appears in no rule file.
- [x] `rule-lint.sh` passes and the corpus is within the committed ratchet cap — 11,171 words against a cap of 11,749, and now under the 12,000 soft budget as well, so this adds no warning (note: the script lives at `.github/scripts/rule-lint.sh`, not the `.claude/scripts/` path the issue cites).
- [x] Existing hook tests still pass — `silence-detector-time-dedupe.test.sh` green, and the full auto-discovered run is 47/47 suites, 0 failures.
- [x] The two new suites are picked up with no workflow edit (issue #681 auto-discovery) and `shellcheck -S warning` is clean on all three new scripts.

## Review notes

- **CodeAnt CLI was not run** — it is not installed on this host and its auth is browser-only (rung 4 of the `safety.md` capability ladder), so per `cr-local-review.md` it is dropped for this session and noted here. The CodeAnt **GitHub App** is unaffected and satisfies the merge gate on its own.
- **CodeRabbit CLI: one verified-successful pass, then a stall.** Round 1 completed normally with 6 findings (triaged below). Round 2, re-run after staging so it would also cover the new scripts, sat in `status: reviewing` for 16+ minutes with no findings and no error — well past the 2-minute hang threshold in `cr-local-review.md` — so it was stopped and the CLI dropped for this session. The new files therefore have **not** had a local CLI pass; the CodeRabbit and CodeAnt **GitHub Apps** review them on this PR and are what gates the merge.
- Of round 1's 6 findings: 3 accepted (ceiling described as a backstop rather than a replacement poll; re-arm recovery in the pre-exit checklist; the bounded stand-down stated explicitly in the failure-mode doc). 3 declined with reasoning — moving `session-start-sync.sh` to a `SessionStart` segment (it really is registered under `PostToolUse`); requiring arm-*before*-spawn (the design is spawn-then-arm within the same step, and there is nothing to arm against beforehand); and collapsing the `monitor-mode.md` / `subagent-orchestration.md` one-liners into references (AC7 requires the step to appear in both).

## Rebased onto PR #804

PR #804 (rule-corpus compression, 12,166 → 10,999 words + ratchet reset) landed mid-flight and touched the same three rule files. Rebased with both conflicts hand-merged rather than resolved ours/theirs (`feedback_merge_conflict_trace_both_sides.md`): main's compressed wording is kept everywhere, with the ceiling additions layered on top. Two trims I had made *purely* to fit the old budget — the "Why the Never above" line in `scheduling-reliability.md` and the `File-Write Status Updates` text in `monitor-mode.md` — are **reverted**, since the compression removed the pressure that justified them. The diff is now the feature and nothing else.

## Follow-up spotted, not fixed here

`scheduling-reliability.md` still describes `CronCreate` as the primitive for "cross-session durability", but the tool's own contract now states `durable` has no effect and jobs are session-only. Out of scope for this change; worth its own issue.

