### PR TITLE
fix(#802): make chip-model-guard-lint match the placement statement, not stray phrases

### DIFF
--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -28,7 +28,7 @@ Separately from Fast mode: for Light-tier work, **Haiku** is a valid cheaper alt
 
 **MANDATORY OUTPUT FORMAT:** Every per-issue prompt block printed to the transcript MUST open and close with `~~~` tilde fences. NEVER use backtick fences as the outer prompt-block delimiter. This governs fallback mode and print-on-demand replay — the two paths that print a block. In chip mode the prompt rides inside the chip rather than being printed, so it needs no fence; its content is otherwise identical.
 
-**Per-block model and effort labels (mandatory):** The first content inside each tilde-fenced block (immediately after the opening `~~~`) MUST be two lines, in this order and with no blank line between them:
+**Per-block model and effort labels (mandatory):** The `**Model:**` line is the first content inside each tilde-fenced block (immediately after the opening `~~~`), immediately followed by the `**Effort:**` line — no blank line between the two:
 
 ```text
 **Model:** {MODEL} — {REASON}

--- a/.github/scripts/chip-model-guard-lint.sh
+++ b/.github/scripts/chip-model-guard-lint.sh
@@ -142,7 +142,7 @@ for skill in "${CANONICAL_EMITTERS[@]}"; do
   require_pattern "$skill_file" '\*\*Model:\*\*' "${skill} **Model:** requirement"
   require_pattern "$skill_file" '\*\*Effort:\*\*' "${skill} **Effort:** requirement"
   require_pattern "$skill_file" 'model-guard preamble|MODEL GUARD' "${skill} model-guard requirement"
-  require_pattern "$skill_file" '\*\*Model:\*\*.*(first line|first prompt|first content|MUST open|open the chip|base block|\bfirst\b)|(first line|first prompt|first content|MUST open|open the chip|base block|\bfirst\b).*\*\*Model:\*\*' "${skill} first-line **Model:** placement"
+  require_pattern "$skill_file" '\*\*Model:\*\*.*(first line|first prompt|first content|MUST open|open the chip|base block|\bfirst\b)|(first line|first prompt|first content|MUST open|open the chip|base block).*\*\*Model:\*\*' "${skill} first-line **Model:** placement"
   require_pattern "$skill_file" 'no blank line' "${skill} no-blank-line guard placement"
   require_pattern "$skill_file" 'short summary|Short-summary transcript format' "${skill} short-summary repetition"
 

--- a/.github/scripts/chip-model-guard-lint.sh
+++ b/.github/scripts/chip-model-guard-lint.sh
@@ -142,7 +142,7 @@ for skill in "${CANONICAL_EMITTERS[@]}"; do
   require_pattern "$skill_file" '\*\*Model:\*\*' "${skill} **Model:** requirement"
   require_pattern "$skill_file" '\*\*Effort:\*\*' "${skill} **Effort:** requirement"
   require_pattern "$skill_file" 'model-guard preamble|MODEL GUARD' "${skill} model-guard requirement"
-  require_pattern "$skill_file" 'first line|first prompt|MUST open|open the chip|MUST open with|first content|base block' "${skill} first-line **Model:** placement"
+  require_pattern "$skill_file" '\*\*Model:\*\*.*(first line|first prompt|first content|MUST open|open the chip|base block|\bfirst\b)|(first line|first prompt|first content|MUST open|open the chip|base block|\bfirst\b).*\*\*Model:\*\*' "${skill} first-line **Model:** placement"
   require_pattern "$skill_file" 'no blank line' "${skill} no-blank-line guard placement"
   require_pattern "$skill_file" 'short summary|Short-summary transcript format' "${skill} short-summary repetition"
 

--- a/.github/scripts/tests/chip-model-guard-lint.test.sh
+++ b/.github/scripts/tests/chip-model-guard-lint.test.sh
@@ -334,6 +334,23 @@ expect "PR#799 rewording (**Model:** line first in chip prompt) still passes" 0 
   'chip-model-guard-lint: OK' \
   rewording_pr799
 
+# The right-side over-match: bare `\bfirst\b` before **Model:** on the same line
+# was accepted even in non-contractual prose such as "the first time we reference
+# **Model:**".  The fix removes `\bfirst\b` from the right-side alternation, so
+# only the specific placement phrases (first line, first content, MUST open, …)
+# satisfy the check when the phrase precedes **Model:** on the same line.  Bare
+# "first" that precedes **Model:** is now correctly rejected as insufficient.
+# (Bare "first" that FOLLOWS **Model:** on the same line still satisfies the
+# left-side alternation — preserving the PR #799 rewording above.)
+noncontractual_first_before_model() {
+  mutate .claude/skills/issue-maker/SKILL.md \
+    's/MUST open with the `\*\*Model:\*\*` line from/the first time we reference `\*\*Model:\*\*` is from/'
+}
+
+expect "non-contractual 'first' before **Model:** does not satisfy placement (#802 fix)" 1 \
+  'issue-maker first-line \*\*Model:\*\* placement' \
+  noncontractual_first_before_model
+
 if (cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1); then
   echo "ok   — real repo conformance is intact"
 else

--- a/.github/scripts/tests/chip-model-guard-lint.test.sh
+++ b/.github/scripts/tests/chip-model-guard-lint.test.sh
@@ -103,9 +103,18 @@ expect "missing model-guard in pm skill fails" 1 \
   'pm model-guard requirement' \
   mutate .claude/skills/pm/SKILL.md '/model-guard preamble/d'
 
+# After the co-occurrence tightening (#802) wave has TWO lines that satisfy the
+# check: the "Chip model + effort contract" line (has "MUST open" + **Model:**)
+# and the prompt-description line (`**Model:**` line first).  Removing only the
+# first still leaves the second, so both must be cleared to prove the check fires.
+decouple_wave_placement() {
+  mutate .claude/skills/wave/SKILL.md '/Chip model + effort contract/d'
+  mutate .claude/skills/wave/SKILL.md 's/`\*\*Model:\*\*` line first,/the Model line first,/'
+}
+
 expect "missing first-line placement in wave skill fails" 1 \
   'wave first-line \*\*Model:\*\* placement' \
-  mutate .claude/skills/wave/SKILL.md '/Chip model + effort contract/d'
+  decouple_wave_placement
 
 expect "missing Fable warning in start-issue skill fails" 1 \
   'start-issue Fable pre-click warning requirement' \
@@ -290,6 +299,40 @@ plant_versioned_literal_in_pm() {
 expect "versioned literal fails even in a literal emitter" 1 \
   'Versioned model name' \
   plant_versioned_literal_in_pm
+
+# --- #802: co-occurrence check (placement phrase must be *about* **Model:**) ---
+
+# The too-loose direction: a placement phrase on a line that does NOT also carry
+# **Model:**.  The issue body calls out "MUST open with the task description" as
+# the canonical example of a claim that the old loose alternation accepted (it
+# matched "MUST open") but the new co-occurrence check rejects.  The mutation
+# replaces issue-maker's real placement claim ("MUST open with the `**Model:**`
+# line") with that exact example text so the replacement deliberately keeps the
+# phrase — otherwise a loose /MUST open/ check would still fail here and the
+# case would not distinguish strict from loose.
+must_open_task_description() {
+  mutate .claude/skills/issue-maker/SKILL.md \
+    's/MUST open with the `\*\*Model:\*\*` line from/MUST open with the task description from/'
+}
+
+expect "placement phrase without **Model:** co-occurrence fails (Issue #802 example)" 1 \
+  'issue-maker first-line \*\*Model:\*\* placement' \
+  must_open_task_description
+
+# The too-brittle direction: PR #799 proposed rewording "the **Model:** line
+# first" — more direct than "as the first line of the prompt" but broke the old
+# loose check because bare "first" was not in its vocabulary. The new
+# co-occurrence check must accept it because **Model:** and "first" appear on
+# the same line. The replacement deliberately retains both so the case proves
+# co-occurrence strictness, not mere phrase-absence.
+rewording_pr799() {
+  mutate .claude/skills/pm/SKILL.md \
+    's/ as the \*\*first line\*\* of the / **first** in the chip /'
+}
+
+expect "PR#799 rewording (**Model:** line first in chip prompt) still passes" 0 \
+  'chip-model-guard-lint: OK' \
+  rewording_pr799
 
 if (cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1); then
   echo "ok   — real repo conformance is intact"


### PR DESCRIPTION
Closes #802

## Summary

The first-line placement check in `chip-model-guard-lint.sh` had two opposing defects:

1. **Too loose:** phrases like "MUST open with the task description" passed because they contained "MUST open" — which matched even when `**Model:**` was nowhere on that line.
2. **Too brittle:** the PR #799 rewording "the `**Model:**` line **first**" failed because `\bfirst\b` was not in the alternation.

**Fix:** Replace the seven-way phrase alternation with a co-occurrence pattern that requires `**Model:**` AND a placement phrase to appear on the **same line** (in either order):

```
\*\*Model:\*\*.*(first line|first prompt|first content|MUST open|open the chip|base block|\bfirst\b)
|(first line|first prompt|first content|MUST open|open the chip|base block|\bfirst\b).*\*\*Model:\*\*
```

**Scope:** Only the lint script, its test file, and `/prompt`'s SKILL.md are changed. No rule corpus files touched (contention with sibling PR #806).

**`/prompt` SKILL.md reword:** The placement sentence previously put "first content" and `**Model:**` on separate lines. Line 31 is rewording so both appear together: "The `**Model:**` line is the first content inside each tilde-fenced block…"

**Wave test update:** After the fix, `wave/SKILL.md` has TWO co-occurrence lines that satisfy the check (line 164: "MUST open" + `**Model:**`; line 168: `` `**Model:**` line first ``). The existing wave mutation only cleared line 164, so the failure test would have passed the lint after the fix. `decouple_wave_placement` now clears both lines.

## Test plan

- [x] Co-occurrence tightening: `**Model:**` must appear on the SAME line as the placement phrase (new pattern requirement)
- [x] Too-loose case (Issue #802 example): "MUST open with the task description" fails when `**Model:**` is removed from that line — `must_open_task_description` fixture exits 1
- [x] Too-brittle case (PR #799 rewording): "the `**Model:**` line **first**" passes — `rewording_pr799` fixture exits 0
- [x] Wave test correctness: `decouple_wave_placement` clears BOTH co-occurrence lines so the failure test reliably fires
- [x] Full test suite: all 34 fixtures pass (`chip-model-guard-lint.test.sh`)
- [x] `rule-lint.sh` passes (corpus unchanged — skill files not in the corpus)
- [x] `skill-catalog-lint.sh` passes (29 commands, no drift)

**Local CLI status:** CodeRabbit CLI and CodeAnt CLI attempted. CodeRabbit: rate-limit cap hit (free OSS tier, ~3 reviews then 40-min lockout). CodeAnt: daily agent-review cap reached (403). Both CLIs unavailable for this session — self-review completed; GitHub App reviewers (CR/CodeAnt) are unaffected and will gate the merge.