### PR TITLE
feat(#824): record usage-limit turn deaths; document why pre-emptive wind-down is blocked upstream

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -143,3 +143,27 @@ Both write through `lib/skill-usage-recorder.sh`, which owns the storage layout 
 
 - `python3` (both hooks) and `jq` (PostToolUse tracker only)
 - Registered automatically via `global-settings.json` — see **Hook Auto-Registration** above
+
+## usage-limit-record.sh
+
+Records a durable breadcrumb when a turn dies because the account hit an Anthropic usage limit, so the next session finds a pointer instead of silence (issue #824).
+
+Registered on **`StopFailure`** with matcher **`rate_limit`** — the first use of that event in this repo. The runtime fires `StopFailure` instead of `Stop` when an API error ends a turn, and matches on the payload's `error` field.
+
+**This is a recorder, not a wind-down.** `StopFailure` is documented by the runtime as *"Fire-and-forget — hook output and exit codes are ignored"*, and it fires only after the turn has already failed. The hook therefore cannot warn the session, inject context, or gate any decision — it writes to disk and exits 0.
+
+Claude Code exposes **no** approaching-limit signal to any hook, skill, or session; the only surface carrying `rate_limits` is the status line, which is display-only and never executes in a headless desktop-app session. Full evidence: `.claude/reference/usage-limit-signal-audit-2026-07.md`.
+
+**Safety.** Its sole input is the runtime's own `error` classification. It estimates nothing and gates nothing, so `.claude/rules/safety.md` §"Anthropic Quota & Spend Authority" is satisfied as written and was not amended.
+
+**Outputs**
+
+- `~/.claude/usage-limit-events.jsonl` — append-only history, rotated to `.1` past 256 KiB
+- `~/.claude/usage-limit-last.json` — the most recent event, written atomically; read this first when resuming
+
+Each record carries `recorded_at`, `session_id`, `cwd`, `transcript_path`, a truncated `last_assistant_message`, and a `resume_hint`.
+
+### Prerequisites
+
+- `jq` must be installed — the hook exits 0 silently without it
+- Override the output directory with `CLAUDE_USAGE_LIMIT_DIR` (used by the tests)

--- a/.claude/hooks/tests/usage-limit-record.test.sh
+++ b/.claude/hooks/tests/usage-limit-record.test.sh
@@ -134,9 +134,19 @@ grep -q 'Verdict' "$AUDIT_DOC" || fail "finding doc does not state a verdict"
 
 # --- 11. State files are owner-only ---
 # The record embeds conversation content and absolute paths.
+# Switch on uname, matching the hook's own file_size() helper: GNU `stat -f`
+# means "filesystem status" and SUCCEEDS with unrelated output, so a
+# `stat -f ... || stat -c ...` fallback never reaches the GNU form on Linux.
+file_mode() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    stat -f '%Lp' "$1" 2>/dev/null
+  else
+    stat -c '%a' "$1" 2>/dev/null
+  fi
+}
 for f in "$EVENTS" "$LAST"; do
-  MODE=$(stat -f '%Lp' "$f" 2>/dev/null || stat -c '%a' "$f" 2>/dev/null)
-  [[ "$MODE" == "600" ]] || fail "$(basename "$f") is mode $MODE, expected 600 (owner-only)"
+  MODE=$(file_mode "$f")
+  [[ "$MODE" == "600" ]] || fail "$(basename "$f") is mode '$MODE', expected 600 (owner-only)"
 done
 
 # --- 12. Concurrent invocations lose no records ---
@@ -164,5 +174,35 @@ UNIQ=$(jq -r '.session_id' "$CONC_LOG" | sort -u | wc -l | tr -d ' ')
 
 [[ -d "$CONC_DIR/.usage-limit-record.lock" ]] && fail "lock directory was left behind"
 true
+
+# --- 13. Non-string fields are truncated too ---
+# A structured error_details object must not bypass the breadcrumb limit.
+STRUCT_DIR="$TMP_DIR/struct"
+mkdir -p "$STRUCT_DIR"
+BIG_VAL=$(printf 'y%.0s' $(seq 1 4000))
+printf '%s' "{\"hook_event_name\":\"StopFailure\",\"error\":\"rate_limit\",\"error_details\":{\"blob\":\"$BIG_VAL\"},\"last_assistant_message\":{\"nested\":\"$BIG_VAL\"}}" \
+  | CLAUDE_USAGE_LIMIT_DIR="$STRUCT_DIR" bash "$HOOK"
+
+STRUCT_LAST="$STRUCT_DIR/usage-limit-last.json"
+[[ -f "$STRUCT_LAST" ]] || fail "structured payload produced no record"
+jq -e . "$STRUCT_LAST" >/dev/null || fail "structured payload produced invalid JSON"
+ED_LEN=$(jq -r '.error_details | length' "$STRUCT_LAST")
+LAM_LEN=$(jq -r '.last_assistant_message | length' "$STRUCT_LAST")
+[[ "$ED_LEN" -le 500 ]] || fail "object error_details not truncated (len=$ED_LEN)"
+[[ "$LAM_LEN" -le 1000 ]] || fail "object last_assistant_message not truncated (len=$LAM_LEN)"
+
+# --- 14. Rotation fires at the cap and preserves the archive ---
+ROT_DIR="$TMP_DIR/rotate"
+mkdir -p "$ROT_DIR"
+ROT_LOG="$ROT_DIR/usage-limit-events.jsonl"
+# Seed just past the 256 KiB cap so the next append must rotate.
+head -c 262200 /dev/zero | tr '\0' 'a' >"$ROT_LOG"
+printf '\n' >>"$ROT_LOG"
+printf '%s' '{"hook_event_name":"StopFailure","error":"rate_limit","session_id":"rot","last_assistant_message":"em—dashes—are—multibyte"}' \
+  | CLAUDE_USAGE_LIMIT_DIR="$ROT_DIR" bash "$HOOK"
+
+[[ -f "$ROT_LOG.1" ]] || fail "rotation did not create the .1 archive"
+[[ "$(wc -l <"$ROT_LOG" | tr -d ' ')" == "1" ]] || fail "post-rotation log should hold exactly the new record"
+jq -e '.session_id == "rot"' <"$ROT_LOG" >/dev/null || fail "post-rotation log lost the new record"
 
 echo "PASS: usage-limit-record.sh"

--- a/.claude/hooks/tests/usage-limit-record.test.sh
+++ b/.claude/hooks/tests/usage-limit-record.test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Tests for usage-limit-record.sh — the StopFailure recorder (issue #824).
+#
+# Covers the behavior the issue's Test Plan requires: the recorder fires only
+# on the upstream rate-limit signal, a healthy session is completely
+# unaffected, and no code path computes a local spend estimate.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK="$REPO_ROOT/.claude/hooks/usage-limit-record.sh"
+SETTINGS="$REPO_ROOT/global-settings.json"
+SETUP_SCRIPT="$REPO_ROOT/setup-skills-worktree.sh"
+AUDIT_DOC="$REPO_ROOT/.claude/reference/usage-limit-signal-audit-2026-07.md"
+SAFETY_RULE="$REPO_ROOT/.claude/rules/safety.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not installed"; exit 0; }
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+run_hook() {
+  # $1 = JSON payload. Isolated output dir so tests never touch ~/.claude.
+  printf '%s' "$1" | CLAUDE_USAGE_LIMIT_DIR="$TMP_DIR" bash "$HOOK"
+}
+
+EVENTS="$TMP_DIR/usage-limit-events.jsonl"
+LAST="$TMP_DIR/usage-limit-last.json"
+
+# --- 1. Executable ---
+[[ -x "$HOOK" ]] || fail "hook is not executable"
+
+# --- 2. Fires on the upstream rate_limit signal ---
+run_hook '{"hook_event_name":"StopFailure","error":"rate_limit","session_id":"sess-abc","cwd":"/tmp/work","transcript_path":"/tmp/t.jsonl","last_assistant_message":"was mid-fix on PR #1"}'
+
+[[ -f "$EVENTS" ]] || fail "rate_limit did not append to the events log"
+[[ -f "$LAST" ]] || fail "rate_limit did not write usage-limit-last.json"
+[[ "$(wc -l <"$EVENTS" | tr -d ' ')" == "1" ]] || fail "expected exactly one event record"
+
+jq -e '.reason == "rate_limit"' "$LAST" >/dev/null || fail "record reason is not rate_limit"
+jq -e '.session_id == "sess-abc"' "$LAST" >/dev/null || fail "session_id not captured"
+jq -e '.transcript_path == "/tmp/t.jsonl"' "$LAST" >/dev/null || fail "transcript_path not captured"
+jq -e '.cwd == "/tmp/work"' "$LAST" >/dev/null || fail "cwd not captured"
+jq -e '.last_assistant_message | test("mid-fix")' "$LAST" >/dev/null || fail "last_assistant_message not captured"
+jq -e '.resume_hint | length > 0' "$LAST" >/dev/null || fail "resume_hint missing"
+jq -e '.recorded_at | length > 0' "$LAST" >/dev/null || fail "recorded_at missing"
+
+# The durable log is what a later session actually reads — assert the record
+# landed there with its context, not just that usage-limit-last.json is right.
+jq -e '.reason == "rate_limit"' <"$EVENTS" >/dev/null || fail "events record reason is not rate_limit"
+jq -e '.session_id == "sess-abc"' <"$EVENTS" >/dev/null || fail "events record lost session_id"
+jq -e '.transcript_path == "/tmp/t.jsonl"' <"$EVENTS" >/dev/null || fail "events record lost transcript_path"
+jq -e '.cwd == "/tmp/work"' <"$EVENTS" >/dev/null || fail "events record lost cwd"
+
+# --- 3. Healthy session unaffected: non-rate-limit errors record nothing ---
+# A drifted/removed matcher must not turn every API failure into a usage-limit
+# record. Each of these is a real StopFailure `error` value from the runtime.
+# Snapshot BOTH files by content: a line-count check alone would miss a
+# non-rate-limit error overwriting usage-limit-last.json.
+EVENTS_SNAP="$(cat "$EVENTS")"
+LAST_SNAP="$(cat "$LAST")"
+for other in overloaded authentication_failed billing_error server_error max_output_tokens unknown; do
+  run_hook "{\"hook_event_name\":\"StopFailure\",\"error\":\"$other\",\"session_id\":\"s\"}"
+done
+[[ "$(cat "$EVENTS")" == "$EVENTS_SNAP" ]] || fail "a non-rate_limit error mutated the events log"
+[[ "$(cat "$LAST")" == "$LAST_SNAP" ]] || fail "a non-rate_limit error mutated usage-limit-last.json"
+
+# --- 4. Malformed / empty payloads never append a broken line ---
+run_hook 'not json at all'
+run_hook '{}'
+run_hook ''
+[[ "$(cat "$EVENTS")" == "$EVENTS_SNAP" ]] || fail "a malformed payload mutated the events log"
+[[ "$(cat "$LAST")" == "$LAST_SNAP" ]] || fail "a malformed payload mutated usage-limit-last.json"
+while read -r line; do
+  printf '%s' "$line" | jq -e . >/dev/null 2>&1 || fail "events log contains a non-JSON line"
+done <"$EVENTS"
+
+# --- 5. Long fields are truncated (resume hint, not a transcript dump) ---
+# Assert the new record was actually written before asserting its length —
+# checking length alone would pass against the *previous* record if this
+# invocation silently recorded nothing.
+LONG=$(printf 'x%.0s' $(seq 1 5000))
+run_hook "{\"hook_event_name\":\"StopFailure\",\"error\":\"rate_limit\",\"last_assistant_message\":\"$LONG\"}"
+[[ "$(wc -l <"$EVENTS" | tr -d ' ')" == "2" ]] || fail "long-field invocation did not append a second record"
+jq -e '.last_assistant_message | test("^x+$")' "$LAST" >/dev/null \
+  || fail "usage-limit-last.json does not hold the long-field record"
+LEN=$(jq -r '.last_assistant_message | length' "$LAST")
+[[ "$LEN" -le 1000 ]] || fail "last_assistant_message not truncated (len=$LEN)"
+
+# --- 6. Registration: one entry carrying matcher + command + timeout together ---
+# Checked as a single conjunction on purpose. Split assertions would accept a
+# matcher on one group and the timeout on another — a registration that looks
+# valid to the tests but is not the one the runtime fires.
+python3 - "$SETTINGS" <<'PY' || fail "no single StopFailure entry has matcher rate_limit + usage-limit-record.sh + timeout 5"
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+ok = any(
+    g.get("matcher") == "rate_limit"
+    and any(
+        h.get("command", "").endswith("usage-limit-record.sh") and h.get("timeout") == 5
+        for h in g.get("hooks", [])
+    )
+    for g in data.get("hooks", {}).get("StopFailure", [])
+)
+sys.exit(0 if ok else 1)
+PY
+
+# --- 7. Registration: HOOKS_MANIFEST entry, timeout must match global-settings.json ---
+# Two sources of truth for the same timeout; they drift silently otherwise.
+grep -qF "StopFailure"$'\t'"rate_limit"$'\t'"usage-limit-record.sh"$'\t'"5" "$SETUP_SCRIPT" \
+  || grep -qF "StopFailure\\trate_limit\\tusage-limit-record.sh\\t5" "$SETUP_SCRIPT" \
+  || fail "HOOKS_MANIFEST missing StopFailure/rate_limit entry for usage-limit-record.sh with timeout 5"
+
+# --- 8. No local spend/quota estimation in any executable line ---
+# The whole point of the issue: the trigger must be the upstream signal only.
+# Comments are stripped first — the hook's own header *describes* the ban, and
+# matching that prose would fail the test for saying the right thing.
+CODE_ONLY="$TMP_DIR/hook-code-only.sh"
+sed -e 's/[[:space:]]*#.*$//' "$HOOK" | grep -v '^[[:space:]]*$' >"$CODE_ONLY"
+if grep -nEi 'input_tokens|output_tokens|cache_read|used_percentage|spend|budget_remaining|estimate' "$CODE_ONLY"; then
+  fail "hook computes/reads token or spend accounting — the trigger must be the upstream error signal only"
+fi
+
+# --- 9. safety.md's quota prohibition is intact and unamended ---
+grep -q 'MUST NOT gate agent decisions' "$SAFETY_RULE" \
+  || fail "safety.md quota prohibition text is missing or was altered"
+
+# --- 10. The gating finding doc exists and states the verdict ---
+[[ -f "$AUDIT_DOC" ]] || fail "signal-investigation finding doc is missing"
+grep -q 'Verdict' "$AUDIT_DOC" || fail "finding doc does not state a verdict"
+
+# --- 11. State files are owner-only ---
+# The record embeds conversation content and absolute paths.
+for f in "$EVENTS" "$LAST"; do
+  MODE=$(stat -f '%Lp' "$f" 2>/dev/null || stat -c '%a' "$f" 2>/dev/null)
+  [[ "$MODE" == "600" ]] || fail "$(basename "$f") is mode $MODE, expected 600 (owner-only)"
+done
+
+# --- 12. Concurrent invocations lose no records ---
+# This is the expected case, not an edge case: one account hitting its limit
+# fails every active session at once.
+CONC_DIR="$TMP_DIR/concurrent"
+mkdir -p "$CONC_DIR"
+N=25
+for i in $(seq 1 "$N"); do
+  printf '%s' "{\"hook_event_name\":\"StopFailure\",\"error\":\"rate_limit\",\"session_id\":\"s$i\"}" \
+    | CLAUDE_USAGE_LIMIT_DIR="$CONC_DIR" bash "$HOOK" &
+done
+wait
+
+CONC_LOG="$CONC_DIR/usage-limit-events.jsonl"
+COUNT=$(wc -l <"$CONC_LOG" | tr -d ' ')
+[[ "$COUNT" == "$N" ]] || fail "concurrent writes lost records: got $COUNT, expected $N"
+
+while read -r line; do
+  printf '%s' "$line" | jq -e . >/dev/null 2>&1 || fail "concurrent writes produced an interleaved/non-JSON line"
+done <"$CONC_LOG"
+
+UNIQ=$(jq -r '.session_id' "$CONC_LOG" | sort -u | wc -l | tr -d ' ')
+[[ "$UNIQ" == "$N" ]] || fail "concurrent writes clobbered records: $UNIQ distinct sessions, expected $N"
+
+[[ -d "$CONC_DIR/.usage-limit-record.lock" ]] && fail "lock directory was left behind"
+true
+
+echo "PASS: usage-limit-record.sh"

--- a/.claude/hooks/usage-limit-record.sh
+++ b/.claude/hooks/usage-limit-record.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# usage-limit-record.sh — StopFailure hook (issue #824)
+#
+# PURPOSE
+#   Leave a durable breadcrumb when a turn dies because the account hit its
+#   usage limit, so the next session finds a pointer instead of silence.
+#
+#   This is a RECORDER, not a shutdown. By the time StopFailure fires the turn
+#   is already over: the runtime documents the event as "Fire-and-forget — hook
+#   output and exit codes are ignored", so this hook cannot warn the session,
+#   inject context, or change any decision. It can only write to disk.
+#
+# WHY THIS SHAPE (and not a pre-emptive wind-down)
+#   Claude Code exposes no approaching-limit signal to any hook, skill, or
+#   session. The only surface carrying `rate_limits` is the status line, which
+#   is display-only and never executes in a headless (`--output-format
+#   stream-json`) desktop-app session. Full evidence, including the live probe
+#   that produced zero invocations:
+#       .claude/reference/usage-limit-signal-audit-2026-07.md
+#
+# SAFETY (.claude/rules/safety.md §"Anthropic Quota & Spend Authority")
+#   The sole input is the runtime's own error classification (`error ==
+#   "rate_limit"`). Nothing here estimates tokens, spend, or remaining quota,
+#   and nothing here pauses, downgrades, defers, or refuses work. That rule is
+#   satisfied as written and was NOT amended for this hook.
+#
+# INPUT   StopFailure payload on stdin:
+#           { session_id, transcript_path, cwd, error, error_details,
+#             last_assistant_message, ... }
+# OUTPUT  Appends to ~/.claude/usage-limit-events.jsonl
+#         Rewrites  ~/.claude/usage-limit-last.json (atomically)
+#         Always exits 0 — a recorder must never become a new failure mode.
+
+set -uo pipefail
+
+STDIN_JSON=$(cat)
+
+# jq is the only dependency; without it the payload cannot be parsed safely.
+command -v jq >/dev/null 2>&1 || exit 0
+
+ERROR=$(printf '%s' "$STDIN_JSON" | jq -r '.error // empty' 2>/dev/null)
+
+# Defense in depth: the registered matcher already scopes this hook to
+# `rate_limit`, but matcher config lives in a different file and can drift.
+# Any other API failure (auth, overloaded, server_error) is not a usage limit
+# and must not be recorded as one.
+[[ "$ERROR" == "rate_limit" ]] || exit 0
+
+STATE_DIR="${CLAUDE_USAGE_LIMIT_DIR:-$HOME/.claude}"
+
+# The record embeds conversation content (a truncated assistant message) plus
+# absolute paths. Create everything owner-only so it is not readable by other
+# users on a shared machine.
+umask 077
+
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+
+EVENTS_LOG="$STATE_DIR/usage-limit-events.jsonl"
+LAST_FILE="$STATE_DIR/usage-limit-last.json"
+LOCK_DIR="$STATE_DIR/.usage-limit-record.lock"
+LOG_MAX_SIZE=262144 # 256 KiB, then rotate to .1
+
+# umask only constrains newly created files; tighten anything left behind by an
+# earlier run (or an earlier version of this hook) too.
+chmod 600 "$EVENTS_LOG" "$LAST_FILE" 2>/dev/null
+
+file_size() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    stat -f %z "$1" 2>/dev/null
+  else
+    stat -c %s "$1" 2>/dev/null
+  fi
+}
+
+RECORDED_AT=$(date -u +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)
+[[ -n "$RECORDED_AT" ]] || RECORDED_AT="unknown"
+
+# Build the record with jq so every field is escaped correctly. The last
+# assistant message is truncated — it is a resume hint, not a transcript.
+RECORD=$(printf '%s' "$STDIN_JSON" | jq -c \
+  --arg recorded_at "$RECORDED_AT" \
+  '{
+     recorded_at: $recorded_at,
+     reason: "rate_limit",
+     session_id: (.session_id // null),
+     cwd: (.cwd // null),
+     transcript_path: (.transcript_path // null),
+     error_details: ((.error_details // null) | if type == "string" then .[0:500] else . end),
+     last_assistant_message: ((.last_assistant_message // null) | if type == "string" then .[0:1000] else . end),
+     resume_hint: "Turn ended on an Anthropic usage limit. Reconstruct in-flight state from the transcript above, then resume; see .claude/reference/usage-limit-signal-audit-2026-07.md."
+   }' 2>/dev/null)
+
+# A malformed or unparseable payload must not append a broken line.
+[[ -n "$RECORD" ]] || exit 0
+
+# Concurrency is the EXPECTED case here, not an edge case: one account hitting
+# its limit fails every active session at once, so several copies of this hook
+# can run simultaneously. Serialize rotation + append + publish so a rotation
+# race cannot drop records.
+#
+# mkdir is the portable atomic mutex — macOS ships no flock(1). The wait is
+# bounded (~1s); if the lock cannot be taken we proceed anyway, because losing
+# the record is worse than a rare interleave.
+LOCKED=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    LOCKED=1
+    break
+  fi
+  # Reap a lock orphaned by a killed hook (the runtime kills us at the timeout).
+  LOCK_AGE_REF=$(find "$LOCK_DIR" -maxdepth 0 -mmin +1 2>/dev/null)
+  if [[ -n "$LOCK_AGE_REF" ]]; then
+    rmdir "$LOCK_DIR" 2>/dev/null
+    continue
+  fi
+  sleep 0.1
+done
+if (( LOCKED )); then
+  # Single quotes on purpose: expand LOCK_DIR at trap time, so a state dir
+  # containing a quote character cannot break the trap string.
+  trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT
+fi
+
+SIZE=$(file_size "$EVENTS_LOG")
+[[ -n "$SIZE" ]] || SIZE=0
+if (( SIZE + ${#RECORD} >= LOG_MAX_SIZE )); then
+  rm -f "${EVENTS_LOG}.1" 2>/dev/null
+  mv "$EVENTS_LOG" "${EVENTS_LOG}.1" 2>/dev/null
+fi
+
+# Publish `last` only if the durable append succeeded — otherwise the pointer
+# would advertise an event the log does not contain.
+if printf '%s\n' "$RECORD" >>"$EVENTS_LOG" 2>/dev/null; then
+  # `last` is what a resuming session should read first; write it atomically so
+  # a reader never observes a partial file.
+  TMP_LAST="${LAST_FILE}.tmp.$$"
+  if printf '%s\n' "$RECORD" >"$TMP_LAST" 2>/dev/null; then
+    mv -f "$TMP_LAST" "$LAST_FILE" 2>/dev/null || rm -f "$TMP_LAST" 2>/dev/null
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/usage-limit-record.sh
+++ b/.claude/hooks/usage-limit-record.sh
@@ -85,8 +85,14 @@ RECORD=$(printf '%s' "$STDIN_JSON" | jq -c \
      session_id: (.session_id // null),
      cwd: (.cwd // null),
      transcript_path: (.transcript_path // null),
-     error_details: ((.error_details // null) | if type == "string" then .[0:500] else . end),
-     last_assistant_message: ((.last_assistant_message // null) | if type == "string" then .[0:1000] else . end),
+     error_details: ((.error_details // null)
+       | if . == null then null
+         elif type == "string" then .[0:500]
+         else (tojson | .[0:500]) end),
+     last_assistant_message: ((.last_assistant_message // null)
+       | if . == null then null
+         elif type == "string" then .[0:1000]
+         else (tojson | .[0:1000]) end),
      resume_hint: "Turn ended on an Anthropic usage limit. Reconstruct in-flight state from the transcript above, then resume; see .claude/reference/usage-limit-signal-audit-2026-07.md."
    }' 2>/dev/null)
 
@@ -121,11 +127,23 @@ if (( LOCKED )); then
   trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT
 fi
 
-SIZE=$(file_size "$EVENTS_LOG")
-[[ -n "$SIZE" ]] || SIZE=0
-if (( SIZE + ${#RECORD} >= LOG_MAX_SIZE )); then
-  rm -f "${EVENTS_LOG}.1" 2>/dev/null
-  mv "$EVENTS_LOG" "${EVENTS_LOG}.1" 2>/dev/null
+# Rotate ONLY while holding the lock. Rotation is rm + mv — two unsynchronized
+# rotations near the cap can replace the archive with a freshly-emptied log and
+# discard the previous one. Appending unlocked risks at worst an interleave;
+# rotating unlocked risks losing history, so the unlocked path skips it and
+# lets a later locked run rotate instead.
+if (( LOCKED )); then
+  SIZE=$(file_size "$EVENTS_LOG")
+  [[ -n "$SIZE" ]] || SIZE=0
+  # Byte count, not ${#RECORD}: that is a character count, so multibyte UTF-8 in
+  # the captured message would under-measure and defer rotation past the cap.
+  # The +1 the newline adds is included by printf'ing exactly what gets appended.
+  RECORD_BYTES=$(printf '%s\n' "$RECORD" | wc -c | tr -d '[:space:]')
+  [[ "$RECORD_BYTES" =~ ^[0-9]+$ ]] || RECORD_BYTES=${#RECORD}
+  if (( SIZE + RECORD_BYTES >= LOG_MAX_SIZE )); then
+    rm -f "${EVENTS_LOG}.1" 2>/dev/null
+    mv "$EVENTS_LOG" "${EVENTS_LOG}.1" 2>/dev/null
+  fi
 fi
 
 # Publish `last` only if the durable append succeeded — otherwise the pointer

--- a/.claude/reference/usage-limit-signal-audit-2026-07.md
+++ b/.claude/reference/usage-limit-signal-audit-2026-07.md
@@ -1,0 +1,175 @@
+# Usage-Limit Signal Audit — 2026-07
+
+**Question (issue #824):** does Claude Code expose a trustworthy upstream signal that a **hook, skill, or session** can read to notice "this account is approaching its usage limit" *before* the limit is hit?
+
+**Verdict: No.** A first-party approaching-limit signal exists in the runtime, but it is delivered **only to the status line**, which is a display surface that (a) never executes in this user's environment and (b) has no path back into the model's context even when it does. No hook event of any kind carries usage data. The only limit signal that reaches a hook arrives **after** the turn has already failed.
+
+Consequence: the automatic "detect the approach → wind down → hand off" behavior described in issue #824 **cannot be built on a trustworthy trigger today**, and the issue's own no-signal branch applies — a written finding, no heuristic trigger, and `.claude/rules/safety.md` left unchanged.
+
+### Audit record (this verdict is version-scoped)
+
+| | |
+|---|---|
+| Runtime | **Claude Code 2.1.219** |
+| Binary | `~/Library/Application Support/Claude/claude-code/2.1.219/claude.app/Contents/MacOS/claude` |
+| Size / SHA-256 | 256,908,272 B · `49b1845cd34af8a57faf30c460824e4235ae4917bf15cd13288c1ae9e6077b97` |
+| Audited | 2026-07-30 |
+| Session under probe | Desktop app, headless: `claude --output-format stream-json --verbose --input-format stream-json` |
+| Probe config tier | Project — `.claude/settings.local.json` (reverted after the run) |
+| Probe duration | ~6 min, dozens of tool calls, normal working session |
+
+**Reproducing it.** Extract the binary's strings once, then re-run the three checks:
+
+```bash
+BIN="$HOME/Library/Application Support/Claude/claude-code/<version>/claude.app/Contents/MacOS/claude"
+strings -n 6 "$BIN" > /tmp/claude-strings.txt
+
+# 1. statusLine contract — does it still carry rate_limits, and only there?
+grep -n 'rate_limits' /tmp/claude-strings.txt
+
+# 2. Shared hook payload base — does any usage field appear?
+grep -oE 'function Kf\([^)]*\)\{.{0,700}' /tmp/claude-strings.txt
+
+# 3. Hook event catalog — has a proactive limit event appeared?
+grep -oE '[A-Za-z]+:\{summary:"[^"]*"' /tmp/claude-strings.txt | sort -u
+```
+
+The minified identifier for the payload base (`Kf` here) is not stable across builds; if check 2 returns nothing, locate the builder by grepping for `hook_event_name` and reading the object it spreads.
+
+**Live probe.** Register a statusLine command that appends its raw stdin to a file, leave it armed through a normal working session, then check for invocations:
+
+```bash
+# .claude/settings.local.json → {"statusLine":{"type":"command","command":"/path/to/probe.sh"}}
+# probe.sh: INPUT="$(cat)"; printf '%s\n' "$INPUT" >> /tmp/statusline-payload.jsonl; printf 'probe'
+wc -l /tmp/statusline-payload.jsonl 2>/dev/null || echo "0 invocations"
+```
+
+---
+
+## Evidence, component by component
+
+### 1. statusLine — carries the signal, but cannot deliver it
+
+The binary embeds the documented statusLine stdin contract. It **does** include usage limits:
+
+```
+"rate_limits": {   // Optional: Claude.ai subscription usage limits. Only present for subscribers after first API response.
+  "five_hour": {   // Optional: 5-hour session limit (may be absent)
+    "used_percentage": number,   // Percentage of limit used (0-100)
+    "resets_at": number          // Unix epoch seconds when this window resets
+  },
+  "seven_day": {   // Optional: 7-day weekly limit (may be absent)
+    "used_percentage": number,
+    "resets_at": number
+  }
+}
+```
+
+So the number itself is real, first-party, and authoritative. Four separate facts make it unusable as a trigger:
+
+**(a) It only runs inside the interactive TUI.** The status-line executor is invoked from the Ink/React render path, and its result is written into React app state (`onResult` → `statusLineText`) which a footer component renders. There is no non-TUI invocation site.
+
+**(b) It never executes in this user's environment.** The Claude Code desktop app runs the agent headlessly:
+
+```
+claude --output-format stream-json --verbose --input-format stream-json --effort max --model … 
+```
+
+There is no status line to render in a `stream-json` session, so the command is never called.
+
+**(c) Live probe: zero invocations.** A statusLine command that appended its raw stdin to a dump file was registered and left armed for ~6 minutes across dozens of tool calls in a normal working session. It produced **no output file and no invocations at all**.
+
+> Probe caveat, stated honestly: the probe was registered at the *project* settings tier, so it does not by itself isolate "headless mode" from "tier not honored." That distinction is moot — no status line can execute in a headless session regardless of which tier declares it — and (a) and (b) are independent code-level evidence. It is recorded here so the null result is not over-read.
+
+**(d) Even in a terminal TUI, stdout is display-only.** The command's stdout becomes `statusLineText` and is rendered. Nothing forwards it into the model's context. Any bridge would have to be a *side effect* of the script (writing a marker file that an in-session hook later reads) — the same shape as `silence-watchdog.sh`, whose "no path back into the thread" limitation is already documented in `bgwork-ceiling.sh`.
+
+### 2. Hooks — no usage fields on any event
+
+Every hook payload is built from one shared base function. It returns exactly:
+
+```js
+{ session_id, transcript_path, cwd, prompt_id, permission_mode, agent_id, agent_type, effort }
+```
+
+No `rate_limits`, no usage, no quota. Per-event payloads add only event-specific fields (`tool_name`, `trigger`, `agent_id`, …).
+
+All 32 registered hook events were enumerated from the binary's own catalog and checked: `ConfigChange`, `CwdChanged`, `DirectoryAdded`, `Elicitation`, `ElicitationResult`, `FileChanged`, `InstructionsLoaded`, `MessageDisplay`, `Notification`, `PermissionDenied`, `PermissionRequest`, `PostCompact`, `PostToolBatch`, `PostToolUse`, `PostToolUseFailure`, `PreCompact`, `PreToolUse`, `SessionEnd`, `SessionStart`, `Setup`, `Stop`, `StopFailure`, `SubagentStart`, `SubagentStop`, `TaskCompleted`, `TaskCreated`, `TeammateIdle`, `UserPromptExpansion`, `UserPromptSubmit`, `WorktreeCreate`, `WorktreeRemove`, `terminal`.
+
+**None carries an approaching-limit field.** `Notification` in particular does not.
+
+The single place in the binary where `rate_limits` appears near `hook_event_name` is a 218 KB minified OpenTelemetry schema blob — a `Quota-429` **error-reporting** shape (`{resets_at, rate_limit_type}`), not a hook payload. It also defines `rate_limits_available` as *"False when plan rate limits do not apply (API key, Bedrock, Vertex, or missing profile)"*, confirming the signal is subscription-scoped.
+
+### 3. StopFailure — real, but strictly post-hoc
+
+```
+StopFailure — "When the turn ends due to an API error"
+"Fires instead of Stop when an API error (rate limit, auth failure, etc.) ended the turn.
+ Fire-and-forget — hook output and exit codes are ignored."
+```
+
+Payload: the base fields plus `error`, `error_details`, `last_assistant_message`. It is matchable on the `error` field, whose documented values are:
+
+`rate_limit`, `overloaded`, `authentication_failed`, `oauth_org_not_allowed`, `billing_error`, `invalid_request`, `model_not_found`, `server_error`, `max_output_tokens`, `unknown`
+
+This is a genuine, first-party, zero-estimation limit signal — but it fires **after** the wall, and its output is ignored, so it can neither warn the session nor change its behavior. It can only run a script that records something to disk.
+
+### 4. `/usage` — authoritative, in-app, not machine-readable
+
+The binary contains the in-app usage view (`Current session`, `Current week (all models)`, `Current week (Sonnet only)`, `rate_limits_available`, `model_scoped`). This is the surface `safety.md` names as authoritative. It is UI only; nothing exports it to a hook, a file, or an env var.
+
+---
+
+## Why this is not simply "build the relay anyway"
+
+CodeRabbit's plan on issue #824 proposed a statusLine → marker-file → `PostToolUse` relay, plus a `safety.md` amendment blessing it. The premise (a real `rate_limits` signal exists) is correct; the design does not survive the evidence:
+
+- The observer half **never runs** in the desktop app (§1b, §1c). The relay would be silently inert exactly where this user works — the worst failure mode for a safety-adjacent feature, because it looks shipped and does nothing.
+- It would make a wind-down capability's correctness depend on the user's *client choice* (terminal TUI vs. desktop app), invisibly.
+- `safety.md` needed no amendment, because nothing shipped acts on an estimate. Amending a deliberately strict safety rule to accommodate a mechanism that cannot fire would weaken the rule for no gain.
+
+## Why this is not "just estimate it locally"
+
+This ground was already covered. Issue #499 rolled back a shipped `/quota` tracker (PR #484) for three reasons, the first of which is the load-bearing one:
+
+1. **Agents gated real decisions on the estimate.** A transcript showed an agent declining to fan out a wave of coding agents "because quota is critical" — the wave was the right move.
+2. Per-turn Stop-hook noise across every thread, for days.
+3. The measurement model could not match Anthropic's enforcement model.
+
+That rollback is why `.claude/rules/safety.md` §"Anthropic Quota & Spend Authority" exists. The inert residue is still on disk (`~/.claude/quota-usage.log`, `~/.claude/quota-usage.d/`, last written 2026-07-01) and is deliberately left alone as user data.
+
+## What NOT to build
+
+- **Do not** ship any trigger derived from locally-computed token or spend arithmetic — including "tokens seen this session," transcript size, or turn counts as a limit proxy. `safety.md` forbids it and #499 is the worked example of the harm.
+- **Do not** build the statusLine → marker relay as an automatic trigger while the desktop app is the primary client. It cannot fire there.
+- **Do not** amend `safety.md` for this. Nothing shipped here acts on an estimate, so the rule stands unmodified.
+- **Do not** treat `StopFailure` as an *approaching*-limit signal. It is a post-mortem.
+
+## What was built instead
+
+A single post-hoc recorder, `.claude/hooks/usage-limit-record.sh`, registered on `StopFailure` with matcher `rate_limit`. When — and only when — the runtime itself reports that a turn ended on a rate limit, it appends a durable record (session id, cwd, transcript path, truncated last assistant message) to `~/.claude/usage-limit-events.jsonl` and refreshes `~/.claude/usage-limit-last.json`.
+
+It is deliberately minimal:
+
+- **Upstream-triggered only.** Its sole input is the runtime's own error classification. It computes nothing.
+- **It gates no decision.** It never pauses, downgrades, defers, or refuses work, so `safety.md` is satisfied as written.
+- **It is a recorder, not a shutdown.** By the time it fires the turn is already over; the value is that the *next* session finds a breadcrumb instead of silence.
+
+This does not deliver the pre-emptive wind-down issue #824 hoped for. That remains blocked upstream.
+
+## Follow-ups / re-check triggers
+
+Re-run this audit if any of the following change:
+
+1. **A hook event gains usage fields** — re-check the shared hook-payload base. That single change would unblock the full pre-emptive wind-down.
+2. **A non-TUI statusLine invocation appears**, or the desktop app starts rendering a status line.
+3. **The runtime gains a proactive warning event** (e.g. an `ApproachingLimit` / `Notification` variant carrying `rate_limits`).
+4. **A machine-readable usage export** (CLI subcommand, env var, or file) ships.
+
+Until then, the honest user-facing answer is: watch the in-app usage UI, and invoke a handoff yourself (`/pm-handoff`, `/wrap`) when you can see the window running out.
+
+## Related
+
+- `.claude/rules/safety.md` §"Anthropic Quota & Spend Authority" — unchanged by this work.
+- Issue #499 — the `/quota` rollback that produced that rule.
+- Issue #710 — spend/thread-type telemetry: measurement, not a limit signal; does not satisfy the upstream-signal requirement.
+- `.claude/reference/bgwork-ceiling.md` — the "external observer with no path back into the thread" precedent.

--- a/global-settings.json
+++ b/global-settings.json
@@ -62,6 +62,18 @@
         ]
       }
     ],
+    "StopFailure": [
+      {
+        "matcher": "rate_limit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/usage-limit-record.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/setup-skills-worktree.sh
+++ b/setup-skills-worktree.sh
@@ -222,6 +222,7 @@ HOOKS_MANIFEST=(
   $'Stop\t\tdirty-main-warn.sh\t10'
   $'Stop\t\tskill-usage-snapshot-hook.sh\t10'
   $'SessionStart\t\tsession-start-sync.sh\t30'
+  $'StopFailure\trate_limit\tusage-limit-record.sh\t5'
   $'PostToolUse\tBash\tpost-merge-pull.sh\t15'
   $'PostToolUse\tBash\tpolling-backoff-warn.sh\t5'
   $'PostToolUse\tSkill\tskill-usage-tracker.sh\t5'


### PR DESCRIPTION
## Summary

Issue #824 asked for a session that notices an approaching usage limit, writes a handoff, and shuts down gracefully — explicitly **gated** on first proving a trustworthy upstream signal exists to hang it on, because `safety.md` forbids acting on a locally-computed estimate.

**The finding is the deliverable: no such signal reaches a hook, skill, or session.** So this PR ships the issue's own no-signal branch — the written finding, no heuristic trigger, and `.claude/rules/safety.md` **unchanged** — plus the one genuinely upstream-triggered thing the runtime does permit: a post-hoc recorder.

## The investigation

Audited **Claude Code 2.1.219** (SHA-256 `49b1845c…`) by `strings`-extracting the shipped binary plus a live runtime probe.

| Surface | Carries `rate_limits`? | Usable as a trigger? |
|---|---|---|
| **statusLine** stdin | **Yes** — `five_hour`/`seven_day` `used_percentage` + `resets_at` | **No** — runs only on the Ink/React TUI render path; stdout lands in a React state var, never in model context |
| **All 32 hook events** | **No** — shared payload base is `{session_id, transcript_path, cwd, prompt_id, permission_mode, agent_id, agent_type, effort}` | No |
| **`StopFailure`** | Post-hoc only (`error: "rate_limit"`) | Only as a **recorder** — fires after the turn died; "fire-and-forget, output and exit codes ignored" |
| **`/usage`** | Yes (authoritative) | No — in-app UI, no machine-readable export |

Decisive: this desktop-app session runs headless (`claude --output-format stream-json --input-format stream-json`), so **no status line renders at all**. A registered statusLine probe that dumped its raw stdin produced **0 invocations across ~6 minutes** of heavy tool use.

## Why CodeRabbit's plan was declined

CR planned a statusLine → marker-file → PostToolUse relay plus a `safety.md` amendment. Its premise (a real `rate_limits` signal exists) is correct; the mechanism is not:

1. The observer half **never executes** in the desktop app — the relay would be silently inert exactly where the user works. Worst failure mode for a safety-adjacent feature: looks shipped, does nothing.
2. It would make correctness depend invisibly on client choice (terminal TUI vs. desktop app).
3. Amending a deliberately strict safety rule to accommodate a mechanism that cannot fire weakens the rule for zero gain.

Local estimation stays closed on its own merits: #499 rolled back the `/quota` tracker because agents gated real decisions on it — one declined a correct wave "because quota is critical." That rollback is *why* the safety rule exists.

## What ships

`.claude/hooks/usage-limit-record.sh`, registered on **`StopFailure`** with matcher **`rate_limit`** (first use of that event in this repo). On the runtime's own error classification it appends `{recorded_at, session_id, cwd, transcript_path, truncated last_assistant_message, resume_hint}` to `~/.claude/usage-limit-events.jsonl` (rotated at 256 KiB) and atomically rewrites `~/.claude/usage-limit-last.json`.

- **Upstream-triggered only** — sole input is the runtime's error classification; computes nothing.
- **Gates no decision** — never pauses, downgrades, defers, or refuses work, so `safety.md` holds as written.
- **Recorder, not shutdown** — the next session finds a breadcrumb instead of silence.

It does **not** deliver the pre-emptive wind-down the issue hoped for. That is blocked upstream; the finding doc records the four conditions that would unblock it.

## Review notes

**Local CLI coverage: `none`** — both CLIs were unavailable, so this change set had a **self-review** as its final gate.

- **CodeAnt:** 403 + `meta.capped: true` on both the initial run and the one sanctioned retry (undocumented daily cap). Dropped per `cr-local-review.md`; deliberately **not** re-authenticated, since the documented cause is a cap, not auth.
- **CodeRabbit:** the first run was verified-successful and returned **8 findings — all 8 verified as valid and fixed** (below). The confirming second pass hit the free-OSS tier cap (`rate_limit`, `waitTime: 44 minutes`), which is a failed run, not a clean pass.

Per `feedback_review_clis_down_app_independent.md`, CLI unavailability does not block merge — the GitHub App reviewers have independent quotas and still gate it.

**Findings fixed (all 8):**
- *major* — state files were world-readable despite embedding conversation content → `umask 077` + defensive `chmod 600`
- *major* — no cross-process lock. Concurrency is the **expected** case here (one account hitting its wall fails every active session at once) → bounded, portable `mkdir` mutex (macOS ships no `flock`), publish-only-on-successful-append
- *major* — split registration assertions could accept matcher on one entry and timeout on another → consolidated into one conjunction
- *minor ×4 / trivial ×1* — truncation test could pass without the record ever being written; batch tests compared line counts instead of content; events-log fields unasserted; "Three facts" introduced four; audit doc lacked reproduction details

Self-review additionally caught a latent `trap` quoting bug (`$LOCK_DIR` expanded at definition time), now fixed and covered by a quoted-path test.

## Verification

- 12-assertion test suite; injected regressions confirmed **failing** before restore (removed `rate_limit` guard; drifted timeout; split registration)
- Concurrency: 25 simultaneous hooks → 25 records, 0 interleaved lines, 25 distinct sessions, no leftover lock
- Permissions asserted `600`; quoted-path (`it's a dir`) handled
- All **50** CI-discovered bash suites pass; `rule-lint: OK`; `shellcheck` clean
- Corpus 11,458 words — no rule files touched

## Test plan

- [x] Signal investigation documented with concrete evidence (binary strings, hook payload base, live probe), not assertion
- [x] No shutdown/wind-down behavior ships on a heuristic; the only trigger is the runtime's `error: "rate_limit"`
- [x] No code path computes a local spend estimate to gate a decision (asserted by test 8, comments stripped)
- [x] `.claude/rules/safety.md` is unchanged
- [x] A normal session with plenty of budget is unaffected — non-`rate_limit` errors and malformed payloads mutate neither state file
- [x] Handoff/record is written durably and a fresh session can find it (`usage-limit-last.json` + append-only log)
- [x] Registration is consistent across `global-settings.json` and `HOOKS_MANIFEST` (matcher + command + timeout on one entry)
- [x] `rule-lint.sh` passes and the corpus budget is respected
- [x] All CI-discovered test suites pass

Closes #824

