### PR TITLE
fix(#819): document CodeAnt CLI install + absent-binary handling

### DIFF
--- a/.claude/memory/feedback_review_clis_down_app_independent.md
+++ b/.claude/memory/feedback_review_clis_down_app_independent.md
@@ -17,3 +17,5 @@ During PR #763, both local review CLIs were unavailable simultaneously: CodeRabb
 3. **Self-review is risk-reduction, not coverage.** A self-review exits the local loop correctly per the rules but never satisfies the GitHub merge gate. It should be surfaced in-thread, not only as a footnote in the PR body.
 
 **Provenance:** Issue #769, PR #763 incident; related issues #642 (CodeAnt false-clean on API failure), #643 (403 entitlement), #663 (CodeAnt 403 re-auth advice).
+
+**Standing state update (2026-07-30, Issue #819):** CodeAnt CLI binary is now installed (`npm install -g codeant-cli` ran during PR #819, v0.5.1 at `/opt/homebrew/bin/codeant`). Auth (`codeant login`) is blocked at rung 3 — browser OAuth only, no non-interactive path. Coverage remains `cr-only` until a human runs `codeant login` or `codeant set-codeant-api-key <key>`. Merge gate is unaffected — CodeAnt GitHub App still approves independently. Restore runbook: `.claude/reference/codeant-graphite-supplemental.md` §Install state.

--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -20,7 +20,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `capability-discovery-examples.md` — false-walls vs real-walls catalog for try-CLI-before-handoff (`safety.md` Capability Discovery)
 - `merge-gate-reviewer-paths.md` — per-reviewer merge-gate path details (CR/CodeAnt, BugBot, Greptile)
 - `codeant-graphite-supplemental.md` — CodeAnt and Graphite supplemental polling on the CR path
-- `local-review-cli-failure-modes.md` — how CodeAnt/CodeRabbit fake a clean pass on failure, 403 triage, 15-file cap (#642)
+- `local-review-cli-failure-modes.md` — how CodeAnt/CodeRabbit fake a clean pass on failure, 403 triage, 15-file cap, and binary-absent detection (#642, #819)
 - `wrap-fixpr-delegation.md` — `/wrap` Step 2.1 → full `/fixpr` recovery handoff contract
 - `state-file-contracts.md` — expanded scoping, write-lock, migration, and field-type mechanics for `session-state.json` + handoffs (`handoff-files.md`; #625, #638, #639, #651, #655, #682, #687, #704)
 - `authorship-guard.md` — `pr-authorship.sh` exit-code semantics, the three shared-script fail-safes, and `--allow-nonauthor` override plumbing (`safety.md` §Authorship; #733)

--- a/.claude/reference/codeant-graphite-supplemental.md
+++ b/.claude/reference/codeant-graphite-supplemental.md
@@ -31,3 +31,31 @@ CodeAnt and Graphite are parallel supplements; the primary chain stays CR → Bu
 - `--fail-on <severity>`: `BLOCKER` / `CRITICAL` / `MAJOR` / `MINOR` / `INFO` (default `CRITICAL`) — sets the exit-code threshold.
 - `--headless`: JSON results on stdout, progress/status on stderr — for agent/CI parsing.
 - An MCP server mode and a Claude Code integration also exist (`docs.codeant.ai/cli/mcp-server`, `docs.codeant.ai/cli/claude-code-integration`) — not wired into this repo's workflow yet.
+
+### Install state on this machine (updated 2026-07-30, issue #819)
+
+**Binary:** `npm install -g codeant-cli` was run successfully 2026-07-30. `codeant --version` = 0.5.1 at `/opt/homebrew/bin/codeant`.
+
+**Auth:** blocked at capability-ladder rung 3. `codeant login` is a browser OAuth flow (`app.codeant.ai`) — no non-interactive path exists. The CLI also accepts `codeant set-codeant-api-key <key>` (no browser), but no API key is stored in shell config, env vars, or `~/.codeant/config.json` (which does not yet exist).
+
+**Current baseline:** `cr-only` — every local review runs CodeRabbit only until auth completes. The CodeAnt **GitHub App** is independent and unaffected; it continues to satisfy the CR-path merge gate on its own.
+
+**Rung-4 restore runbook (user must run interactively):**
+
+```bash
+# Option A — browser OAuth (standard):
+codeant login
+# Opens app.codeant.ai in your browser; key saved to ~/.codeant/config.json.
+
+# Option B — API key (non-interactive, if you have a key from the CodeAnt dashboard):
+codeant set-codeant-api-key <your-api-key>
+
+# Verify auth (safe — reads org membership, no write):
+codeant scans orgs
+
+# Run a proof review (check stderr for errors before trusting "no findings"):
+codeant review --all --headless >ca.json 2>ca.err
+grep -qE 'API Error|\[error\]|40[13]' ca.err && echo "FAILED RUN" || echo "clean"
+```
+
+Failure modes once installed: false-clean on API failure and 403 daily-cap — see `local-review-cli-failure-modes.md`.

--- a/.claude/reference/local-review-cli-failure-modes.md
+++ b/.claude/reference/local-review-cli-failure-modes.md
@@ -14,6 +14,46 @@ Checking one stream catches one CLI and misses the other:
 
 Observed with `codeant` v0.5.1 and `coderabbit` v0.6.5 on 2026-07-21.
 
+## CodeAnt CLI not installed (issue #819)
+
+This is the third, simplest CodeAnt failure state — the binary is absent entirely. It is distinct from the false-clean (#642) and 403 daily-cap (#643) states: there is no API call to fail, no stderr error, and no ambiguity. The only signal is a shell error before any review runs.
+
+| Signal | Value | Usable? |
+|---|---|---|
+| Shell exit code | non-zero (`127` on most shells) | Yes — `codeant: command not found` |
+| stderr | `command not found: codeant` (or similar) | Yes — unambiguous before any API call |
+| stdout JSON | (none) | N/A |
+
+**Contrast with the other two states:**
+
+| State | Binary present? | API call made? | stderr signal |
+|---|---|---|---|
+| Not installed (#819) | **No** | No | `command not found` before any review |
+| False-clean (#642) | Yes | Yes (fails silently) | `API Error` / `[error] Failed to review` on stderr |
+| 403 daily-cap (#643) | Yes | Yes (quota exhausted) | 403 text on stderr; token is fine |
+
+**Rung-1 evidence shape.** When checking for the binary, probe absolute paths — the Bash tool's minimal PATH makes a bare `which` unreliable:
+
+```bash
+for p in /opt/homebrew/bin/codeant ~/.local/bin/codeant ~/bin/codeant /usr/local/bin/codeant; do
+  ls "$p" 2>/dev/null && echo "FOUND: $p" || true
+done
+npm list -g codeant-cli 2>/dev/null
+```
+
+**Coverage-enum mapping:** CodeAnt `command not found` / not installed → CodeAnt **not covered** → `cr-only` coverage (see table below).
+
+**Restore path (capability-ladder rung 3 → 4).** The package name `codeant-cli` is confirmed in this doc and in `.claude/reference/codeant-graphite-supplemental.md`. Install is non-interactive and satisfies all rails (no `curl|sh`, no TLS bypass, no `sudo` required at the Homebrew npm prefix):
+
+```bash
+npm install -g codeant-cli   # rung 3 — installs the binary
+codeant login                 # rung 4 — browser OAuth; cannot be run non-interactively
+```
+
+Auth (`codeant login`) opens a browser flow against `app.codeant.ai` and is the only blocker for a non-interactive agent. Full runbook with Option B (API key) and the proof-run stderr check: `.claude/reference/codeant-graphite-supplemental.md` §Install state. Ladder definition: `.claude/rules/safety.md` §Capability Discovery.
+
+**Standing state on this machine (as of 2026-07-30):** binary installed (v0.5.1 at `/opt/homebrew/bin/codeant`), auth pending — `cr-only` baseline until `codeant login` or `codeant set-codeant-api-key` is run interactively.
+
 ## The false-clean
 
 On total API failure, `codeant review` produces a result that is indistinguishable from a


### PR DESCRIPTION
## Summary

Issue #819 surfaced that the `codeant` binary was absent from every plausible path on this machine, causing every local pre-push review to run at half coverage (CodeRabbit only). This PR walks the capability ladder to its logical conclusion and documents the outcome.

**Capability-ladder walk (Issue #819):**
- **Rung 1:** Binary absent — confirmed across `/opt/homebrew/bin`, `~/.local/bin`, `~/bin`, `/usr/local/bin`, and npm global
- **Rung 2:** Package confirmed: `codeant-cli` on npm (per `.claude/reference/codeant-graphite-supplemental.md`)
- **Rung 3:** `npm install -g codeant-cli` ran successfully → v0.5.1 at `/opt/homebrew/bin/codeant`. Auth (`codeant login`) is browser OAuth only — no non-interactive path. CLI also offers `set-codeant-api-key <key>` but no key is stored in env, shell config, or `~/.codeant/config.json`
- **Rung 4:** Runbook produced (user must run interactively)

**BINARY IS NOW INSTALLED.** `codeant --version` = 0.5.1. Coverage is still `cr-only` pending auth, but the half-coverage era ends once the user runs `codeant login` or `codeant set-codeant-api-key <key>`.

## Changes

- **`.claude/reference/codeant-graphite-supplemental.md`** — Added "Install state" subsection with install outcome (v0.5.1), auth-blocked rationale, current `cr-only` baseline, and complete rung-4 restore runbook (browser OAuth or API key)
- **`.claude/reference/local-review-cli-failure-modes.md`** — Added "CodeAnt CLI not installed" as a first-class, documented failure mode alongside false-clean (#642) and 403 daily-cap (#643), with signal table, contrast table, rung-1 probe commands, coverage-enum mapping, and restore path
- **`.claude/reference/README.md`** — Updated index entry for `local-review-cli-failure-modes.md` to reference #819
- **`.claude/memory/feedback_review_clis_down_app_independent.md`** — Added standing-state update noting binary now installed, auth pending

No rule files were modified (corpus budget constraint: main ~11,451 vs cap 11,749 with PR #820 in flight).

**Local review coverage:** `none` — CodeAnt 403 (no auth credentials), CodeRabbit OSS rate-limited (23 min wait). Self-review ran; no issues found. CodeAnt GitHub App remains independent and satisfies the merge gate.

## Test plan

- [x] Decide whether to restore the CodeAnt CLI locally or document its absence as expected — **resolved: binary installed (rung 3), auth pending (rung 4 runbook provided)**
- [x] If restoring: `codeant --version` succeeds and `codeant review --all --headless` returns a verified-successful run — **partial: `codeant --version` = 0.5.1; `codeant review` returns 403 (no auth); full verification requires interactive `codeant login`**
- [x] If documenting: `.claude/reference/local-review-cli-failure-modes.md` states the expected coverage so a single-CLI pass is not silently read as a full dual pass — **done: new "CodeAnt CLI not installed" subsection with explicit `cr-only` mapping**

Closes #819