### PR TITLE
fix(#771): extract Python discovery to run-python-tests.sh, batch Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/scripts/run-python-tests.sh
+++ b/.github/scripts/run-python-tests.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Discover and run every Python unittest module in tests/. Adding a test needs
+# NO workflow edit: drop a `test_*.py` module into tests/ and it runs
+# automatically under both the default-Python job and the pinned-3.9 job.
+# This script extracts the duplicated inline discovery block that appeared
+# verbatim in both jobs of .github/workflows/hook-scripts.yml, so future
+# edits to Python test discovery touch exactly one file instead of two job
+# bodies (issue #771; companion to the bash-test extraction done in issue #681
+# via run-hook-tests.sh).
+#
+# Discovery contract: tests/test_*.py modules, invoked via
+# `python3 -m unittest discover`.
+#
+# Usage (CI or local, runnable from anywhere):
+#   bash .github/scripts/run-python-tests.sh
+#
+# Python version: determined by whatever `python3` is on PATH. The CI workflow
+# handles version pinning via the `setup-python` step before calling this
+# script, so the script itself takes no arguments.
+set -euo pipefail
+shopt -s nullglob
+
+# Resolve to the repo root regardless of caller cwd so the glob below resolves.
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || {
+  echo "::error::run-python-tests.sh: cannot cd to repo root" >&2
+  exit 1
+}
+
+# Discover tests/test_*.py and fail loud on an empty set — a silent
+# "Ran 0 tests ... OK" must never pass green (issue #681).
+mods=(tests/test_*.py)
+if [ "${#mods[@]}" -eq 0 ]; then
+  echo "::error::No tests/test_*.py modules discovered — a glob is broken or tests/ is empty" >&2
+  exit 1
+fi
+
+echo "Discovered ${#mods[@]} Python test module(s)."
+python3 -m unittest discover -s tests -p 'test_*.py' -v

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -11,6 +11,8 @@ permissions:
 # every in-flight PR collided here (PRs #657/#658/#660/#661/#672/#676; #676 took
 # 3 rebases). Now: drop a `*.test.sh` into a discovered dir, or a
 # `tests/test_*.py` module, and CI runs it with NO edit to this file.
+# Bash discovery: .github/scripts/run-hook-tests.sh
+# Python discovery: .github/scripts/run-python-tests.sh (issue #771)
 # See CONTRIBUTING.md "Adding a Test".
 jobs:
   hook-tests:
@@ -30,18 +32,7 @@ jobs:
         run: bash .github/scripts/run-hook-tests.sh
 
       - name: Run Python hook unit tests (auto-discovered)
-        run: |
-          set -euo pipefail
-          # Discover tests/test_*.py and fail loud on an empty set — a silent
-          # "Ran 0 tests ... OK" must never pass green (issue #681).
-          shopt -s nullglob
-          mods=(tests/test_*.py)
-          if [ "${#mods[@]}" -eq 0 ]; then
-            echo "::error::No tests/test_*.py modules discovered"
-            exit 1
-          fi
-          echo "Discovered ${#mods[@]} Python test module(s)."
-          python3 -m unittest discover -s tests -p 'test_*.py' -v
+        run: bash .github/scripts/run-python-tests.sh
 
   # macOS system python3 is 3.9.6 (Xcode CLT) while ubuntu-latest ships 3.10+,
   # so a hook that crashes on 3.9 (e.g. eagerly-evaluated PEP 604 unions,
@@ -62,16 +53,7 @@ jobs:
           python-version: '3.9'
 
       - name: Python hook unit tests (3.9, auto-discovered)
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          mods=(tests/test_*.py)
-          if [ "${#mods[@]}" -eq 0 ]; then
-            echo "::error::No tests/test_*.py modules discovered"
-            exit 1
-          fi
-          echo "Discovered ${#mods[@]} Python test module(s)."
-          python3 -m unittest discover -s tests -p 'test_*.py' -v
+        run: bash .github/scripts/run-python-tests.sh
 
       - name: Hooks import smoke (3.9)
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,8 @@ Tests are **auto-discovered** by the [`hook-scripts.yml`](.github/workflows/hook
 Run the whole suite locally from the repo root before pushing:
 
 ```bash
-bash .github/scripts/run-hook-tests.sh                       # all bash suites
-python3 -m unittest discover -s tests -p 'test_*.py' -v       # all Python suites
+bash .github/scripts/run-hook-tests.sh        # all bash suites
+bash .github/scripts/run-python-tests.sh      # all Python suites
 ```
 
 ## Git Pre-commit Hook (Worktree Enforcement)


### PR DESCRIPTION
## Summary

Reduces the edit surface of `hook-scripts.yml` by targeting the two remaining churn drivers identified in Issue #771:

1. **Duplicated Python discovery block** — the `tests/test_*.py` discover/fail-loud/run shell was verbatim identical in both CI jobs. Each future change to Python test discovery would touch the file twice. Extracted to `.github/scripts/run-python-tests.sh`, following the established `run-hook-tests.sh` pattern.

2. **Ungrouped Dependabot action bumps** — two pinned actions (`actions/checkout` and `actions/setup-python`) previously each generated a separate weekly PR against this file. Now batched into a single PR via `dependabot.yml` `groups:`.

`CONTRIBUTING.md` updated to point the Python local-repro command at the new script.

**Zero behavior change:** Same triggers (`on: pull_request`), same job names (`hook-tests`, `hook-tests-py39`), same discovery contract (zero-file guard, same `unittest discover` invocation), same failure semantics.

## Test plan

- [x] `actionlint .github/workflows/hook-scripts.yml` passes clean
- [x] `rule-lint.sh` passes (rule corpus unchanged)
- [x] Required status check `rule-lint` name is unchanged — verified against `gh api repos/auerbachb/claude-code-config/branches/main/protection --jq '.required_status_checks.contexts'` (returns `["rule-lint"]`; job names `hook-tests`/`hook-tests-py39` are not required checks)
- [x] Job names `hook-tests` and `hook-tests-py39` unchanged in `hook-scripts.yml`
- [x] Auto-discovery property preserved: `tests/test_*.py` drop-in still requires NO workflow edit (discovery logic identical, just moved to `run-python-tests.sh`)
- [x] `run-python-tests.sh` zero-discovery guard present (fails loud on empty glob per issue #681 contract)
- [x] Python 3.9 pinning, smoke test step, `Configure git`, and checkout steps all unchanged
- [x] CI green on this PR

Closes #771

[COVERAGE] none — CodeRabbit CLI binary absent; CodeAnt CLI returned 403 (daily cap, not an auth issue per repo memory). Self-review performed: `actionlint` clean, `rule-lint.sh` passes, all changes verified against original inline behavior.