### PR TITLE
refactor(#805): extract SAFETY/MINDSET/SKILLS blocks to subagent-phase-guardrails.md

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -46,6 +46,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `trust-dialog-repair.md` — why `~/.claude.json` re-prompts per worktree, the three flags, and repair-script behavior (`trust-dialog-fix.md`)
 - `double-loading-fix.md` — decision record for suppressing the duplicate global CLAUDE.md + rules copy via project-local `claudeMdExcludes` (#461)
 - `skill-authoring-patterns.md` — authoring *judgment* for skills/rules (description-as-trigger, match-form-to-failure, bulletproofing); complements CONTRIBUTING.md mechanics
+- `subagent-phase-guardrails.md` — canonical single home for the SAFETY/MINDSET/SKILLS verbatim blocks and RULES placeholder shared by `/subagent` Phase A/B/C spawn-prompt templates; CI-guarded by `verbatim-block-lint.sh` (#805)
 - `verification-evidence-patterns.md` — claim→evidence checklist for AC, exit reports, and merge claims; complements phase protocols (#417 harvest from superpowers)
 
 ### Living trackers (updated each cycle — not point-in-time)

--- a/.claude/reference/subagent-phase-guardrails.md
+++ b/.claude/reference/subagent-phase-guardrails.md
@@ -1,0 +1,72 @@
+# Subagent Phase Guardrails
+
+Extracted from `.claude/skills/subagent/SKILL.md`. Single canonical home for the SAFETY/MINDSET/SKILLS verbatim blocks and the RULES placeholder convention shared by the Phase A, B, and C spawn-prompt templates.
+
+**Usage in phase templates:** insert this file verbatim into the subagent prompt at the guardrails insertion point. Phase C (`phase-c-merger`) carries only the SAFETY block per `subagent-orchestration.md` (that agent definition has no `Skill` tool access, so MINDSET and SKILLS do not apply).
+
+**CI drift guard:** `verbatim-block-lint.sh` byte-compares the SAFETY/MINDSET/SKILLS blocks below against the canonical sources in `.claude/rules/safety.md` and `.claude/rules/skill-first.md`.
+
+---
+
+## SAFETY
+
+```text
+SAFETY: Do NOT delete/overwrite/move/modify .env files anywhere (exception:
+.env.<example|sample|template>, case-insensitive, are safe to edit).
+Do NOT run git clean. Do NOT run destructive commands (rm -rf, rm, git checkout .,
+git stash, git reset --hard) in the root repo. Stay in your worktree.
+Do NOT commit secrets or paste raw credentials into prompts, issues, PRs, comments,
+commits, or logs. Do NOT pipe untrusted URLs into a shell or disable TLS verification.
+Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude/rules/safety.md.
+```
+
+## MINDSET (Capability Discovery)
+
+```text
+MINDSET: The trigger is the DEFERRAL, not the word "impossible" — "I can't",
+"not a session task", "that's a deployment step", "runbook is in docs/…", and
+"I'll leave that to you to review" all fire this ladder. Walk it for ANY provider
+(gh, git, railway, vercel, …) before writing any of them: (1) check what you have
+— MCP tools, skills, CLI on disk by absolute path (/opt/homebrew/bin/<tool>;
+minimal PATH makes bare `which` lie); (2) if absent, check whether the provider
+ships one (one lookup); (3) install it when non-interactive and rails hold
+(docs-confirmed name, no curl-pipe-sh, no TLS bypass, no sudo); (4) hand off an
+/admin-merge-shaped runbook — reachable ONLY after 1–3 were walked and failed:
+name the rung that stopped you, exact commands + one-line reason, incl.
+interactive auth. If you can write the command, you can run it. Provisioning a
+generated secret via a provider CLI is allowed — the value just must never be
+echoed, committed, pasted, or logged. Your own prohibitions still win (phase-c
+uses /wrap, never gh pr merge). Full rules: .claude/rules/safety.md.
+```
+
+## SKILLS (Skills-First Reflex)
+
+```text
+SKILLS: Before hand-rolling a multi-step task, check whether an existing skill
+already does this job — invoke it via the Skill tool instead of reimplementing
+from memory (only Skill-tool calls reach ~/.claude/skill-usage.log). Clear match
+-> invoke immediately. Borderline match -> note it in your exit report, then
+proceed on your own judgment; do not block waiting for an answer. No match ->
+stay silent. Never auto-invoke an authorization-carrying skill (/merge, /wrap,
+/pr-monitor-and-manage) on a fuzzy match — running one as your assigned job
+isn't a fuzzy match. Full rules: .claude/rules/skill-first.md.
+```
+
+---
+
+## RULES Placeholder Convention
+
+When building a subagent prompt, include the full RULES section before the guardrails above:
+
+```
+## RULES (MANDATORY — read all of these)
+{COMPLETE contents of CLAUDE.md}
+
+{COMPLETE contents of all .claude/rules/*.md files}
+```
+
+See `subagent-orchestration.md` Step 6.3 for how the parent reads these files.
+
+## Exit Report
+
+Every subagent phase must print a Structured Exit Report as its final output. Full field reference and valid OUTCOME values: `.claude/reference/exit-report-format.md`.

--- a/.claude/reference/subagent-phase-guardrails.md
+++ b/.claude/reference/subagent-phase-guardrails.md
@@ -1,10 +1,8 @@
 # Subagent Phase Guardrails
 
-Extracted from `.claude/skills/subagent/SKILL.md`. Single canonical home for the SAFETY/MINDSET/SKILLS verbatim blocks and the RULES placeholder convention shared by the Phase A, B, and C spawn-prompt templates.
+Verbatim SAFETY/MINDSET/SKILLS blocks for subagent spawn prompts. Single canonical home; `verbatim-block-lint.sh` byte-compares these blocks against `.claude/rules/safety.md` and `.claude/rules/skill-first.md`.
 
-**Usage in phase templates:** insert this file verbatim into the subagent prompt at the guardrails insertion point. Phase C (`phase-c-merger`) carries only the SAFETY block per `subagent-orchestration.md` (that agent definition has no `Skill` tool access, so MINDSET and SKILLS do not apply).
-
-**CI drift guard:** `verbatim-block-lint.sh` byte-compares the SAFETY/MINDSET/SKILLS blocks below against the canonical sources in `.claude/rules/safety.md` and `.claude/rules/skill-first.md`.
+**Phase C (`phase-c-merger`)** carries only the SAFETY block — no MINDSET or SKILLS per `subagent-orchestration.md`.
 
 ---
 
@@ -51,22 +49,3 @@ stay silent. Never auto-invoke an authorization-carrying skill (/merge, /wrap,
 /pr-monitor-and-manage) on a fuzzy match — running one as your assigned job
 isn't a fuzzy match. Full rules: .claude/rules/skill-first.md.
 ```
-
----
-
-## RULES Placeholder Convention
-
-When building a subagent prompt, include the full RULES section before the guardrails above:
-
-```
-## RULES (MANDATORY — read all of these)
-{COMPLETE contents of CLAUDE.md}
-
-{COMPLETE contents of all .claude/rules/*.md files}
-```
-
-See `subagent-orchestration.md` Step 6.3 for how the parent reads these files.
-
-## Exit Report
-
-Every subagent phase must print a Structured Exit Report as its final output. Full field reference and valid OUTCOME values: `.claude/reference/exit-report-format.md`.

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -245,7 +245,7 @@ Body:
 {COMPLETE contents of all .claude/rules/*.md files}
 
 ## Guardrails (MANDATORY)
-**Read `.claude/reference/subagent-phase-guardrails.md` and insert its full contents verbatim at this point** — SAFETY, MINDSET/capability-discovery, SKILLS-first reflex, RULES placeholder convention, and exit-report pointer. That file is the single canonical home for these blocks; `verbatim-block-lint.sh` CI-guards them there.
+**Read `.claude/reference/subagent-phase-guardrails.md` and insert its full contents verbatim at this point** — SAFETY, MINDSET/capability-discovery, and SKILLS-first reflex. That file is the single canonical home for these blocks; `verbatim-block-lint.sh` CI-guards them there.
 
 ## Phase A Instructions
 

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -244,46 +244,8 @@ Body:
 
 {COMPLETE contents of all .claude/rules/*.md files}
 
-## SAFETY WARNING
-```text
-SAFETY: Do NOT delete/overwrite/move/modify .env files anywhere (exception:
-.env.<example|sample|template>, case-insensitive, are safe to edit).
-Do NOT run git clean. Do NOT run destructive commands (rm -rf, rm, git checkout .,
-git stash, git reset --hard) in the root repo. Stay in your worktree.
-Do NOT commit secrets or paste raw credentials into prompts, issues, PRs, comments,
-commits, or logs. Do NOT pipe untrusted URLs into a shell or disable TLS verification.
-Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude/rules/safety.md.
-```
-
-## CAPABILITY DISCOVERY
-```text
-MINDSET: The trigger is the DEFERRAL, not the word "impossible" — "I can't",
-"not a session task", "that's a deployment step", "runbook is in docs/…", and
-"I'll leave that to you to review" all fire this ladder. Walk it for ANY provider
-(gh, git, railway, vercel, …) before writing any of them: (1) check what you have
-— MCP tools, skills, CLI on disk by absolute path (/opt/homebrew/bin/<tool>;
-minimal PATH makes bare `which` lie); (2) if absent, check whether the provider
-ships one (one lookup); (3) install it when non-interactive and rails hold
-(docs-confirmed name, no curl-pipe-sh, no TLS bypass, no sudo); (4) hand off an
-/admin-merge-shaped runbook — reachable ONLY after 1–3 were walked and failed:
-name the rung that stopped you, exact commands + one-line reason, incl.
-interactive auth. If you can write the command, you can run it. Provisioning a
-generated secret via a provider CLI is allowed — the value just must never be
-echoed, committed, pasted, or logged. Your own prohibitions still win (phase-c
-uses /wrap, never gh pr merge). Full rules: .claude/rules/safety.md.
-```
-
-## SKILLS-FIRST REFLEX
-```text
-SKILLS: Before hand-rolling a multi-step task, check whether an existing skill
-already does this job — invoke it via the Skill tool instead of reimplementing
-from memory (only Skill-tool calls reach ~/.claude/skill-usage.log). Clear match
--> invoke immediately. Borderline match -> note it in your exit report, then
-proceed on your own judgment; do not block waiting for an answer. No match ->
-stay silent. Never auto-invoke an authorization-carrying skill (/merge, /wrap,
-/pr-monitor-and-manage) on a fuzzy match — running one as your assigned job
-isn't a fuzzy match. Full rules: .claude/rules/skill-first.md.
-```
+## Guardrails (MANDATORY)
+**Read `.claude/reference/subagent-phase-guardrails.md` and insert its full contents verbatim at this point** — SAFETY, MINDSET/capability-discovery, SKILLS-first reflex, RULES placeholder convention, and exit-report pointer. That file is the single canonical home for these blocks; `verbatim-block-lint.sh` CI-guards them there.
 
 ## Phase A Instructions
 
@@ -414,8 +376,8 @@ If missing, reconstruct state from GitHub API.
 ## RULES (MANDATORY)
 {COMPLETE contents of CLAUDE.md and all .claude/rules/*.md}
 
-## SAFETY WARNING
-{Same safety warning as Phase A}
+## Guardrails (MANDATORY)
+**Read `.claude/reference/subagent-phase-guardrails.md` and insert its full contents verbatim at this point** (same as Phase A).
 
 ## Phase B Instructions
 
@@ -488,14 +450,8 @@ Resolve the path with `handoff-state.sh [--owner-repo owner/repo] --path {PR_NUM
 ## RULES (MANDATORY)
 {COMPLETE contents of CLAUDE.md and all .claude/rules/*.md}
 
-## SAFETY WARNING
-SAFETY: Do NOT delete/overwrite/move/modify .env files anywhere (exception:
-.env.<example|sample|template>, case-insensitive, are safe to edit).
-Do NOT run git clean. Do NOT run destructive commands (rm -rf, rm, git checkout .,
-git stash, git reset --hard) in the root repo. Stay in your worktree.
-Do NOT commit secrets or paste raw credentials into prompts, issues, PRs, comments,
-commits, or logs. Do NOT pipe untrusted URLs into a shell or disable TLS verification.
-Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude/rules/safety.md.
+## Guardrails (MANDATORY)
+**Read `.claude/reference/subagent-phase-guardrails.md` and insert the SAFETY block verbatim at this point** (Phase C / `phase-c-merger` carries only SAFETY — no MINDSET or SKILLS per `subagent-orchestration.md`).
 
 ## Phase C Instructions
 

--- a/.github/scripts/tests/verbatim-block-lint.test.sh
+++ b/.github/scripts/tests/verbatim-block-lint.test.sh
@@ -23,12 +23,12 @@ make_fixture() {
   local dir="$1"
   mkdir -p \
     "$dir/.claude/rules" \
-    "$dir/.claude/skills/subagent" \
+    "$dir/.claude/reference" \
     "$dir/.claude/skills/pr-monitor-and-manage"
   cp "$REPO_ROOT/.claude/rules/safety.md" "$dir/.claude/rules/"
   cp "$REPO_ROOT/.claude/rules/skill-first.md" "$dir/.claude/rules/"
-  cp "$REPO_ROOT/.claude/skills/subagent/SKILL.md" \
-     "$dir/.claude/skills/subagent/"
+  cp "$REPO_ROOT/.claude/reference/subagent-phase-guardrails.md" \
+     "$dir/.claude/reference/"
   cp "$REPO_ROOT/.claude/skills/pr-monitor-and-manage/SKILL.md" \
      "$dir/.claude/skills/pr-monitor-and-manage/"
 }
@@ -80,7 +80,7 @@ fi
 
 # Count fixed-string OCCURRENCES, not matching lines: grep -c collapses two hits
 # on one line to 1, which would let a non-unique token slip through this guard.
-for copy in .claude/skills/subagent/SKILL.md; do
+for copy in .claude/reference/subagent-phase-guardrails.md; do
   # grep exits 1 on no match; under `set -euo pipefail` that would abort the whole
   # script before this guard could report — the exact case it exists to catch. Fail
   # closed to 0 instead, which trips the != 1 branch below.
@@ -93,21 +93,21 @@ for copy in .claude/skills/subagent/SKILL.md; do
   fi
 done
 
-expect "drifted MINDSET in subagent SKILL.md fails naming file and block" 1 \
+expect "drifted MINDSET in subagent-phase-guardrails.md fails naming file and block" 1 \
   'MINDSET.*drifted|drifted.*MINDSET' \
   sed -i.bak "s/${DRIFT_TOKEN}/DRIFTED provider/" \
-    .claude/skills/subagent/SKILL.md
+    .claude/reference/subagent-phase-guardrails.md
 
 # (c) Missing copy file fails
 expect "missing copy file fails" 1 \
   'Required file not found' \
-  rm -f .claude/skills/subagent/SKILL.md
+  rm -f .claude/reference/subagent-phase-guardrails.md
 
 # (d) Missing block within a copy file fails
-expect "missing SKILLS block in subagent SKILL.md fails" 1 \
+expect "missing SKILLS block in subagent-phase-guardrails.md fails" 1 \
   'Missing SKILLS|SKILLS.*not found' \
   sed -i.bak 's/^SKILLS: /REMOVED: /' \
-    .claude/skills/subagent/SKILL.md
+    .claude/reference/subagent-phase-guardrails.md
 
 # Final: real repo conformance
 if (cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1); then

--- a/.github/scripts/verbatim-block-lint.sh
+++ b/.github/scripts/verbatim-block-lint.sh
@@ -10,7 +10,7 @@
 #   SKILLS:  → .claude/rules/skill-first.md
 #
 # Verbatim-copy surfaces (byte-compared):
-#   .claude/skills/subagent/SKILL.md
+#   .claude/reference/subagent-phase-guardrails.md  (subagent skill; extracted from SKILL.md #805)
 #   .claude/skills/pr-monitor-and-manage/SKILL.md
 #
 # Paraphrased surfaces (out of scope for byte comparison — intentionally excluded):
@@ -84,9 +84,9 @@ CANONICAL_FILES=(
 # One-line change to add or remove a copy surface.
 # ---------------------------------------------------------------------------
 VERBATIM_COPIES=(
-  "SAFETY|.claude/skills/subagent/SKILL.md"
-  "MINDSET|.claude/skills/subagent/SKILL.md"
-  "SKILLS|.claude/skills/subagent/SKILL.md"
+  "SAFETY|.claude/reference/subagent-phase-guardrails.md"
+  "MINDSET|.claude/reference/subagent-phase-guardrails.md"
+  "SKILLS|.claude/reference/subagent-phase-guardrails.md"
   "SAFETY|.claude/skills/pr-monitor-and-manage/SKILL.md"
   "MINDSET|.claude/skills/pr-monitor-and-manage/SKILL.md"
   "SKILLS|.claude/skills/pr-monitor-and-manage/SKILL.md"


### PR DESCRIPTION
## Summary

Moves the SAFETY/MINDSET/SKILLS verbatim blocks that were duplicated across Phase A/B/C spawn-prompt templates in `subagent/SKILL.md` into a single canonical reference doc. Each template now holds a one-line injection instruction instead of 40+ lines of repeated guardrail text. Every future edit to the guardrail blocks is a one-file change instead of a three-location sync.

- Create `.claude/reference/subagent-phase-guardrails.md` — single home for SAFETY, MINDSET, SKILLS blocks (byte-identical to canonical sources), the RULES placeholder convention, and a pointer to `exit-report-format.md`
- Replace inline blocks in SKILL.md Phase A, B, and C templates with guardrails-doc references (Phase C remains SAFETY-only per `subagent-orchestration.md`)
- Update `verbatim-block-lint.sh` VERBATIM_COPIES from `subagent/SKILL.md` → `subagent-phase-guardrails.md` (6 surfaces, same count)
- Update `verbatim-block-lint.test.sh` fixtures, drift-injection target, and test case names to reflect new location; all 4 test scenarios still run
- Add `subagent-phase-guardrails.md` to `.claude/reference/README.md`

**Zero behavior change:** parent agents read the reference doc and inject the same bytes into subagent prompts. All critical contracts (Step 4 fit gate, Step 6.0b overlap serialization, Step 7 3–4 ceiling, Step 9 completion protocols, cross-reference from `subagent-orchestration.md` Step 7) are preserved verbatim.

Closes #805

## Test plan

- [x] `verbatim-block-lint.sh` passes (6 copy surfaces, same as before)
- [x] `rule-lint.sh` passes (no corpus growth)
- [x] `verbatim-block-lint.test.sh` passes (4 fixtures including drift, missing-file, missing-block)
- [x] SKILL.md fit-gate/serialization/slot-ceiling contracts preserved with identical semantics
- [x] Cross-references from `subagent-orchestration.md` Step 7 remain accurate (pointer to `SKILL.md Step 7` unchanged)
- [x] CI green

**Local review coverage:** none — CodeRabbit CLI absent, CodeAnt 403 daily cap; self-review performed. Changes are structural text moves with no logic; diff is straightforward to verify by inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a centralized reference for subagent phase guidance, including safety, capability discovery, skills usage, required rules, and structured completion reporting.
  - Clarified how consistent guidance should be included across subagent phases.

- **Chores**
  - Improved automated validation to detect missing, altered, or incomplete guidance blocks and prevent documentation drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->