### PR TITLE
fix(#794): reconcile stable-state backoff ladder across rule, skill, and hook

### DIFF
--- a/.claude/hooks/polling-backoff-warn.sh
+++ b/.claude/hooks/polling-backoff-warn.sh
@@ -74,10 +74,18 @@ blocker=$("$state_helper" --get "${pr_jq}.blocker // empty" 2>/dev/null || true)
 blocker_kind=$("$state_helper" --get "${pr_jq}.blocker_kind // empty" 2>/dev/null || true)
 last_cron_type=$("$state_helper" --get "${pr_jq}.last_cron_action.type // empty" 2>/dev/null || true)
 last_cron_interval=$("$state_helper" --get "${pr_jq}.last_cron_action.interval // empty" 2>/dev/null || true)
+base_min=$("$state_helper" --get "${pr_jq}.babysit.cadence_base_minutes // 5" 2>/dev/null || printf '5')
 
 if ! [[ "$streak" =~ ^[0-9]+$ ]]; then
   streak=0
 fi
+if ! [[ "$base_min" =~ ^[0-9]+$ ]]; then
+  base_min=5
+fi
+
+# Widened cadence: max(15m, 3 × base) — always strictly greater than the default 5m base.
+WIDE_MIN=$(( base_min * 3 ))
+(( WIDE_MIN < 15 )) && WIDE_MIN=15
 
 user_blocker=0
 if [[ "$blocker_kind" == "user_input" ]]; then
@@ -98,21 +106,12 @@ if (( user_blocker == 1 || streak >= 9 )); then
   exit 0
 fi
 
-if (( streak >= 6 )); then
-  [[ "$last_cron_type" == "delete" ]] && exit 0
-  if [[ "$last_cron_type" == "update" && "$last_cron_interval" == "15m" ]]; then
-    exit 0
-  fi
-  emit_context "STOP - PR #${pr_number} has ${streak} identical polling ticks. Call CronUpdate to widen the interval to 15m before exiting this turn, update prs.${pr_number}.last_cron_action, and suppress duplicate heartbeat noise."
-  exit 0
-fi
-
 if (( streak >= 3 )); then
   [[ "$last_cron_type" == "delete" ]] && exit 0
-  if [[ "$last_cron_type" == "update" && ( "$last_cron_interval" == "5m" || "$last_cron_interval" == "15m" ) ]]; then
+  if [[ "$last_cron_type" == "update" && "$last_cron_interval" == "${WIDE_MIN}m" ]]; then
     exit 0
   fi
-  emit_context "STOP - PR #${pr_number} has ${streak} identical polling ticks. Call CronUpdate to widen the interval to 5m before exiting this turn, update prs.${pr_number}.last_cron_action, and suppress duplicate heartbeat noise."
+  emit_context "STOP - PR #${pr_number} has ${streak} identical polling ticks. Call CronUpdate to widen the interval to ${WIDE_MIN}m before exiting this turn, update prs.${pr_number}.last_cron_action, and suppress duplicate heartbeat noise."
 fi
 
 exit 0

--- a/.claude/hooks/tests/polling-backoff-warn.test.sh
+++ b/.claude/hooks/tests/polling-backoff-warn.test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Tests for polling-backoff-warn.sh (issue #794).
+#
+# Verifies the base-relative stable-state backoff ladder:
+#   digest_streak >= 3 → widen to max(15m, 3×base); streak >= 9 → CronDelete
+# Covers multiple base cadences, the "already applied" no-op guard, and the
+# user_input blocker stop. Never touches real session state.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK="$REPO_ROOT/.claude/hooks/polling-backoff-warn.sh"
+
+TMP_DIR="$(mktemp -d)"
+# Redirect HOME so the hook reads our fixture state file.
+export HOME="$TMP_DIR"
+export CLAUDE_SESSION_REPO="test/repo"
+mkdir -p "$TMP_DIR/.claude"
+
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "ok   — $*"; }
+
+# Extract additionalContext from hook JSON output.
+context_of() {
+  jq -r '.hookSpecificOutput.additionalContext // ""'
+}
+
+# Write a fixture state file for a given PR.
+# $1 = PR number, $2 = JSON object for the PR fields.
+write_state() {
+  local pr="$1" pr_json="$2"
+  jq -n \
+    --arg repo "$CLAUDE_SESSION_REPO" \
+    --arg pr   "$pr" \
+    --argjson  body "$pr_json" \
+    '{repos: {($repo): {prs: {($pr): $body}}}}' \
+    > "$TMP_DIR/.claude/session-state.json"
+}
+
+# Invoke the hook with a Bash tool_input referencing a PR number in the command.
+run_hook() {
+  local pr="$1"
+  local cmd="${2:-gh pr view $1 --json state}"
+  jq -cn --arg cmd "$cmd" '{tool_input: {command: $cmd}}' | bash "$HOOK"
+}
+
+PR="775"
+
+# ── 1. No warning below streak=3 ─────────────────────────────────────────────
+write_state "$PR" '{"digest_streak":2,"babysit":{"cadence_base_minutes":5}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -z "$ctx" ]] || fail "expected no warning at streak=2, got: $ctx"
+ok "no warning at streak=2 (below threshold)"
+
+# ── 2. Streak=3, base=5m → widen to 15m ─────────────────────────────────────
+write_state "$PR" '{"digest_streak":3,"babysit":{"cadence_base_minutes":5}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -n "$ctx" ]] || fail "expected warning at streak=3 base=5m"
+echo "$ctx" | grep -q "15m" || fail "expected 15m in message at base=5m, got: $ctx"
+# 15 > 5 — strictly wider than base
+ok "streak=3 base=5m → widen to 15m (strictly greater than base)"
+
+# ── 3. Streak=3, base=1m → widen to 15m (floor applies) ─────────────────────
+write_state "$PR" '{"digest_streak":3,"babysit":{"cadence_base_minutes":1}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -n "$ctx" ]] || fail "expected warning at streak=3 base=1m"
+echo "$ctx" | grep -q "15m" || fail "expected 15m in message at base=1m, got: $ctx"
+# 15 > 1 — strictly wider
+ok "streak=3 base=1m → widen to 15m (floor, strictly greater than base)"
+
+# ── 4. Streak=3, base=20m → widen to 60m (3×base > 15) ──────────────────────
+write_state "$PR" '{"digest_streak":3,"babysit":{"cadence_base_minutes":20}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -n "$ctx" ]] || fail "expected warning at streak=3 base=20m"
+echo "$ctx" | grep -q "60m" || fail "expected 60m in message at base=20m, got: $ctx"
+# 60 > 20 — strictly wider
+ok "streak=3 base=20m → widen to 60m (3×base, strictly greater than base)"
+
+# ── 5. No mid-tier: streak=6 with base=5m still widens to 15m (not 5m) ──────
+write_state "$PR" '{"digest_streak":6,"babysit":{"cadence_base_minutes":5}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -n "$ctx" ]] || fail "expected warning at streak=6 base=5m"
+echo "$ctx" | grep -q "15m"  || fail "expected 15m at streak=6 base=5m, got: $ctx"
+echo "$ctx" | grep -qv "5m " || true   # 5m should NOT be the recommended interval
+ok "streak=6 base=5m → still 15m (no 5m no-op interval, no mid-tier)"
+
+# ── 6. Missing cadence_base_minutes defaults to 5m → 15m ─────────────────────
+write_state "$PR" '{"digest_streak":3}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -n "$ctx" ]] || fail "expected warning when cadence_base_minutes absent"
+echo "$ctx" | grep -q "15m" || fail "expected 15m when base absent (default 5), got: $ctx"
+ok "absent cadence_base_minutes defaults to 5 → 15m"
+
+# ── 7. Already-applied guard: no re-emit when update matches WIDE_MIN ─────────
+# base=5m → WIDE_MIN=15m; last_cron_action already says update/15m → no-op
+write_state "$PR" '{"digest_streak":4,"babysit":{"cadence_base_minutes":5},"last_cron_action":{"type":"update","interval":"15m"}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -z "$ctx" ]] || fail "expected no re-emit when update to 15m already applied, got: $ctx"
+ok "already-applied guard: update to 15m not re-emitted at base=5m"
+
+# ── 8. Already-applied guard: different interval → still emit ────────────────
+# last_cron_action says update/5m (the old no-op interval) → hook must still emit
+write_state "$PR" '{"digest_streak":4,"babysit":{"cadence_base_minutes":5},"last_cron_action":{"type":"update","interval":"5m"}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -n "$ctx" ]] || fail "expected warning when previous update was to wrong interval"
+echo "$ctx" | grep -q "15m" || fail "expected 15m after stale 5m interval, got: $ctx"
+ok "already-applied guard respects WIDE_MIN: stale 5m update → still emit 15m"
+
+# ── 9. Already-applied guard for base=20m (WIDE_MIN=60m) ─────────────────────
+write_state "$PR" '{"digest_streak":4,"babysit":{"cadence_base_minutes":20},"last_cron_action":{"type":"update","interval":"60m"}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -z "$ctx" ]] || fail "expected no re-emit when update to 60m already applied, got: $ctx"
+ok "already-applied guard: update to 60m not re-emitted at base=20m"
+
+# ── 10. CronDelete already issued → no re-emit for either branch ─────────────
+write_state "$PR" '{"digest_streak":5,"babysit":{"cadence_base_minutes":5},"last_cron_action":{"type":"delete","interval":"paused"}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -z "$ctx" ]] || fail "expected no re-emit when delete already applied, got: $ctx"
+ok "delete already applied → no re-emit from widen branch"
+
+# ── 11. Streak >= 9 → stop (CronDelete) ──────────────────────────────────────
+write_state "$PR" '{"digest_streak":9,"babysit":{"cadence_base_minutes":5}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -n "$ctx" ]] || fail "expected STOP message at streak=9"
+echo "$ctx" | grep -q "CronDelete" || fail "expected CronDelete in stop message, got: $ctx"
+ok "streak>=9 → STOP with CronDelete"
+
+# ── 12. blocker_kind=user_input → stop immediately (any streak) ──────────────
+write_state "$PR" '{"digest_streak":1,"blocker_kind":"user_input","babysit":{"cadence_base_minutes":5}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -n "$ctx" ]] || fail "expected STOP message on user_input even at streak=1"
+echo "$ctx" | grep -q "CronDelete" || fail "expected CronDelete in user_input stop, got: $ctx"
+ok "blocker_kind=user_input → STOP with CronDelete regardless of streak"
+
+# ── 13. Stop branch "already applied" guard ───────────────────────────────────
+write_state "$PR" '{"digest_streak":9,"babysit":{"cadence_base_minutes":5},"last_cron_action":{"type":"delete","interval":"paused"}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -z "$ctx" ]] || fail "expected no re-emit on stop branch when delete already applied, got: $ctx"
+ok "stop branch: CronDelete already applied → no re-emit"
+
+# ── 14. Non-polling command exits silently ────────────────────────────────────
+write_state "$PR" '{"digest_streak":5,"babysit":{"cadence_base_minutes":5}}'
+ctx="$(jq -cn '{"tool_input":{"command":"echo hello"}}' | bash "$HOOK" | context_of)"
+[[ -z "$ctx" ]] || fail "non-polling command should produce no context, got: $ctx"
+ok "non-polling command → no context injected"
+
+echo ""
+echo "OK: polling-backoff-warn tests passed"

--- a/.claude/reference/scheduling-failure-modes.md
+++ b/.claude/reference/scheduling-failure-modes.md
@@ -48,7 +48,9 @@ The common thread: **between-turn scheduling has no in-turn observer.** Once the
 
 **Root cause.** The scheduler had no stable-state digest or backoff gate, so "nothing changed" was treated like actionable progress forever. In PR #359 on 2026-04-25, cron `e7230e2f` kept a 1-minute cadence while orphan one-shot `4e56074f` also remained alive; ticks #45-#93 repeated the same state for roughly 50 minutes until the user manually stopped it.
 
-**Fix.** Apply `scheduling-reliability.md` "Stable-State Backoff & Auto-Pause": compute the digest, increment `digest_streak`, widen to 5m at streak 3, widen to 15m at streak 6, and pause at streak 9. If `blocker_kind == "user_input"` or the blocker text says the agent is awaiting the user's direction, pause after the first visible message. When deleting or promoting the cron, also cancel sibling `ScheduleWakeup` jobs.
+**Fix.** Apply `scheduling-reliability.md` "Stable-State Backoff": compute the digest, increment `digest_streak`, widen to `max(15m, 3×base)` at streak 3 (for the default 5m base this is 15m — always strictly greater than the base), and pause at streak 9. If `blocker_kind == "user_input"` or the blocker text says the agent is awaiting the user's direction, pause after the first visible message. When deleting or promoting the cron, also cancel sibling `ScheduleWakeup` jobs.
+
+> **Authoritative source decision (issue #794):** the base-relative formula `max(15m, 3×base)` from `babysit-pr/SKILL.md` T5 was made authoritative over the earlier absolute `5m`/`15m` ladder in `scheduling-reliability.md`, because absolute minutes silently no-op at the documented 5m default (widening to 5m from 5m is no change). The base-relative form is correct at every `--cadence` value and was validated live on PR #775.
 
 ## Pattern 6 — Background Work With No Armed Observer
 

--- a/.claude/reference/session-state-schema.json
+++ b/.claude/reference/session-state-schema.json
@@ -19,8 +19,10 @@
     },
     "pr_nested": {
       "last_cron_action": "object",
+      "_last_cron_action_inner_keys": "Inner fields read by polling-backoff-warn.sh (issue #794): type (string: create/update/delete), interval (string: e.g. 1m/5m/15m/paused), at (ISO-8601 UTC). Write via session-state.sh after every CronCreate/CronUpdate/CronDelete. The hook skips re-emitting a widen when type==update && interval==${WIDE_MIN}m; skips re-emitting stop when type==delete. Using other field names (e.g. action/to_minutes) causes the guard to miss and the hook to fire repeatedly.",
       "preflight_triggered": "object",
       "babysit": "object",
+      "_babysit_backoff_fields": "Cadence fields inside .babysit read by polling-backoff-warn.sh (issue #794): cadence_base_minutes (number, set at arm-time from --cadence, default 5) drives WIDE_MIN=max(15,3*base); cadence_effective_minutes (number) is the currently-active cadence updated at tier crossings. Both are written by /babysit-pr; the hook defaults cadence_base_minutes to 5 when absent.",
       "wrap_sweep": "object",
       "cr_explicit_triggers": "array",
       "digest_streak": "number",
@@ -79,7 +81,14 @@
           "last_cron_action": {
             "type": "update",
             "at": "2026-04-29T13:58:00Z",
-            "interval": "5m"
+            "interval": "15m"
+          },
+          "babysit": {
+            "active": true,
+            "cadence_base_minutes": 5,
+            "cadence_effective_minutes": 15,
+            "tick_count": 4,
+            "blocker_streak": 4
           }
         },
         "620": {

--- a/.claude/reference/state-file-contracts.md
+++ b/.claude/reference/state-file-contracts.md
@@ -80,6 +80,24 @@ Resolve the canonical path for any PR with:
 
 `handoff-state.sh --owner-repo <owner>/<repo> --create` calls `mkdir -p` on the subdirectory automatically, so callers never need to pre-create it.
 
+## Backoff schema fields consumed by `polling-backoff-warn.sh` (issue #794)
+
+The hook reads three groups of fields from `.prs["<N>"]` to enforce the stable-state backoff ladder without re-emitting a widen/stop that was already applied.
+
+**`last_cron_action`** — object, written by the agent after each CronCreate/CronUpdate/CronDelete:
+
+| Sub-field | Type | Values |
+|-----------|------|--------|
+| `.type` | string | `"create"` / `"update"` / `"delete"` |
+| `.interval` | string | e.g. `"1m"` / `"5m"` / `"15m"` / `"paused"` |
+| `.at` | string | ISO-8601 UTC timestamp of the action |
+
+The hook skips re-emitting a widen instruction when `.type == "update"` and `.interval` already equals the computed widened value (`${WIDE_MIN}m`). It skips the stop instruction when `.type == "delete"`. Field names `action`/`to_minutes` (written before this schema was documented) caused the hook to keep firing — always use the names above.
+
+**`babysit.cadence_base_minutes`** — number, set by `/babysit-pr` arm mode from the `--cadence` argument (default `5`). The hook reads this to compute `WIDE_MIN = max(15, 3 × base)`. When absent or unparseable the hook defaults to `5`, matching the skill default.
+
+**`babysit.cadence_effective_minutes`** — number, updated by `/babysit-pr` T5 whenever the effective cadence crosses a tier boundary. Informational; the hook does not read it (it derives the widened value from `cadence_base_minutes` directly).
+
 ## Diff-survival snapshot — deliberately outside these mechanisms (issue #757)
 
 `diff-survival-check.sh` persists one file at `git rev-parse --git-path claude-diff-survival.json` — `.git/claude-diff-survival.json` in the main worktree, `.git/worktrees/<name>/claude-diff-survival.json` in a linked one. It is **not** session state and **not** a handoff file: it is written and read only by `diff-survival-check.sh`, scoped to a single worktree's in-flight rebase/merge rather than to a PR or a session, untracked, and transient — deleting it (or running `diff-survival-check.sh clear`) costs nothing but the ability to verify the current resolution. It lives in the git dir precisely so it survives a session being killed mid-rebase, which is the scenario it exists for. Full rationale: `.claude/reference/diff-survival-guard.md`.

--- a/.claude/rules/scheduling-reliability.md
+++ b/.claude/rules/scheduling-reliability.md
@@ -42,7 +42,7 @@ Before any polling turn ends (`/loop`, `CronCreate`, legacy one-shot, or a turn 
 
 ## Stable-State Backoff
 
-Each tick hash `(head_sha, cr_state, bugbot_state, greptile_state, ci_blocking_conclusions_sorted, blocker_kind)` into `prs.{N}.digest_streak` (free-text `blocker` excluded). Widen at streak ≥3→5m, ≥6→15m; `CronDelete` at ≥9 or `blocker_kind == "user_input"`. Resume at base cadence after user message or changed digest. `polling-backoff-warn.sh` enforces this. Backoff cannot reach the ceiling watch: it widens and deletes cron jobs; the watch is a `Monitor`.
+Each tick hash `(head_sha, cr_state, bugbot_state, greptile_state, ci_blocking_conclusions_sorted, blocker_kind)` into `prs.{N}.digest_streak` (free-text `blocker` excluded). Widen at streak ≥3 to `max(15m, 3×base)`; `CronDelete` at ≥9 or `blocker_kind == "user_input"`. Resume at base cadence after user message or changed digest. `polling-backoff-warn.sh` enforces this (reads `babysit.cadence_base_minutes`, defaults to 5). Backoff cannot reach the ceiling watch: it widens and deletes cron jobs; the watch is a `Monitor`.
 
 ## Failure Recovery
 


### PR DESCRIPTION
## Summary

- `scheduling-reliability.md` said "widen to 5m at streak≥3, 15m at streak≥6" while `babysit-pr/SKILL.md` T5 used `max(15m, 3×base)` — contradicting each other
- At the default 5m base, "widen to 5m" is a no-op: the hook kept emitting every tick forever (the flooding bug)
- This PR makes the base-relative formula from the skill authoritative across all three surfaces

## Changes

- **`scheduling-reliability.md`** — Stable-State Backoff paragraph: `≥3→5m, ≥6→15m` replaced with `≥3 to max(15m, 3×base)`; added note that the hook reads `babysit.cadence_base_minutes` (default 5)
- **`polling-backoff-warn.sh`** — reads `babysit.cadence_base_minutes` (default 5), computes `WIDE_MIN=max(15,3×base)`, drops the ≥6 tier entirely (2-tier: widen or stop)
- **`scheduling-failure-modes.md`** — Pattern 5 Fix text updated; added authoritative-source decision note (issue #794)
- **`state-file-contracts.md`** — new section documenting the 3 field groups the hook reads (`last_cron_action.type/interval/at`, `babysit.cadence_base_minutes`, `babysit.cadence_effective_minutes`)
- **`session-state-schema.json`** — added `_last_cron_action_inner_keys` and `_babysit_backoff_fields` comment keys to `_field_types.pr_nested`; corrected PR-619 worked example (`last_cron_action.interval` 5m→15m, added `babysit` object)
- **`hooks/tests/polling-backoff-warn.test.sh`** (new) — 14 test cases covering all key scenarios

## Local review state

Both CLIs (CodeRabbit, CodeAnt) not installed in this environment. Self-review performed; no issues found. Coverage state: `none` (self-review only). GitHub CR/BugBot will gate the merge per the normal review flow.

Closes #794

## Test plan

- [x] `polling-backoff-warn.sh` reads `babysit.cadence_base_minutes` and computes `WIDE_MIN=max(15, 3×base)`
- [x] At streak=3 with default base 5m, hook emits `CronUpdate 15m` (not 5m — the old no-op)
- [x] At streak=3 with base=1m, floor applies: hook emits `CronUpdate 15m`
- [x] At streak=3 with base=20m, `3×20=60 > 15`: hook emits `CronUpdate 60m`
- [x] No mid-tier: streak=6 base=5m still emits 15m (≥6 tier removed)
- [x] Already-applied guard respects WIDE_MIN: `last_cron_action = {type:update, interval:15m}` → no re-emit at base=5m; `{interval:5m}` (old stale) → still emits 15m
- [x] `scheduling-reliability.md` Stable-State Backoff paragraph matches the formula in the hook and the skill
- [x] All 14 new tests in `polling-backoff-warn.test.sh` pass; full hook test suite passes