### PR TITLE
fix(#837): compare model families in the MODEL GUARD, not version numbers

### DIFF
--- a/.claude/reference/chip-launching.md
+++ b/.claude/reference/chip-launching.md
@@ -79,18 +79,26 @@ The recommended model is worthless if nothing checks it at launch time. Every `p
 
 ```text
 MODEL GUARD: Your very first action — before any repo reads, file edits, or
-other tool calls — is to compare the model you are actually running as
-against the recommendation on the **Model:** line above.
-- Match: state "Running on {MODEL} as recommended." (one line) and proceed
-  immediately — no further prompts.
-- Mismatch, in EITHER direction (under- or over-powered): STOP. Do no other
-  work. Report, in one message, the model you are actually running as and the
-  model recommended above, then wait. Resume only on an explicit user reply
-  (e.g. "continue anyway"), proceeding on the current model — switching
-  models and relaunching is the recommended path instead.
+other tool calls — is to compare the model family you are actually running as
+against the family named on the **Model:** line above. Compare families only —
+`Opus`, `Sonnet`, `Haiku`, `Fable`. A trailing `<N>` or `<N>.<N>` after a
+family name is an old-style version qualifier: ignore it on either side, it is
+never evidence of a mismatch.
+- Match (same family): state "Running on {FAMILY} as recommended." (one line,
+  naming the family you are running — not the possibly-qualified string you
+  read) and proceed immediately — no further prompts.
+- Mismatch (different family), in EITHER direction (under- or over-powered):
+  STOP. Do no other work. Report, in one message, the model you are actually
+  running as and the model recommended above, then wait. Resume only on an
+  explicit user reply (e.g. "continue anyway"), proceeding on the current
+  model — switching models and relaunching is the recommended path instead.
 This is a best-effort self-report: no runtime API exists to introspect the
 active model, so the check relies on the model naming itself accurately.
 ```
+
+**Why family-level:** the guard exists to catch a thread running at the wrong *tier*, and tier is the family — a bare family name already resolves to the newest non-legacy model of that family ("Model and effort lines" above), so two versions inside one family are the same recommendation, and stopping between them reports a disagreement that does not exist.
+
+**What that reaches — and what it does not.** Every payload rendered from this file after the change is family-safe: a chip spawned from here on, a fallback block printed from here on. A chip **already offered** does not change — it froze a copy of the preamble into its `prompt` at spawn time, so it is still read under whatever wording it was emitted with, and editing this file cannot rewrite a payload sitting in a task list. Replaying such a chip reproduces that frozen wording too, and correctly so: replay is pinned to the chip's own `prompt` ("Print-on-demand replay" below), because a printed block that disagreed with the chip it describes would be the worse bug. The fix closes the class going forward rather than draining the existing backlog; that backlog is [#838](https://github.com/auerbachb/claude-code-config/issues/838). Rationale, scope limit, and the retired-family gap: `chip-model-guard-decision.md`.
 
 **Placement rule:** for every emitter, the `**Model:**` line is the first line of the `prompt` payload, the `**Effort:**` line is next, and this preamble is the content that immediately follows them — see each skill's Step for how its own template maps onto this shape.
 

--- a/.claude/reference/chip-model-guard-decision.md
+++ b/.claude/reference/chip-model-guard-decision.md
@@ -18,6 +18,26 @@ Issue #791 added an `**Effort:** {LEVEL} — {REASON}` line to the same unit, an
 
 Keeping the guard's promise narrow is what makes it worth trusting. If #735 ships `model`/`effort` parameters on `spawn_task`, both become tool-layer settings and the question is moot for chips — the guard reverts to a paste-flow safety net, exactly as this record's closing note anticipated.
 
+### Amendment (#837): the comparison is family-level
+
+**Family is the guarded axis; a trailing version number is noise.** The preamble compares the family the thread is running — `Opus`, `Sonnet`, `Haiku`, `Fable` — against the family named on the `**Model:**` line, ignoring any trailing version qualifier on either side. A cross-family difference still stops the thread cold in both directions, with the stop wording untouched.
+
+This follows from what the guard is *for*. It catches a thread running at the wrong **tier** — the judgment a chip encodes is "this work deserves this much model" — and tier is the family. Two versions inside one family are the same recommendation, so stopping on the difference between them reports a disagreement that does not exist. String equality was never the intended rule; it was simply the only reading the old wording left available.
+
+**The two branches report differently, on purpose.** The match branch names the *family* it is running, because echoing back a possibly-stale qualifier would assert the thread is running a version it is not — a one-line confirmation is no place for a claim that is false. The mismatch branch keeps reporting **both models in full**, qualifier included: that message exists to help a human decide whether to switch models or continue, and the qualifier is part of what they are deciding on. Reducing it to families there would strip detail at precisely the moment the most of it is wanted. So the asymmetry is not an oversight in the rewrite — comparison is family-level on both branches, and only the *reporting* differs.
+
+It composes with #791 rather than repeating it. #791 fixed which name gets **written** onto a `**Model:**` line — a bare family name, which resolves forward to the newest non-legacy model of its family on its own. This fixes what a thread **does** with a name it did not expect, a question none of #791's acceptance criteria reached, because every one of them is about what gets written into the corpus.
+
+**Scope limit — this does not retroactively fix chips already offered.** #837 was captured on the premise that a wording change "fixes every past and future stale payload at once." That holds for the future half only, and the correction is worth stating plainly because the premise is load-bearing: the preamble is copied into a chip's `prompt` **at spawn time**, so an already-offered chip carries a frozen copy of the old wording, is read under it, and never consults this file. Editing here cannot rewrite a payload sitting in a task list. What does change is that every payload rendered from this point — a chip spawned now, a fallback block printed now — is family-safe by construction. Replay is deliberately *not* in that list: it stays pinned to the chip's own `prompt` so the printed block and the chip never diverge (an invariant this record's opening already fixes), which means replaying an old chip faithfully reproduces its old guard wording. The class stops growing; the existing backlog is unaffected and is tracked as [#838](https://github.com/auerbachb/claude-code-config/issues/838).
+
+**Rejected as the primary fix: sweeping and re-emitting the stale chips.** A one-time cleanup does not answer a recurring problem, it needs a handle on every outstanding chip, and it does nothing for a paste block saved in someone's notes — so the reading rule had to change first regardless. With the recurring half now closed, a sweep is the right shape for the remaining one-time backlog *if* it proves big enough to be worth it, which is the call #838 makes.
+
+**Known gap — a retired family.** If a family is ever dropped from the fleet, a chip naming it would compare against nothing, and should stop. Not a live case today (the fleet has only gained families), so the preamble carries no wording for it; recorded here so a future retirement is a known open question rather than a surprise.
+
+**Terminology.** The preamble calls a trailing version number an *old-style* qualifier, not a *legacy* one. "Legacy" already means "a superseded model within a family" in `.claude/agents/README.md` ("the newest non-legacy model of that family"), and reusing it here would invite exactly the wrong reading — that only qualifiers naming an outdated version are ignorable. Every qualifier of the documented form is ignored, whichever version it names.
+
+**And only that form.** What the preamble discards is the numeric grammar it names — a trailing `<N>` or `<N>.<N>` — because that is what the pre-#791 lines actually carried. A non-numeric suffix is deliberately *not* covered: it is not a version number, nothing in the fleet's history produced one, and a rule that waved through any trailing token would quietly turn an unrecognized name into a match. If such a form ever appears, it should reach the mismatch branch and be looked at, like the retired-family case above.
+
 ## Rationale
 
 Two invariants existed before this ticket and a new preamble can preserve at most one of them:
@@ -48,5 +68,8 @@ Adding a guard that only some threads receive forces a choice: put it in the chi
 - Issue [#731](https://github.com/auerbachb/claude-code-config/issues/731) — universal enforcement + conformance lint
 - Issue [#735](https://github.com/auerbachb/claude-code-config/issues/735) — upstream ask for `spawn_task` `model` parameter
 - Issue [#791](https://github.com/auerbachb/claude-code-config/issues/791) — versionless model names + the `**Effort:**` line; amended this record to hold the guard at model-only
+- Issue [#837](https://github.com/auerbachb/claude-code-config/issues/837) — family-level comparison; the read side of the contract #791 fixed on the write side
+- Issue [#749](https://github.com/auerbachb/claude-code-config/issues/749) — the version-pin that put version numbers on these lines in the first place; #791 and #837 reversed it on the write and read sides respectively
+- Issue [#838](https://github.com/auerbachb/claude-code-config/issues/838) — the stale-chip backlog #837 does not reach; see the scope limit above
 - `pm-handoff-chips-decision.md` — the house style this record follows (`## Decision` / `## Rationale` / `## Explicitly Rejected` / `## References`)
 - Issue [#547](https://github.com/auerbachb/claude-code-config/issues/547) (closed) — model fleet reconciliation across selection surfaces, the related prior work this ticket builds on

--- a/.github/scripts/chip-model-guard-lint.sh
+++ b/.github/scripts/chip-model-guard-lint.sh
@@ -113,6 +113,37 @@ require_file "$CLAUDE_MD" || true
 if [[ -f "$CHIP_LAUNCHING" ]]; then
   require_pattern "$CHIP_LAUNCHING" 'MODEL GUARD:' 'MODEL GUARD preamble marker'
   require_pattern "$CHIP_LAUNCHING" 'Your very first action' 'guard first-action text'
+  # The guard compares FAMILIES, not strings (#837). Chips stay clickable
+  # indefinitely, so ones emitted before the versionless rename still name a
+  # version; a reword back to string equality would make every one of them a
+  # false stop. Each of the three sentences that carry that semantics is
+  # asserted separately — one assertion would leave the other two free to go.
+  #
+  # Each pattern spans enough of its sentence to survive a SEMANTIC INVERSION —
+  # a reword that keeps the vocabulary but reverses the rule ("...qualifier:
+  # honor it on both sides"). Matching the noun alone would pass such a reword,
+  # which is the #802 lesson applied to this contract: assert the instruction,
+  # not the keyword.
+  #
+  # Scope of that promise: these anchors catch an inversion written INTO the
+  # asserted sentence. No line-oriented pattern can catch a contradiction
+  # planted in a different sentence of the same file, and none of these claims
+  # to — that residual case is what review is for.
+  #
+  # The trailing em dash is load-bearing, not incidental punctuation: it pins
+  # the phrase to the family list that follows, so "Compare families only, and
+  # the exact model strings must match," cannot satisfy the check by keeping
+  # the substring.
+  require_pattern "$CHIP_LAUNCHING" 'Compare families only —' 'family-level comparison rule'
+  require_pattern "$CHIP_LAUNCHING" 'old-style version qualifier: ignore it on either side' \
+    'version-qualifier-is-noise rule'
+  # Anchored to the Match branch specifically: {FAMILY} loose in the document
+  # does not prove the MATCH branch reports a family, and the mismatch branch
+  # deliberately still reports full model names (see the decision record).
+  # Bracket expressions, not \{ — literal braces are unambiguous this way under
+  # both GNU and BSD ERE, where \{ shades into interval-expression territory.
+  require_pattern "$CHIP_LAUNCHING" 'Match \(same family\): state "Running on [{]FAMILY[}]' \
+    'family self-report in match branch'
   require_pattern "$CHIP_LAUNCHING" 'six canonical emitters' 'canonical emitters preamble'
   require_pattern "$CHIP_LAUNCHING" 'first line of the `prompt`' 'first-line placement rule'
   require_pattern "$CHIP_LAUNCHING" 'no blank line' 'no-blank-line placement rule'

--- a/.github/scripts/tests/chip-model-guard-lint.test.sh
+++ b/.github/scripts/tests/chip-model-guard-lint.test.sh
@@ -351,6 +351,93 @@ expect "non-contractual 'first' before **Model:** does not satisfy placement (#8
   'issue-maker first-line \*\*Model:\*\* placement' \
   noncontractual_first_before_model
 
+# --- #837: the guard compares families, not strings --------------------------
+
+# Three preamble sentences carry the family-level semantics, and each can be
+# reverted independently — so each gets its own revert-fails case. A suite that
+# only covered one would leave the other two free to regress silently.
+# None of these mutations touch an em dash: BSD sed's handling of multibyte
+# patterns is locale-dependent, and a pattern that quietly stops matching would
+# be caught by `mutate`'s no-op guard but only after wasting a debugging round.
+drop_family_comparison() {
+  mutate .claude/reference/chip-launching.md '/Compare families only/d'
+}
+
+expect "missing family-comparison rule in chip-launching fails" 1 \
+  'Missing required family-level comparison rule' \
+  drop_family_comparison
+
+drop_version_qualifier_rule() {
+  mutate .claude/reference/chip-launching.md '/old-style version qualifier/d'
+}
+
+expect "missing version-qualifier rule in chip-launching fails" 1 \
+  'version-qualifier-is-noise rule' \
+  drop_version_qualifier_rule
+
+# The literal pre-#837 regression: the match branch echoing whatever string it
+# read ({MODEL}) instead of naming the family it is running ({FAMILY}).
+revert_family_self_report() {
+  mutate .claude/reference/chip-launching.md 's/Running on {FAMILY}/Running on {MODEL}/'
+}
+
+expect "match branch reporting {MODEL} instead of {FAMILY} fails" 1 \
+  'family self-report in match branch' \
+  revert_family_self_report
+
+# A bare mention of "families" must not satisfy the comparison check — the
+# assertion has to bind to the contractual instruction, not to the word. The
+# replacement deliberately keeps "families" AND states the string-equality rule
+# this ticket removed, so the case proves strictness in both directions at once:
+# a loose /families/ check would pass here, and only the phrase check fails it.
+weaken_family_comparison() {
+  mutate .claude/reference/chip-launching.md \
+    's/Compare families only/Compare the exact strings; the families are listed as/'
+}
+
+expect "bare 'families' mention does not satisfy the family-comparison check" 1 \
+  'family-level comparison rule' \
+  weaken_family_comparison
+
+# Semantic inversion, not deletion: a reword that keeps every keyword but
+# reverses the rule is the failure mode a keyword-presence check cannot see.
+# Both cases below deliberately leave the vocabulary intact, so a looser
+# pattern would pass them and the case would prove nothing.
+
+# "old-style version qualifier" survives verbatim; only the instruction flips.
+invert_version_qualifier_rule() {
+  mutate .claude/reference/chip-launching.md \
+    's/qualifier: ignore it on either side/qualifier: honor it on both sides/'
+}
+
+expect "inverted version-qualifier rule (keyword intact) fails" 1 \
+  'version-qualifier-is-noise rule' \
+  invert_version_qualifier_rule
+
+# "Running on {FAMILY}" survives in the document but leaves the Match branch,
+# so the branch that must report a family no longer does.
+unbind_family_report_from_match_branch() {
+  mutate .claude/reference/chip-launching.md \
+    's/Match (same family): state "Running on {FAMILY} as recommended."/Match: say you are proceeding. (Docs elsewhere use "Running on {FAMILY}".)/'
+}
+
+expect "{FAMILY} outside the Match branch does not satisfy the self-report check" 1 \
+  'family self-report in match branch' \
+  unbind_family_report_from_match_branch
+
+# The third inversion: "Compare families only" survives as an exact substring
+# while the sentence goes on to re-require string equality — the precise reword
+# this ticket exists to prevent. Only the em-dash anchor rejects it; a bare
+# substring check would pass it, which is why the anchor is not cosmetic.
+readd_string_equality_after_family_rule() {
+  mutate .claude/reference/chip-launching.md \
+    's/Compare families only/Compare families only, and the exact model strings must match,/'
+}
+
+expect "family rule re-requiring exact strings (substring intact) fails" 1 \
+  'family-level comparison rule' \
+  readd_string_equality_after_family_rule
+
 if (cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1); then
   echo "ok   — real repo conformance is intact"
 else


### PR DESCRIPTION
Closes #837

## What changed

The MODEL GUARD told a launched thread to compare "the model you are actually running as" against the `**Model:**` line and stop on a difference — without ever defining what a difference *is*. String equality was the only reading available, so a chip emitted before #791 (carrying a family name plus a trailing version number) hard-stopped a thread already running that family. Right tier, real chip, full round-trip lost — and a check that cries wolf on the common case is one that gets waved through on the day it's right.

The comparison is now **family-level**:

- Families are the compared unit — `Opus`, `Sonnet`, `Haiku`, `Fable`.
- A trailing `<N>` or `<N>.<N>` after a family name is an old-style version qualifier, ignored on **either** side, never evidence of a mismatch.
- A **cross-family** difference still stops cold in both directions. Every word after `STOP.` is byte-unchanged.
- The **match** branch now reports the *family* it is running (`{FAMILY}`) instead of echoing the possibly-stale string it read.

The two branches report differently on purpose: the match branch names the family (echoing a stale qualifier would assert a version the thread isn't running), while the mismatch branch keeps reporting both models in full, because that message is a human's decision aid and the qualifier is part of what they're deciding on. Comparison is family-level on both; only reporting differs.

## Scope correction — worth reading before approving

The issue was captured on the premise that a wording change "fixes every past and future stale payload at once." **That holds for the future half only**, and the PR says so out loud rather than shipping the overclaim.

A chip copies the preamble into its `prompt` **at spawn time**. The text is frozen there. Editing `chip-launching.md` rewrites the template, not payloads already sitting in a task list — a thread launched from an old chip reads the old wording and never consults this file. Replay is the same, and correctly so: it's pinned to the chip's own prompt so the printed block and the chip never diverge.

So this **closes the class going forward** rather than draining the backlog. The existing stale chips are [Issue #838](https://github.com/auerbachb/claude-code-config/issues/838), filed during this work, which also notes that `/pm` and `/wave` chips may not be enumerable across threads at all.

This surfaced during local review, not at capture. It does not change any acceptance criterion — every AC is about the preamble, the decision record, and the lint — but it does make one of the issue's Test Plan lines unverifiable; see the note under the Test plan below.

## Lint hardening

Three `require_pattern` assertions pin the new semantics, each anchored through enough of its sentence to survive a **semantic inversion** — a reword that keeps the vocabulary but reverses the rule (`"...qualifier: honor it on both sides"`). Matching the noun alone would pass exactly that. This applies the #802 lesson: assert the instruction, not the keyword.

The scope of that promise is stated in the script: these anchors catch an inversion written *into* the asserted sentence. No line-oriented pattern can catch a contradiction planted in a different sentence of the same file, and none of them claims to.

Six new test cases — three deletions, three inversions (keyword retained, meaning reversed).

## Test plan

- [x] A `**Model:**` line carrying a version qualifier, pasted into a thread of that same family, proceeds with a one-line confirmation and no stop
- [x] A `**Model:**` line naming a *different* family still stops, reports both models, and waits — unchanged
- [x] A bare family name matching the running family is the unchanged happy path
- [x] `bash .github/scripts/chip-model-guard-lint.sh` exits 0
- [x] `bash .github/scripts/tests/chip-model-guard-lint.test.sh` passes
- [x] Each of the three new assertions fails when the preamble fix is reverted (not merely when a sentence is deleted)
- [x] Each new test case fails when the fix is reverted, rather than passing vacuously
- [x] `grep -rl "MODEL GUARD: Your very first action"` returns exactly one file — no emitter restates the rule
- [x] `rule-lint`, `merge-authority-lint`, `verbatim-block-lint`, `skill-catalog-lint` all pass; rule corpus unchanged

> **Removed from the issue's Test Plan:** "click one of the genuinely old chips still sitting in the task list and confirm it launches into work instead of stopping." That is not achievable by this or any wording change, for the frozen-payload reason above — an old chip carries the old preamble. Tracked as [Issue #838](https://github.com/auerbachb/claude-code-config/issues/838) rather than checked off on a false basis.

## Verification

```
chip-model-guard-lint    OK (6 emitters)
guard-lint tests         OK (42 fixtures)
rule-lint                OK
merge-authority-lint     OK (5 emitters)
verbatim-block-lint      OK (6 copy surfaces)
skill-catalog-lint       OK (29 commands)
rule corpus              11,680 words (unchanged — both edited docs are under .claude/reference/, not auto-loaded)
```

Revert-proof, run against a scratch tree with the original preamble and the new lint — three errors, one per assertion, no collateral:

```
Missing required family-level comparison rule (expected /Compare families only —/)
Missing required version-qualifier-is-noise rule (expected /old-style version qualifier: ignore it on either side/)
Missing required family self-report in match branch (expected /Match \(same family\): state "Running on [{]FAMILY[}]/)
```

Running the new **test suite** against that same reverted preamble fails every new case through `mutate`'s no-op guard — the fixtures cannot pass vacuously.

## Local review coverage: `none`

Both CLIs went down mid-loop; **all findings they produced were resolved before this push.**

- **CodeAnt** — HTTP 403 on both the initial run and its one permitted retry (the known undocumented daily cap, not auth; per `cr-local-review.md` no `logout`/`login` was attempted). Exit 0 with an empty `issues[]` both times — a false clean caught by the stderr check.
- **CodeRabbit CLI** — three successful reviews (9 findings, all fixed: the replay-behavior contradiction, the overclaimed scope, and the semantic-inversion hardening), then the free-OSS tier cap on the confirming pass, with a 48-minute reset.

A self-review stood in for the fourth pass. Per `cr-local-review.md` this never satisfies the merge gate — and it doesn't need to: the CodeRabbit and CodeAnt **GitHub Apps** have quotas independent of their CLIs and gate this PR normally.
