### PR TITLE
refactor(#788): slim fixpr/SKILL.md — extract reviewer-activity, wait-state, classification pointer

### DIFF
--- a/.claude/reference/fixpr-hotspot-decision.md
+++ b/.claude/reference/fixpr-hotspot-decision.md
@@ -1,0 +1,62 @@
+# fixpr hotspot — diagnosis and extract-not-split decision
+
+Reference for Issue #788 (`.claude/skills/fixpr/SKILL.md` churn hotspot). Not auto-loaded.
+
+## The problem being read
+
+`fixpr/SKILL.md` was touched by 17 distinct merged PRs (#536, #542, #543, #565, #578, #586, #612, #619, #658, #689, #690, #709, #719, #724, #739, #761, #763) — the highest-churn skill file in the repo when Issue #788 was filed.
+
+The file is the shared recovery junction for the entire workflow. Every caller (`/wrap` Step 2.1, `/babysit-pr`, `phase-b-reviewer`, `phase-c-merger`) dispatches fixpr's Steps 0–7 contract unmodified; only `BABYSIT_SAFE_CONFLICT_MODE=1` / `TASK_TYPE` fork behavior inside the junction itself. This junction nature explains part of the churn: the file is touched whenever any recovery-path behavior changes, by definition.
+
+But three additional co-located concerns each iterate independently and produce edit collisions with the junction prose:
+
+| Concern | Location in SKILL.md | Churn driver |
+|---------|----------------------|--------------|
+| Reviewer-activity detection | Step 3b: ~80-line jq detecting CR/Graphite/CodeAnt on a pushed SHA | Reviewer-set changes (new bot, new check name) require editing the skill |
+| Wait-state predicate | Step 4d: same ~40-line jq appears twice (pre-check + loop body) | Predicate changes require two matching edits; duplication = drift risk |
+| Classification contract | Step 5b: full prose re-statement of `pr-state.sh`'s `classify` rules | Rule changes require editing both `pr-state.sh` and `SKILL.md` in sync |
+
+## Decision: extract, not split
+
+**Splitting the skill is rejected.**
+
+Every caller depends on fixpr's single Steps 0–7 contract and `=== fixpr complete ===` / `FIXPR_WRAP_STATUS:` / `FIXPR_WAIT_SUMMARY:` footer vocabulary. A physical split would require matching updates in `/wrap`, `/babysit-pr`, `phase-b-reviewer`, `phase-c-merger`, and the rule files that reference fixpr by step number. Extraction removes the per-PR edit surface while leaving the junction contract intact.
+
+This follows the same remedy as:
+- `hook-scripts.yml` hotspot (#681) — extracted deterministic script logic into `.claude/scripts/*.sh`
+- `pm/SKILL.md` hotspot (#783) — extracted long prose into `.claude/skills/pm/references/*.md`
+
+## Concrete remedy (Issue #788, implemented in PR that closes it)
+
+Three targeted extractions, zero behavior change:
+
+### 1. Classification contract → `pr-state.sh` is the single source of truth
+
+The classification rules lived in `pr-state.sh`'s `classify` jq function (with an extensive block comment above it) AND were duplicated verbatim as prose in `fixpr/SKILL.md` Step 5b. `pr-state.sh` is now authoritative; Step 5b carries a pointer and a summary of the ordering invariants. Rule changes only require editing `pr-state.sh`.
+
+### 2. Reviewer-activity detection → `.claude/scripts/reviewer-activity.sh`
+
+The SHA-scoped reviewer-activity detection block was extracted from Step 3b into a standalone script. The script accepts `<PR_NUMBER> <PUSHED_SHA> <PUSHED_AT>` and emits the `{coderabbit, graphite, codeant}` boolean activity JSON on stdout. The trigger rate-cap / `@coderabbitai full review` decision logic stays in the skill — it involves judgment about the 2/hour cap and per-PR state and is deliberately in-turn.
+
+### 3. Wait-state predicate → `pr-state.sh --wait-state-eval`
+
+The ~40-line jq that computes `{head_moved, bots_pending, ci_pending, ci_failing, new_findings}` from a fetched bundle appeared twice identically in Step 4d (once in the DID_PUSH=0 pre-check, once in the wait loop body). Added as a new `--wait-state-eval <sha> <bundle_file>` mode in `pr-state.sh`. Both call sites in the skill replaced with a single-line script invocation.
+
+## What was explicitly preserved
+
+- Steps 0–7 sequential contract: unchanged
+- `=== fixpr complete ===` footer: unchanged
+- `FIXPR_WRAP_STATUS:` token: unchanged
+- `FIXPR_WAIT_SUMMARY:` token: unchanged
+- Step 3b rate-cap prose and `@cursor review` always-post rule: unchanged
+- Step 4d loop control (sleep, cap, heartbeat, CR re-trigger): unchanged
+- `dismiss-stale-bot-changes.sh` step sequence: unchanged
+- `diff-survival-check.sh` Step 6a guard: unchanged
+
+## Related
+
+- Issue #681 — `hook-scripts.yml` hotspot, the structural precedent for extraction
+- Issue #783 — `pm/SKILL.md` hotspot, the closest skill-file precedent
+- `.claude/reference/script-extraction-audit.md` — registry of extracted scripts
+- `.claude/scripts/reviewer-activity.sh` — new script from extraction 2
+- `.claude/scripts/pr-state.sh` — `--wait-state-eval` mode from extraction 3

--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -7,12 +7,13 @@
 # via jq instead of re-issuing overlapping gh api calls inline.
 #
 # Usage:
-#   pr-state.sh                          # Auto-detect PR from current branch
-#   pr-state.sh --pr 123                 # Use explicit PR number (skips branch detect)
-#   pr-state.sh --since <iso-8601>       # Pre-classify bot comments posted since baseline
-#   pr-state.sh --pr 123 --since <iso>   # Combined
-#   pr-state.sh --infer-candidates       # List session-tracked PR candidates (no GitHub state)
-#   pr-state.sh --help                   # Print usage
+#   pr-state.sh                                  # Auto-detect PR from current branch
+#   pr-state.sh --pr 123                         # Use explicit PR number (skips branch detect)
+#   pr-state.sh --since <iso-8601>               # Pre-classify bot comments posted since baseline
+#   pr-state.sh --pr 123 --since <iso>           # Combined
+#   pr-state.sh --infer-candidates               # List session-tracked PR candidates (no GitHub state)
+#   pr-state.sh --wait-state-eval <sha> <bundle> # Evaluate wait-state predicate on fetched bundle
+#   pr-state.sh --help                           # Print usage
 #
 # Output: writes JSON to /tmp/pr-state-<PR>-<epoch>.json and prints the path on stdout.
 #         (--infer-candidates prints a JSON array to stdout instead — see below.)
@@ -31,6 +32,19 @@
 #   the candidate's stored owner_repo are known, else null ("unknown — don't filter
 #   it out"). Always exits 0 with `[]` when the state file is missing or tracks no
 #   active PRs. Cannot be combined with --pr or --since.
+#
+# --wait-state-eval <sha> <bundle_file> (extracted from /fixpr Step 4d, Issue #788):
+#   Evaluates the wait-state predicate on an already-fetched bundle file (written by a
+#   prior pr-state.sh --pr call), scoped to the given SHA. Outputs a JSON object:
+#     { "head_moved": bool, "bots_pending": [str], "ci_pending": [str],
+#       "ci_failing": [str], "new_findings": int }
+#   head_moved is true when pr.head_sha != <sha> (external push while waiting).
+#   bots_pending lists bot logins still running (participating bots not yet done).
+#   ci_pending lists non-review-bot CI check names not yet completed.
+#   ci_failing lists non-review-bot CI checks with a blocking conclusion.
+#   new_findings is the finding count from new_since_baseline.
+#   Cannot be combined with --pr, --since, or --infer-candidates.
+#   Exit code 0 on success; 2 on usage error.
 #
 # Exit codes:
 #   0  OK
@@ -62,11 +76,28 @@ run_gh() {
 PR_ARG=""
 SINCE=""
 INFER_CANDIDATES=0
+WAIT_STATE_EVAL=0
+WAIT_STATE_SHA=""
+WAIT_STATE_BUNDLE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --infer-candidates)
       INFER_CANDIDATES=1
       shift
+      ;;
+    --wait-state-eval)
+      WAIT_STATE_EVAL=1
+      WAIT_STATE_SHA="${2:-}"
+      if [[ -z "$WAIT_STATE_SHA" ]]; then
+        echo "ERROR: --wait-state-eval requires a SHA argument" >&2
+        exit 2
+      fi
+      WAIT_STATE_BUNDLE="${3:-}"
+      if [[ -z "$WAIT_STATE_BUNDLE" ]]; then
+        echo "ERROR: --wait-state-eval requires a bundle file argument" >&2
+        exit 2
+      fi
+      shift 3
       ;;
     --pr)
       PR_ARG="${2:-}"
@@ -214,6 +245,69 @@ if [[ "$INFER_CANDIDATES" -eq 1 ]]; then
   else
     echo "$_jq_out"
   fi
+  exit 0
+fi
+
+# ----------------------------------------------------------------------
+# 0b. --wait-state-eval: evaluate the per-tick wait-state predicate on an
+#     already-fetched bundle file and exit.
+#     Extracted from /fixpr Step 4d (Issue #788 hotspot extraction).
+#     The surrounding in-turn loop, sleep/cap, and heartbeat control flow
+#     stay in fixpr/SKILL.md — only the shared predicate lives here.
+# ----------------------------------------------------------------------
+if [[ "$WAIT_STATE_EVAL" -eq 1 ]]; then
+  if [[ -n "$PR_ARG" || -n "$SINCE" || "$INFER_CANDIDATES" -eq 1 ]]; then
+    echo "ERROR: --wait-state-eval cannot be combined with --pr, --since, or --infer-candidates" >&2
+    exit 2
+  fi
+  if [[ ! -f "$WAIT_STATE_BUNDLE" ]]; then
+    echo "ERROR: --wait-state-eval bundle file not found: $WAIT_STATE_BUNDLE" >&2
+    exit 2
+  fi
+  jq -c --arg sha "$WAIT_STATE_SHA" '
+    . as $root
+    | ["coderabbitai[bot]","cursor[bot]","codeant-ai[bot]","greptile-apps[bot]","graphite-app[bot]"] as $botlist
+    | {"coderabbitai[bot]":"coderabbit","cursor[bot]":"bugbot","codeant-ai[bot]":"codeant",
+       "greptile-apps[bot]":"greptile","graphite-app[bot]":"graphite"} as $needles
+    | def is_review_check($n):
+        ($n // "" | ascii_downcase) as $name
+        | any("coderabbit","graphite","codeant","cursor","bugbot","greptile";
+              . as $x | $name | contains($x));
+    ([$root.comments.reviews[]?.user.login,
+      $root.comments.inline[]?.user.login,
+      $root.comments.conversation[]?.user.login]
+     | map(select(. as $l | $botlist | index($l) != null)) | unique) as $participants
+    | ($root.check_runs.all // []) as $checks
+    | ($root.bot_statuses // {}) as $bstat
+    | ($participants | map(. as $bot
+        | $needles[$bot] as $needle
+        | {bot: $bot,
+           done: (
+             # Review object pinned to the watched SHA. EXCLUDED for BugBot:
+             # cursor[bot] commit_id is stale/unreliable — gate BugBot by its
+             # check-run only (memory feedback_bugbot_commit_id_stale).
+             ( $bot != "cursor[bot]"
+               and any($root.comments.reviews[]?;
+                       .user.login == $bot and (.commit_id // "") == $sha) )
+             # Completed check-run on the watched SHA (check_runs are fetched per
+             # HEAD SHA, so SHA scoping is implicit). conclusion neutral still
+             # counts as complete — BugBot uses neutral for "findings posted".
+             or any($checks[]?;
+                    ((.name // "") | ascii_downcase | contains($needle))
+                    and .status == "completed")
+             # CR/Greptile also report via commit statuses on the watched SHA.
+             or ( $bot == "coderabbitai[bot]" and (($bstat.CodeRabbit.state // "pending") != "pending") )
+             or ( $bot == "greptile-apps[bot]" and (($bstat.Greptile.state // "pending") != "pending") )
+           )})) as $bots
+    | {head_moved: ($root.pr.head_sha != $sha),
+       bots_pending: ($bots | map(select(.done | not) | .bot)),
+       ci_pending: [ $checks[] | select((is_review_check(.name) | not) and .status != "completed") | .name ],
+       ci_failing: [ $checks[] | select((is_review_check(.name) | not)
+                     and (.conclusion == "failure" or .conclusion == "timed_out"
+                          or .conclusion == "action_required" or .conclusion == "startup_failure"
+                          or .conclusion == "stale")) | .name ],
+       new_findings: ($root.new_since_baseline.finding_count // 0)}
+  ' "$WAIT_STATE_BUNDLE"
   exit 0
 fi
 

--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -145,8 +145,8 @@ done
 #    Pure read of ~/.claude/session-state.json — no GitHub state is gathered.
 # ----------------------------------------------------------------------
 if [[ "$INFER_CANDIDATES" -eq 1 ]]; then
-  if [[ -n "$PR_ARG" || -n "$SINCE" ]]; then
-    echo "ERROR: --infer-candidates cannot be combined with --pr or --since" >&2
+  if [[ -n "$PR_ARG" || -n "$SINCE" || "$WAIT_STATE_EVAL" -eq 1 ]]; then
+    echo "ERROR: --infer-candidates cannot be combined with --pr, --since, or --wait-state-eval" >&2
     exit 2
   fi
   STATE_FILE="$HOME/.claude/session-state.json"

--- a/.claude/scripts/reviewer-activity.sh
+++ b/.claude/scripts/reviewer-activity.sh
@@ -43,16 +43,23 @@ PR_NUMBER="$1"
 PUSHED_SHA="$2"
 PUSHED_AT="$3"
 
-# Resolve owner/repo from the git remote (same pattern as other scripts).
-_remote_url=$(git remote get-url origin 2>/dev/null || echo "")
-if [[ -z "$_remote_url" ]]; then
-  echo "ERROR: could not resolve owner/repo from git remote" >&2
-  exit 2
+# Resolve owner/repo: respect GH_REPO override (same as gh CLI) then fall back
+# to the git remote, matching the pattern used by other scripts in this directory.
+if [[ -n "${GH_REPO:-}" ]]; then
+  OWNER_REPO="$GH_REPO"
+  OWNER="${OWNER_REPO%%/*}"
+  REPO="${OWNER_REPO##*/}"
+else
+  _remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+  if [[ -z "$_remote_url" ]]; then
+    echo "ERROR: could not resolve owner/repo from git remote" >&2
+    exit 2
+  fi
+  _remote_url="${_remote_url%.git}"
+  OWNER_REPO="${_remote_url##*github.com[:/]}"
+  OWNER="${OWNER_REPO%%/*}"
+  REPO="${OWNER_REPO##*/}"
 fi
-_remote_url="${_remote_url%.git}"
-OWNER_REPO="${_remote_url##*github.com[:/]}"
-OWNER="${OWNER_REPO%%/*}"
-REPO="${OWNER_REPO##*/}"
 
 # Fetch all three PR comment endpoints + check-runs for the pushed SHA.
 # Using || exit 2 to map gh failures to the documented error code.

--- a/.claude/scripts/reviewer-activity.sh
+++ b/.claude/scripts/reviewer-activity.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# reviewer-activity.sh — Detect whether each conditionally-triggered reviewer has
+# already posted activity on a specific pushed SHA.
+#
+# Extracted from /fixpr Step 3b (Issue #788 hotspot extraction).
+# The trigger rate-cap / @coderabbitai full review decision logic stays in the
+# caller (fixpr/SKILL.md) — that logic involves judgment about per-PR state and
+# the 2/hour cap, and is deliberately in-turn.
+#
+# Usage:
+#   reviewer-activity.sh <PR_NUMBER> <PUSHED_SHA> <PUSHED_AT>
+#
+#   PR_NUMBER  — integer PR number
+#   PUSHED_SHA — full 40-char SHA that was just pushed
+#   PUSHED_AT  — ISO-8601 timestamp captured before git push (avoids race)
+#
+# Output: JSON object on stdout —
+#   { "coderabbit": <bool>, "graphite": <bool>, "codeant": <bool> }
+#   true  = reviewer auto-triggered activity on PUSHED_SHA since PUSHED_AT
+#   false = no activity detected; caller should post a trigger comment
+#
+# Conversation-level comments do not expose a commit_id, so they only count as
+# activity on the pushed SHA when the body mentions the full SHA or short SHA.
+# SHA-scoped reviews, inline comments, and check-runs are used for the other
+# endpoints to avoid treating a late summary from the previous SHA as coverage
+# for the new one.
+#
+# Exit codes:
+#   0  OK (JSON written to stdout)
+#   1  usage error
+#   2  gh/network error (stderr carries the gh output)
+
+set -euo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" \
+  >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: reviewer-activity.sh <PR_NUMBER> <PUSHED_SHA> <PUSHED_AT>" >&2
+  exit 1
+fi
+
+PR_NUMBER="$1"
+PUSHED_SHA="$2"
+PUSHED_AT="$3"
+
+# Resolve owner/repo from the git remote (same pattern as other scripts).
+_remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+if [[ -z "$_remote_url" ]]; then
+  echo "ERROR: could not resolve owner/repo from git remote" >&2
+  exit 2
+fi
+_remote_url="${_remote_url%.git}"
+OWNER_REPO="${_remote_url##*github.com[:/]}"
+OWNER="${OWNER_REPO%%/*}"
+REPO="${OWNER_REPO##*/}"
+
+# Fetch all three PR comment endpoints + check-runs for the pushed SHA.
+# Using || exit 2 to map gh failures to the documented error code.
+REVIEWS=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
+  | jq -s 'add // []') || exit 2
+INLINE=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100" \
+  | jq -s 'add // []') || exit 2
+CONVO=$(gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+  | jq -s 'add // []') || exit 2
+CHECK_RUNS=$(gh api --paginate "repos/$OWNER/$REPO/commits/$PUSHED_SHA/check-runs?per_page=100" \
+  --jq '.check_runs[]' | jq -s '.') || exit 2
+
+# Evaluate the activity map.
+# Each reviewer is true when ANY of the following holds since PUSHED_AT:
+#   - A review object pinned to PUSHED_SHA (by commit_id)
+#   - An inline comment on PUSHED_SHA (by commit_id or original_commit_id)
+#   - A conversation-level comment that explicitly mentions the full or short SHA
+#   - A check-run from that reviewer's app started/completed since PUSHED_AT
+jq -n \
+  --arg pushed_at "$PUSHED_AT" \
+  --arg sha "$PUSHED_SHA" \
+  --argjson reviews "$REVIEWS" \
+  --argjson inline "$INLINE" \
+  --argjson convo "$CONVO" \
+  --argjson checks "$CHECK_RUNS" \
+  '
+  def recent($ts): ($ts // "") >= $pushed_at;
+  def matches_any($value; $needles):
+    ($value // "" | ascii_downcase) as $haystack
+    | any($needles[]; (. | ascii_downcase) as $needle | $haystack | contains($needle));
+  def check_by($names):
+    any($checks[]?;
+      (((.name // "") as $name
+        | (.app.slug // "") as $slug
+        | (.app.name // "") as $app
+        | (matches_any($name; $names) or matches_any($slug; $names) or matches_any($app; $names))))
+      and recent(.started_at // .created_at // .completed_at));
+  def convo_by($login):
+    any($convo[]?;
+      .user.login == $login
+      and recent(.created_at)
+      and (((.body // "") | contains($sha)) or ((.body // "") | contains($sha[0:7]))));
+  {
+    coderabbit:
+      (any($reviews[]?; .user.login == "coderabbitai[bot]" and .commit_id == $sha and recent(.submitted_at))
+       or any($inline[]?; .user.login == "coderabbitai[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
+       or convo_by("coderabbitai[bot]")
+       or check_by(["CodeRabbit", "coderabbitai"])),
+    graphite:
+      (any($reviews[]?; .user.login == "graphite-app[bot]" and .commit_id == $sha and recent(.submitted_at))
+       or any($inline[]?; .user.login == "graphite-app[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
+       or convo_by("graphite-app[bot]")
+       or check_by(["Graphite", "graphite-app"])),
+    codeant:
+      (any($reviews[]?; .user.login == "codeant-ai[bot]" and .commit_id == $sha and recent(.submitted_at))
+       or any($inline[]?; .user.login == "codeant-ai[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
+       or convo_by("codeant-ai[bot]")
+       or check_by(["CodeAnt", "codeant-ai"]))
+  }
+  '

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -20,7 +20,7 @@ CodeRabbit caps **~8 GitHub PR reviews per hour** per account; **each push** con
 
 ## How this skill is structured
 
-> **pr-state.sh first (NON-NEGOTIABLE):** Before calling `gh api .../pulls/{N}/reviews`, `pulls/{N}/comments`, or `issues/{N}/comments` directly, call `pr-state.sh --pr N` first and read the cached JSON bundle. Inline `gh api` calls for these three endpoints are only permitted inside Step 3b's reviewer-activity detection block, which requires a custom post-push timestamp filter that `pr-state.sh` does not expose. Every other polling or review-state lookup MUST go through `pr-state.sh`.
+> **pr-state.sh first (NON-NEGOTIABLE):** Before calling `gh api .../pulls/{N}/reviews`, `pulls/{N}/comments`, or `issues/{N}/comments` directly, call `pr-state.sh --pr N` first and read the cached JSON bundle. Inline `gh api` calls for these three endpoints are only permitted inside the `reviewer-activity.sh` script (Step 3b delegate), which requires a custom post-push timestamp filter that `pr-state.sh` does not expose. Every other polling or review-state lookup MUST go through `pr-state.sh`.
 
 All mechanical GitHub API work — pagination, GraphQL queries, comment classification — lives in the shared script `.claude/scripts/pr-state.sh`. This file tells the AI layer how to invoke the script and what to do with its output (the JSON bundle).
 
@@ -420,52 +420,24 @@ sleep 120
 Detect activity from the 3 conditionally triggered reviewers (CodeRabbit, Graphite, CodeAnt) on the pushed SHA. Check all three PR comment endpoints plus check-runs for activity after `$PUSHED_AT`. Conversation-level comments do not expose a `commit_id`, so they only count as activity on the pushed SHA when the body mentions the full SHA or short SHA; otherwise, use SHA-scoped reviews, inline comments, or check-runs to avoid treating a late summary from the previous SHA as coverage for the new one:
 
 ```bash
-REVIEWS=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" | jq -s 'add // []')
-INLINE=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100" | jq -s 'add // []')
-CONVO=$(gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100" | jq -s 'add // []')
-CHECK_RUNS=$(gh api --paginate "repos/$OWNER/$REPO/commits/$PUSHED_SHA/check-runs?per_page=100" --jq '.check_runs[]' | jq -s '.')
-
-REVIEWER_ACTIVITY=$(jq -n \
-  --arg pushed_at "$PUSHED_AT" \
-  --arg sha "$PUSHED_SHA" \
-  --argjson reviews "$REVIEWS" \
-  --argjson inline "$INLINE" \
-  --argjson convo "$CONVO" \
-  --argjson checks "$CHECK_RUNS" \
-  '
-  def recent($ts): ($ts // "") >= $pushed_at;
-  def matches_any($value; $needles):
-    ($value // "" | ascii_downcase) as $haystack
-    | any($needles[]; (. | ascii_downcase) as $needle | $haystack | contains($needle));
-  def check_by($names):
-    any($checks[]?;
-      (((.name // "") as $name
-        | (.app.slug // "") as $slug
-        | (.app.name // "") as $app
-        | (matches_any($name; $names) or matches_any($slug; $names) or matches_any($app; $names))))
-      and recent(.started_at // .created_at // .completed_at));
-  def convo_by($login):
-    any($convo[]?;
-      .user.login == $login
-      and recent(.created_at)
-      and (((.body // "") | contains($sha)) or ((.body // "") | contains($sha[0:7]))));
-  {
-    coderabbit:
-      (any($reviews[]?; .user.login == "coderabbitai[bot]" and .commit_id == $sha and recent(.submitted_at))
-       or any($inline[]?; .user.login == "coderabbitai[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
-       or convo_by("coderabbitai[bot]")
-       or check_by(["CodeRabbit", "coderabbitai"])),
-    graphite:
-      (any($reviews[]?; .user.login == "graphite-app[bot]" and .commit_id == $sha and recent(.submitted_at))
-       or any($inline[]?; .user.login == "graphite-app[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
-       or convo_by("graphite-app[bot]")
-       or check_by(["Graphite", "graphite-app"])),
-    codeant:
-      (any($reviews[]?; .user.login == "codeant-ai[bot]" and .commit_id == $sha and recent(.submitted_at))
-       or any($inline[]?; .user.login == "codeant-ai[bot]" and ((.commit_id // .original_commit_id // "") == $sha) and recent(.created_at))
-       or convo_by("codeant-ai[bot]")
-       or check_by(["CodeAnt", "codeant-ai"])),
-  }')
+# Delegate reviewer-activity detection to the extracted script.
+# The script fetches all 3 comment endpoints + check-runs and emits
+# { coderabbit, graphite, codeant } booleans. The trigger rate-cap /
+# @coderabbitai full review decision logic stays below (in-turn judgment).
+# Full detection logic: .claude/scripts/reviewer-activity.sh
+REVIEWER_ACTIVITY_SH=""
+for _candidate in \
+  "$HOME/.claude/skills-worktree/.claude/scripts/reviewer-activity.sh" \
+  "$HOME/.claude/scripts/reviewer-activity.sh" \
+  ".claude/scripts/reviewer-activity.sh"; do
+  if [[ -x "$_candidate" ]]; then REVIEWER_ACTIVITY_SH="$_candidate"; break; fi
+done
+if [[ -n "$REVIEWER_ACTIVITY_SH" ]]; then
+  REVIEWER_ACTIVITY=$("$REVIEWER_ACTIVITY_SH" "$PR_NUMBER" "$PUSHED_SHA" "$PUSHED_AT")
+else
+  echo "[REVIEWERS] reviewer-activity.sh not found — re-run after .claude/scripts/ is synced from main" >&2
+  REVIEWER_ACTIVITY='{"coderabbit":false,"graphite":false,"codeant":false}'
+fi
 ```
 
 For each of **coderabbit**, **graphite**, **codeant** whose value is `false`, post exactly one dedicated PR-level trigger comment. Do not batch mentions; combined-mention comments fail to trigger reliably. Post these comments sequentially in this order, skipping reviewers that already auto-triggered. CodeRabbit is additionally capped at 2 manual `@coderabbitai full review` triggers per PR in the trailing hour:
@@ -615,43 +587,7 @@ if [[ "${DID_PUSH:-0}" -eq 0 ]]; then
   WATCH_SHA=$HEAD_SHA
   WAIT_BASELINE=$RUN_STARTED_AT
   TICK=$("$SCRIPT" --pr "$PR_NUMBER" --since "$WAIT_BASELINE")
-  WAIT_STATE=$(jq -c --arg sha "$WATCH_SHA" '
-    . as $root
-    | ["coderabbitai[bot]","cursor[bot]","codeant-ai[bot]","greptile-apps[bot]","graphite-app[bot]"] as $botlist
-    | {"coderabbitai[bot]":"coderabbit","cursor[bot]":"bugbot","codeant-ai[bot]":"codeant",
-       "greptile-apps[bot]":"greptile","graphite-app[bot]":"graphite"} as $needles
-    | def is_review_check($n):
-        ($n // "" | ascii_downcase) as $name
-        | any("coderabbit","graphite","codeant","cursor","bugbot","greptile";
-              . as $x | $name | contains($x));
-    ([$root.comments.reviews[]?.user.login,
-      $root.comments.inline[]?.user.login,
-      $root.comments.conversation[]?.user.login]
-     | map(select(. as $l | $botlist | index($l) != null)) | unique) as $participants
-    | ($root.check_runs.all // []) as $checks
-    | ($root.bot_statuses // {}) as $bstat
-    | ($participants | map(. as $bot
-        | $needles[$bot] as $needle
-        | {bot: $bot,
-           done: (
-             ( $bot != "cursor[bot]"
-               and any($root.comments.reviews[]?;
-                       .user.login == $bot and (.commit_id // "") == $sha) )
-             or any($checks[]?;
-                    ((.name // "") | ascii_downcase | contains($needle))
-                    and .status == "completed")
-             or ( $bot == "coderabbitai[bot]" and (($bstat.CodeRabbit.state // "pending") != "pending") )
-             or ( $bot == "greptile-apps[bot]" and (($bstat.Greptile.state // "pending") != "pending") )
-           )})) as $bots
-    | {head_moved: ($root.pr.head_sha != $sha),
-       bots_pending: ($bots | map(select(.done | not) | .bot)),
-       ci_pending: [ $checks[] | select((is_review_check(.name) | not) and .status != "completed") | .name ],
-       ci_failing: [ $checks[] | select((is_review_check(.name) | not)
-                     and (.conclusion == "failure" or .conclusion == "timed_out"
-                          or .conclusion == "action_required" or .conclusion == "startup_failure"
-                          or .conclusion == "stale")) | .name ],
-       new_findings: ($root.new_since_baseline.finding_count // 0)}
-  ' "$TICK")
+  WAIT_STATE=$("$SCRIPT" --wait-state-eval "$WATCH_SHA" "$TICK")
   BOTS_PENDING=$(jq -r '.bots_pending | join(", ") | if . == "" then "none" else . end' <<<"$WAIT_STATE")
   CI_PENDING=$(jq -r '.ci_pending | join(", ") | if . == "" then "none" else . end' <<<"$WAIT_STATE")
   if [[ "$BOTS_PENDING" == "none" && "$CI_PENDING" == "none"
@@ -678,50 +614,7 @@ if [[ "$SKIP_WAIT_LOOP" -eq 0 ]]; then
   RETRIGGERED_THIS_WAIT=0
   while :; do
   TICK=$("$SCRIPT" --pr "$PR_NUMBER" --since "$WAIT_BASELINE")
-  WAIT_STATE=$(jq -c --arg sha "$WATCH_SHA" '
-    . as $root
-    | ["coderabbitai[bot]","cursor[bot]","codeant-ai[bot]","greptile-apps[bot]","graphite-app[bot]"] as $botlist
-    | {"coderabbitai[bot]":"coderabbit","cursor[bot]":"bugbot","codeant-ai[bot]":"codeant",
-       "greptile-apps[bot]":"greptile","graphite-app[bot]":"graphite"} as $needles
-    | def is_review_check($n):
-        ($n // "" | ascii_downcase) as $name
-        | any("coderabbit","graphite","codeant","cursor","bugbot","greptile";
-              . as $x | $name | contains($x));
-    ([$root.comments.reviews[]?.user.login,
-      $root.comments.inline[]?.user.login,
-      $root.comments.conversation[]?.user.login]
-     | map(select(. as $l | $botlist | index($l) != null)) | unique) as $participants
-    | ($root.check_runs.all // []) as $checks
-    | ($root.bot_statuses // {}) as $bstat
-    | ($participants | map(. as $bot
-        | $needles[$bot] as $needle
-        | {bot: $bot,
-           done: (
-             # Review object pinned to the watched SHA. EXCLUDED for BugBot:
-             # cursor[bot] commit_id is stale/unreliable — gate BugBot by its
-             # check-run only (memory feedback_bugbot_commit_id_stale).
-             ( $bot != "cursor[bot]"
-               and any($root.comments.reviews[]?;
-                       .user.login == $bot and (.commit_id // "") == $sha) )
-             # Completed check-run on the watched SHA (check_runs are fetched per
-             # HEAD SHA, so SHA scoping is implicit). conclusion neutral still
-             # counts as complete — BugBot uses neutral for "findings posted".
-             or any($checks[]?;
-                    ((.name // "") | ascii_downcase | contains($needle))
-                    and .status == "completed")
-             # CR/Greptile also report via commit statuses on the watched SHA.
-             or ( $bot == "coderabbitai[bot]" and (($bstat.CodeRabbit.state // "pending") != "pending") )
-             or ( $bot == "greptile-apps[bot]" and (($bstat.Greptile.state // "pending") != "pending") )
-           )})) as $bots
-    | {head_moved: ($root.pr.head_sha != $sha),
-       bots_pending: ($bots | map(select(.done | not) | .bot)),
-       ci_pending: [ $checks[] | select((is_review_check(.name) | not) and .status != "completed") | .name ],
-       ci_failing: [ $checks[] | select((is_review_check(.name) | not)
-                     and (.conclusion == "failure" or .conclusion == "timed_out"
-                          or .conclusion == "action_required" or .conclusion == "startup_failure"
-                          or .conclusion == "stale")) | .name ],
-       new_findings: ($root.new_since_baseline.finding_count // 0)}
-  ' "$TICK")
+  WAIT_STATE=$("$SCRIPT" --wait-state-eval "$WATCH_SHA" "$TICK")
 
   ELAPSED=$(( $(date +%s) - WAIT_STARTED ))
   BOTS_PENDING=$(jq -r '.bots_pending | join(", ") | if . == "" then "none" else . end' <<<"$WAIT_STATE")
@@ -805,31 +698,7 @@ jq -r '
 ' "$VERIFY"
 ```
 
-**Classification rules** (these live in `pr-state.sh`; the list below is the contract — keep the two in sync if either changes). Patterns are checked in this order; first match wins:
-
-1. **Explicit-resolution / clean-pass overrides** (checked first — these signals mean CR or BugBot has issued a clean pass, reported a rate/usage limit instead of reviewing, posted a review-started ack, or emitted a transient error. They win even if the body still contains finding language from a quoted earlier review):
-   - HTML marker `<!-- <review_comment_addressed> -->` → `acknowledgment`
-   - HTML marker `<!-- <review_comment_withdrawn> -->` → `acknowledgment` (CR retracts its own finding after you push back — "Withdrawing the finding"; observed on PR #601). Marker-only, mirroring the addressed marker, so the prose phrase alone never reclassifies (#557 generic-phrase risk). Safe in tier 1 unlike the walkthrough marker in §4: a withdrawal retracts the single finding in its own thread, so it cannot mask another active finding.
-   - `actionable comments posted: 0` → `acknowledgment`. This specific zero-count pattern MUST be checked before the general `actionable comments posted` pattern below — otherwise the general finding pattern would swallow the zero case.
-   - `no actionable comments were generated` → `acknowledgment`
-   - CR rate-limit notices — `rate limit exceeded`, `rate[- ]limited by coderabbit`, `currently rate limited`, `review limit reached`, or `next review (will be) available in` → `acknowledgment`. CR wraps its Fair-Usage notice in a "Full review **finished**" ack, so the `full review triggered` rule below does not cover it — these phrases must. Every phrase names CR's own notice wording: a bare `fair usage limits policy` was tried and rejected (#557) because a real finding *quoting* the policy would classify as an ack. Each observed CR variant matches ≥2 of these phrases, so no single generic phrase carries it.
-   - BugBot usage-limit notices — `couldn't run - usage limit reached` (apostrophe and dash variants tolerated) or `this run hit a usage or spend limit` → `acknowledgment` (BugBot did not review at all, so there is nothing actionable). Both patterns quote BugBot's boilerplate closely on purpose: a looser `hit a usage or spend limit` would swallow a genuine finding *about* rate-limit code, which this repo's PRs frequently touch.
-   - `full review triggered` → `acknowledgment`
-   - `found no new issues` (case-insensitive) → `acknowledgment` (BugBot clean-pass review body: "✅ Bugbot reviewed your changes and found no new issues!")
-   - `<!-- BUGBOT_REVIEW -->` marker present AND body does NOT match `found [1-9][0-9]* potential issue` → `acknowledgment` (BugBot zero-issue summary). This MUST be checked before the generic `issues? found` finding pattern below. Non-zero BugBot summaries ("found 3 potential issues") keep the `<!-- BUGBOT_REVIEW -->` marker but match the non-zero guard and fall through to the finding tier.
-   - `Oops, something went wrong` (case-insensitive) → `acknowledgment` (CodeRabbit transient error stub — not an actionable finding)
-   - HTML marker `<!-- This is an auto-generated reply by CodeRabbit -->` (case-insensitive) → `acknowledgment` (CR auto-reply ack — CR posts this on its own reply-ack comments, e.g. "Received — CodeRabbit is reviewing…"; observed producing phantom findings on PR #659 while wrapping #638, issue #669). Marker-only to avoid the #557 generic-phrase risk: the prose "Received — CodeRabbit is reviewing" is NOT matched, so a real finding quoting that phrase still reaches the finding tier. Safe in tier 1 unlike the §4 walkthrough marker: reply-ack comments never carry their own findings, so an early override cannot mask an active finding.
-2. **Finding patterns**:
-   - Severity keywords `\b(critical|major|minor|nitpick|p[0-2])\b` or badges `🔴|🟠|🟡`
-   - Actionable phrases: `actionable comments posted` (non-zero), `issues? found`, `findings?:`, `potential[_ ]issue`
-   - Fix markers: a fenced ```` ```suggestion ```` block, or a `Prompt for AI Agent` heading
-3. **Weak-ack fallbacks** (only if no finding matched):
-   - LGTM variants: `lgtm`, `looks good`, `approved`, `confirmed`, `resolved`
-4. **CR walkthrough/summary override** (the LAST override, checked immediately before the default):
-   - Marker `<!-- This is an auto-generated comment: summarize by coderabbit.ai -->` → `acknowledgment` (CR's walkthrough boilerplate, posted on nearly every PR; it matched no rule at all and fell through to `default → finding`, producing phantom findings on PRs where CR posted zero reviews — #575).
-   - **Its late position is load-bearing — do not hoist it into the tier-1 override group.** The walkthrough can carry `actionable comments posted: N` (N>0) and severity keywords for the findings it summarizes, so an early override would classify a real-finding summary as an acknowledgment and drop it from `finding_count` — a false clean on the review gate, strictly worse than the phantom-finding noise it fixes. Every finding pattern in tier 2 must be evaluated first and win. Ordering alone supplies that guard, so no AND-not guard (of the `BUGBOT_REVIEW` kind) is needed. Guarded by `Bug6a`/`Bug6b` in `pr-state-classify.test.sh`.
-   - Distinct trigger from #557's rate-limit/usage-limit family in tier 1. Note CR edits this comment in place and may merge a rate-limit notice into the same body, in which case the tier-1 rate-limit rule matches it first — both yield `acknowledgment`.
-5. **Default** (no pattern matched) → `finding`. The safer default — under-classifying here is the failure mode this whole skill exists to prevent.
+**Classification rules** live in `.claude/scripts/pr-state.sh`'s `classify` jq function (the block comment above the `def classify:` line is the authoritative contract — do NOT duplicate it here). Key ordering invariants: tier-1 explicit-resolution overrides (addressed/withdrawn markers, zero-actionable phrases, rate-limit notices, BugBot usage-limit notices, full-review-triggered ack, clean-pass phrases, error stub, auto-reply ack) are checked first and win even if finding language appears in quoted context. Finding patterns (severity, badges, actionable phrases, suggestion blocks) come next. Weak-ack fallbacks (lgtm variants) follow. The CR walkthrough summary override and Greptile clean-pass summary come LAST — their late placement is load-bearing (a walkthrough can carry N>0 finding count; hoisting it would produce false-clean verdicts). Default → finding (under-classifying is the failure mode).
 
 **If `finding_count > 0`:** findings landed between the Step 4d wait exit and this verify. If `FIXPR_WAIT_ITER < FIXPR_MAX_ITERATIONS`, start the next sweep at Step 0 (a fresh `$RUN_STARTED_AT` re-audits and picks them up). At the outer cap: set `FIXPR_WAIT_FINAL=new-findings-pending`, emit `NEW_FINDINGS` in Step 7, and stop — re-running `/fixpr` resets the iteration budget.
 


### PR DESCRIPTION
## Summary

Reduces future-change churn in `fixpr/SKILL.md` (17 distinct merged PRs touched it before this issue was filed) by extracting three co-located concerns into shared scripts and reference docs. Zero behavior change.

Closes #788

## What changed

- **New `.claude/scripts/reviewer-activity.sh`**: Extracted the ~80-line SHA-scoped jq block from Step 3b that detects CodeRabbit/Graphite/CodeAnt auto-trigger activity on a pushed SHA. Step 3b now calls the script; rate-cap / trigger-count decision logic stays in the skill.

- **New `pr-state.sh --wait-state-eval <sha> <bundle_file>` mode**: Extracted the ~40-line WAIT_STATE jq predicate that appeared twice identically in Step 4d (DID_PUSH=0 pre-check and loop body). Both call sites replaced with `"$SCRIPT" --wait-state-eval "$WATCH_SHA" "$TICK"`. Participating-bot set remains DYNAMIC.

- **Step 5b slimmed**: Replaced the full duplicate classification-rules prose with a pointer to `pr-state.sh`'s `classify` block + one-paragraph summary of key ordering invariants. Rule changes now only require editing `pr-state.sh`.

- **New `.claude/reference/fixpr-hotspot-decision.md`**: Records the extract-not-split diagnosis and decision, following the hook-scripts.yml (#681) and pm/SKILL.md (#783) precedents.

## Preserved (zero behavior change)

- Steps 0–7 contract: identical
- `=== fixpr complete ===` footer: identical
- `FIXPR_WRAP_STATUS:` and `FIXPR_WAIT_SUMMARY:` tokens: identical
- Step 3b rate-cap prose and `@cursor review` always-post rule: unchanged, stays in skill
- Step 4d loop control (sleep, cap, heartbeat, CR re-trigger): unchanged, stays in skill

## Test plan

- [x] `fixpr/SKILL.md` Steps 0–7 contract is intact — no step renumbered or removed
- [x] `=== fixpr complete ===`, `FIXPR_WRAP_STATUS:`, `FIXPR_WAIT_SUMMARY:` tokens still present in SKILL.md
- [x] `reviewer-activity.sh` is executable and passes `bash -n`
- [x] `pr-state.sh --wait-state-eval` is documented in the script's usage comment and passes `bash -n`
- [x] Step 3b in SKILL.md calls `reviewer-activity.sh` with `$PR_NUMBER $PUSHED_SHA $PUSHED_AT`
- [x] Step 4d has exactly 2 `--wait-state-eval` invocations (pre-check and loop body)
- [x] Step 5b points to `pr-state.sh`'s `classify` block rather than duplicating rules
- [x] `rule-lint.sh` passes
- [x] `verbatim-block-lint.sh` passes

[COVERAGE] none — CR CLI rate-limited (free OSS tier cap), CodeAnt 403 daily cap. Both GitHub Apps (CodeRabbit, CodeAnt) remain active and will gate the merge.
