### PR TITLE
fix(#836): reject approvals predating HEAD commit (force-push retargeting)

### DIFF
--- a/.claude/reference/merge-gate-reviewer-paths.md
+++ b/.claude/reference/merge-gate-reviewer-paths.md
@@ -16,6 +16,10 @@ GitHub keeps a record for **every** run of a check on a commit, and each re-trig
 
 **Consequence for polling:** a check that failed and was re-run stops blocking the moment the newer run lands — no rebase or new push required. If tooling still reports a failure GitHub's merge box shows as green, suspect the fetch bypassed the helper, not the dedup rule.
 
+## Stale-approval guard — all review paths (issue #836)
+
+GitHub retargets a review's `commit_id` to the new HEAD SHA after a force-push (when diff context persists), but `submitted_at` is never changed. An approval submitted _before_ the force-push therefore shows `commit_id == HEAD` with a `submitted_at` that predates the HEAD commit's `committer.date`. `merge-gate.sh` rejects such approvals even when `commit_id` matches, using `LAST_COMMIT_TS` (HEAD committer date, already fetched for the Greptile freshness gate). Applies to: CR/CodeAnt `APPROVED` reviews, CodeAnt clean check-run `completed_at`, and BugBot reviews. Guard is disabled when `LAST_COMMIT_TS` is empty (API failure). Distinct `missing[]` reason: "predates the HEAD commit (force-push retargeting) — re-review required".
+
 ## CR path
 
 Applies when neither BugBot nor Greptile was triggered (`merge-gate.sh` reviewer `cr`).

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -610,7 +610,11 @@ case "$REVIEWER" in
     if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false ]]; then
       if [[ -z "$LAST_COMMIT_TS" ]]; then
         CR_APPROVAL_FRESHNESS_UNKNOWN=true
-      elif [[ -n "$LATEST_CR_APPROVED_AT" && "$LATEST_CR_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
+      elif [[ -z "$LATEST_CR_APPROVED_AT" ]]; then
+        # submitted_at is missing — cannot verify freshness without a timestamp
+        # to compare against; treat as unknown (fail-closed, issue #836).
+        CR_APPROVAL_FRESHNESS_UNKNOWN=true
+      elif [[ "$LATEST_CR_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
         CR_APPROVAL_STALE=true
       fi
     fi
@@ -619,7 +623,10 @@ case "$REVIEWER" in
     if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false ]]; then
       if [[ -z "$LAST_COMMIT_TS" ]]; then
         CA_APPROVAL_FRESHNESS_UNKNOWN=true
-      elif [[ -n "$LATEST_CA_APPROVED_AT" && "$LATEST_CA_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
+      elif [[ -z "$LATEST_CA_APPROVED_AT" ]]; then
+        # submitted_at is missing — cannot verify freshness (fail-closed, issue #836).
+        CA_APPROVAL_FRESHNESS_UNKNOWN=true
+      elif [[ "$LATEST_CA_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
         CA_APPROVAL_STALE=true
       fi
     fi
@@ -739,7 +746,19 @@ case "$REVIEWER" in
         fi
       fi
 
-      if [[ -n "$LATEST_CA_CHANGES_REQUESTED_AT" && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
+      # Stale CHANGES_REQUESTED guard (issue #836): GitHub retargets commit_id on
+      # force-push, so a pre-push CHANGES_REQUESTED can have commit_id==HEAD while
+      # its submitted_at predates the current commit. dismiss-stale-bot-changes.sh
+      # only handles wrong commit_id, not retargeted timestamps; this freshness
+      # check is needed. If LAST_COMMIT_TS is unavailable, treat as blocking (fail-closed).
+      CA_CHANGES_BLOCKING=false
+      if [[ -n "$LATEST_CA_CHANGES_REQUESTED_AT" ]]; then
+        if [[ -z "$LAST_COMMIT_TS" || ! "$LATEST_CA_CHANGES_REQUESTED_AT" < "$LAST_COMMIT_TS" ]]; then
+          CA_CHANGES_BLOCKING=true
+        fi
+      fi
+
+      if [[ "$CA_CHANGES_BLOCKING" == true && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
         MISSING+=("CodeAnt CHANGES_REQUESTED on HEAD ${HEAD_SHA:0:7} is newer than the latest CodeAnt clean signal — address findings or wait for APPROVED / successful CodeAnt check-run")
       elif [[ "$CA_APPROVAL_VALID" != true && "$CODEANT_CHECK_OK" != true ]]; then
         if [[ "$CA_APPROVAL_STALE" == true && "$CA_STALE_MISSING_EMITTED" != true ]]; then
@@ -790,7 +809,11 @@ case "$REVIEWER" in
         # so the review does not satisfy the gate (callers poll every ~60 s).
         if [[ -z "$LAST_COMMIT_TS" ]]; then
           MISSING+=("cannot verify BugBot review freshness — HEAD commit timestamp unavailable; retrying next cycle")
-        elif [[ -n "$BB_SUBMITTED_AT" && "$BB_SUBMITTED_AT" < "$LAST_COMMIT_TS" ]]; then
+        elif [[ -z "$BB_SUBMITTED_AT" ]]; then
+          # submitted_at is missing — cannot verify freshness without a timestamp
+          # to compare against; treat as unknown (fail-closed, issue #836).
+          MISSING+=("cannot verify BugBot review freshness — submitted_at unavailable; retrying next cycle")
+        elif [[ "$BB_SUBMITTED_AT" < "$LAST_COMMIT_TS" ]]; then
           MISSING+=("BugBot review on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — re-review required; post @cursor review")
         else
           BB_STATE=$(echo "$LATEST_BB" | jq -r '.state // ""')

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -538,6 +538,16 @@ if [[ -n "$REVIEW_DECISION" && "$REVIEW_DECISION" != "APPROVED" ]]; then
   fi
 fi
 
+# Timestamp normaliser — used by all reviewer paths below (issue #836, BugBot round 5).
+# GitHub can return mixed ISO-8601 UTC forms ("…Z" and "…+00:00"). Bash [[ < ]] is
+# purely lexicographic; Z (ASCII 90) > + (ASCII 43), so "…Z" > "…+00:00" even for
+# equal instants, breaking stale-approval comparisons. Strip the timezone suffix to
+# produce a bare "YYYY-MM-DDTHH:MM:SS" string that sorts correctly for UTC timestamps.
+norm_ts() {
+  local t="${1%Z}"       # strip trailing Z
+  echo "${t%+00:00}"     # strip trailing +00:00 (all GitHub timestamps are UTC)
+}
+
 # Path-specific checks.
 # Default false — only the cr) branch below computes a meaningful value.
 PRIMARY_REVIEW_MET=false
@@ -583,13 +593,13 @@ case "$REVIEWER" in
     # Retraction: later CHANGES_REQUESTED on same SHA invalidates APPROVED (ISO timestamps).
     CR_RETRACTED=false
     if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && -n "$LATEST_CR_CHANGES_REQUESTED_AT" && -n "$LATEST_CR_APPROVED_AT" ]]; then
-      if [[ "$LATEST_CR_CHANGES_REQUESTED_AT" > "$LATEST_CR_APPROVED_AT" ]]; then
+      if [[ "$(norm_ts "$LATEST_CR_CHANGES_REQUESTED_AT")" > "$(norm_ts "$LATEST_CR_APPROVED_AT")" ]]; then
         CR_RETRACTED=true
       fi
     fi
     CA_RETRACTED=false
     if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && -n "$LATEST_CA_CHANGES_REQUESTED_AT" && -n "$LATEST_CA_APPROVED_AT" ]]; then
-      if [[ "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_APPROVED_AT" ]]; then
+      if [[ "$(norm_ts "$LATEST_CA_CHANGES_REQUESTED_AT")" > "$(norm_ts "$LATEST_CA_APPROVED_AT")" ]]; then
         CA_RETRACTED=true
       fi
     fi
@@ -598,8 +608,8 @@ case "$REVIEWER" in
     # but does NOT update submitted_at. An approval whose submitted_at predates
     # the HEAD commit's committer date was submitted before the current commit
     # and must not count even when commit_id matches. Equal timestamps are
-    # accepted (submitted_at >= LAST_COMMIT_TS). ISO 8601 strings are
-    # lexicographically comparable so bash [[ < ]] is correct here.
+    # accepted (submitted_at >= LAST_COMMIT_TS). Use norm_ts for comparisons
+    # to handle mixed Z/+00:00 UTC suffixes (issue #836, BugBot round 5).
     #
     # Fail-closed (issue #836): when LAST_COMMIT_TS is empty (HEAD timestamp API
     # failure) we CANNOT verify freshness, so qualifying approvals do NOT satisfy
@@ -617,7 +627,7 @@ case "$REVIEWER" in
         # submitted_at is missing from the approval itself (not a transient API
         # failure) — cannot verify freshness (fail-closed, issue #836).
         CR_APPROVAL_SUBMITTED_AT_MISSING=true
-      elif [[ "$LATEST_CR_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
+      elif [[ "$(norm_ts "$LATEST_CR_APPROVED_AT")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
         CR_APPROVAL_STALE=true
       fi
     fi
@@ -629,7 +639,7 @@ case "$REVIEWER" in
         CA_APPROVAL_FRESHNESS_UNKNOWN=true
       elif [[ -z "$LATEST_CA_APPROVED_AT" ]]; then
         CA_APPROVAL_SUBMITTED_AT_MISSING=true
-      elif [[ "$LATEST_CA_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
+      elif [[ "$(norm_ts "$LATEST_CA_APPROVED_AT")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
         CA_APPROVAL_STALE=true
       fi
     fi
@@ -739,7 +749,7 @@ case "$REVIEWER" in
         if [[ -z "$LAST_COMMIT_TS" ]]; then
           # Cannot verify whether the check-run predates the current commit.
           CODEANT_CHECK_FRESHNESS_UNKNOWN=true
-        elif [[ ! "$LATEST_CA_CHECK_OK_AT" < "$LAST_COMMIT_TS" ]]; then
+        elif [[ ! "$(norm_ts "$LATEST_CA_CHECK_OK_AT")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
           CODEANT_CHECK_OK=true
         else
           # check-run completed before the HEAD commit — stale via force-push
@@ -757,7 +767,7 @@ case "$REVIEWER" in
         LATEST_CA_CLEAN_AT="$LATEST_CA_APPROVED_AT"
       fi
       if [[ "$CODEANT_CHECK_OK" == true ]]; then
-        if [[ -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHECK_OK_AT" > "$LATEST_CA_CLEAN_AT" ]]; then
+        if [[ -z "$LATEST_CA_CLEAN_AT" || "$(norm_ts "$LATEST_CA_CHECK_OK_AT")" > "$(norm_ts "$LATEST_CA_CLEAN_AT")" ]]; then
           LATEST_CA_CLEAN_AT="$LATEST_CA_CHECK_OK_AT"
         fi
       fi
@@ -769,12 +779,12 @@ case "$REVIEWER" in
       # check is needed. If LAST_COMMIT_TS is unavailable, treat as blocking (fail-closed).
       CA_CHANGES_BLOCKING=false
       if [[ -n "$LATEST_CA_CHANGES_REQUESTED_AT" ]]; then
-        if [[ -z "$LAST_COMMIT_TS" || ! "$LATEST_CA_CHANGES_REQUESTED_AT" < "$LAST_COMMIT_TS" ]]; then
+        if [[ -z "$LAST_COMMIT_TS" || ! "$(norm_ts "$LATEST_CA_CHANGES_REQUESTED_AT")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
           CA_CHANGES_BLOCKING=true
         fi
       fi
 
-      if [[ "$CA_CHANGES_BLOCKING" == true && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
+      if [[ "$CA_CHANGES_BLOCKING" == true && ( -z "$LATEST_CA_CLEAN_AT" || "$(norm_ts "$LATEST_CA_CHANGES_REQUESTED_AT")" > "$(norm_ts "$LATEST_CA_CLEAN_AT")" ) ]]; then
         MISSING+=("CodeAnt CHANGES_REQUESTED on HEAD ${HEAD_SHA:0:7} is newer than the latest CodeAnt clean signal — address findings or wait for APPROVED / successful CodeAnt check-run")
       elif [[ "$CA_APPROVAL_VALID" != true && "$CODEANT_CHECK_OK" != true ]]; then
         if [[ "$CA_APPROVAL_STALE" == true && "$CA_STALE_MISSING_EMITTED" != true ]]; then
@@ -845,7 +855,7 @@ case "$REVIEWER" in
           # submitted_at is missing — cannot verify freshness without a timestamp
           # to compare against; treat as unknown (fail-closed, issue #836).
           MISSING+=("cannot verify BugBot review freshness — submitted_at unavailable; retrying next cycle")
-        elif [[ "$BB_SUBMITTED_AT" < "$LAST_COMMIT_TS" ]]; then
+        elif [[ "$(norm_ts "$BB_SUBMITTED_AT")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
           MISSING+=("BugBot review on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — re-review required; post @cursor review")
         else
           BB_STATE=$(echo "$LATEST_BB" | jq -r '.state // ""')

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -10,6 +10,15 @@
 #                     clean signal (APPROVED or successful check completion).
 #   - BugBot path   : 1 clean BugBot review on current HEAD + zero unresolved BugBot threads
 #   - Greptile path : severity-gated — clean OR only P1/P2 (fixed) OR P0 fixed + re-review clean
+#
+# Stale-approval guard (issue #836): GitHub retargets review commit_id to the new
+#   HEAD SHA after a force-push, but submitted_at is never updated. An approval
+#   whose submitted_at predates the HEAD commit's committer date is rejected even
+#   when commit_id matches — distinct missing[] reason so callers know to re-trigger
+#   rather than rebase. Applied to: CR/CodeAnt APPROVED reviews, CodeAnt clean
+#   check-run completed_at, BugBot reviews. Grace window: none (submitted_at must
+#   be >= committer date; equal timestamps are accepted). Guard is disabled when
+#   LAST_COMMIT_TS is empty (API failure) to avoid silently blocking clean reviews.
 # Also enforces the pre-merge CI gate from .claude/rules/cr-merge-gate.md Step 1b
 # (incomplete runs OR blocking conclusions = not merge-ready), merge metadata
 # (mergeStateStatus including BEHIND, mergeable including CONFLICTING) per
@@ -224,9 +233,11 @@ if [[ -z "$HEAD_SHA" ]]; then
   exit 4
 fi
 
-# Fetch last commit timestamp for Greptile freshness gate (issue #723).
-# Used in the greptile) branch to confirm a 👍 issue comment is post-push.
-# Non-fatal: an empty result disables the freshness filter (comments accepted
+# Fetch last commit timestamp for Greptile freshness gate (issue #723) and the
+# stale-approval guard (issue #836). Used in greptile) to confirm a 👍 issue
+# comment is post-push; used in cr) and bugbot) to reject approvals whose
+# submitted_at predates this committer date (force-push retargeting).
+# Non-fatal: an empty result disables both filters (comments/approvals accepted
 # regardless of age), which is preferable to silently blocking a clean review.
 LAST_COMMIT_TS=$(gh api "repos/$OWNER/$REPO/git/commits/$HEAD_SHA" 2>/dev/null | jq -r '.committer.date // ""' 2>/dev/null || echo "")
 
@@ -583,12 +594,35 @@ case "$REVIEWER" in
       fi
     fi
 
+    # Stale-approval guard (issue #836): GitHub retargets commit_id on force-push
+    # but does NOT update submitted_at. An approval whose submitted_at predates
+    # the HEAD commit's committer date was submitted before the current commit
+    # and must not count even when commit_id matches. Guard fires only when
+    # LAST_COMMIT_TS is non-empty; an empty value (API failure) disables the
+    # guard to avoid silently blocking a valid review. Equal timestamps are
+    # accepted (submitted_at >= LAST_COMMIT_TS). ISO 8601 strings are
+    # lexicographically comparable so bash [[ < ]] is correct here.
+    CR_APPROVAL_STALE=false
+    if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false \
+          && -n "$LAST_COMMIT_TS" && -n "$LATEST_CR_APPROVED_AT" ]]; then
+      if [[ "$LATEST_CR_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
+        CR_APPROVAL_STALE=true
+      fi
+    fi
+    CA_APPROVAL_STALE=false
+    if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false \
+          && -n "$LAST_COMMIT_TS" && -n "$LATEST_CA_APPROVED_AT" ]]; then
+      if [[ "$LATEST_CA_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
+        CA_APPROVAL_STALE=true
+      fi
+    fi
+
     CR_APPROVAL_VALID=false
-    if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false ]]; then
+    if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false && "$CR_APPROVAL_STALE" == false ]]; then
       CR_APPROVAL_VALID=true
     fi
     CA_APPROVAL_VALID=false
-    if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false ]]; then
+    if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false && "$CA_APPROVAL_STALE" == false ]]; then
       CA_APPROVAL_VALID=true
     fi
 
@@ -604,7 +638,14 @@ case "$REVIEWER" in
       if [[ "$CA_RETRACTED" == true && "$CR_APPROVAL_VALID" != true ]]; then
         MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger @codeant-ai review")
       fi
-      if [[ "$CR_RETRACTED" != true && "$CA_RETRACTED" != true ]]; then
+      if [[ "$CR_APPROVAL_STALE" == true && "$CA_APPROVAL_VALID" != true ]]; then
+        MISSING+=("CodeRabbit approval on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — re-review required; trigger @coderabbitai full review")
+      fi
+      if [[ "$CA_APPROVAL_STALE" == true && "$CR_APPROVAL_VALID" != true ]]; then
+        MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — re-review required; trigger @codeant-ai review")
+      fi
+      if [[ "$CR_RETRACTED" != true && "$CA_RETRACTED" != true \
+            && "$CR_APPROVAL_STALE" != true && "$CA_APPROVAL_STALE" != true ]]; then
         MISSING+=("need 1 explicit CodeRabbit or CodeAnt APPROVED review on HEAD ${HEAD_SHA:0:7} (have $TOTAL_CR_ON_HEAD CodeRabbit, $TOTAL_CA_ON_HEAD CodeAnt review(s) on this SHA)")
       fi
     fi
@@ -649,9 +690,13 @@ case "$REVIEWER" in
             )
           | (.completed_at // .started_at // "")]
         | sort | last // ""')
+      # Stale-approval guard (issue #836): check-run completed_at must postdate
+      # the HEAD committer date, mirroring the APPROVED review guard above.
       CODEANT_CHECK_OK=false
       if [[ -n "$LATEST_CA_CHECK_OK_AT" ]]; then
-        CODEANT_CHECK_OK=true
+        if [[ -z "$LAST_COMMIT_TS" || ! "$LATEST_CA_CHECK_OK_AT" < "$LAST_COMMIT_TS" ]]; then
+          CODEANT_CHECK_OK=true
+        fi
       fi
 
       LATEST_CA_CLEAN_AT="$LATEST_CA_APPROVED_AT"
@@ -662,7 +707,14 @@ case "$REVIEWER" in
       if [[ -n "$LATEST_CA_CHANGES_REQUESTED_AT" && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
         MISSING+=("CodeAnt CHANGES_REQUESTED on HEAD ${HEAD_SHA:0:7} is newer than the latest CodeAnt clean signal — address findings or wait for APPROVED / successful CodeAnt check-run")
       elif [[ "$CA_APPROVAL_VALID" != true && "$CODEANT_CHECK_OK" != true ]]; then
-        MISSING+=("CodeAnt participated on HEAD ${HEAD_SHA:0:7} but no explicit APPROVED review and no successful CodeAnt check-run (have $TOTAL_CA_ON_HEAD CodeAnt review(s) on this SHA) — wait or comment @codeant-ai review")
+        if [[ "$CA_APPROVAL_STALE" == true ]]; then
+          # Stale-approval guard (issue #836): CodeAnt's approval is retargeted;
+          # emit a stale-specific message so callers know to re-trigger rather than
+          # interpret this as a complete absence of CodeAnt review.
+          MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — trigger @codeant-ai review")
+        else
+          MISSING+=("CodeAnt participated on HEAD ${HEAD_SHA:0:7} but no explicit APPROVED review and no successful CodeAnt check-run (have $TOTAL_CA_ON_HEAD CodeAnt review(s) on this SHA) — wait or comment @codeant-ai review")
+        fi
       fi
     fi
 
@@ -681,15 +733,24 @@ case "$REVIEWER" in
         [.[]? | select(.user.login == "cursor[bot]" and .commit_id == $sha)]
         | sort_by(.submitted_at) | last // empty')
       if [[ -n "$LATEST_BB" ]]; then
-        BB_STATE=$(echo "$LATEST_BB" | jq -r '.state // ""')
-        # Always check for inline findings — BugBot can post inline diff comments
-        # without a review body, so gating on body length would miss them.
-        # Filter by original_commit_id == sha to exclude stale comments GitHub
-        # "moves" to the new HEAD when commit_id advances but the diff line persists.
-        INLINE_BB=$(echo "$PR_COMMENTS_JSON" | jq --arg sha "$HEAD_SHA" '
-          [.[]? | select(.user.login == "cursor[bot]" and .commit_id == $sha and (.original_commit_id // .commit_id) == $sha)] | length')
-        if [[ "$BB_STATE" == "CHANGES_REQUESTED" ]] || [[ "$INLINE_BB" -gt 0 ]]; then
-          MISSING+=("latest BugBot review on HEAD has findings ($INLINE_BB inline)")
+        BB_SUBMITTED_AT=$(echo "$LATEST_BB" | jq -r '.submitted_at // ""')
+        # Stale-approval guard (issue #836): same retargeting risk as CR/CodeAnt —
+        # BugBot review commit_id can be advanced by GitHub on force-push while
+        # submitted_at stays at the pre-push time. Guard is disabled when
+        # LAST_COMMIT_TS is empty (prefer leniency to blocking a valid review).
+        if [[ -n "$LAST_COMMIT_TS" && -n "$BB_SUBMITTED_AT" && "$BB_SUBMITTED_AT" < "$LAST_COMMIT_TS" ]]; then
+          MISSING+=("BugBot review on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — re-review required; post @cursor review")
+        else
+          BB_STATE=$(echo "$LATEST_BB" | jq -r '.state // ""')
+          # Always check for inline findings — BugBot can post inline diff comments
+          # without a review body, so gating on body length would miss them.
+          # Filter by original_commit_id == sha to exclude stale comments GitHub
+          # "moves" to the new HEAD when commit_id advances but the diff line persists.
+          INLINE_BB=$(echo "$PR_COMMENTS_JSON" | jq --arg sha "$HEAD_SHA" '
+            [.[]? | select(.user.login == "cursor[bot]" and .commit_id == $sha and (.original_commit_id // .commit_id) == $sha)] | length')
+          if [[ "$BB_STATE" == "CHANGES_REQUESTED" ]] || [[ "$INLINE_BB" -gt 0 ]]; then
+            MISSING+=("latest BugBot review on HEAD has findings ($INLINE_BB inline)")
+          fi
         fi
       fi
     fi

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -607,25 +607,28 @@ case "$REVIEWER" in
     # on the next cycle without wedging a merge indefinitely.
     CR_APPROVAL_STALE=false
     CR_APPROVAL_FRESHNESS_UNKNOWN=false
+    # Separate flag for missing submitted_at (distinct from LAST_COMMIT_TS missing):
+    # the approval's timestamp is absent — different cause, different user message.
+    CR_APPROVAL_SUBMITTED_AT_MISSING=false
     if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false ]]; then
       if [[ -z "$LAST_COMMIT_TS" ]]; then
         CR_APPROVAL_FRESHNESS_UNKNOWN=true
       elif [[ -z "$LATEST_CR_APPROVED_AT" ]]; then
-        # submitted_at is missing — cannot verify freshness without a timestamp
-        # to compare against; treat as unknown (fail-closed, issue #836).
-        CR_APPROVAL_FRESHNESS_UNKNOWN=true
+        # submitted_at is missing from the approval itself (not a transient API
+        # failure) — cannot verify freshness (fail-closed, issue #836).
+        CR_APPROVAL_SUBMITTED_AT_MISSING=true
       elif [[ "$LATEST_CR_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
         CR_APPROVAL_STALE=true
       fi
     fi
     CA_APPROVAL_STALE=false
     CA_APPROVAL_FRESHNESS_UNKNOWN=false
+    CA_APPROVAL_SUBMITTED_AT_MISSING=false
     if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false ]]; then
       if [[ -z "$LAST_COMMIT_TS" ]]; then
         CA_APPROVAL_FRESHNESS_UNKNOWN=true
       elif [[ -z "$LATEST_CA_APPROVED_AT" ]]; then
-        # submitted_at is missing — cannot verify freshness (fail-closed, issue #836).
-        CA_APPROVAL_FRESHNESS_UNKNOWN=true
+        CA_APPROVAL_SUBMITTED_AT_MISSING=true
       elif [[ "$LATEST_CA_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
         CA_APPROVAL_STALE=true
       fi
@@ -633,12 +636,14 @@ case "$REVIEWER" in
 
     CR_APPROVAL_VALID=false
     if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false \
-          && "$CR_APPROVAL_STALE" == false && "$CR_APPROVAL_FRESHNESS_UNKNOWN" == false ]]; then
+          && "$CR_APPROVAL_STALE" == false && "$CR_APPROVAL_FRESHNESS_UNKNOWN" == false \
+          && "$CR_APPROVAL_SUBMITTED_AT_MISSING" == false ]]; then
       CR_APPROVAL_VALID=true
     fi
     CA_APPROVAL_VALID=false
     if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false \
-          && "$CA_APPROVAL_STALE" == false && "$CA_APPROVAL_FRESHNESS_UNKNOWN" == false ]]; then
+          && "$CA_APPROVAL_STALE" == false && "$CA_APPROVAL_FRESHNESS_UNKNOWN" == false \
+          && "$CA_APPROVAL_SUBMITTED_AT_MISSING" == false ]]; then
       CA_APPROVAL_VALID=true
     fi
 
@@ -670,9 +675,15 @@ case "$REVIEWER" in
         # every ~60 s so this self-heals on the next cycle.
         MISSING+=("cannot verify approval freshness — HEAD commit timestamp unavailable; retrying next cycle")
       fi
+      if [[ "$CR_APPROVAL_SUBMITTED_AT_MISSING" == true || "$CA_APPROVAL_SUBMITTED_AT_MISSING" == true ]]; then
+        # submitted_at is absent from the approval itself (not a transient API
+        # failure) — distinct message from the LAST_COMMIT_TS-unavailable case above.
+        MISSING+=("cannot verify approval freshness — submitted_at missing from approval (fail-closed, issue #836)")
+      fi
       if [[ "$CR_RETRACTED" != true && "$CA_RETRACTED" != true \
             && "$CR_APPROVAL_STALE" != true && "$CA_APPROVAL_STALE" != true \
-            && "$CR_APPROVAL_FRESHNESS_UNKNOWN" != true && "$CA_APPROVAL_FRESHNESS_UNKNOWN" != true ]]; then
+            && "$CR_APPROVAL_FRESHNESS_UNKNOWN" != true && "$CA_APPROVAL_FRESHNESS_UNKNOWN" != true \
+            && "$CR_APPROVAL_SUBMITTED_AT_MISSING" != true && "$CA_APPROVAL_SUBMITTED_AT_MISSING" != true ]]; then
         MISSING+=("need 1 explicit CodeRabbit or CodeAnt APPROVED review on HEAD ${HEAD_SHA:0:7} (have $TOTAL_CR_ON_HEAD CodeRabbit, $TOTAL_CA_ON_HEAD CodeAnt review(s) on this SHA)")
       fi
     fi
@@ -723,14 +734,19 @@ case "$REVIEWER" in
       # so the check-run does not satisfy the supplemental gate.
       CODEANT_CHECK_OK=false
       CODEANT_CHECK_FRESHNESS_UNKNOWN=false
+      CODEANT_CHECK_STALE=false
       if [[ -n "$LATEST_CA_CHECK_OK_AT" ]]; then
         if [[ -z "$LAST_COMMIT_TS" ]]; then
           # Cannot verify whether the check-run predates the current commit.
           CODEANT_CHECK_FRESHNESS_UNKNOWN=true
         elif [[ ! "$LATEST_CA_CHECK_OK_AT" < "$LAST_COMMIT_TS" ]]; then
           CODEANT_CHECK_OK=true
+        else
+          # check-run completed before the HEAD commit — stale via force-push
+          # retargeting. A stale check-run must not satisfy the gate, and the
+          # error message must say "stale", not "no successful check-run".
+          CODEANT_CHECK_STALE=true
         fi
-        # else: check-run completed before the HEAD commit — stale; CODEANT_CHECK_OK stays false
       fi
 
       # LATEST_CA_CLEAN_AT: most-recent FRESH clean signal — only signals that have
@@ -777,11 +793,22 @@ case "$REVIEWER" in
             MISSING+=("cannot verify CodeAnt approval freshness — HEAD commit timestamp unavailable; retrying next cycle")
           fi
           # else: PRIMARY_REVIEW_MET=false — primary block already emitted the message.
+        elif [[ "$CA_APPROVAL_SUBMITTED_AT_MISSING" == true ]]; then
+          if [[ "$PRIMARY_REVIEW_MET" == true ]]; then
+            # Same rationale as FRESHNESS_UNKNOWN case above — primary block skipped.
+            # Distinct message: the missing timestamp is on the approval, not LAST_COMMIT_TS.
+            MISSING+=("cannot verify CodeAnt approval freshness — submitted_at missing from approval (fail-closed, issue #836)")
+          fi
+          # else: PRIMARY_REVIEW_MET=false — primary block already emitted the message.
         elif [[ "$CODEANT_CHECK_FRESHNESS_UNKNOWN" == true ]]; then
           # A successful CodeAnt check-run exists but its freshness cannot be verified
           # because LAST_COMMIT_TS is unavailable. Emit a distinct message so callers
           # know a check-run IS present — the blocker is freshness, not absence of review.
           MISSING+=("cannot verify CodeAnt check-run freshness — HEAD commit timestamp unavailable; retrying next cycle")
+        elif [[ "$CODEANT_CHECK_STALE" == true ]]; then
+          # A successful CodeAnt check-run exists but it predates the HEAD commit —
+          # report stale, not absent, so callers know to wait for a re-check.
+          MISSING+=("CodeAnt check-run on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — wait for CodeAnt re-check or trigger @codeant-ai review")
         elif [[ "$CA_APPROVAL_STALE" != true ]]; then
           # None of the freshness/stale conditions apply — emit the generic "no review"
           # message. The CA_APPROVAL_STALE guard prevents emitting this alongside the

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -715,14 +715,28 @@ case "$REVIEWER" in
       # Fail-closed: when LAST_COMMIT_TS is empty we cannot verify freshness,
       # so the check-run does not satisfy the supplemental gate.
       CODEANT_CHECK_OK=false
-      if [[ -n "$LATEST_CA_CHECK_OK_AT" && -n "$LAST_COMMIT_TS" \
-            && ! "$LATEST_CA_CHECK_OK_AT" < "$LAST_COMMIT_TS" ]]; then
-        CODEANT_CHECK_OK=true
+      CODEANT_CHECK_FRESHNESS_UNKNOWN=false
+      if [[ -n "$LATEST_CA_CHECK_OK_AT" ]]; then
+        if [[ -z "$LAST_COMMIT_TS" ]]; then
+          # Cannot verify whether the check-run predates the current commit.
+          CODEANT_CHECK_FRESHNESS_UNKNOWN=true
+        elif [[ ! "$LATEST_CA_CHECK_OK_AT" < "$LAST_COMMIT_TS" ]]; then
+          CODEANT_CHECK_OK=true
+        fi
+        # else: check-run completed before the HEAD commit — stale; CODEANT_CHECK_OK stays false
       fi
 
-      LATEST_CA_CLEAN_AT="$LATEST_CA_APPROVED_AT"
-      if [[ -n "$LATEST_CA_CHECK_OK_AT" && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHECK_OK_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
-        LATEST_CA_CLEAN_AT="$LATEST_CA_CHECK_OK_AT"
+      # LATEST_CA_CLEAN_AT: most-recent FRESH clean signal — only signals that have
+      # passed the freshness guard (issue #836) qualify. Stale or unverifiable signals
+      # must not suppress a CHANGES_REQUESTED that postdates the last genuine clean pass.
+      LATEST_CA_CLEAN_AT=""
+      if [[ "$CA_APPROVAL_VALID" == true ]]; then
+        LATEST_CA_CLEAN_AT="$LATEST_CA_APPROVED_AT"
+      fi
+      if [[ "$CODEANT_CHECK_OK" == true ]]; then
+        if [[ -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHECK_OK_AT" > "$LATEST_CA_CLEAN_AT" ]]; then
+          LATEST_CA_CLEAN_AT="$LATEST_CA_CHECK_OK_AT"
+        fi
       fi
 
       if [[ -n "$LATEST_CA_CHANGES_REQUESTED_AT" && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
@@ -735,9 +749,19 @@ case "$REVIEWER" in
           # Guard: CA_STALE_MISSING_EMITTED prevents a duplicate entry when the
           # primary review block already reported this condition above.
           MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — trigger @codeant-ai review")
-        elif [[ "$CA_APPROVAL_FRESHNESS_UNKNOWN" != true && "$CA_APPROVAL_STALE" != true ]]; then
-          # Freshness-unknown case is already reported in the primary block above;
-          # only emit the generic "no review" message when neither applies.
+        elif [[ "$CA_APPROVAL_FRESHNESS_UNKNOWN" == true ]]; then
+          # Primary block already emitted "cannot verify approval freshness" above.
+          # No-op: avoids a misleading "no review" message in the approval-unknown path.
+          :
+        elif [[ "$CODEANT_CHECK_FRESHNESS_UNKNOWN" == true ]]; then
+          # A successful CodeAnt check-run exists but its freshness cannot be verified
+          # because LAST_COMMIT_TS is unavailable. Emit a distinct message so callers
+          # know a check-run IS present — the blocker is freshness, not absence of review.
+          MISSING+=("cannot verify CodeAnt check-run freshness — HEAD commit timestamp unavailable; retrying next cycle")
+        elif [[ "$CA_APPROVAL_STALE" != true ]]; then
+          # None of the freshness/stale conditions apply — emit the generic "no review"
+          # message. The CA_APPROVAL_STALE guard prevents emitting this alongside the
+          # stale message when CA_STALE_MISSING_EMITTED was already set by the primary block.
           MISSING+=("CodeAnt participated on HEAD ${HEAD_SHA:0:7} but no explicit APPROVED review and no successful CodeAnt check-run (have $TOTAL_CA_ON_HEAD CodeAnt review(s) on this SHA) — wait or comment @codeant-ai review")
         fi
       fi

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -591,16 +591,26 @@ case "$REVIEWER" in
       | length')
 
     # Retraction: later CHANGES_REQUESTED on same SHA invalidates APPROVED (ISO timestamps).
+    # Freshness guard (issue #836): GitHub retargets commit_id on force-push, so a
+    # pre-push CHANGES_REQUESTED can appear on HEAD while predating the commit.
+    # Only treat as retraction if the CHANGES_REQUESTED is itself fresh
+    # (submitted_at >= LAST_COMMIT_TS). When LAST_COMMIT_TS is unknown, skip
+    # retraction — the approval's own freshness check will block via
+    # CR/CA_APPROVAL_FRESHNESS_UNKNOWN.
     CR_RETRACTED=false
     if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && -n "$LATEST_CR_CHANGES_REQUESTED_AT" && -n "$LATEST_CR_APPROVED_AT" ]]; then
       if [[ "$(norm_ts "$LATEST_CR_CHANGES_REQUESTED_AT")" > "$(norm_ts "$LATEST_CR_APPROVED_AT")" ]]; then
-        CR_RETRACTED=true
+        if [[ -n "$LAST_COMMIT_TS" && ! "$(norm_ts "$LATEST_CR_CHANGES_REQUESTED_AT")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
+          CR_RETRACTED=true
+        fi
       fi
     fi
     CA_RETRACTED=false
     if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && -n "$LATEST_CA_CHANGES_REQUESTED_AT" && -n "$LATEST_CA_APPROVED_AT" ]]; then
       if [[ "$(norm_ts "$LATEST_CA_CHANGES_REQUESTED_AT")" > "$(norm_ts "$LATEST_CA_APPROVED_AT")" ]]; then
-        CA_RETRACTED=true
+        if [[ -n "$LAST_COMMIT_TS" && ! "$(norm_ts "$LATEST_CA_CHANGES_REQUESTED_AT")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
+          CA_RETRACTED=true
+        fi
       fi
     fi
 

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -597,32 +597,41 @@ case "$REVIEWER" in
     # Stale-approval guard (issue #836): GitHub retargets commit_id on force-push
     # but does NOT update submitted_at. An approval whose submitted_at predates
     # the HEAD commit's committer date was submitted before the current commit
-    # and must not count even when commit_id matches. Guard fires only when
-    # LAST_COMMIT_TS is non-empty; an empty value (API failure) disables the
-    # guard to avoid silently blocking a valid review. Equal timestamps are
+    # and must not count even when commit_id matches. Equal timestamps are
     # accepted (submitted_at >= LAST_COMMIT_TS). ISO 8601 strings are
     # lexicographically comparable so bash [[ < ]] is correct here.
+    #
+    # Fail-closed (issue #836): when LAST_COMMIT_TS is empty (HEAD timestamp API
+    # failure) we CANNOT verify freshness, so qualifying approvals do NOT satisfy
+    # the gate. Callers poll every ~60 s, so a transient API failure self-heals
+    # on the next cycle without wedging a merge indefinitely.
     CR_APPROVAL_STALE=false
-    if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false \
-          && -n "$LAST_COMMIT_TS" && -n "$LATEST_CR_APPROVED_AT" ]]; then
-      if [[ "$LATEST_CR_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
+    CR_APPROVAL_FRESHNESS_UNKNOWN=false
+    if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false ]]; then
+      if [[ -z "$LAST_COMMIT_TS" ]]; then
+        CR_APPROVAL_FRESHNESS_UNKNOWN=true
+      elif [[ -n "$LATEST_CR_APPROVED_AT" && "$LATEST_CR_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
         CR_APPROVAL_STALE=true
       fi
     fi
     CA_APPROVAL_STALE=false
-    if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false \
-          && -n "$LAST_COMMIT_TS" && -n "$LATEST_CA_APPROVED_AT" ]]; then
-      if [[ "$LATEST_CA_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
+    CA_APPROVAL_FRESHNESS_UNKNOWN=false
+    if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false ]]; then
+      if [[ -z "$LAST_COMMIT_TS" ]]; then
+        CA_APPROVAL_FRESHNESS_UNKNOWN=true
+      elif [[ -n "$LATEST_CA_APPROVED_AT" && "$LATEST_CA_APPROVED_AT" < "$LAST_COMMIT_TS" ]]; then
         CA_APPROVAL_STALE=true
       fi
     fi
 
     CR_APPROVAL_VALID=false
-    if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false && "$CR_APPROVAL_STALE" == false ]]; then
+    if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false \
+          && "$CR_APPROVAL_STALE" == false && "$CR_APPROVAL_FRESHNESS_UNKNOWN" == false ]]; then
       CR_APPROVAL_VALID=true
     fi
     CA_APPROVAL_VALID=false
-    if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false && "$CA_APPROVAL_STALE" == false ]]; then
+    if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false \
+          && "$CA_APPROVAL_STALE" == false && "$CA_APPROVAL_FRESHNESS_UNKNOWN" == false ]]; then
       CA_APPROVAL_VALID=true
     fi
 
@@ -631,6 +640,9 @@ case "$REVIEWER" in
       PRIMARY_REVIEW_MET=true
     fi
 
+    # Track whether the CA stale message was emitted here, to prevent the
+    # supplemental CodeAnt gate below from adding a duplicate entry.
+    CA_STALE_MISSING_EMITTED=false
     if [[ "$PRIMARY_REVIEW_MET" != true ]]; then
       if [[ "$CR_RETRACTED" == true && "$CA_APPROVAL_VALID" != true ]]; then
         MISSING+=("CodeRabbit approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger @coderabbitai full review")
@@ -643,9 +655,17 @@ case "$REVIEWER" in
       fi
       if [[ "$CA_APPROVAL_STALE" == true && "$CR_APPROVAL_VALID" != true ]]; then
         MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — re-review required; trigger @codeant-ai review")
+        CA_STALE_MISSING_EMITTED=true
+      fi
+      if [[ "$CR_APPROVAL_FRESHNESS_UNKNOWN" == true || "$CA_APPROVAL_FRESHNESS_UNKNOWN" == true ]]; then
+        # Fail-closed (issue #836): HEAD commit timestamp unavailable — cannot
+        # verify whether the approval predates the current commit. Callers retry
+        # every ~60 s so this self-heals on the next cycle.
+        MISSING+=("cannot verify approval freshness — HEAD commit timestamp unavailable; retrying next cycle")
       fi
       if [[ "$CR_RETRACTED" != true && "$CA_RETRACTED" != true \
-            && "$CR_APPROVAL_STALE" != true && "$CA_APPROVAL_STALE" != true ]]; then
+            && "$CR_APPROVAL_STALE" != true && "$CA_APPROVAL_STALE" != true \
+            && "$CR_APPROVAL_FRESHNESS_UNKNOWN" != true && "$CA_APPROVAL_FRESHNESS_UNKNOWN" != true ]]; then
         MISSING+=("need 1 explicit CodeRabbit or CodeAnt APPROVED review on HEAD ${HEAD_SHA:0:7} (have $TOTAL_CR_ON_HEAD CodeRabbit, $TOTAL_CA_ON_HEAD CodeAnt review(s) on this SHA)")
       fi
     fi
@@ -692,11 +712,12 @@ case "$REVIEWER" in
         | sort | last // ""')
       # Stale-approval guard (issue #836): check-run completed_at must postdate
       # the HEAD committer date, mirroring the APPROVED review guard above.
+      # Fail-closed: when LAST_COMMIT_TS is empty we cannot verify freshness,
+      # so the check-run does not satisfy the supplemental gate.
       CODEANT_CHECK_OK=false
-      if [[ -n "$LATEST_CA_CHECK_OK_AT" ]]; then
-        if [[ -z "$LAST_COMMIT_TS" || ! "$LATEST_CA_CHECK_OK_AT" < "$LAST_COMMIT_TS" ]]; then
-          CODEANT_CHECK_OK=true
-        fi
+      if [[ -n "$LATEST_CA_CHECK_OK_AT" && -n "$LAST_COMMIT_TS" \
+            && ! "$LATEST_CA_CHECK_OK_AT" < "$LAST_COMMIT_TS" ]]; then
+        CODEANT_CHECK_OK=true
       fi
 
       LATEST_CA_CLEAN_AT="$LATEST_CA_APPROVED_AT"
@@ -707,12 +728,16 @@ case "$REVIEWER" in
       if [[ -n "$LATEST_CA_CHANGES_REQUESTED_AT" && ( -z "$LATEST_CA_CLEAN_AT" || "$LATEST_CA_CHANGES_REQUESTED_AT" > "$LATEST_CA_CLEAN_AT" ) ]]; then
         MISSING+=("CodeAnt CHANGES_REQUESTED on HEAD ${HEAD_SHA:0:7} is newer than the latest CodeAnt clean signal — address findings or wait for APPROVED / successful CodeAnt check-run")
       elif [[ "$CA_APPROVAL_VALID" != true && "$CODEANT_CHECK_OK" != true ]]; then
-        if [[ "$CA_APPROVAL_STALE" == true ]]; then
+        if [[ "$CA_APPROVAL_STALE" == true && "$CA_STALE_MISSING_EMITTED" != true ]]; then
           # Stale-approval guard (issue #836): CodeAnt's approval is retargeted;
           # emit a stale-specific message so callers know to re-trigger rather than
           # interpret this as a complete absence of CodeAnt review.
+          # Guard: CA_STALE_MISSING_EMITTED prevents a duplicate entry when the
+          # primary review block already reported this condition above.
           MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — trigger @codeant-ai review")
-        else
+        elif [[ "$CA_APPROVAL_FRESHNESS_UNKNOWN" != true && "$CA_APPROVAL_STALE" != true ]]; then
+          # Freshness-unknown case is already reported in the primary block above;
+          # only emit the generic "no review" message when neither applies.
           MISSING+=("CodeAnt participated on HEAD ${HEAD_SHA:0:7} but no explicit APPROVED review and no successful CodeAnt check-run (have $TOTAL_CA_ON_HEAD CodeAnt review(s) on this SHA) — wait or comment @codeant-ai review")
         fi
       fi
@@ -736,9 +761,12 @@ case "$REVIEWER" in
         BB_SUBMITTED_AT=$(echo "$LATEST_BB" | jq -r '.submitted_at // ""')
         # Stale-approval guard (issue #836): same retargeting risk as CR/CodeAnt —
         # BugBot review commit_id can be advanced by GitHub on force-push while
-        # submitted_at stays at the pre-push time. Guard is disabled when
-        # LAST_COMMIT_TS is empty (prefer leniency to blocking a valid review).
-        if [[ -n "$LAST_COMMIT_TS" && -n "$BB_SUBMITTED_AT" && "$BB_SUBMITTED_AT" < "$LAST_COMMIT_TS" ]]; then
+        # submitted_at stays at the pre-push time.
+        # Fail-closed: when LAST_COMMIT_TS is empty we cannot verify freshness,
+        # so the review does not satisfy the gate (callers poll every ~60 s).
+        if [[ -z "$LAST_COMMIT_TS" ]]; then
+          MISSING+=("cannot verify BugBot review freshness — HEAD commit timestamp unavailable; retrying next cycle")
+        elif [[ -n "$BB_SUBMITTED_AT" && "$BB_SUBMITTED_AT" < "$LAST_COMMIT_TS" ]]; then
           MISSING+=("BugBot review on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — re-review required; post @cursor review")
         else
           BB_STATE=$(echo "$LATEST_BB" | jq -r '.state // ""')

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -769,9 +769,14 @@ case "$REVIEWER" in
           # primary review block already reported this condition above.
           MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — trigger @codeant-ai review")
         elif [[ "$CA_APPROVAL_FRESHNESS_UNKNOWN" == true ]]; then
-          # Primary block already emitted "cannot verify approval freshness" above.
-          # No-op: avoids a misleading "no review" message in the approval-unknown path.
-          :
+          if [[ "$PRIMARY_REVIEW_MET" == true ]]; then
+            # CR already satisfies the primary gate, so the primary block was skipped
+            # (it only runs when PRIMARY_REVIEW_MET=false) and did NOT emit the
+            # freshness-unknown message. The supplemental gate still requires a
+            # verified CodeAnt clean signal when CodeAnt participated — emit here.
+            MISSING+=("cannot verify CodeAnt approval freshness — HEAD commit timestamp unavailable; retrying next cycle")
+          fi
+          # else: PRIMARY_REVIEW_MET=false — primary block already emitted the message.
         elif [[ "$CODEANT_CHECK_FRESHNESS_UNKNOWN" == true ]]; then
           # A successful CodeAnt check-run exists but its freshness cannot be verified
           # because LAST_COMMIT_TS is unavailable. Emit a distinct message so callers

--- a/.claude/scripts/tests/merge-gate-ci-dedup.test.sh
+++ b/.claude/scripts/tests/merge-gate-ci-dedup.test.sh
@@ -66,6 +66,12 @@ case "\$ARGS" in
     printf '%s' "\${FAKE_ISSUE_COMMENTS:-[]}"; exit 0 ;;
   *graphql*)
     jq -cn '{data:{repository:{pullRequest:{reviewThreads:{nodes:[]}}}}}'; exit 0 ;;
+  *"git/commits/"*)
+    # Return a HEAD committer date earlier than all check-run completed_at values
+    # (which are derived from check-run id as "2026-07-21T10:00:0{id}Z"). This
+    # lets the stale-approval guard (issue #836) treat every check-run as fresh
+    # — the important variable for CI-dedup tests is suite ordering, not freshness.
+    jq -cn '{committer:{date:"2026-07-21T09:59:00Z"}}'; exit 0 ;;
   *contents/*)
     # No CODEOWNERS file — merge-gate.sh tolerates the 404.
     echo "Not Found" >&2; exit 1 ;;

--- a/.claude/scripts/tests/merge-gate-stale-approval.test.sh
+++ b/.claude/scripts/tests/merge-gate-stale-approval.test.sh
@@ -266,6 +266,41 @@ check_eq "yes"   "$(missing_has "$STALE_CHECK_MSG")"  "(i) stale ca check: missi
 check_eq "1"     "$RC"                                "(i) stale ca check: exit 1"
 
 # -------------------------------------------------------------------------
+# Test (j): stale CHANGES_REQUESTED should not retract stale APPROVED
+# (issue #836, BugBot round 6). When both APPROVED and CHANGES_REQUESTED
+# predate the HEAD commit (force-push retargeting), the retraction guard
+# must skip CR_RETRACTED and let the stale-approval guard report the real
+# blocker. Without the freshness guard the old code would set CR_RETRACTED=true
+# and emit the retraction message instead of the stale message.
+# -------------------------------------------------------------------------
+echo "--- (j) stale CHANGES_REQUESTED should not retract stale APPROVED ---"
+PRE_COMMIT_CHANGES_TS="2026-07-30T19:25:00Z"   # between STALE_TS and COMMIT_TS
+J_REVIEWS=$(jq -cn \
+  --arg sha "$HEAD_SHA" \
+  --arg approved_ts "$STALE_TS" \
+  --arg changes_ts "$PRE_COMMIT_CHANGES_TS" \
+  '[
+    {id:1,user:{login:"coderabbitai[bot]"},state:"APPROVED",
+     commit_id:$sha,submitted_at:$approved_ts},
+    {id:2,user:{login:"coderabbitai[bot]"},state:"CHANGES_REQUESTED",
+     commit_id:$sha,submitted_at:$changes_ts}
+  ]')
+STALE_MSG="predates the HEAD commit (force-push retargeting)"
+RETRACT_MSG="retracted by later CHANGES_REQUESTED"
+OUT=$(PATH="$BIN:$PATH" \
+      FAKE_COMMIT_TS="$COMMIT_TS" \
+      FAKE_COMMIT_TS_FAIL="" \
+      FAKE_REVIEWS="$J_REVIEWS" \
+      FAKE_PR_COMMENTS="[]" \
+      FAKE_ISSUE_COMMENTS="[]" \
+      "$SUT" 1 --reviewer cr 2>/dev/null)
+RC=$?
+check_eq "false" "$(met)"                             "(j) stale changes+approved: met == false"
+check_eq "yes"   "$(missing_has "$STALE_MSG")"        "(j) stale changes+approved: stale msg present"
+check_eq "no"    "$(missing_has "$RETRACT_MSG")"      "(j) stale changes+approved: no retract msg"
+check_eq "1"     "$RC"                                "(j) stale changes+approved: exit 1"
+
+# -------------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------------
 echo "----------------------------------------"

--- a/.claude/scripts/tests/merge-gate-stale-approval.test.sh
+++ b/.claude/scripts/tests/merge-gate-stale-approval.test.sh
@@ -214,6 +214,26 @@ check_eq "no"    "$(missing_has "$RETARGET_MSG")" \
 check_eq "0"     "$RC"      "(g) bugbot fresh: exit 0"
 
 # -------------------------------------------------------------------------
+# (h) CR has a fresh APPROVED + CA has approval with empty submitted_at.
+#     PRIMARY_REVIEW_MET=true (CR satisfies it), so the primary freshness-
+#     unknown block is skipped. The supplemental CodeAnt gate must still
+#     block because CA_APPROVAL_FRESHNESS_UNKNOWN=true and we cannot pass
+#     without a verified CodeAnt clean signal.
+# -------------------------------------------------------------------------
+echo "--- (h) CR fresh + CA approval missing submitted_at (supplemental freshness) ---"
+CA_FRESHNESS_MSG="cannot verify CodeAnt approval freshness"
+BOTH_REVIEWS=$(jq -cn --arg sha "$HEAD_SHA" --arg cr_ts "$FRESH_TS" \
+  '[{user:{login:"coderabbitai[bot]",type:"Bot"},
+     commit_id:$sha, state:"APPROVED", submitted_at:$cr_ts},
+    {user:{login:"codeant-ai[bot]",type:"Bot"},
+     commit_id:$sha, state:"APPROVED", submitted_at:""}]')
+run_gate cr "$COMMIT_TS" "$BOTH_REVIEWS"
+check_eq "false" "$(met)"   "(h) cr fresh + ca no-ts: met == false"
+check_eq "yes"   "$(missing_has "$CA_FRESHNESS_MSG")" \
+                             "(h) cr fresh + ca no-ts: missing has CA freshness reason"
+check_eq "1"     "$RC"      "(h) cr fresh + ca no-ts: exit 1"
+
+# -------------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------------
 echo "----------------------------------------"

--- a/.claude/scripts/tests/merge-gate-stale-approval.test.sh
+++ b/.claude/scripts/tests/merge-gate-stale-approval.test.sh
@@ -16,7 +16,7 @@
 #       same missing reason
 #   (d) BugBot review submitted BEFORE HEAD, matching commit_id → not met,
 #       same missing reason
-#   (e) Empty LAST_COMMIT_TS (API failure) → guard disabled, gate met
+#   (e) Empty LAST_COMMIT_TS (API failure) → fail-closed, gate NOT met, distinct reason
 #   (f) Equal timestamps (submitted_at == committer date) → accepted (met)
 #
 # Only `gh` is stubbed; merge-gate.sh, ci-status.sh, check-runs-dedup.sh,
@@ -179,16 +179,20 @@ check_eq "yes"   "$(missing_has "$RETARGET_MSG")" \
 check_eq "1"     "$RC"      "(d) bugbot stale: exit 1"
 
 # -------------------------------------------------------------------------
-# (e) Empty LAST_COMMIT_TS (API failure) — guard disabled, gate met
+# (e) Empty LAST_COMMIT_TS (API failure) — fail-closed: gate NOT met,
+#     distinct "cannot verify freshness" reason (not the retargeting message)
 # -------------------------------------------------------------------------
-echo "--- (e) LAST_COMMIT_TS empty (guard disabled) ---"
+FRESHNESS_MSG="cannot verify approval freshness"
+echo "--- (e) LAST_COMMIT_TS empty (fail-closed) ---"
 FAKE_COMMIT_TS_FAIL=1
 run_gate cr "" "$(cr_approved "$STALE_TS")"
 unset FAKE_COMMIT_TS_FAIL
-check_eq "true"  "$(met)"   "(e) guard disabled when ts empty: met == true"
+check_eq "false" "$(met)"   "(e) fail-closed when ts empty: met == false"
+check_eq "yes"   "$(missing_has "$FRESHNESS_MSG")" \
+                             "(e) fail-closed: missing has freshness reason"
 check_eq "no"    "$(missing_has "$RETARGET_MSG")" \
-                             "(e) guard disabled: no retarget message"
-check_eq "0"     "$RC"      "(e) guard disabled: exit 0"
+                             "(e) fail-closed: no retarget message (distinct from stale)"
+check_eq "1"     "$RC"      "(e) fail-closed: exit 1"
 
 # -------------------------------------------------------------------------
 # (f) submitted_at EQUAL to committer date — boundary, must be accepted (met)

--- a/.claude/scripts/tests/merge-gate-stale-approval.test.sh
+++ b/.claude/scripts/tests/merge-gate-stale-approval.test.sh
@@ -76,6 +76,9 @@ case "$ARGS" in
     jq -cn --arg d "$FAKE_COMMIT_TS" '{committer:{date:$d}}'
     exit 0 ;;
   *check-runs*)
+    if [[ -n "${FAKE_CHECK_RUNS:-}" ]]; then
+      printf '%s' "$FAKE_CHECK_RUNS"; exit 0
+    fi
     jq -cn '{check_runs:[{id:1,name:"ci",status:"completed",conclusion:"success",
                completed_at:"2026-07-30T19:32:00Z",
                check_suite:{id:1},app:{slug:"gha",id:1}}]}'
@@ -215,13 +218,13 @@ check_eq "0"     "$RC"      "(g) bugbot fresh: exit 0"
 
 # -------------------------------------------------------------------------
 # (h) CR has a fresh APPROVED + CA has approval with empty submitted_at.
-#     PRIMARY_REVIEW_MET=true (CR satisfies it), so the primary freshness-
-#     unknown block is skipped. The supplemental CodeAnt gate must still
-#     block because CA_APPROVAL_FRESHNESS_UNKNOWN=true and we cannot pass
-#     without a verified CodeAnt clean signal.
+#     PRIMARY_REVIEW_MET=true (CR satisfies it), so the primary block is
+#     skipped. The supplemental CodeAnt gate must still block because
+#     CA_APPROVAL_SUBMITTED_AT_MISSING=true — the approval's timestamp is
+#     absent and freshness cannot be verified (fail-closed, issue #836).
 # -------------------------------------------------------------------------
 echo "--- (h) CR fresh + CA approval missing submitted_at (supplemental freshness) ---"
-CA_FRESHNESS_MSG="cannot verify CodeAnt approval freshness"
+CA_SUBMITTED_AT_MSG="cannot verify CodeAnt approval freshness"
 BOTH_REVIEWS=$(jq -cn --arg sha "$HEAD_SHA" --arg cr_ts "$FRESH_TS" \
   '[{user:{login:"coderabbitai[bot]",type:"Bot"},
      commit_id:$sha, state:"APPROVED", submitted_at:$cr_ts},
@@ -229,9 +232,38 @@ BOTH_REVIEWS=$(jq -cn --arg sha "$HEAD_SHA" --arg cr_ts "$FRESH_TS" \
      commit_id:$sha, state:"APPROVED", submitted_at:""}]')
 run_gate cr "$COMMIT_TS" "$BOTH_REVIEWS"
 check_eq "false" "$(met)"   "(h) cr fresh + ca no-ts: met == false"
-check_eq "yes"   "$(missing_has "$CA_FRESHNESS_MSG")" \
+check_eq "yes"   "$(missing_has "$CA_SUBMITTED_AT_MSG")" \
                              "(h) cr fresh + ca no-ts: missing has CA freshness reason"
 check_eq "1"     "$RC"      "(h) cr fresh + ca no-ts: exit 1"
+
+# -------------------------------------------------------------------------
+# (i) Stale CodeAnt check-run (completed_at < COMMIT_TS) — must NOT met.
+#     The message must say "predates the HEAD commit" (stale), not "no
+#     successful CodeAnt check-run" (absent). CODEANT_PARTICIPATED is true
+#     because the CodeAnt check-run is present in check-runs.
+# -------------------------------------------------------------------------
+echo "--- (i) stale CodeAnt check-run (force-push retargeting) ---"
+STALE_CA_CHECK=$(jq -cn \
+  --arg ca_ts "$STALE_TS" \
+  '{check_runs:[
+      {id:1,name:"ci",status:"completed",conclusion:"success",
+       completed_at:"2026-07-30T19:32:00Z",check_suite:{id:1},app:{slug:"gha",id:1}},
+      {id:2,name:"CodeAnt AI",status:"completed",conclusion:"success",
+       completed_at:$ca_ts,check_suite:{id:2},app:{slug:"codeant",id:2}}
+    ]}')
+STALE_CHECK_MSG="predates the HEAD commit (force-push retargeting)"
+OUT=$(PATH="$BIN:$PATH" \
+      FAKE_COMMIT_TS="$COMMIT_TS" \
+      FAKE_COMMIT_TS_FAIL="" \
+      FAKE_REVIEWS="[]" \
+      FAKE_PR_COMMENTS="[]" \
+      FAKE_ISSUE_COMMENTS="[]" \
+      FAKE_CHECK_RUNS="$STALE_CA_CHECK" \
+      "$SUT" 1 --reviewer cr 2>/dev/null)
+RC=$?
+check_eq "false" "$(met)"                             "(i) stale ca check: met == false"
+check_eq "yes"   "$(missing_has "$STALE_CHECK_MSG")"  "(i) stale ca check: missing has retarget reason"
+check_eq "1"     "$RC"                                "(i) stale ca check: exit 1"
 
 # -------------------------------------------------------------------------
 # Summary

--- a/.claude/scripts/tests/merge-gate-stale-approval.test.sh
+++ b/.claude/scripts/tests/merge-gate-stale-approval.test.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# merge-gate-stale-approval.test.sh — Regression tests for issue #836:
+# merge-gate.sh must reject approvals whose submitted_at predates the HEAD
+# commit's committer date (GitHub force-push commit_id retargeting).
+#
+# Scenario: after a squash-rebase + force-push, GitHub retargets existing
+# review commit_ids to the new HEAD SHA but does NOT update submitted_at.
+# An approval submitted before the push therefore shows commit_id == HEAD
+# with submitted_at < HEAD committer date — a false-positive "valid approval".
+#
+# Acceptance criteria covered:
+#   (a) Approval submitted AFTER HEAD commit → met (normal case unchanged)
+#   (b) CR approval submitted BEFORE HEAD, matching commit_id → not met,
+#       missing says "predates the HEAD commit (force-push retargeting)"
+#   (c) CA approval submitted BEFORE HEAD, matching commit_id → not met,
+#       same missing reason
+#   (d) BugBot review submitted BEFORE HEAD, matching commit_id → not met,
+#       same missing reason
+#   (e) Empty LAST_COMMIT_TS (API failure) → guard disabled, gate met
+#   (f) Equal timestamps (submitted_at == committer date) → accepted (met)
+#
+# Only `gh` is stubbed; merge-gate.sh, ci-status.sh, check-runs-dedup.sh,
+# and session-state.sh are the real scripts.
+#
+# Run from repo root: bash .claude/scripts/tests/merge-gate-stale-approval.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SUT="$REPO_ROOT/.claude/scripts/merge-gate.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+export HOME="$TMP/home"; mkdir -p "$HOME/.claude"
+
+PASS=0; FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+check_eq() { # expected actual label
+  if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected: '$1', got: '$2')"; fi
+}
+
+HEAD_SHA="aabbccddeeff0011223344556677889900aabbcc"
+# Committer date for the HEAD commit (i.e., when the force-push landed).
+COMMIT_TS="2026-07-30T19:30:00Z"
+# Approval submitted AFTER the push — normal, valid.
+FRESH_TS="2026-07-30T19:35:00Z"
+# Approval submitted BEFORE the push — stale via retargeting.
+STALE_TS="2026-07-30T19:21:54Z"
+# Approval submitted at exactly the same second as the commit — boundary, accepted.
+EQUAL_TS="$COMMIT_TS"
+
+# --- Fake gh stub -------------------------------------------------------
+BIN="$TMP/bin"; mkdir -p "$BIN"
+cat > "$BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  "repo view --json nameWithOwner --jq .nameWithOwner")
+    echo "solo/repo"; exit 0 ;;
+  "api user --jq .login")
+    echo "solouser"; exit 0 ;;
+  *"pr view "*headRefOid*)
+    jq -cn \
+      --arg sha  "$HEAD_SHA" \
+      '{number:1, state:"OPEN", headRefOid:$sha, baseRefName:"main",
+        mergeStateStatus:"CLEAN", mergeable:"MERGEABLE", reviewDecision:"APPROVED",
+        author:{login:"solouser", type:"User"}}'
+    exit 0 ;;
+  *"git/commits/"*)
+    # Return FAKE_COMMIT_TS as the HEAD committer date.
+    if [ -n "${FAKE_COMMIT_TS_FAIL:-}" ]; then
+      echo "gh: network error" >&2; exit 1
+    fi
+    jq -cn --arg d "$FAKE_COMMIT_TS" '{committer:{date:$d}}'
+    exit 0 ;;
+  *check-runs*)
+    jq -cn '{check_runs:[{id:1,name:"ci",status:"completed",conclusion:"success",
+               completed_at:"2026-07-30T19:32:00Z",
+               check_suite:{id:1},app:{slug:"gha",id:1}}]}'
+    exit 0 ;;
+  *pulls/*/reviews*)
+    printf '%s' "${FAKE_REVIEWS:-[]}"; exit 0 ;;
+  *pulls/*/comments*)
+    printf '%s' "${FAKE_PR_COMMENTS:-[]}"; exit 0 ;;
+  *issues/*/comments*)
+    printf '%s' "${FAKE_ISSUE_COMMENTS:-[]}"; exit 0 ;;
+  *graphql*)
+    jq -cn '{data:{repository:{pullRequest:{reviewThreads:{nodes:[]}}}}}'; exit 0 ;;
+  *contents/*)
+    echo "Not Found" >&2; exit 1 ;;
+esac
+echo "unexpected gh call: $ARGS" >&2
+exit 1
+GHEOF
+chmod +x "$BIN/gh"
+export HEAD_SHA
+
+# Build a CR (coderabbitai) APPROVED review with configurable submitted_at.
+cr_approved() { # submitted_at
+  jq -cn --arg sha "$HEAD_SHA" --arg ts "$1" \
+    '[{user:{login:"coderabbitai[bot]",type:"Bot"},
+       commit_id:$sha, state:"APPROVED", submitted_at:$ts}]'
+}
+# Build a CodeAnt (codeant-ai) APPROVED review.
+ca_approved() { # submitted_at
+  jq -cn --arg sha "$HEAD_SHA" --arg ts "$1" \
+    '[{user:{login:"codeant-ai[bot]",type:"Bot"},
+       commit_id:$sha, state:"APPROVED", submitted_at:$ts}]'
+}
+# Build a BugBot (cursor) review with configurable state and submitted_at.
+bb_review() { # submitted_at state
+  jq -cn --arg sha "$HEAD_SHA" --arg ts "$1" --arg st "$2" \
+    '[{user:{login:"cursor[bot]",type:"Bot"},
+       commit_id:$sha, state:$st, submitted_at:$ts}]'
+}
+
+OUT=""; RC=0
+run_gate() {
+  # $1 = reviewer (cr|bugbot), $2 = FAKE_COMMIT_TS, $3 = FAKE_REVIEWS
+  local reviewer="$1" commit_ts="$2" reviews="$3"
+  local fail_ts="${FAKE_COMMIT_TS_FAIL:-}"
+  OUT=$(PATH="$BIN:$PATH" \
+        FAKE_COMMIT_TS="$commit_ts" \
+        FAKE_COMMIT_TS_FAIL="$fail_ts" \
+        FAKE_REVIEWS="$reviews" \
+        FAKE_PR_COMMENTS="[]" \
+        FAKE_ISSUE_COMMENTS="[]" \
+        "$SUT" 1 --reviewer "$reviewer" 2>/dev/null)
+  RC=$?
+}
+
+met()           { echo "$OUT" | jq -r '.met'; }
+missing_count() { echo "$OUT" | jq -r '.missing | length'; }
+missing_has()   { echo "$OUT" | jq -e --arg s "$1" \
+                    '[.missing[]? | select(contains($s))] | length > 0' \
+                  >/dev/null && echo yes || echo no; }
+
+RETARGET_MSG="predates the HEAD commit (force-push retargeting)"
+
+# -------------------------------------------------------------------------
+# (a) CR approval AFTER HEAD commit — normal case, must be met
+# -------------------------------------------------------------------------
+echo "--- (a) CR approval after HEAD commit (normal, must be met) ---"
+run_gate cr "$COMMIT_TS" "$(cr_approved "$FRESH_TS")"
+check_eq "true"  "$(met)"           "(a) cr fresh approval: met == true"
+check_eq "0"     "$(missing_count)" "(a) cr fresh approval: no missing entries"
+check_eq "0"     "$RC"              "(a) cr fresh approval: exit 0"
+
+# -------------------------------------------------------------------------
+# (b) CR approval BEFORE HEAD commit (force-push retargeting) — must NOT met
+# -------------------------------------------------------------------------
+echo "--- (b) CR approval before HEAD (stale retargeting) ---"
+run_gate cr "$COMMIT_TS" "$(cr_approved "$STALE_TS")"
+check_eq "false" "$(met)"   "(b) cr stale approval: met == false"
+check_eq "yes"   "$(missing_has "$RETARGET_MSG")" \
+                             "(b) cr stale approval: missing has retarget reason"
+check_eq "1"     "$RC"      "(b) cr stale approval: exit 1"
+
+# -------------------------------------------------------------------------
+# (c) CA approval BEFORE HEAD commit — must NOT met
+# -------------------------------------------------------------------------
+echo "--- (c) CA approval before HEAD (stale retargeting) ---"
+run_gate cr "$COMMIT_TS" "$(ca_approved "$STALE_TS")"
+check_eq "false" "$(met)"   "(c) ca stale approval: met == false"
+check_eq "yes"   "$(missing_has "$RETARGET_MSG")" \
+                             "(c) ca stale approval: missing has retarget reason"
+check_eq "1"     "$RC"      "(c) ca stale approval: exit 1"
+
+# -------------------------------------------------------------------------
+# (d) BugBot review BEFORE HEAD commit — must NOT met
+# -------------------------------------------------------------------------
+echo "--- (d) BugBot review before HEAD (stale retargeting) ---"
+run_gate bugbot "$COMMIT_TS" "$(bb_review "$STALE_TS" "APPROVED")"
+check_eq "false" "$(met)"   "(d) bugbot stale: met == false"
+check_eq "yes"   "$(missing_has "$RETARGET_MSG")" \
+                             "(d) bugbot stale: missing has retarget reason"
+check_eq "1"     "$RC"      "(d) bugbot stale: exit 1"
+
+# -------------------------------------------------------------------------
+# (e) Empty LAST_COMMIT_TS (API failure) — guard disabled, gate met
+# -------------------------------------------------------------------------
+echo "--- (e) LAST_COMMIT_TS empty (guard disabled) ---"
+FAKE_COMMIT_TS_FAIL=1
+run_gate cr "" "$(cr_approved "$STALE_TS")"
+unset FAKE_COMMIT_TS_FAIL
+check_eq "true"  "$(met)"   "(e) guard disabled when ts empty: met == true"
+check_eq "no"    "$(missing_has "$RETARGET_MSG")" \
+                             "(e) guard disabled: no retarget message"
+check_eq "0"     "$RC"      "(e) guard disabled: exit 0"
+
+# -------------------------------------------------------------------------
+# (f) submitted_at EQUAL to committer date — boundary, must be accepted (met)
+# -------------------------------------------------------------------------
+echo "--- (f) submitted_at == committer date (boundary, must be accepted) ---"
+run_gate cr "$COMMIT_TS" "$(cr_approved "$EQUAL_TS")"
+check_eq "true"  "$(met)"           "(f) equal ts: met == true"
+check_eq "0"     "$(missing_count)" "(f) equal ts: no missing entries"
+check_eq "0"     "$RC"              "(f) equal ts: exit 0"
+
+# -------------------------------------------------------------------------
+# (g) BugBot review AFTER HEAD commit — normal case, must be met
+# -------------------------------------------------------------------------
+echo "--- (g) BugBot review after HEAD commit (normal, must be met) ---"
+run_gate bugbot "$COMMIT_TS" "$(bb_review "$FRESH_TS" "APPROVED")"
+check_eq "true"  "$(met)"   "(g) bugbot fresh: met == true"
+check_eq "no"    "$(missing_has "$RETARGET_MSG")" \
+                             "(g) bugbot fresh: no retarget message"
+check_eq "0"     "$RC"      "(g) bugbot fresh: exit 0"
+
+# -------------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------------
+echo "----------------------------------------"
+echo "merge-gate-stale-approval.test.sh: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

- GitHub retargets a review's `commit_id` to the new HEAD SHA after a force-push (when diff context persists), but `submitted_at` is never updated — creating false-positive "valid approval" results in `merge-gate.sh` (observed live on PR #831).
- Add a stale-approval guard that compares each qualifying approval's `submitted_at` against `LAST_COMMIT_TS` (HEAD committer date, already fetched) across all three review paths: CR/CodeAnt APPROVED, CodeAnt clean check-run `completed_at`, and BugBot reviews.
- Guard is disabled when `LAST_COMMIT_TS` is empty (API failure); equal timestamps are accepted.

Closes #836

## Test plan

- [x] (a) CR approval submitted AFTER HEAD commit → `met: true` (normal case unchanged)
- [x] (b) CR approval submitted BEFORE HEAD, `commit_id == HEAD` → `met: false`, `missing[]` contains "predates the HEAD commit (force-push retargeting)"
- [x] (c) CodeAnt approval submitted BEFORE HEAD, `commit_id == HEAD` → `met: false`, same retargeting reason
- [x] (d) BugBot review submitted BEFORE HEAD, `commit_id == HEAD` → `met: false`, same retargeting reason
- [x] (e) `LAST_COMMIT_TS` empty (API failure) → guard disabled, gate met (leniency over false block)
- [x] (f) `submitted_at == committer date` (boundary) → accepted, `met: true`
- [x] (g) BugBot review submitted AFTER HEAD commit → `met: true` (normal case unchanged)

All 21 tests in `merge-gate-stale-approval.test.sh` pass. Existing test suites (authorship: 11/11, greptile-comment: 27/27, ci-dedup: 17/17) unaffected. `bash -n` clean; shellcheck clean.

[COVERAGE: none] — CodeRabbit CLI not installed; CodeAnt CLI hit 403 daily cap. Self-review performed; no issues found.