### PR TITLE
fix(#810): fire the capability ladder on deferral, not on "impossible"

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -91,15 +91,20 @@ Agent tool call:
            commands (rm -rf, rm, git checkout ., git stash, git reset --hard) in the
            root repo directory. Stay in your worktree directory at all times.
 
-           MINDSET: Before handing off, walk the capability ladder for ANY provider
-           CLI (gh, git, vercel, neonctl, railway, cloudinary, or one you've never
-           used): look at what you already have — MCP tools, skills, and the CLI on
-           disk by absolute path (/opt/homebrew/bin/<tool>); if absent, check
-           whether the provider ships a CLI; install it yourself when
+           MINDSET: The trigger is the DEFERRAL, not the word 'impossible' —
+           'I can't', 'not a session task', 'that's a deployment step', 'runbook is
+           in docs/…' all fire this ladder. Walk it for ANY provider CLI (gh, git,
+           vercel, neonctl, railway, cloudinary, or one you've never used) before
+           writing any of them: look at what you already have — MCP tools, skills,
+           and the CLI on disk by absolute path (/opt/homebrew/bin/<tool>); if
+           absent, check whether the provider ships a CLI; install it yourself when
            non-interactive and the safety rails hold; else hand off an
-           /admin-merge-shaped runbook — exact commands + one-line reason. 'I can't'
-           is valid only after the ladder dead-ends, and must name the rung and the
-           reason.
+           /admin-merge-shaped runbook — reachable only after the first three rungs
+           were walked and failed. It must name the rung that stopped you and the
+           reason, and give the exact commands, including the interactive auth step
+           when that is the wall. If you can write the command, you can run it.
+           Provisioning a generated secret via a provider CLI is allowed — the
+           value just must never be echoed, committed, pasted, or logged.
 
            SKILLS: Before hand-rolling a multi-step task, check whether an existing
            skill already does this job — invoke it via the Skill tool instead of

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -42,7 +42,7 @@ The parent agent provides these values in your prompt:
 - NEVER run destructive commands (`rm -rf`, `rm`, `git checkout .`, `git stash`, `git reset --hard`) in the root repo directory.
 - Stay in your worktree directory at all times.
 - NEVER add `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `noqa`, or any linter suppression comment. Fix the actual code.
-- Before treating something as impossible, walk the capability ladder for any provider CLI (`gh`, `git`, `curl`, or a service CLI like `railway`/`vercel`) — check locally by absolute path, check whether the provider ships one, install it when safe; only hand off for real walls, naming the rung you stopped on, per the capability-discovery mindset in `safety.md`.
+- Before leaving any work undone — whether you'd frame it as impossible, out of scope, a deployment step, or a runbook for someone else — walk the capability ladder for any provider CLI (`gh`, `git`, `curl`, or a service CLI like `railway`/`vercel`): check locally by absolute path, check whether the provider ships one, install it when safe. Handing off is rung 4, reachable only after rungs 1–3 actually failed: name the rung that stopped you and why, and give the exact commands, including the interactive auth step when that is the wall — per the capability-discovery mindset in `safety.md`.
 
 ## Workflow
 

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -23,7 +23,7 @@ The parent agent provides:
 - NEVER run destructive commands (`rm -rf`, `rm`, `git checkout .`, `git stash`, `git reset --hard`) in the root repo directory.
 - Stay in your worktree directory at all times.
 - NEVER add linter suppression comments. Fix the actual code.
-- Before treating something as impossible, walk the capability ladder for any provider CLI (`gh`, `git`, `curl`, or a service CLI like `railway`/`vercel`) — check locally by absolute path, check whether the provider ships one, install it when safe; only hand off for real walls, naming the rung you stopped on, per the capability-discovery mindset in `safety.md`.
+- Before leaving any work undone — whether you'd frame it as impossible, out of scope, a deployment step, or a runbook for someone else — walk the capability ladder for any provider CLI (`gh`, `git`, `curl`, or a service CLI like `railway`/`vercel`): check locally by absolute path, check whether the provider ships one, install it when safe. Handing off is rung 4, reachable only after rungs 1–3 actually failed: name the rung that stopped you and why, and give the exact commands, including the interactive auth step when that is the wall — per the capability-discovery mindset in `safety.md`.
 
 ## Initialization
 

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -25,7 +25,7 @@ The parent agent provides:
 - Stay in your worktree directory at all times except for `/wrap` helper calls that explicitly target the resolved root repo path.
 - Do not run `gh pr merge` directly. After verification, execute the shared `/wrap` instructions from `.claude/skills/wrap/SKILL.md` so Phase C and `/wrap` cannot drift.
 - Do not delete the running worktree or feature branch. `/wrap` intentionally leaves them in place; stale cleanup is owned by `/pm-update` via `.claude/scripts/stale-cleanup.sh`.
-- Before treating something as impossible, walk the capability ladder for any provider CLI (`gh`, `git`, `curl`, or a service CLI like `railway`/`vercel`) — check locally by absolute path, check whether the provider ships one, install it when safe; only hand off for real walls, naming the rung you stopped on, per the capability-discovery mindset in `safety.md`.
+- Before leaving any work undone — whether you'd frame it as impossible, out of scope, a deployment step, or a runbook for someone else — walk the capability ladder for any provider CLI (`gh`, `git`, `curl`, or a service CLI like `railway`/`vercel`): check locally by absolute path, check whether the provider ships one, install it when safe. Handing off is rung 4, reachable only after rungs 1–3 actually failed: name the rung that stopped you and why, and give the exact commands, including the interactive auth step when that is the wall — per the capability-discovery mindset in `safety.md`. This never overrides your no-fix contract: a code issue found during AC verification is still `OUTCOME: blocked`, not yours to fix.
 
 ## Initialization
 

--- a/.claude/reference/capability-discovery-examples.md
+++ b/.claude/reference/capability-discovery-examples.md
@@ -1,6 +1,6 @@
 # Capability Discovery — False Walls vs Real Walls
 
-Extracted from `.claude/rules/safety.md` "Capability Discovery — Try the CLI Before Handoff". The rule file keeps the operative ladder and the verbatim `MINDSET:` block; this file holds the worked catalog. **Extend the false-walls list as new ones are observed.**
+Extracted from `.claude/rules/safety.md` "Capability Discovery — Try the CLI Before Deferring". The rule file keeps the operative ladder and the verbatim `MINDSET:` block; this file holds the worked catalog. **Extend the false-walls list as new ones are observed.**
 
 ## Common false walls — GitHub (usually doable)
 
@@ -29,6 +29,39 @@ The ladder is not a GitHub rule. Every provider below is a one-liner, not a dash
 | upload an asset to Cloudinary | `cloudinary uploader upload {file} public_id={id}` |
 
 Writing a markdown file full of copy-paste commands **and then saying "you'll have to run these"** — on a project where the CLI is installed and linked — is the exact anti-pattern this ladder exists to kill. If you can write the command, you can run it.
+
+## Common false walls — scope, not capability (issue #810)
+
+The ladder's other entry point, and the one that slipped past issue #759. These deferrals never claim the work is impossible — they reassign it, so a rule keyed on "I can't" never fires:
+
+| The deferral | What it actually is |
+|--------------|---------------------|
+| "that's not a session task" | rung 1 never walked |
+| "that's a deployment step" | rung 1 never walked |
+| "the runbook is in `docs/…`" | rung 4 claimed without rungs 1–3 |
+| "I'll leave that to you in case you want to review it first" | rung 4 dressed up as courtesy |
+
+Courtesy is the hardest of these to catch, because deferring to the user's judgment is sometimes right. Two things have to hold before you act instead of asking: the work is **reversible and inspectable**, and the target is **already established** by the task. Setting an env var on the service this session is already working against — one you can read back and change — is a step you can take and report, not a decision needing pre-approval. Standing up a new environment, or writing to one the task never named, is not: that is a real rung-4 handoff, and it should say so.
+
+### Worked example — the motivating case
+
+A security fix merged, CI green, session reported complete. The change altered no production behavior, because three env vars were still unset. The agent detected exactly that, named all three, wrote a correct runbook into `docs/security/S2S-IDENTITY.md`, and handed the session back. It never said "I can't" — it treated provisioning as somebody else's job, so the ladder sat loaded in context and never triggered.
+
+Rung 1 would have ended it: `railway` was on disk and linked. Rungs 2 and 3 were unnecessary, and rung 4 was never reachable.
+
+```bash
+railway variables            # rung 1: which of the three are already set?
+
+NEW_KEY=$(openssl rand -base64 32)                   # generated, never printed
+[ -n "$NEW_KEY" ] || { echo "key generation failed" >&2; exit 1; }
+railway variables --set "S2S_SIGNING_KEY=$NEW_KEY"   # provisioned, value stays out of output
+```
+
+That is one of the three. Repeat it for the second key, and set the third — `S2S_ISSUER`, not a secret — directly. Validating before provisioning matters: an unchecked `openssl` failure would quietly install an empty signing key, which is worse than the unset variable you started with.
+
+**Secrets are not pre-refused.** The deferred work was generating and provisioning signing keys, and `safety.md`'s credential prohibitions read at a glance like "don't touch keys at all." They are narrower than that: generating a key and setting it through a provider CLI is the allowed path. What's prohibited is letting the *value* land anywhere durable — a commit, an issue or PR body, a subagent prompt, a review comment, or a log. Reference credentials by name in all of those. A credential-shaped task earns the same ladder walk as any other.
+
+The interfaces differ — `vercel env add` reads the value from stdin, `railway variables --set` takes it as an argument — but the boundary does not: the value never reaches your output, a commit, or a PR body. Where a CLI offers a stdin path, prefer it.
 
 ## Rungs 1–3 in practice — the not-installed case
 
@@ -66,4 +99,4 @@ Never substitute a prose description of what needs doing for the commands themse
 
 ## Anti-pattern
 
-Typing "agents can't do X" where X sounds like something a CLI handles — stop and walk the ladder; the default answer is you probably CAN. A handoff that fails to name the rung it stopped on, with a concrete reason, is not a finished answer. This doesn't loosen any prohibition: check `safety.md`'s "Never" lists before assuming a capability is off-limits.
+Typing "agents can't do X" where X sounds like something a CLI handles — stop and walk the ladder; the default answer is you probably CAN. The scope-shaped version of the same anti-pattern is quieter and just as wrong: calling X a deployment step, a follow-up, or somebody else's task, without ever having checked. Both are deferrals, and a handoff that fails to name the rung it stopped on, with a concrete reason, is not a finished answer. This doesn't loosen any prohibition: check `safety.md`'s "Never" lists before assuming a capability is off-limits.

--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -1,6 +1,6 @@
 # Safety — Destructive Command & Secret Prohibitions
 
-> **Always:** Stay in your worktree. Treat `.env` files and any unencrypted secret as untouchable. Pin and inspect installers. Warn subagents of these rules. Treat Anthropic's in-app UI as the sole authority on quota and spend. Restrict automated PR writes to PRs you authored.
+> **Always:** Stay in your worktree. Treat `.env` files as untouchable and secret values as never committed, pasted, echoed, or logged. Pin and inspect installers. Warn subagents of these rules. Treat Anthropic's in-app UI as the sole authority on quota and spend. Restrict automated PR writes to PRs you authored.
 > **Ask first:** Never — these are absolute prohibitions with no exceptions.
 > **Never:** Delete `.env` files. Run `git clean`. Run destructive commands in the root repo. Commit secrets. Pipe untrusted URLs into a shell. Pass raw credentials to subagents. Gate agent decisions on locally-estimated quota or spend. Have an automated tool write to (merge, rebase, comment, trigger a review, resolve threads, close, enroll in polling) a PR you did not author, absent an explicit per-PR chat override.
 
@@ -17,6 +17,8 @@
 1. **NEVER commit secrets** — API keys, tokens, private keys, OAuth secrets, DB URLs with passwords, signing keys. If you spot one in a diff, fail the commit and rotate out-of-band before pushing.
 2. **NEVER paste raw credentials into subagent prompts, issue/PR bodies, comments, commits, or logs.** These surfaces are durable and often public. Reference by name (e.g., `$CODERABBIT_API_KEY` from `~/.zshrc`) — never inline the value.
 3. **NEVER weaken `.gitignore` to commit a "just-this-once" config.** Move the secret to `.env` and commit a `.env.example` instead.
+
+**Provisioning is not committing.** Setting a generated secret through a provider CLI — `railway variables --set`, `vercel env add` (value on stdin where the CLI accepts it) — is ordinary work; the ban is on committing, pasting, echoing, or logging the value. Credential-shaped tasks are not pre-refused: they walk the capability ladder below like anything else.
 
 ## Untrusted Code & Network
 
@@ -52,28 +54,32 @@ commits, or logs. Do NOT pipe untrusted URLs into a shell or disable TLS verific
 Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude/rules/safety.md.
 ```
 
-## Capability Discovery — Try the CLI Before Handoff
+## Capability Discovery — Try the CLI Before Deferring
 
-Before declaring any task impossible, walk this ladder (covers **any** provider — `gh`, `git`, `vercel`, `neonctl`, `railway`, `cloudinary`, etc., not just GitHub):
+**The trigger is the deferral, not the word "impossible."** Walk this ladder before writing *any* of: "I can't", "not a session task", "that's a deployment step", "runbook is in `docs/…`", "I'll leave that to you to review." Each must first answer *could I do this with the tools I already have?* Covers **any** provider — `gh`, `git`, `vercel`, `neonctl`, `railway`, `cloudinary`, etc., not just GitHub:
 
-1. **Look at what you already have** — MCP tools, custom skills, and the provider's CLI on disk, the last checked by absolute path (`/opt/homebrew/bin/<tool>`): the Bash tool's PATH is minimal, so a bare `which` under-reports what is installed.
-2. **Absent? Check whether the provider ships a CLI at all** — most do. One lookup, then move on; a research detour mid-task is not warranted.
-3. **Install it yourself** when a non-interactive path exists and the rails above hold: package name confirmed against official docs, no `curl … | sh` of an unvetted URL, no TLS bypass, no `sudo`. Any rail that blocks — or an install whose auth step opens a browser — drops to rung 4. Note a new install in your response; don't edit the CLI docs as a side effect.
-4. **Hand off a runbook, not a description** — exact copy-paste command(s) plus one line on why it needs a human, in the `/admin-merge` (#451) shape, covering the `<tool> login` step when auth is interactive.
+1. **Look at what you already have** — MCP tools, custom skills, and the provider's CLI on disk; check the CLI by absolute path (`/opt/homebrew/bin/<tool>`), since the Bash tool's minimal PATH makes a bare `which` under-report.
+2. **Absent? Check whether the provider ships a CLI at all** — most do. One lookup, then move on.
+3. **Install it yourself** when a non-interactive path exists and the rails above hold: package name confirmed against official docs, no `curl … | sh` of an unvetted URL, no TLS bypass, no `sudo`. Note a new install in your response; don't edit the CLI docs as a side effect.
+4. **Hand off a runbook — reachable only after rungs 1–3 were walked and actually failed.** A blocked rail or a browser-based auth step lands you here; a judgment that the work is someone else's does not. If you can write the command, you can run it. Name the rung that stopped you and why, then the exact copy-paste command(s) in the `/admin-merge` (#451) shape, covering the `<tool> login` step when auth is interactive.
 
-"I can't" is valid only after the ladder dead-ends, naming the rung and concrete reason. Your own agent definition's prohibitions still win. Worked examples: `.claude/reference/capability-discovery-examples.md`.
+Deferring — "can't", "out of scope", or a runbook — is valid only after the ladder dead-ends. Your own agent definition's prohibitions still win. Worked examples: `.claude/reference/capability-discovery-examples.md`.
 
 ```text
-MINDSET: Before handing off, walk the capability ladder for ANY provider
-(gh, git, railway, vercel, …): (1) check what you have — MCP tools, skills, CLI
-on disk by absolute path (/opt/homebrew/bin/<tool>; minimal PATH makes bare
-`which` lie); (2) if absent, check whether the provider ships one (one lookup);
-(3) install it when non-interactive and rails hold (docs-confirmed name, no
-curl-pipe-sh, no TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped
-runbook: exact commands + one-line reason, incl. interactive auth. Your own
-prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
-valid only after the ladder dead-ends, naming the rung and reason.
-Full rules: .claude/rules/safety.md.
+MINDSET: The trigger is the DEFERRAL, not the word "impossible" — "I can't",
+"not a session task", "that's a deployment step", "runbook is in docs/…", and
+"I'll leave that to you to review" all fire this ladder. Walk it for ANY provider
+(gh, git, railway, vercel, …) before writing any of them: (1) check what you have
+— MCP tools, skills, CLI on disk by absolute path (/opt/homebrew/bin/<tool>;
+minimal PATH makes bare `which` lie); (2) if absent, check whether the provider
+ships one (one lookup); (3) install it when non-interactive and rails hold
+(docs-confirmed name, no curl-pipe-sh, no TLS bypass, no sudo); (4) hand off an
+/admin-merge-shaped runbook — reachable ONLY after 1–3 were walked and failed:
+name the rung that stopped you, exact commands + one-line reason, incl.
+interactive auth. If you can write the command, you can run it. Provisioning a
+generated secret via a provider CLI is allowed — the value just must never be
+echoed, committed, pasted, or logged. Your own prohibitions still win (phase-c
+uses /wrap, never gh pr merge). Full rules: .claude/rules/safety.md.
 ```
 
 ## Anthropic Quota & Spend Authority

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -724,16 +724,20 @@ Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude
 - The verbatim `MINDSET:` block from `.claude/rules/safety.md`:
 
 ```text
-MINDSET: Before handing off, walk the capability ladder for ANY provider
-(gh, git, railway, vercel, …): (1) check what you have — MCP tools, skills, CLI
-on disk by absolute path (/opt/homebrew/bin/<tool>; minimal PATH makes bare
-`which` lie); (2) if absent, check whether the provider ships one (one lookup);
-(3) install it when non-interactive and rails hold (docs-confirmed name, no
-curl-pipe-sh, no TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped
-runbook: exact commands + one-line reason, incl. interactive auth. Your own
-prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
-valid only after the ladder dead-ends, naming the rung and reason.
-Full rules: .claude/rules/safety.md.
+MINDSET: The trigger is the DEFERRAL, not the word "impossible" — "I can't",
+"not a session task", "that's a deployment step", "runbook is in docs/…", and
+"I'll leave that to you to review" all fire this ladder. Walk it for ANY provider
+(gh, git, railway, vercel, …) before writing any of them: (1) check what you have
+— MCP tools, skills, CLI on disk by absolute path (/opt/homebrew/bin/<tool>;
+minimal PATH makes bare `which` lie); (2) if absent, check whether the provider
+ships one (one lookup); (3) install it when non-interactive and rails hold
+(docs-confirmed name, no curl-pipe-sh, no TLS bypass, no sudo); (4) hand off an
+/admin-merge-shaped runbook — reachable ONLY after 1–3 were walked and failed:
+name the rung that stopped you, exact commands + one-line reason, incl.
+interactive auth. If you can write the command, you can run it. Provisioning a
+generated secret via a provider CLI is allowed — the value just must never be
+echoed, committed, pasted, or logged. Your own prohibitions still win (phase-c
+uses /wrap, never gh pr merge). Full rules: .claude/rules/safety.md.
 ```
 
 - The verbatim `SKILLS:` block from `.claude/rules/skill-first.md` (`phase-a-fixer` is in the "paste this too" list per `subagent-orchestration.md`'s spawn checklist):

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -246,16 +246,20 @@ Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude
 
 ## CAPABILITY DISCOVERY
 ```text
-MINDSET: Before handing off, walk the capability ladder for ANY provider
-(gh, git, railway, vercel, …): (1) check what you have — MCP tools, skills, CLI
-on disk by absolute path (/opt/homebrew/bin/<tool>; minimal PATH makes bare
-`which` lie); (2) if absent, check whether the provider ships one (one lookup);
-(3) install it when non-interactive and rails hold (docs-confirmed name, no
-curl-pipe-sh, no TLS bypass, no sudo); (4) else hand off an /admin-merge-shaped
-runbook: exact commands + one-line reason, incl. interactive auth. Your own
-prohibitions still win (phase-c uses /wrap, never gh pr merge). "I can't" is
-valid only after the ladder dead-ends, naming the rung and reason.
-Full rules: .claude/rules/safety.md.
+MINDSET: The trigger is the DEFERRAL, not the word "impossible" — "I can't",
+"not a session task", "that's a deployment step", "runbook is in docs/…", and
+"I'll leave that to you to review" all fire this ladder. Walk it for ANY provider
+(gh, git, railway, vercel, …) before writing any of them: (1) check what you have
+— MCP tools, skills, CLI on disk by absolute path (/opt/homebrew/bin/<tool>;
+minimal PATH makes bare `which` lie); (2) if absent, check whether the provider
+ships one (one lookup); (3) install it when non-interactive and rails hold
+(docs-confirmed name, no curl-pipe-sh, no TLS bypass, no sudo); (4) hand off an
+/admin-merge-shaped runbook — reachable ONLY after 1–3 were walked and failed:
+name the rung that stopped you, exact commands + one-line reason, incl.
+interactive auth. If you can write the command, you can run it. Provisioning a
+generated secret via a provider CLI is allowed — the value just must never be
+echoed, committed, pasted, or logged. Your own prohibitions still win (phase-c
+uses /wrap, never gh pr merge). Full rules: .claude/rules/safety.md.
 ```
 
 ## SKILLS-FIRST REFLEX

--- a/.github/scripts/tests/verbatim-block-lint.test.sh
+++ b/.github/scripts/tests/verbatim-block-lint.test.sh
@@ -66,9 +66,36 @@ noop() { :; }
 expect "well-formed repo passes" 0 'verbatim-block-lint: OK' noop
 
 # (b) Drifted verbatim copy fails naming the file and block
+# The substitution target must be a string that appears inside the MINDSET block
+# and nowhere else in the copy file — otherwise the sed is a no-op there, no drift
+# is injected, and this negative test silently passes for the wrong reason (#810).
+# The guard below fails loudly if a future reword breaks that assumption.
+DRIFT_TOKEN='ANY provider'
+
+# The token is used unescaped as a sed pattern, so keep it metacharacter-free.
+if [[ ! "$DRIFT_TOKEN" =~ ^[A-Za-z0-9\ ]+$ ]]; then
+  echo "FAIL — drift token '${DRIFT_TOKEN}' must contain only letters, digits, and spaces"
+  failures=$(( failures + 1 ))
+fi
+
+# Count fixed-string OCCURRENCES, not matching lines: grep -c collapses two hits
+# on one line to 1, which would let a non-unique token slip through this guard.
+for copy in .claude/skills/subagent/SKILL.md; do
+  # grep exits 1 on no match; under `set -euo pipefail` that would abort the whole
+  # script before this guard could report — the exact case it exists to catch. Fail
+  # closed to 0 instead, which trips the != 1 branch below.
+  occurrences=$(grep -o -F -- "$DRIFT_TOKEN" "${REPO_ROOT}/${copy}" 2>/dev/null | wc -l | tr -d '[:space:]') || occurrences=0
+  [[ "$occurrences" =~ ^[0-9]+$ ]] || occurrences=0
+  if (( occurrences != 1 )); then
+    echo "FAIL — drift fixture token '${DRIFT_TOKEN}' occurs ${occurrences}x in ${copy};" \
+         "pick a token that appears exactly once, inside the MINDSET block"
+    failures=$(( failures + 1 ))
+  fi
+done
+
 expect "drifted MINDSET in subagent SKILL.md fails naming file and block" 1 \
   'MINDSET.*drifted|drifted.*MINDSET' \
-  sed -i.bak 's/capability ladder/DRIFTED ladder/' \
+  sed -i.bak "s/${DRIFT_TOKEN}/DRIFTED provider/" \
     .claude/skills/subagent/SKILL.md
 
 # (c) Missing copy file fails


### PR DESCRIPTION
## Summary

The capability ladder in `.claude/rules/safety.md` fired on **capability** claims ("I can't") but not on **scope** claims ("that's a deployment step", "the runbook is in `docs/…`"). An agent that reassigns work rather than declaring it impossible never triggered it — the guardrail was loaded and simply stayed silent.

This makes the **deferral** the trigger, not the word "impossible", and closes the two things that made the gap easy to fall into:

- **Rung 4 read like permission.** "Hand off a runbook" was stated as a peer of rungs 1–3, so writing a good runbook looked like compliance rather than the fallback it is. It now states its own precondition — reachable only after rungs 1–3 were walked and *actually failed*, naming the rung that stopped you. The counterweight sentence that would have caught the motivating case, *"if you can write the command, you can run it"*, moves into the loaded rule; it previously lived only in `capability-discovery-examples.md`, which `CLAUDE.md` deliberately excludes from auto-loading.
- **Secrets work looked pre-refused.** `safety.md`'s credential prohibitions read at a glance as "don't touch keys at all", which gave scope deferral cover it shouldn't have. A new **Provisioning is not committing** clarifier draws the line where it actually falls: setting a generated secret through a provider CLI is ordinary work; committing, pasting, echoing, or logging the value is not.

Closes #810

## Changes

| File | Change |
|------|--------|
| `.claude/rules/safety.md` | Ladder entry condition names the deferral shapes; rung 4 gains its precondition; credential clarifier; `MINDSET:` block carries all of it |
| `.claude/skills/subagent/SKILL.md` | Verbatim `MINDSET:` re-sync |
| `.claude/skills/pr-monitor-and-manage/SKILL.md` | Verbatim `MINDSET:` re-sync |
| `.claude/reference/capability-discovery-examples.md` | Scope-deferral shapes added to the false-walls catalog + the motivating case as a worked example |
| `.claude/agents/{phase-a-fixer,phase-b-reviewer,phase-c-merger}.md` | Reframed off "before treating something as impossible" |
| `.claude/agents/README.md` | Paraphrased `MINDSET:` in the example spawn prompt reframed to match |

**Scope note — the four agent definitions were not in the issue's AC list.** They are included because all four restated the ladder with the "impossible"-only trigger, and they load as system context for every subagent. Leaving them would have preserved the exact bug on the surface `MINDSET:` exists to protect.

## Word budget

`11,171 → 11,356` against the `.budget-soft-cap` of **11,749** (393 headroom). Additions were partly funded by trimming within the same section — rung 2's "a research detour mid-task is not warranted", rung 1's PATH clause, rung 3's relocated rung-4 gate, and the closing sentence made redundant by the new rung 4. Net positive rather than net-neutral because the change adds a genuinely new trigger class, a precondition, and a credential boundary; no existing qualifier was dropped to fund it.

## Divergences from CodeRabbit's issue plan

- **Worked-example placement.** CR proposed appending it inside `## Real walls (handoff is correct, but structured)`. AC6 says *false-walls catalog*, and a scope deferral is a false wall by definition — the work was doable the whole time. Filing it under "Real walls" would teach the opposite lesson, so it went to the false-walls catalog.
- **Agent definitions.** Not in CR's plan; added for the reason above.
- **CR Design Choice 1 — accepted.** The third framing from the issue's open questions ("I'll leave that to you in case you want to review it first") is named inline rather than deferred to a follow-up issue, and the reference file explains why courtesy is the hardest of the shapes to catch.

## Local review

- **CodeRabbit CLI:** two passes. First pass returned 4 findings; 3 were applied and 1 declined:
  - *Applied* — the `Always:` summary said secrets were "never-committed or -pasted" while the body and `MINDSET:` say "echoed, committed, pasted, or logged"; the summary now matches.
  - *Applied* — the reference's "reversible and inspectable" test could be read as licence to mutate any production environment. It now requires the target to be **already established by the task**; standing up a new environment, or writing to one the task never named, is an explicit rung-4 handoff.
  - *Applied* — `phase-c-merger.md`: the strengthened "before leaving any work undone" wording conflicted with Phase C's no-fix contract. The line now states that it never overrides `OUTCOME: blocked`.
  - *Declined* — replacing `/opt/homebrew/bin/<tool>` with `command -v` / `type -P` in `agents/README.md`. This would reverse a deliberate, documented decision: the Bash tool runs with a minimal PATH, so bare `which`/`command -v` under-reports installed tools. `safety.md` rung 1, the `MINDSET:` block, `cli-tool-defaults.md`, and `capability-discovery-examples.md` (which shows `ls -l /opt/homebrew/bin/railway || command -v railway` — absolute path first, `command -v` as fallback) all encode this. It also reproduced live in this session: `command -v codeant` found nothing useful, and `coderabbit` was only located by an explicit path sweep to `~/.local/bin`.
- **CodeAnt CLI:** dropped for this session — not installed. Ladder walked per `safety.md`: rung 1 absent from every install path; rung 2 confirms it ships one (`npm install -g codeant-cli`); rung 3 blocked because auth is `codeant login` browser OAuth with no `~/.codeant/config.json` present, which no agent can drive. **Stopped at rung 3 (interactive auth).** The CodeAnt GitHub App is unaffected and still gates the merge.

## Incidental fix — `verbatim-block-lint.test.sh`

The lint's own negative test injected drift with `sed 's/capability ladder/DRIFTED ladder/'`. This rewrite removes that literal from the `MINDSET:` block, so the sed became a no-op, no drift was injected, and the test that is supposed to prove the lint *catches* drift passed for the wrong reason. Retargeted to `ANY provider`, plus a uniqueness guard that fails loudly if a future reword breaks the assumption again. Verified the guard fires: substituting the old token back reproduces the failure with an explicit message instead of a silent pass.

## Test plan

- [x] `{ cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } | wc -w` reports under 11,749
- [x] `.github/scripts/rule-lint.sh` exits 0
- [x] `.github/scripts/verbatim-block-lint.sh` exits 0 — the `MINDSET:` copies in `.claude/skills/subagent/SKILL.md` and `.claude/skills/pr-monitor-and-manage/SKILL.md` match the canonical block in `safety.md`
- [x] Read-back check against the motivating transcript: given *"merging changed no behaviour — three env vars are absent in production, runbook in `docs/security/S2S-IDENTITY.md`"*, the revised text unambiguously requires walking the ladder before that sentence may be written
- [x] Read-back check on the credential line: an agent reading only `safety.md` can tell that `railway variables --set` with a generated key is allowed and that echoing the key into a PR body is not
- [x] Ladder entry condition names the scope-shaped deferrals explicitly (AC1)
- [x] Rung 4 states its own precondition and requires naming the failed rung (AC2)
- [x] `.claude/reference/capability-discovery-examples.md` carries the scope-deferral shape in its false-walls catalog with the motivating case worked through (AC6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

