### PR TITLE
refactor(#815): slim pr-monitor-and-manage/SKILL.md — extract prose to references/

### DIFF
--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -164,6 +164,7 @@ For each PR `$N`, fetch gate + unresolved threads in parallel, then pull fields:
 
 ```bash
 GATE=$(.claude/scripts/merge-gate.sh "$N"); GATE_EXIT=$?
+GATE_BY_PR[$N]="$GATE"   # Step 5c/5d look up per-PR gate by number — never rely on loop-scoped $GATE
 MET=$(jq -r '.met' <<<"$GATE")
 MERGE_STATE=$(jq -r '.merge_state' <<<"$GATE")
 MERGEABLE=$(jq -r '.mergeable' <<<"$GATE")

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -112,7 +112,7 @@ READ_ONLY_FLEET=0
 if [[ -z "$GH_ME" || "$PMM_AUTHOR" != "$GH_ME" ]]; then READ_ONLY_FLEET=1; fi  # fail-closed
 ```
 
-When `READ_ONLY_FLEET=1`, skip every dispatch in the decision tree — display only.
+When `READ_ONLY_FLEET=1`, skip every dispatch in the decision tree — display only. Override only when the user names a specific PR in chat (per-PR, per-session).
 
 ---
 

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -167,6 +167,7 @@ GATE=$(.claude/scripts/merge-gate.sh "$N"); GATE_EXIT=$?
 MET=$(jq -r '.met' <<<"$GATE")
 MERGE_STATE=$(jq -r '.merge_state' <<<"$GATE")
 MERGEABLE=$(jq -r '.mergeable' <<<"$GATE")
+REVIEW_DECISION=$(jq -r '.review_decision' <<<"$GATE")
 CI_FAILING=$(jq -r '.ci_status.failing' <<<"$GATE")
 HUMAN_CR=$(jq -r '.human_changes_requested | join(",")' <<<"$GATE")
 STALE_BOT_CR=$(jq -r '.stale_bot_changes_requested_count // 0' <<<"$GATE")
@@ -421,3 +422,47 @@ This skill is a **parent orchestrator**. The parent rebases/force-pushes (Step 5
 - **Never use GitHub's update-branch API** for `BEHIND` — only `git rebase origin/main` + `--force-with-lease`.
 - **Stay in the worktree; never run destructive commands in the root repo** — no `git clean`, `git reset --hard`, or `.env` edits anywhere.
 - **Never merge directly** — PMM never runs `gh pr merge` itself. It lands PRs only by dispatching the full `/wrap` workflow inline after gate + AC pass. No bypass path exists.
+
+---
+
+## Subagent prompt blocks (verbatim — pass to every `phase-a-fixer` dispatch)
+
+Include these three blocks in every `phase-a-fixer` subagent prompt (Step 5c). Blocks are byte-compared by `verbatim-block-lint.sh` — do not paraphrase.
+
+```text
+SAFETY: Do NOT delete/overwrite/move/modify .env files anywhere (exception:
+.env.<example|sample|template>, case-insensitive, are safe to edit).
+Do NOT run git clean. Do NOT run destructive commands (rm -rf, rm, git checkout .,
+git stash, git reset --hard) in the root repo. Stay in your worktree.
+Do NOT commit secrets or paste raw credentials into prompts, issues, PRs, comments,
+commits, or logs. Do NOT pipe untrusted URLs into a shell or disable TLS verification.
+Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude/rules/safety.md.
+```
+
+```text
+MINDSET: The trigger is the DEFERRAL, not the word "impossible" — "I can't",
+"not a session task", "that's a deployment step", "runbook is in docs/…", and
+"I'll leave that to you to review" all fire this ladder. Walk it for ANY provider
+(gh, git, railway, vercel, …) before writing any of them: (1) check what you have
+— MCP tools, skills, CLI on disk by absolute path (/opt/homebrew/bin/<tool>;
+minimal PATH makes bare `which` lie); (2) if absent, check whether the provider
+ships one (one lookup); (3) install it when non-interactive and rails hold
+(docs-confirmed name, no curl-pipe-sh, no TLS bypass, no sudo); (4) hand off an
+/admin-merge-shaped runbook — reachable ONLY after 1–3 were walked and failed:
+name the rung that stopped you, exact commands + one-line reason, incl.
+interactive auth. If you can write the command, you can run it. Provisioning a
+generated secret via a provider CLI is allowed — the value just must never be
+echoed, committed, pasted, or logged. Your own prohibitions still win (phase-c
+uses /wrap, never gh pr merge). Full rules: .claude/rules/safety.md.
+```
+
+```text
+SKILLS: Before hand-rolling a multi-step task, check whether an existing skill
+already does this job — invoke it via the Skill tool instead of reimplementing
+from memory (only Skill-tool calls reach ~/.claude/skill-usage.log). Clear match
+-> invoke immediately. Borderline match -> note it in your exit report, then
+proceed on your own judgment; do not block waiting for an answer. No match ->
+stay silent. Never auto-invoke an authorization-carrying skill (/merge, /wrap,
+/pr-monitor-and-manage) on a fuzzy match — running one as your assigned job
+isn't a fuzzy match. Full rules: .claude/rules/skill-first.md.
+```

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -19,7 +19,9 @@ Thread-level **PR fleet manager**. This skill turns the current thread into a de
 
 This is a **set-and-monitor** command. Once invoked it acknowledges the mode, establishes a `/loop`, and at every tick reprints the fleet table and acts. The **parent thread** never edits feature code directly — it dispatches subagents to do that work — and never drifts into unrelated work.
 
-> **Scope vs `/pm`'s forgotten-PR triage (issue #657).** `/pm` runs a **one-shot** startup triage of *forgotten* PRs (last activity older than a few days), recommends close/merge, and hands merges off to `/wrap` subagents — then it stops. This skill is the opposite: **continuous** fleet monitoring on a recurring `/loop`, driving *every* open PR to merge-ready or a named hard block tick after tick. Reach for `/pm`'s triage to clear a backlog of stale PRs once at startup; reach for `/pr-monitor-and-manage` to actively babysit the whole fleet until it is clean.
+> **Scope vs `/pm`'s forgotten-PR triage (issue #657).** `/pm` runs a **one-shot** startup triage of *forgotten* PRs, recommends close/merge, and hands merges off to `/wrap` subagents — then it stops. This skill is the opposite: **continuous** fleet monitoring on a recurring `/loop`, driving *every* open PR to merge-ready or a named hard block tick after tick.
+
+Parent/subagent scope, prohibited actions, refusal template, and common misreads: `references/pmm-scope.md`.
 
 ---
 
@@ -27,126 +29,68 @@ This is a **set-and-monitor** command. Once invoked it acknowledges the mode, es
 
 ### Step 0a: Resume from pause (when `.pmm.paused_at` is set)
 
-On **every** invocation, before Step 1, check for a pause marker. If present, this invocation is a **resume** — tear down any auto-wake cron, clear the marker, merge config, and continue into normal ticking:
+On **every** invocation, before Step 1, check for a pause marker. If present, this invocation is a **resume** — tear down any auto-wake cron, clear the marker, merge config, and continue. Full resume logic (cron teardown bash, flag-merge precedence rule): `references/pmm-lifecycle.md` "Step 0a: Resume from pause".
 
 ```bash
 PAUSED_AT=$(.claude/scripts/session-state.sh --get '.pmm.paused_at' 2>/dev/null || echo null)
 if [ "$PAUSED_AT" != null ] && [ -n "$PAUSED_AT" ]; then
-  # 1. Read saved config into the $SAVED shell variable (fallback defaults if missing) —
-  #    step 3 below clears .pmm.config_at_pause in session-state, so step 4 MUST use this
-  #    already-captured $SAVED variable, never re-read .pmm.config_at_pause from
-  #    session-state after step 3 has run (it will be null by then).
   SAVED=$(.claude/scripts/session-state.sh --get '.pmm.config_at_pause' 2>/dev/null || echo '{}')
-  # 2. Delete auto-wake cron (fail-closed — see pr-monitor-and-manage-wake Step 3)
-  # 3. Clear pause marker + reset pmm_idle_streak=0 + set pmm_active=true
-  #    + null .pmm_digest and .pmm_row_digest (atomic batch) — the digest reset
-  #    forces Step 4's full table on the first post-resume tick (condition a/b)
-  # 4. Merge flags: explicit $ARGUMENTS override $SAVED (the step-1 variable, not
-  #    session-state — that field is already cleared by step 3 at this point)
+  # tear down auto-wake cron, clear pause marker, reset pmm_idle_streak=0 + pmm_active=true
+  # (full bash in references/pmm-lifecycle.md)
   echo "[PMM] Resuming from pause (paused_at=$PAUSED_AT) — flags on this invocation override saved config."
 fi
 ```
 
-Resume logic is shared with `/pr-monitor-and-manage-wake` — see `.claude/skills/pr-monitor-and-manage-wake/SKILL.md` Step 2 (cron teardown) and Step 3 (marker clear + loop re-arm). When resuming via re-invoking this skill (not `-wake`), apply the precedence rule in Step 1 after parsing `$ARGUMENTS`: any flag explicitly supplied on this invocation wins; omitted flags inherit from `.pmm.config_at_pause`. After resume, continue with Step 1 using the merged config and run a full discovery tick at **base** cadence (not the widened backoff cadence).
+After any resume (and on the **first** invocation in a thread), null the table digests — `session-state.sh --set '.pmm_digest=null' --set '.pmm_row_digest=null'` — so Step 4's first tick always prints the full table.
 
-A stale marker left by a killed session is safely reconciled here: the next `/pr-monitor-and-manage` invocation reads it, resumes (or the user runs `/pmm-stop`), and re-runs discovery from scratch.
-
-On the **first** invocation in a thread (and after any resume), null the table digests — `session-state.sh --set '.pmm_digest=null' --set '.pmm_row_digest=null'` — so Step 4's first tick always prints the full table, and acknowledge the mode up front so the constraints are explicit and survive context compaction:
+Acknowledge mode up front so the constraints survive context compaction:
 
 > **PR-fleet-manager mode active.** My only job in **this parent thread** is to watch and manage your open PRs as a fleet — rediscover them each tick, print a status table, and dispatch rebase / parallel `phase-a-fixer` subagents (fix work, including merge conflicts) / sequential `/wrap` (merge-ready) per the decision tree. Merge-ready PRs are landed autonomously via inline `/wrap` dispatch (unless `--confirm-merges` is set). I will not edit feature code **directly in this thread**, start issues, or do unrelated work here — but I **will** dispatch subagents that edit code, resolve conflicts, fix findings, push, and reply/resolve threads.
-
-### Parent scope vs Subagent scope
-
-| Scope | Role | Allowed | Disallowed |
-|-------|------|---------|------------|
-| **Parent (this thread)** | Fleet orchestrator | Discover PRs, classify state, dispatch subagents, aggregate exit reports, update the fleet table, decide next tick; git rebase/force-push for `BEHIND` (Step 5a); stale-bot dismiss + re-trigger (Steps 5b/5b′); inline `/wrap` for merge-ready PRs | Direct code edits; direct git beyond discovery/rebase/dismiss; direct merges (`gh pr merge`); starting new issues; unrelated work |
-| **Subagents (spawned per PR)** | Fix worker | Edit files, resolve merge conflicts, fix CR/CI findings, push commits, reply to threads, resolve bot threads — one PR each, per `.claude/rules/subagent-orchestration.md` and #509 (parallel subagents) | Modify branch protection; dismiss human reviews; bypass SAFETY rules |
-
-Spawn pattern reference: `.claude/rules/subagent-orchestration.md` (Phase A fixer / Phase C merger). Every spawn includes the verbatim `SAFETY:` block from `.claude/rules/safety.md`.
-
-**Prohibited for the parent thread (refuse and redirect):**
-
-- Writing or editing **feature code directly** — dispatch a `phase-a-fixer` subagent instead (merge conflicts, CR findings, CI failures are all dispatch cases, not refusal cases).
-- Invoking `/start-issue`, `/prompt`, or spawning subagents for **new work unrelated to the discovered fleet**.
-- Creating issues or PRs (other than the follow-ups `/wrap` itself creates on merge).
-- Any task unrelated to managing the discovered PR fleet.
-
-**Refusal template** when asked for genuinely out-of-scope *parent* work (not dispatchable fleet fix work):
-
-> That's outside PR-fleet-manager mode. I'm keeping this thread focused on monitoring your open PRs. Start a separate thread (e.g. `/start-issue`) for that work — say `/pmm-stop` first if you want me to stop monitoring here.
-
-### Common misreads / Anti-patterns
-
-> If you catch yourself telling the user "I can't edit code in this thread" as a reason to **stop** rather than **dispatch**, that's wrong — the parent doesn't edit code, but its subagents do, and that's the whole point. Merge conflicts, CR findings, and CI failures are all handled by spawning fix subagents, not by refusing or hard-blocking pre-dispatch.
-
-The parent is orchestration-only with respect to source edits: the only direct writes it performs are git rebase/force-push (Step 5a), stale-bot review dismissal + owning-bot re-trigger (Steps 5b/5b′), and the bounded mutations that `phase-a-fixer` subagents and `/wrap` already own. Fix work — including merge-conflict resolution — is delegated to parallel `phase-a-fixer` subagents (`.claude/agents/phase-a-fixer.md`); merge work stays sequential via `/wrap`. The parent never reimplements fix/merge logic beyond the shared dismiss/re-trigger helpers that `/fixpr` also uses.
 
 ---
 
 ## Step 1: Parse arguments + identify the fleet (every tick)
 
-Parse `$ARGUMENTS` (re-parse every tick — a `/loop` re-invocation passes the same args, but treat them as the source of truth, never a cached value):
+Parse `$ARGUMENTS` (re-parse every tick — a `/loop` re-invocation passes the same args, treat them as the source of truth, never a cached value):
 
-- `--author <login>` — whose PRs to manage. **Default:** the current authenticated user via `gh api user --jq .login`.
-- `--repo <owner/repo>` — which repo. **Default:** the current repo.
+- `--author <login>` — whose PRs to manage. **Default:** current authenticated user via `gh api user --jq .login`.
+- `--repo <owner/repo>` — which repo. **Default:** current repo. `--repo` scopes discovery and reads; per-PR helpers and git actions operate on the **current checkout**. If `--repo` names a different repo than the current checkout, **stop and reconcile**. Full constraint: `references/pmm-scope.md`.
 - `--cadence Nm` — base poll interval. **Default:** `5m`.
-- `--max-parallel N` — max concurrent `phase-a-fixer` subagents for fix work. **Default:** `3`. Excess PRs needing fixes wait for a slot to free on a subsequent tick.
+- `--max-parallel N` — max concurrent `phase-a-fixer` subagents. **Default:** `3`.
 - `--idle-pause-after N` — consecutive idle ticks before auto-pause. **Default:** `3`.
-- `--auto-wake` — when set, register an hourly `CronCreate` job at pause time that lightweight-scans for fleet changes. **Default:** off.
+- `--auto-wake` — register an hourly `CronCreate` job at pause time. **Default:** off.
 - `--auto-wake-cadence Nm` — cadence for the auto-wake cron. **Default:** `60m`.
 - `--confirm-merges` — require an explicit user confirmation before each `/wrap` merge dispatch. **Default:** off (invocation is authorization). This flag only adds a prompt before the `/wrap` dispatch — it never overrides hard stops (`BLOCKED:*` verdicts, gate failures, AC failures). Safety checks in `/wrap` still apply.
 
-> **`--repo` constraint (load-bearing).** `--repo` scopes **discovery** (`gh pr list`) and the GraphQL/REST reads. But the per-PR helpers (`merge-gate.sh`, `pr-issue-ref.sh`, `cr-review-hourly.sh`, `dismiss-stale-bot-changes.sh`) and all git actions (rebase, force-push, fix subagents, `/wrap`) operate on the **current checkout** — they resolve the repo via `gh repo view`, not a flag. So managing a repo requires running this skill from a worktree of **that** repo. If `--repo` names a repo other than the current checkout, **stop and reconcile** (same multi-repo hazard guard as `cr-github-review.md`) rather than acting against the wrong repo.
-
-> **Invoking-repo scope (issue #687).** The `--repo` constraint above already keeps
-> discovery + actions in one repo's lane. The one shared-state read that spans repos is
-> the global `.active_agents` array; PMM already scopes its own work by `id` prefix
-> (`pmm-fix-`) and treats foreign entries as read-only. When a broader, repo-scoped view
-> of session state is needed, prefer `session-state.sh --session-view` (drops other repos'
-> PRs and their agents) over `--get .`. Cross-repo fleet management is never implicit —
-> point it at one repo per invocation.
-
 ```bash
-# Defaults
 PMM_AUTHOR=""; PMM_REPO=""; PMM_CADENCE="5m"; PMM_MAX_PARALLEL=3
 PMM_IDLE_PAUSE_AFTER=3; PMM_AUTO_WAKE=false; PMM_AUTO_WAKE_CADENCE="60m"
 PMM_CONFIRM_MERGES=false
-# (parse $ARGUMENTS into the vars above; bare flags override defaults)
+# parse $ARGUMENTS into the vars above; bare flags override defaults
 
-# When resuming from pause (Step 0a), merge saved config into flags omitted on
-# this invocation — explicit $ARGUMENTS win. Detect omission via $ARGUMENTS
-# substring (or parse-time *_EXPLICIT tracking).
+# When resuming (Step 0a), merge saved config: explicit $ARGUMENTS win
 if [ -n "${SAVED:-}" ] && [ "$SAVED" != "{}" ]; then
   [[ "$ARGUMENTS" != *"--author"* ]]            && PMM_AUTHOR=$(jq -r '.author // empty' <<<"$SAVED")
   [[ "$ARGUMENTS" != *"--repo"* ]]              && PMM_REPO=$(jq -r '.repo // empty' <<<"$SAVED")
   [[ "$ARGUMENTS" != *"--cadence"* ]]           && PMM_CADENCE=$(jq -r '.cadence // "5m"' <<<"$SAVED")
   [[ "$ARGUMENTS" != *"--max-parallel"* ]]      && PMM_MAX_PARALLEL=$(jq -r '.max_parallel // 3' <<<"$SAVED")
   [[ "$ARGUMENTS" != *"--idle-pause-after"* ]]  && PMM_IDLE_PAUSE_AFTER=$(jq -r '.idle_pause_after // 3' <<<"$SAVED")
-  [[ "$ARGUMENTS" != *"--auto-wake-cadence"* ]]  && PMM_AUTO_WAKE_CADENCE=$(jq -r '.auto_wake_cadence // "60m"' <<<"$SAVED")
-  if [[ "$ARGUMENTS" != *"--auto-wake"* ]]; then
-    PMM_AUTO_WAKE=$(jq -r '.auto_wake // false' <<<"$SAVED")
-  fi
-  [[ "$ARGUMENTS" != *"--confirm-merges"* ]]    && \
-    PMM_CONFIRM_MERGES=$(jq -r '.confirm_merges // false' <<<"$SAVED")
+  [[ "$ARGUMENTS" != *"--auto-wake-cadence"* ]] && PMM_AUTO_WAKE_CADENCE=$(jq -r '.auto_wake_cadence // "60m"' <<<"$SAVED")
+  [[ "$ARGUMENTS" != *"--auto-wake"* ]]         && PMM_AUTO_WAKE=$(jq -r '.auto_wake // false' <<<"$SAVED")
+  [[ "$ARGUMENTS" != *"--confirm-merges"* ]]    && PMM_CONFIRM_MERGES=$(jq -r '.confirm_merges // false' <<<"$SAVED")
 fi
 
 if [ -z "$PMM_AUTHOR" ]; then
   PMM_AUTHOR=$(gh api user --jq .login 2>/dev/null || true)
-  if [ -z "$PMM_AUTHOR" ]; then
-    echo "WARNING: gh api user failed — pass --author <login> explicitly"; exit 1
-  fi
+  [ -z "$PMM_AUTHOR" ] && { echo "WARNING: gh api user failed — pass --author <login> explicitly"; exit 1; }
 fi
-
-# Current checkout is the source of truth for per-PR actions.
 CURRENT_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 OWNER_REPO="${PMM_REPO:-$CURRENT_REPO}"
 if [ -n "$PMM_REPO" ] && [ "$PMM_REPO" != "$CURRENT_REPO" ]; then
-  echo "[PMM] STOP: --repo $PMM_REPO != current checkout $CURRENT_REPO. Per-PR actions"
-  echo "      (rebase, fix subagents, /wrap) run against the checkout. Re-run from a worktree of"
-  echo "      $PMM_REPO, or drop --repo to manage $CURRENT_REPO."; exit 1
+  echo "[PMM] STOP: --repo $PMM_REPO != current checkout $CURRENT_REPO. Re-run from a worktree of $PMM_REPO."; exit 1
 fi
 OWNER="${OWNER_REPO%/*}"; REPO="${OWNER_REPO#*/}"
-REPO_FLAG=(--repo "$OWNER_REPO")   # explicit so discovery + reads always agree
+REPO_FLAG=(--repo "$OWNER_REPO")
 echo "[PMM] fleet = author:$PMM_AUTHOR repo:$OWNER_REPO cadence:$PMM_CADENCE max-parallel:$PMM_MAX_PARALLEL idle-pause-after:$PMM_IDLE_PAUSE_AFTER auto-wake:$PMM_AUTO_WAKE confirm-merges:$PMM_CONFIRM_MERGES"
 ```
 
@@ -154,7 +98,7 @@ echo "[PMM] fleet = author:$PMM_AUTHOR repo:$OWNER_REPO cadence:$PMM_CADENCE max
 
 ## Step 2: Discover open PRs (every tick — NEVER cache across ticks)
 
-**Rediscover the fleet on every single tick.** A PR may have merged, closed, or been opened since the last tick — a cached list silently rots. Always re-run `gh pr list`:
+**Rediscover the fleet on every single tick.** A PR may have merged, closed, or been opened since the last tick — a cached list silently rots.
 
 ```bash
 PMM_LIMIT=500   # high cap so a real fleet is never silently truncated
@@ -164,349 +108,165 @@ PR_NUMS=$(jq -r '.[].number' <<<"$PR_LIST")
 PR_COUNT=$(jq 'length' <<<"$PR_LIST")
 ```
 
-> **No silent truncation.** `gh pr list` caps results at `--limit`; with `--author` it goes through the Search API (hard ceiling ~1000). Use a high `--limit` (500 above) and **warn** when the fleet hits it: if `PR_COUNT == PMM_LIMIT`, print "Showing $PMM_LIMIT PRs — fleet may be larger; results may be incomplete" and, if you genuinely expect >500 open PRs for one author, page via `gh api`/GraphQL instead. A default 30 (the `gh` default) or a small fixed cap would silently drop PRs — never rely on it.
+Warn when `PR_COUNT == PMM_LIMIT` (silent truncation risk). **Empty fleet → immediate Pause** (Step 8) with reason `empty fleet` — no 3-tick wait.
 
-**Empty fleet → immediate Pause.** If `PR_COUNT == 0`, jump to **Pause** (Step 8) with reason `empty fleet`. Do not keep polling an empty fleet — pause immediately with no 3-tick wait.
+**Authorship guard (issue #733).** PMM dispatches writes — so it manages only PRs **you** authored. `--author` defaults to the authenticated user.
 
-> **Authorship guard (issue #733, `safety.md`).** `/pr-monitor-and-manage` dispatches **writes** — `/fixpr` (rebase/force-push), `/wrap` (merge), review triggers — so it manages only PRs **you** authored. `--author` defaults to the authenticated user; discovery is already `--author "$PMM_AUTHOR"`-scoped. If `$PMM_AUTHOR` is not the authenticated user, the fleet is **read-only**: print the status table for context (AC6) and **dispatch nothing**.
-> ```bash
-> GH_ME=$(gh api user --jq .login 2>/dev/null || echo "")
-> READ_ONLY_FLEET=0
-> if [[ -z "$GH_ME" || "$PMM_AUTHOR" != "$GH_ME" ]]; then READ_ONLY_FLEET=1; fi  # fail-closed
-> ```
-> When `READ_ONLY_FLEET=1`, skip every dispatch in the decision tree (rebase, `phase-a-fixer`, `/wrap`) — display only. The per-PR helpers (`polling-state-gate.sh --ensure-session`, `merge-gate.sh`, `admin-merge.sh`) also refuse non-author PRs as a fail-safe. Override only when the user names a specific PR in chat (per-PR, per-session).
+```bash
+GH_ME=$(gh api user --jq .login 2>/dev/null || echo "")
+READ_ONLY_FLEET=0
+if [[ -z "$GH_ME" || "$PMM_AUTHOR" != "$GH_ME" ]]; then READ_ONLY_FLEET=1; fi  # fail-closed
+```
+
+When `READ_ONLY_FLEET=1`, skip every dispatch in the decision tree — display only.
 
 ---
 
 ## Step 2.5: Aggregate prior-tick subagent exit reports (every tick — BEFORE classification)
 
-Before Step 3 re-classifies the fleet, process any **PMM-owned** `phase-a-fixer` subagents that completed (or failed) since the last tick. Read `session-state.json`'s `active_agents` and match entries where `phase == "A"`, `id` starts with `pmm-fix-`, and `task` references PMM fix work. **Foreign Phase A entries** (any other `id` sharing the same `active_agents` array) are intentionally out of scope here — PMM has no exit report to parse for them and must never remove or mutate state it does not own; they drain solely via Step 5e's poll-based mechanism (disappearance / terminal `status` / staleness timeout).
+Before Step 3 re-classifies the fleet, process any **PMM-owned** `phase-a-fixer` subagents (`id` starts with `pmm-fix-`) that completed since the last tick.
 
-**Initialize `EXHAUSTION_RESPAWN_PRS='[]'` at the start of this step, every tick — never carry it over.** Like `GATE_BY_PR`, it is a plain in-memory variable scoped to the current tick's execution (each `/loop` re-invocation is a fresh run of this skill from Step 1), not a durable field in `session-state.json` — so there is nothing to reset from a *prior* tick's memory, but the step must still start from an explicitly empty list rather than an implicit/undefined one, so a tick with zero exhaustion outcomes never accidentally inherits stale entries from a bug elsewhere in this skill's execution.
+**Initialize `EXHAUSTION_RESPAWN_PRS='[]'` at the start of this step, every tick — never carry it over.**
 
-**Load persisted hard blocks at tick start** so a `blocked` merge-conflict outcome from a prior tick is not re-dispatched when Step 3 still sees `mergeable == CONFLICTING`:
-
-```bash
-PERSISTED_HARD_BLOCK=$(.claude/scripts/session-state.sh --get '.pmm_hard_block // {}' 2>/dev/null || echo '{}')
-HARD_BLOCK_JSON="$PERSISTED_HARD_BLOCK"   # map PR number → reason; survives across ticks
-```
-
-When Step 2.5 (or Step 5e) adds a PR to `HARD_BLOCK[]`, also persist it: `.claude/scripts/session-state.sh --set ".pmm_hard_block.\"$N\"=\"$REASON\""`. Clear the entry only when the user explicitly approves a respawn or the PR merges/closes (Step 3 sets `VERDICT=gone` → `--set ".pmm_hard_block.\"$N\"=null"`).
-
-For each completed subagent, run steps 1-3 **unconditionally first** (cleanup must finish before any respawn, so a replacement's fresh record can never be clobbered by the completed agent's own removal):
-
-1. **Parse the Structured Exit Report** from its output (`EXIT_REPORT` block per `.claude/reference/exit-report-format.md`). No exit report = silent failure — check GitHub for the PR's current HEAD and surface `failed` in the Subagent column.
-2. **Clean up the Phase A worktree.** `phase-a-fixer` subagents run with `isolation: "worktree"` (Step 5c) — the worktree persists whenever the subagent made changes (only a no-op agent gets auto-cleaned). If the subagent's completion result names a worktree path, remove it: `git worktree remove <path> --force`; on failure, fall back to `git worktree prune`. Do this for every outcome (success, exhaustion, crash) — a leftover child worktree keeps the PR's branch checked out and blocks the parent's later `git checkout`/rebase (Step 5a) or another dispatch for the same PR.
-3. **Remove this agent's own `active_agents` record and clear its `pmm_in_flight[N]` lock — for every outcome, including crash and exhaustion.** Scope the removal to this specific completed entry (`id == "pmm-fix-$N"`), not a blanket `pr`+`phase` filter — a blanket filter would also delete a sibling Phase A row for the same PR belonging to a different (non-PMM) workflow sharing `active_agents`. **Always read → filter with `jq` → pass the evaluated JSON array as the `--set` value, never a raw filter expression** — `session-state.sh` rejects a known array field like `active_agents` if the write would leave it holding anything but an array (issue #625's field-type contract), which is exactly what an unevaluated filter string would do:
-   ```bash
-   CURRENT_AGENTS=$(.claude/scripts/session-state.sh --get '.active_agents' 2>/dev/null || echo null)
-   [ "$CURRENT_AGENTS" = "null" ] && CURRENT_AGENTS='[]'
-   FILTERED_AGENTS=$(jq --arg id "pmm-fix-$N" '[.[] | select(.id != $id)]' <<<"$CURRENT_AGENTS")
-   .claude/scripts/session-state.sh --set ".active_agents=$FILTERED_AGENTS" \
-     --set ".pmm_in_flight.\"$N\"=null"
-   ```
-   This must be a real read-filter-write, not a no-op comment — Step 3's concurrency cap and idempotency check both count live entries in this array.
-4. **Branch on OUTCOME** (steps 1-3 above are already done, so this branch never races the cleanup):
-   - `pushed_fixes` or `no_findings` → verify push SHA matches `HEAD_SHA` in the report (`gh pr view N --json commits --jq '.commits[-1].oid'`). Verify handoff file exists (resolve path: `handoff-state.sh [--owner-repo owner/repo] --path N`) with `phase_completed: "A"`. When OUTCOME is `pushed_fixes`, run **Step 5b dismiss helper + Step 5b′ owning-bot re-trigger** on `#N` immediately (same contract as `/fixpr` Steps 3a/3b — a push without dismissal leaves obsolete bot `CHANGES_REQUESTED` on old SHAs and the gate never clears). Step 5e's inline completion path (item 2) runs the same pair when a subagent exits mid-tick.
-   - `blocked` → add `#N` to `HARD_BLOCK[]` with reason from the exit report (e.g. `conflicts(needs-human)` for unresolvable merge conflicts). **Persist** the same reason to `pmm_hard_block` in `session-state.json` (see tick-start load above). Report once and drop from the actionable fleet this tick — the subagent already attempted resolution; do not re-dispatch silently.
-   - `exhaustion` → **do not launch the replacement inline here.** Step 2.5 runs before Step 3 every tick, so `GATE_BY_PR`/pre-fetched `FINDINGS_JSON` (both populated in Step 3) are not available yet — Step 5c's full spawn pattern needs them. Instead, rely on step 3 above already clearing this PR's `active_agents`/`pmm_in_flight[N]` entries: the PR falls through into Step 3's classification with a clean slate later in this same tick, and if the underlying condition (CI failing, unresolved threads, stale bot review, merge conflicts) still holds, Step 3 naturally re-verdicts it `fixpr` and Step 5c's normal per-tick spawn respawns it — using this tick's freshly-computed `GATE_BY_PR`/`FINDINGS_JSON`. This still satisfies `subagent-orchestration.md`'s 60s Token/Turn Exhaustion Protocol SLA: Step 3 and Step 5c run seconds later in the same continuous tick execution, not on a separate `/loop` cycle. **Record `$N` into `EXHAUSTION_RESPAWN_PRS` for this tick** — Step 3's cap check (item 2) must never let this PR lose its slot to a competing fresh `fixpr` PR, since `subagent-orchestration.md` treats exhaustion-with-handoff respawn as mandatory, not slot-competitive. Report to user.
-   - Missing/corrupt report, or a crash with no handoff file → mark `failed` and add `#N` to `HARD_BLOCK[]` with reason `crashed(needs-approval)`. **Persist** the same reason to `pmm_hard_block` in `session-state.json`. **Do NOT leave it eligible for silent re-dispatch** — `subagent-orchestration.md`'s Phase Transition Autonomy table requires user permission before respawning a crashed/no-handoff subagent. Reported once and dropped from the actionable fleet this tick (Step 3's `HARD_BLOCK[]` handling — it does not force-stop the fleet); the user can explicitly approve a respawn.
-5. **Record per-PR outcome** in a `SUBAGENT_STATUS[N]` map (`complete` / `failed`) for the Step 4 table.
-
-PMM does **not** launch Phase B/C after Phase A — it only fixes and pushes. Step 5e's monitor posture borrows `monitor-mode.md`'s orchestration-only discipline but explicitly skips `phase-protocols.md`'s Phase Completion Protocols (which would otherwise auto-launch Phase B). The next tick re-classifies each PR on its new SHA (may become `waiting`, `wrap`, or `fixpr` again).
-
-**Handoff file isolation:** each PR uses its own scoped handoff file (`~/.claude/handoffs/{owner}/{repo}/pr-{N}-handoff.json`, resolved via `handoff-state.sh --owner-repo ... --path N`; flat legacy path `~/.claude/handoffs/pr-{N}-handoff.json` during migration window). Parallel subagents never share a handoff path — confirm no cross-PR or cross-repo handoff references before spawning.
-
----
-
-## Step 3: Gather per-PR state + classify (compute verdicts — NO actions)
-
-**Refresh `HARD_BLOCK_JSON` immediately before the per-PR loop** so Step 2.5 `blocked`/`crashed` persists from earlier in this same tick are visible to the decision tree (the Step 2.5 tick-start load is stale once Step 2.5 writes new entries):
+**Load persisted hard blocks at tick start:**
 
 ```bash
 HARD_BLOCK_JSON=$(.claude/scripts/session-state.sh --get '.pmm_hard_block // {}' 2>/dev/null || echo '{}')
 ```
 
-This step performs no PR mutations or dispatches: it gathers state, computes verdicts, and may persist orchestration bookkeeping (e.g. Step 3.6's `.pmm_merge_holds`). PR mutations and dispatches happen in **Step 5**, after the heartbeat/table prints (Step 4). This ordering is required so the classification is always visible *before* any long-running dispatch.
+For each completed PMM-owned subagent, run steps 1-3 **unconditionally first** (cleanup before any respawn decision):
 
-For **each** PR number, gather state. Run the per-PR fetches **in parallel across PRs** (one batch of background jobs, then collect), since they are independent network calls.
+1. Parse the Structured Exit Report. No exit report → surface `failed` in the Subagent column.
+2. Clean up the Phase A worktree: `git worktree remove <path> --force` (or `git worktree prune` on failure).
+3. Remove this agent's `active_agents` record and clear its `pmm_in_flight[N]` lock (scope to `id == "pmm-fix-$N"`, not a blanket filter).
 
-For a single PR `$N` (with `$HEADREF` = its `headRefName` from the Step 2 `$PR_LIST`):
+Then branch on OUTCOME:
+- `pushed_fixes` / `no_findings` → verify push SHA; run Step 5b dismiss helper + Step 5b′ owning-bot re-trigger.
+- `blocked` → add `#N` to `HARD_BLOCK[]`, persist to `pmm_hard_block`, report and drop.
+- `exhaustion` → record `$N` in `EXHAUSTION_RESPAWN_PRS`; Step 3/5c handles respawn this same tick.
+- Missing/corrupt report or crash → `HARD_BLOCK[crashed(needs-approval)]`, persist. **Do NOT re-dispatch silently** — user permission required.
+
+PMM does **not** launch Phase B/C after Phase A — Step 5e explicitly skips `phase-protocols.md`'s Phase Completion Protocols.
+
+Full protocol detail (handoff file isolation, tick-start refresh pattern): `references/pmm-act.md`.
+
+---
+
+## Step 3: Gather per-PR state + classify (compute verdicts — NO actions)
+
+Refresh `HARD_BLOCK_JSON` before the per-PR loop:
 
 ```bash
-# Gate verdict — single source of truth for merge readiness, CI, merge_state,
-# review_decision, human_changes_requested, stale_bot_changes_requested_count.
-GATE=$(.claude/scripts/merge-gate.sh "$N"); GATE_EXIT=$?
-GATE_BY_PR[$N]="$GATE"   # retain per-PR — Step 5c/5d look up THIS PR's gate by
-                          # number rather than relying on a loop-scoped $GATE,
-                          # which is only valid for whichever PR Step 3 last
-                          # iterated and goes stale/wrong once other steps
-                          # iterate their own PR lists.
-# Linked issue for the Issue column (exit 1 = no link, expected).
-ISSUE=$(.claude/scripts/pr-issue-ref.sh "$N" 2>/dev/null || true)
-# Unresolved review threads (GraphQL — covers every bot/human author).
-UNRESOLVED=$(gh api graphql -f query='
-  query($owner:String!,$repo:String!,$n:Int!){
-    repository(owner:$owner,name:$repo){
-      pullRequest(number:$n){
-        reviewThreads(first:100){ nodes { isResolved } } } } }' \
-  -F owner="$OWNER" -F repo="$REPO" -F n="$N" \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length' \
-  2>/dev/null || echo "?")
+HARD_BLOCK_JSON=$(.claude/scripts/session-state.sh --get '.pmm_hard_block // {}' 2>/dev/null || echo '{}')
 ```
 
-Pull the fields the table and decision tree need out of `$GATE`:
+For each PR `$N`, fetch gate + unresolved threads in parallel, then pull fields:
 
 ```bash
+GATE=$(.claude/scripts/merge-gate.sh "$N"); GATE_EXIT=$?
 MET=$(jq -r '.met' <<<"$GATE")
-MERGE_STATE=$(jq -r '.merge_state' <<<"$GATE")          # CLEAN|BEHIND|BLOCKED|...
-MERGEABLE=$(jq -r '.mergeable' <<<"$GATE")              # MERGEABLE|CONFLICTING|UNKNOWN
-REVIEW_DECISION=$(jq -r '.review_decision' <<<"$GATE")  # APPROVED|CHANGES_REQUESTED|REVIEW_REQUIRED
+MERGE_STATE=$(jq -r '.merge_state' <<<"$GATE")
+MERGEABLE=$(jq -r '.mergeable' <<<"$GATE")
 CI_FAILING=$(jq -r '.ci_status.failing' <<<"$GATE")
-CI_INPROG=$(jq -r '.ci_status.in_progress' <<<"$GATE")
-CI_PASSING=$(jq -r '.ci_status.passing' <<<"$GATE")
 HUMAN_CR=$(jq -r '.human_changes_requested | join(",")' <<<"$GATE")
 STALE_BOT_CR=$(jq -r '.stale_bot_changes_requested_count // 0' <<<"$GATE")
+UNRESOLVED=$(gh api graphql ... --jq '[...select(.isResolved==false)]|length' 2>/dev/null || echo "?")
 ```
 
 ### Decision tree (per PR — first match wins → assign `VERDICT`)
 
-Read `merge_state` / `mergeable` **literally** from the gate JSON. **Do NOT infer `BEHIND` from `BLOCKED`** — `BLOCKED` also covers missing checks/reviews, not just behind-base. Only the literal `BEHIND` triggers a rebase.
+Read `merge_state` / `mergeable` **literally** from the gate JSON. **Do NOT infer `BEHIND` from `BLOCKED`.**
 
 | Condition (checked in order) | `VERDICT` | Acted on in Step 5 as |
 |------------------------------|-----------|------------------------|
-| PR in persisted `pmm_hard_block` (prior-tick `blocked` / `crashed` — load at Step 2.5) | `BLOCKED:<reason>` | **Hard block** → reported, dropped; **overrides** `mergeable == CONFLICTING` so Step 5c does not re-dispatch silently |
-| `human_changes_requested` non-empty (human CR on HEAD) | `BLOCKED:human(@login)` | **Hard block** → reported, dropped from actionable fleet (name each login; never auto-dismiss) |
-| `mergeable == CONFLICTING` | `fixpr` (`merge-conflict`) | Spawn `phase-a-fixer` subagent tasked with `/merge-conflict` workflow (Step 5c) — resolves and pushes; never auto-merge |
+| PR in persisted `pmm_hard_block` (prior-tick `blocked` / `crashed`) | `BLOCKED:<reason>` | **Hard block** → reported, dropped; overrides `mergeable == CONFLICTING` |
+| `human_changes_requested` non-empty (human CR on HEAD) | `BLOCKED:human(@login)` | **Hard block** → reported, dropped (name each login; never auto-dismiss) |
+| `mergeable == CONFLICTING` | `fixpr` (`merge-conflict`) | Spawn `phase-a-fixer` subagent for `/merge-conflict` workflow (Step 5c) |
 | `merge_state == BEHIND` | `rebase` | Rebase + force-push + stale-bot dismissal (Step 5a/5b) |
 | `CI_FAILING > 0` **or** `UNRESOLVED > 0` | `fixpr` (`has-recoverable-blockers`) | Spawn `phase-a-fixer` subagent (Step 5c) |
-| `MET == false` **and** (`STALE_BOT_CR > 0` **or** `REVIEW_DECISION == CHANGES_REQUESTED` with no human CR) | `fixpr` (`has-recoverable-blockers`) | Step 5b′ (when `STALE_BOT_CR > 0` only) dismisses stale bot reviews + re-triggers the owning bot, re-gates; spawn `phase-a-fixer` (Step 5c) when fix work remains (`CI_FAILING > 0`, `UNRESOLVED > 0`, or fresh bot CR on HEAD) |
-| `MET == true` (clean review on HEAD + CI green + 0 unresolved threads + no blockers) | `wrap` | Dispatch `/wrap` sequentially (Step 5d) |
-| Otherwise (CI in-progress, reviewer genuinely pending, `REVIEW_REQUIRED` with no bot signal yet, `UNKNOWN`) | `waiting` | No-op — reviewer/CI owns the next move |
+| `MET == false` **and** (`STALE_BOT_CR > 0` **or** `REVIEW_DECISION == CHANGES_REQUESTED` with no human CR) | `fixpr` (`has-recoverable-blockers`) | Step 5b′ (when `STALE_BOT_CR > 0` only) dismisses stale bot reviews + re-triggers owning bot; spawn `phase-a-fixer` (Step 5c) when fix work remains |
+| `MET == true` (clean review on HEAD + CI green + 0 unresolved + no blockers) | `wrap` | Dispatch `/wrap` sequentially (Step 5d) |
+| Otherwise (CI in-progress, reviewer pending, `REVIEW_REQUIRED`, `UNKNOWN`) | `waiting` | No-op |
 
-`merge-gate.sh` exit `3` (PR gone — merged/closed between Step 2 and now) → `VERDICT=gone`, clear persisted block (`.claude/scripts/session-state.sh --set ".pmm_hard_block.\"$N\"=null"`), drop from fleet. When the user explicitly approves respawn of a `crashed(needs-approval)` or `conflicts(needs-human)` PR, clear the same `pmm_hard_block` key before dispatch. Exit `2`/`4` (tooling/network) → `VERDICT=error` (do not act; retry next tick).
+`merge-gate.sh` exit `3` → `VERDICT=gone`, clear persisted block. Exit `2`/`4` → `VERDICT=error` (retry next tick).
 
-**Accumulate `VERDICTS_JSON` as each PR is classified — this is what Step 5.0's pre-flight gone/error skip reads.** Without this, `VERDICTS_JSON` stays an implicit empty object, the skip check never matches, and pre-flight runs against merged/errored PRs it should have skipped:
+**Initialize `VERDICTS_JSON='{}'` once, before the per-PR loop — never via `${VERDICTS_JSON:-{}}`.** A brace-containing default terminates at its first literal `}` and appends a stray trailing brace, breaking every subsequent `jq` from the second PR onward.
 
-**Initialize `VERDICTS_JSON='{}'` once, before the per-PR loop — never via a `${VERDICTS_JSON:-{}}` default.** A brace-containing parameter-expansion default terminates at its **first literal `}`**, so once the variable holds real content that form expands to the JSON *plus a stray trailing brace* (`{"618":{"verdict":"wrap"}}` + `}`) and every subsequent `jq` in the loop fails on invalid input. The bug only shows up from the second PR onward, which is exactly when it is hardest to spot.
+**Collect hard blocks for reporting, but do not force-stop the fleet.** A fleet of only hard-blocked/waiting PRs converges to auto-Pause via the idle counter (Steps 6/7).
 
-```bash
-VERDICTS_JSON='{}'   # once, before the loop — plain expansion everywhere below
+**Pre-fetch findings for fix subagents (verdict `fixpr` only)** — stash in `FINDINGS_JSON[N]` for Step 5c.
 
-# ... per PR:
-TAG=""
-if [[ "$VERDICT" == "fixpr" && "$MERGEABLE" == "CONFLICTING" ]]; then
-  TAG="merge-conflict"
-fi
-if [[ -n "$TAG" ]]; then
-  VERDICTS_JSON=$(jq --arg n "$N" --arg v "$VERDICT" --arg tag "$TAG" \
-    '.[$n] = {verdict: $v, tag: $tag}' <<<"$VERDICTS_JSON")
-else
-  VERDICTS_JSON=$(jq --arg n "$N" --arg v "$VERDICT" '.[$n] = {verdict: $v}' <<<"$VERDICTS_JSON")
-fi
-```
+**Refine `fixpr` verdicts** for concurrency + idempotency: in-flight check → `awaiting fix subagent`; cap check → `queued (cap)`. Exhaustion respawn PRs hold slots unconditionally (tier 1); remaining slots go to fresh `fixpr` PRs by PR number (tier 2).
 
-**Collect hard blocks for reporting, but do not force-stop the fleet.** Push every PR with a `BLOCKED:*` verdict onto a `HARD_BLOCK[]` list (with its reason). These PRs are **reported once and dropped from the actionable fleet** for this tick — they do not trigger Stop & Clean Exit. A fleet of only hard-blocked/waiting PRs converges to auto-Pause via the idle counter (Step 6/7). The `rebase`/`fixpr`/`wrap` verdicts are executed in Step 5.
-
-**Pre-fetch findings for fix subagents (verdict `fixpr` only):** while gathering state, also fetch review findings from the three endpoints so Step 5c can embed them in each subagent prompt without a second round-trip:
-
-```bash
-# Per PR with fixpr verdict — stash in FINDINGS_JSON[N]
-gh api "repos/$OWNER/$REPO/pulls/$N/reviews?per_page=100"
-gh api "repos/$OWNER/$REPO/pulls/$N/comments?per_page=100"
-gh api "repos/$OWNER/$REPO/issues/$N/comments?per_page=100"
-```
-
-Filter to actionable bot findings (`coderabbitai[bot]`, `cursor[bot]`, `greptile-apps[bot]`, `codeant-ai[bot]`, `graphite-app[bot]`). Also record the **reviewer classification** (`cr`, `bugbot`, or `greptile`) from `reviewer-of.sh` or gate JSON for the subagent prompt.
-
-### Refine `fixpr` verdicts for concurrency + idempotency (read-only, still Step 3)
-
-Step 5c's parallel-dispatch decisions (skip-if-in-flight, cap slots) are pure reads against `session-state.json` — compute them here, **before Step 4 prints the table**, so the heartbeat never shows a stale `fixpr` for a PR that is actually already in flight or waiting on a slot.
-
-For every PR whose base verdict is `fixpr`:
-
-1. **In-flight check.** Refine to `awaiting fix subagent` if a **blocking** Phase A `active_agents` entry exists for this PR (per Step 5's shared gate idiom — foreign entries past `PMM_LOCK_STALE_SECS` with no progress evidence are non-blocking), OR if `pmm_in_flight[N]` has an active lock for the same PR **that is not stale** — apply the same `PMM_LOCK_STALE_SECS` (default 3600s) staleness rule Step 5d uses for `/wrap` locks. A stale lock (e.g. a `wrap` lock left over from a crashed parent, on a PR now reclassified `fixpr`) is broken here too, not just in Step 5d — otherwise a stale non-`phase-a-fixer` lock can block fix dispatch forever with no path to clear it.
-2. **Cap check.** Among the PRs still `fixpr` after step 1, count currently active **PMM-spawned** fix subagents (`id` prefixed `pmm-fix-` — excludes Phase A agents spawned by other workflows sharing the same `active_agents` array) and compute remaining slots:
-
-   ```bash
-   ACTIVE_COUNT=$(jq '[.[] | select(.phase == "A" and (.status != "complete" and .status != "failed")
-     and ((.id // "") | startswith("pmm-fix-")))] | length' \
-     <<<"$(.claude/scripts/session-state.sh --get '.active_agents' 2>/dev/null || echo '[]')")
-   SLOTS=$(( PMM_MAX_PARALLEL - ACTIVE_COUNT ))
-   (( SLOTS < 0 )) && SLOTS=0
-   ```
-
-   Allocate the `$SLOTS` available slots in two tiers, never by plain PR-number order alone: **tier 1** — every PR in `EXHAUSTION_RESPAWN_PRS` (populated by Step 2.5 this tick) keeps verdict `fixpr` unconditionally, even if it exceeds `$SLOTS` — an exhaustion-with-handoff respawn is mandatory per `subagent-orchestration.md`, not slot-competitive, so it must never lose to a fresh PR. **Tier 2** — remaining slots (`$SLOTS` minus tier-1 count, floored at 0) go to the rest of the still-`fixpr` PRs by PR number order, for determinism. Anything past that refines to `queued (cap)`. (A tick with more exhaustion respawns than `$PMM_MAX_PARALLEL` will transiently run over the nominal cap — acceptable, since these are already-approved in-flight fixes being continued, not new work.)
-
-Store the refined verdict per PR (`fixpr`, `awaiting fix subagent`, or `queued (cap)`) for both Step 4's table and Step 5c's dispatch loop — Step 5c dispatches only PRs still refined to `fixpr` and does not repeat this check.
+Full per-row rationale, VERDICTS_JSON accumulation, findings pre-fetch, refinement-pass bash: `references/pmm-classify.md`.
 
 ---
 
 ## Step 3.6: Overlap-aware merge sequencing (read-only, still pre-action — issue #756)
 
-First-ready-first-merged is backwards when one PR's diff dwarfs its siblings' in a shared file: every small PR that lands first forces the big one into another conflict round. Before Step 4 prints and Step 5d dispatches, compute a **merge order** over the fleet so the largest footprint in a contested file lands first and the smaller ones wait.
-
-This step is **side-effect-free** — `merge-sequence.sh` reads `pulls/{N}/files` and prints a plan; it never merges, rebases, or comments. Mechanism, state machine, and rationale: `.claude/reference/merge-sequencing.md`.
+Side-effect-free: `merge-sequence.sh` reads file-overlap and prints a plan; it never merges, rebases, or comments. Full implementation (bash blocks, SEQ_RC handling, hold-persistence contract): `references/pmm-classify.md`.
 
 ```bash
-# Prior tick's hold state — this is what makes stall detection work across ticks.
 PRIOR_HOLDS=$(.claude/scripts/session-state.sh --get '.pmm_merge_holds // {}' 2>/dev/null || echo '{}')
-
-# Flatten Step 3's VERDICTS_JSON ({"<n>":{verdict,tag}}) to {"<n>":"<verdict>"},
-# then overwrite each entry with the REFINED verdict where Step 3's refinement
-# pass produced one (`awaiting fix subagent`, `queued (cap)`, `held(#A)` from a
-# prior tick). Pass the WHOLE fleet, not just the `wrap` PRs: the planner needs a
-# non-`wrap` anchor's verdict to tell "progressing" from "hard-blocked", and that
-# is exactly what decides whether its followers hold or release.
-VERDICTS_MAP=$(jq -c 'map_values(.verdict)' <<<"$VERDICTS_JSON")
-HEADS_MAP='{}'   # plain init — never a ${HEADS_MAP:-{}} default (see Step 3 above)
-for N in $PR_NUMS; do
-  VERDICTS_MAP=$(jq -c --arg n "$N" --arg v "${REFINED_VERDICT[$N]:-}" \
-    'if $v == "" then . else .[$n] = $v end' <<<"$VERDICTS_MAP")
-  HEADS_MAP=$(jq -c --arg n "$N" --arg sha "$(jq -r '.head_sha // ""' <<<"${GATE_BY_PR[$N]}")" \
-    'if $sha == "" then . else .[$n] = $sha end' <<<"$HEADS_MAP")
-done
-
-# Sequence only PRs that still exist. A PR classified `gone` (merged/closed
-# between Step 2 and now) would 404 in the planner and, without --skip-missing,
-# take the WHOLE fleet's plan down with exit 3. Filter the known-gone ones here,
-# and pass --skip-missing so a PR that merges during this very step is demoted to
-# an excluded_prs[] entry instead of failing the run.
-SEQ_PRS=$(for N in $PR_NUMS; do
-  V=$(jq -r --arg n "$N" '.[$n] // ""' <<<"$VERDICTS_MAP")
-  [[ "$V" == "gone" || "$V" == "error" ]] || echo "$N"
-done | tr '\n' ',' | sed 's/,$//')
-
-SEQ=""; SEQ_RC=1
-if [[ -n "$SEQ_PRS" ]]; then
-  SEQ=$(.claude/scripts/merge-sequence.sh --prs "$SEQ_PRS" --skip-missing \
-    --verdicts "$VERDICTS_MAP" --heads "$HEADS_MAP" --holds "$PRIOR_HOLDS")
-  SEQ_RC=$?
-fi
+SEQ=$(.claude/scripts/merge-sequence.sh --prs "$SEQ_PRS" --skip-missing \
+  --verdicts "$VERDICTS_MAP" --heads "$HEADS_MAP" --holds "$PRIOR_HOLDS")
+SEQ_RC=$?
 ```
 
-`HEADS_MAP` comes from the gate JSON you already fetched, so passing it saves one `gh pr view` per PR. Both maps are plain in-memory tick state — initialize `HEADS_MAP='{}'` at the top of this step every tick, never carried across ticks.
+`SEQ_RC` `0` (≥1 hold or batch), `1` (no overlap — every PR reads `merge`), `2`/`3`/`4` (errors — sequencing disabled this tick, prior holds intact).
 
-`SEQ_RC` is `0` when sequencing applies (≥1 hold or batch), `1` when the fleet has no overlap (plan still printed, every PR reads `merge`, dispatch unchanged), and `2`/`3`/`4` on usage/not-found/gh errors. **On any error exit, log one line and continue the tick with sequencing disabled** — treat every PR as `merge`. A planner failure must never block the fleet; the merge gate is still the authority on whether anything lands.
+Refine `wrap` → `held(#A)` / `batch(#A)` / `merge` from `SEQ`'s per-PR action. **Persist holds only on `SEQ_RC` 0 or 1** — an error exit leaves `$SEQ` empty/partial; writing null `.holds` would wipe prior tick's stall counters.
 
-**Refine the verdicts once more** from `SEQ`'s per-PR action, for PRs currently verdicted `wrap`:
-
-| `plan[N].action` | Refined verdict | Step 5d does |
-|------------------|-----------------|--------------|
-| `merge` | `wrap` (unchanged) | dispatch normally |
-| `hold` | `held(#A)` | skip this tick — `#A` is landing ahead of it |
-| `batch` | `batch(#A)` | dispatch in this tick's single batch window |
-| `not_merge_ready` | unchanged | n/a — it was never a merge candidate |
-
-**Persist the returned hold state — only on a successful run** (`SEQ_RC` `0` or `1`) so the next tick's stall counter advances. **Never persist after an error exit:** `$SEQ` is empty or partial then, `.holds` evaluates to `null`, and writing it would *wipe* the prior tick's stall counters — turning a transient planner failure into a silent reset that re-holds already-released PRs:
-
-```bash
-if [[ "$SEQ_RC" -eq 0 || "$SEQ_RC" -eq 1 ]]; then
-  NEW_HOLDS=$(jq -c '.holds // {}' <<<"$SEQ")
-  .claude/scripts/session-state.sh --set ".pmm_merge_holds=$NEW_HOLDS"
-else
-  echo "[PMM] merge-sequence.sh failed (exit $SEQ_RC) — sequencing disabled this tick; prior holds left intact"
-  SEQ=""   # every PR falls through to `merge`; Step 4 prints no annotation
-fi
-```
-
-Evaluate the `jq` first and pass the resulting JSON as the value — never a raw filter expression (`handoff-files.md` field-type contract). Keep `SEQ` for Step 4's annotation and Step 5d's dispatch order; an empty `SEQ` means "no sequencing this tick", which every consumer below already treats as `merge`.
-
-> **Authorship is enforced inside the planner** (`pr-authorship.sh`, fail-closed): a collaborator's PR touching the same file is excluded before grouping, so it can never become an anchor holding your PRs behind a merge you have no authority to perform. Under `READ_ONLY_FLEET=1` this step still runs — the plan is display-only context, like the rest of the table.
+> **Authorship is enforced inside the planner** (`pr-authorship.sh`, fail-closed): a collaborator's PR touching the same file is excluded so it can never anchor your PRs behind a merge you have no authority to perform.
 
 ---
 
-## Step 4: Heartbeat + status table (EVERY tick, BEFORE any action — table only when it carries news)
+## Step 4: Heartbeat + status table (EVERY tick, BEFORE any action)
 
-A heartbeat prints **every tick**, **before** Step 5 runs any rebase or dispatch — but the **full table only when something changed or is about to happen** (issue #773; `monitor-mode.md` one-line default). Compute two digests **here** (Step 6 reuses and persists them):
+A heartbeat prints **every tick**, **before** Step 5. Compute two digests (Step 6 reuses and persists them):
 
-- `FLEET_TUPLE_SORTED` — Step 3's per-PR state tuples `(number, head_sha, merge_state, review_decision, ci_failing_count, unresolved_threads)`, sorted by PR number, where `ci_failing_count` is Step 3's `CI_FAILING` (`.ci_status.failing` from the gate JSON). Drives backoff (Step 6) and quiet-tick detection.
-- `ROW_TUPLE_SORTED` — everything the table *displays* per PR: `(number, issue_ref, merge_state, conflicting_flag, review_decision, ci_summary, unresolved_threads, refined_verdict, subagent_cell)`, sorted by PR number. Catches display-only changes the state tuple misses (verdict refinements like `rate-limited` → `waiting`, subagent `spawned` → `working`, `mergeable` flips) so a quiet tick can never mask them.
+- `FLEET_TUPLE_SORTED` — `(number, head_sha, merge_state, review_decision, ci_failing_count, unresolved_threads)` per PR, sorted by PR number. Drives backoff and quiet-tick detection.
+- `ROW_TUPLE_SORTED` — everything the table *displays* per PR. Catches display-only changes the state tuple misses.
 
 ```bash
 DIGEST=$(printf '%s' "$FLEET_TUPLE_SORTED" | sha256sum | awk '{print $1}')
 ROW_DIGEST=$(printf '%s' "$ROW_TUPLE_SORTED" | sha256sum | awk '{print $1}')
-PREV=$(.claude/scripts/session-state.sh --get '.pmm_digest' 2>/dev/null || echo null)       # read-only here —
-ROW_PREV=$(.claude/scripts/session-state.sh --get '.pmm_row_digest' 2>/dev/null || echo null) # Step 6 owns the persist
+PREV=$(.claude/scripts/session-state.sh --get '.pmm_digest' 2>/dev/null || echo null)
+ROW_PREV=$(.claude/scripts/session-state.sh --get '.pmm_row_digest' 2>/dev/null || echo null)
 TS=$(TZ='America/New_York' date +'%a %b %-d %I:%M %p ET')
 echo "[$TS] PMM tick — $PR_COUNT PR(s) in fleet (author:$PMM_AUTHOR)"
 ```
 
-Print the **full table** (below the lead line) when ANY of:
+Print the **full table** when any of: (a) first tick / post-resume (digests are null); (b) `DIGEST != PREV` or `ROW_DIGEST != ROW_PREV`; (c) any PR's verdict is actionable (`rebase`, `fixpr`, `wrap`, `batch(#A)`); (d) Step 2.5 processed subagent outcomes or `HARD_BLOCK[]` gained an entry; (e) Step 3.6 held or batched anything.
 
-- (a) this is the first tick of a fresh invocation (Step 0 mode entry) or the first tick after a resume (Step 0a) — both null `.pmm_digest`/`.pmm_row_digest`, so (b) also fires mechanically;
-- (b) `DIGEST != PREV` or `ROW_DIGEST != ROW_PREV` (or either previous value is null);
-- (c) any PR's verdict this tick is actionable — `rebase`, `fixpr`, `wrap`, or `batch(#A)` — so the classification is always visible before Step 5 acts;
-- (d) Step 2.5 processed any subagent outcome, or `HARD_BLOCK[]` gained a new entry this tick;
-- (e) Step 3.6 held or batched anything (the merge-sequence annotation must stay visible).
+**Quiet tick** (none of a–e): one line: `[$TS] PMM tick — N PR(s) (author:x) — no change (#N1 #N2; hard-blocked: #N3 human-CR; queued (cap): #N4)`.
 
-**Quiet tick** (none of a–e): append `— no change` plus the PR numbers to the lead line; when `HARD_BLOCK[]` is non-empty append the standing blocks with reasons, and when any PR is refined `queued (cap)` or `held(#A)` append those too (e.g. `… (author:x) — no change (#101 #102; hard-blocked: #99 human-CR; queued (cap): #103)`); print **only that line** — no table. **New** hard blocks, gate failures, and terminations always get the full table on the tick they appear ((b)/(c)/(d)); already-reported blocks stay visible via the hard-blocked suffix on every quiet line — never silently dropped. Terminal snapshots (Pause / Stop & Clean Exit) always print the full table regardless of quiet-tick status.
-
-| Issue | PR | State | Reviews | CI | Unresolved Threads | Verdict | Subagent |
-|-------|----|-------|---------|----|--------------------|---------|----------|
-| #<issue or —> | #<N> | <merge_state> | <review_decision> | <pass>/<fail>/<prog> | <count> | <VERDICT from Step 3> | <SUBAGENT_STATUS> |
-
-- **Issue** — from `pr-issue-ref.sh`, or `—` when the PR body has no closing keyword.
-- **State** — literal `merge_state` (`CLEAN`/`BEHIND`/`BLOCKED`/`UNKNOWN`); when `mergeable == CONFLICTING`, append `(CONFLICTING)` to the State cell so the conflict signal is visible (CONFLICTING is a `mergeable` value, not a `merge_state` value).
-- **Reviews** — literal `review_decision` (`APPROVED`/`CHANGES_REQUESTED`/`REVIEW_REQUIRED`).
-- **CI** — `passing`/`failing`/`in_progress` counts from the gate.
-- **Unresolved Threads** — count of `isResolved == false` (or `?` if the GraphQL fetch failed).
-- **Verdict** — the Step 3 verdict: `rebase`, `fixpr`, `wrap`, `waiting`, `awaiting fix subagent`, `queued (cap)`, `rate-limited`, `BLOCKED:human(@x)`, `BLOCKED:conflicts(needs-human)`, `gone`, `error`, plus Step 3.6's merge-sequencing refinements `held(#A)` and `batch(#A)`.
-- **Subagent** — per-PR agent state for fix work: `—` (not spawned / no fix dispatch this tick), `dispatched (merge-conflict)` (conflict-resolution fixer spawned this tick — transitions to `spawned`/`working`/`complete`/`failed` as the subagent runs), `spawned`, `working`, `complete`, `failed`, `deferred(foreign-agent)` (Step 5d/5e deferral gate closed because a foreign Phase A entry blocks this PR), `foreign-agent-stale` (Step 5e staleness timeout fired on a silent foreign entry — gate treated as drained). Populated from `active_agents` + Step 2.5 outcomes (PMM-owned only) + Step 5e foreign-drain polling. Merge-ready `/wrap` dispatches show `—` (wrap is parent-inline, not a subagent).
-
-A PR merged this tick is reported via the per-tick `merged #N` line (Step 5d) and then naturally disappears from the fleet on the next `gh pr list` discovery — no table row lingers.
-
-**Merge-sequence annotation (part of the table block — print it whenever Step 3.6 held or batched anything).** Emit `SEQ`'s `summary` verbatim on the line directly under the table. It names the held PRs, the anchor they are waiting on, and **the shared file(s)** — which is what makes the ordering visible rather than mysterious:
-
-```bash
-jq -e '[.plan[] | select(.action == "hold" or .action == "batch")] | length > 0' >/dev/null <<<"$SEQ" \
-  && echo "Merge sequence: $(jq -r .summary <<<"$SEQ")"
-```
-
-```text
-Merge sequence: holding #101, #102 until #100 lands — they share `.claude/skills/pm/SKILL.md`
-```
-
-Omit the line entirely when nothing is held or batched — a fleet with no overlap gets no annotation and no behavioural change. When `SEQ`'s `excluded_prs[]` is non-empty, add one short line naming the count and reason (e.g. "1 PR excluded from sequencing: not yours") so a collaborator's PR silently sitting out is visible rather than invisible.
-
-Only after the heartbeat (and the table, when any of a–e fired) is printed does Step 5 execute the actions. A quiet tick has no actionable verdicts by construction (condition c); if Step 5.0 pre-flight nonetheless acts on a quiet tick (draft flip, reviewer trigger), its own timestamped output lines report it.
+Table columns: Issue | PR | State | Reviews | CI | Unresolved Threads | Verdict | Subagent. Full column definitions and merge-sequence annotation: `references/pmm-classify.md`.
 
 ---
 
 ## Step 5: Act on the verdicts (after the table)
 
-**Blocking Phase A entry (shared gate idiom — Steps 3, 5a, 5d, 5e, 6):** An `active_agents` row with `phase == "A"` and `status` not in `{complete, failed}` blocks rebase, `/wrap`, and fix-dispatch gates unless drained. **PMM-owned** entries (`id` starts with `pmm-fix-`) are blocking until Step 2.5/5e drains them via exit report. **Foreign** entries (any other `id`) are blocking only while NOT stale: apply `PMM_LOCK_STALE_SECS` (default 3600s) to `last_seen_at` (or `launched`), and when the window is exceeded **and** there is no live progress evidence on that PR (HEAD SHA unchanged, no new bot/CI activity since the timestamp), treat the entry as **non-blocking** — PMM never mutates it, but stops deferring on it. All gate checks below use this idiom consistently.
+**Shared gate idiom:** a blocking Phase A `active_agents` row blocks rebase, `/wrap`, and fix-dispatch gates. PMM-owned (`pmm-fix-` prefix) — blocking until drained by Step 2.5/5e. Foreign — blocking only while not stale (`PMM_LOCK_STALE_SECS` default 3600s with no progress evidence). All gate checks use this idiom consistently.
 
-**Track actions this tick** for idle detection (Step 6). Initialize `TICK_HAD_ACTION=false` and `MERGED_THIS_TICK='[]'` at the start of Step 5; set `TICK_HAD_ACTION=true` whenever any of the following fire for any PR: rebase + force-push (Step 5a), stale-bot dismissal (Step 5b or 5b′), explicit owning-bot re-trigger from Step 5b′ (or post-subagent Step 2.5/5e), `phase-a-fixer` spawn (Step 5c), `/wrap` dispatch (Step 5d), or a reviewer trigger from `pr-preflight.sh` that actually posts (non-no-op output). Append PR numbers to `MERGED_THIS_TICK` when `/wrap` successfully merges a PR (Step 5d). Waiting, gone, error, `BLOCKED:*`, and no-op pre-flight do **not** set the flag.
-
-Iterate the fleet and execute each PR's Step 3 verdict. Skip PRs in `HARD_BLOCK[]` — they were reported in Step 4's table and are dropped from actionable work. `waiting`, `gone`, and `error` verdicts do **no** work here.
+Initialize `TICK_HAD_ACTION=false` and `MERGED_THIS_TICK='[]'` at Step 5 start. Skip PRs in `HARD_BLOCK[]`; `waiting`/`gone`/`error` verdicts do no work.
 
 ### Step 5.0: Pre-flight per discovered PR (before any dispatch — issue #493)
 
-**Before the per-PR decision tree acts, run the shared `pr-preflight.sh` once per discovered PR.** This flips a draft PR you own to ready and engages all four conditionally-triggered reviewers (CodeAnt, CodeRabbit, Cursor, Graphite) on each PR's current SHA, so the fleet is review-ready before any rebase / fix subagent / `/wrap` dispatch. It is the **same** script `/fixpr` Step 0c and `/babysit-pr` T1b use — PMM never re-implements the draft flip or trigger logic.
+Run shared `pr-preflight.sh` once per discovered PR (skip `gone`/`error`). Flips draft PRs to ready and engages all four conditionally-triggered reviewers on the current HEAD SHA. Same script `/fixpr` Step 0c and `/babysit-pr` T1b use — PMM never reimplements draft-flip or trigger logic.
 
 ```bash
 PREFLIGHT_SH=""
 for c in "$HOME/.claude/skills-worktree/.claude/scripts/pr-preflight.sh" \
-         "$HOME/.claude/scripts/pr-preflight.sh" \
-         ".claude/scripts/pr-preflight.sh"; do
+         "$HOME/.claude/scripts/pr-preflight.sh" ".claude/scripts/pr-preflight.sh"; do
   [ -x "$c" ] && { PREFLIGHT_SH="$c"; break; }
 done
-
-# Strictly per-PR — pr-preflight.sh takes a single PR and holds NO cross-PR
-# state, so a draft flip on PR A can never leak into PR B's reviewer-trigger
-# logic. Run it in a per-PR loop over the fleet; skip verdicts gone/error.
 for N in $PR_NUMS; do
-  # Skip PRs whose Step 3 verdict was `gone` or `error` — calling pr-preflight.sh
-  # on them would cause avoidable API failures and noise.
   _verdict=$(jq -r --arg n "$N" '.[$n].verdict // ""' <<<"$VERDICTS_JSON" 2>/dev/null || true)
-  if [[ "$_verdict" == "gone" || "$_verdict" == "error" ]]; then continue; fi
+  [[ "$_verdict" == "gone" || "$_verdict" == "error" ]] && continue
   if [ -n "$PREFLIGHT_SH" ]; then
-    PF_OUT=$("$PREFLIGHT_SH" "$N") || echo "[PMM] pr-preflight.sh #$N exited non-zero (exit $?) — continuing"
-    echo "$PF_OUT"   # timestamped action lines per PR feed the heartbeat
-    # Stash the per-PR PREFLIGHT_SUMMARY for the Step 7 summary (keyed by PR).
-    # Step 5b′ also reads it to avoid re-triggering a bot pre-flight just poked
-    # on this same tick (issue #576).
+    PF_OUT=$("$PREFLIGHT_SH" "$N") || echo "[PMM] pr-preflight.sh #$N exited non-zero — continuing"
+    echo "$PF_OUT"
     PF_SUMMARY_BY_PR[$N]=$(sed -n 's/^PREFLIGHT_SUMMARY: //p' <<<"$PF_OUT" | tail -1)
   else
     echo "[PMM] pr-preflight.sh not found — skipping draft/reviewer pre-flight for #$N"
@@ -514,435 +274,62 @@ for N in $PR_NUMS; do
 done
 ```
 
-`pr-preflight.sh` is idempotent (a PR already ready with all four reviewers engaged **on the current HEAD SHA** is a no-op printing `Pre-flight clean — proceeding`). Since #576 it judges engagement against HEAD, not PR-wide history, so a reviewer whose only artifact sits on a superseded commit — the normal state after any rebase or force-push — is re-triggered rather than silently counted as present. It is rate-cap safe (it gates `@coderabbitai full review` on `cr-review-hourly.sh` — `--check` + atomic `--record-explicit` — and skips only CR when the cap is hit, still posting the other three), never flips another user's intentional draft, and never triggers Greptile. Because the pre-flight may have just triggered reviewers, the verdicts computed in Step 3 are from *before* the triggers; the next tick re-discovers and re-classifies on the post-trigger state — the rebase / fix subagent / `/wrap` actions below still run on this tick's verdicts.
+`pr-preflight.sh` is idempotent, rate-cap safe, strictly per-PR, never triggers Greptile.
 
-### Step 5a: Rebase (verdict `rebase`, i.e. `merge_state == BEHIND`)
+### Step 5a: Rebase (verdict `rebase`)
 
-**Skip if any Phase A agent is still active for this PR — not just PMM's own.** `BEHIND` is checked before `fixpr` in the decision tree (Step 3), so a PR with a fixer subagent still running from a prior tick can flip to verdict `rebase` if main advanced mid-fix — checking out that branch here would collide with that subagent's own worktree (git refuses to check out the same branch twice) and race its push. This check must match Step 3's in-flight check exactly (same reasoning: two Phase A fixers on one PR is risky regardless of which system spawned them) — checking only `pmm-fix-` entries would miss a foreign (non-PMM) Phase A agent sharing the same `active_agents` array, since `BEHIND`-verdict PRs never go through Step 3's `fixpr`-only refinement pass and so get no other protection. Before rebasing, check for any **blocking** Phase A `active_agents` entry for this PR (per Step 5's shared gate idiom — includes PMM-owned and non-stale foreign entries; stale foreign entries with no progress evidence are non-blocking), or an active `pmm_in_flight[N]` lock **that is not stale** (same `PMM_LOCK_STALE_SECS`, default 3600s, staleness rule as Step 3's in-flight check — a stale lock is broken here too, not treated as blocking); if found, skip this PR this tick (verdict stays `rebase` for the table, but no action runs) — it becomes rebase-eligible once the agent completes and its worktree is cleaned up (Step 2.5 for PMM's own fixers; foreign agents clean up under their own workflow's rules). For foreign Phase A agents, PMM detects completion via Step 5e's poll/staleness signal (entry disappearance, terminal `status`, or `PMM_LOCK_STALE_SECS` timeout with no progress evidence) rather than waiting on cleanup or an exit report it cannot observe.
-
-**Use `git rebase origin/main` + `git push --force-with-lease` — NEVER GitHub's update-branch API.** The API creates bot merge commits that block CI; `auto-update-prs.yml` was removed for exactly this reason.
-
-```bash
-# Pre-flight: never rebase on a dirty tree. This skill runs from a worktree;
-# stay in it and never touch the root repo (safety.md).
-if [ -n "$(git status --porcelain)" ]; then
-  echo "[PMM] PR #$N BEHIND but working tree dirty — skipping rebase, surfacing"; # verdict downgrades to error
-else
-  git fetch origin main --quiet
-  git checkout "$HEADREF" 2>/dev/null || git switch "$HEADREF"
-  if git rebase origin/main; then
-    git push --force-with-lease
-    REBASED_SHA=$(git rev-parse HEAD)
-    # then run Step 5b (dismiss stale bot reviews on the new SHA)
-  else
-    git rebase --abort
-    echo "[PMM] PR #$N rebase hit conflicts — routing to merge-conflict fixer dispatch (Step 5c)"
-    # Override Step 3's `rebase` verdict so Step 5c includes this PR in the *same* tick
-    # (Step 5c only dispatches PRs whose refined verdict is `fixpr`, not `rebase`):
-    VERDICTS_JSON=$(jq --arg n "$N" '.[$n] = {verdict: "fixpr", tag: "merge-conflict", refined: "fixpr"}' <<<"$VERDICTS_JSON")
-    REFINED_VERDICT[$N]="fixpr"
-    # Do NOT add to HARD_BLOCK[] — spawn a phase-a-fixer subagent tasked with the
-    # /merge-conflict workflow instead. Step 5c dispatch runs later this tick.
-  fi
-fi
-```
-
-If the checkout/rebase cannot proceed (branch not present locally, multiple worktrees), surface the PR as `error` and leave it for the user rather than guessing.
+Skip if any blocking Phase A agent is active for this PR (shared gate idiom). Use `git rebase origin/main` + `--force-with-lease` — **never GitHub's update-branch API**. Rebase abort → override verdict to `fixpr (merge-conflict)` and dispatch Step 5c in the same tick. Full bash and dirty-tree check: `references/pmm-act.md`.
 
 ### Step 5b: Dismiss stale bot reviews after a force-push
 
-Run only after Step 5a actually force-pushed. Uses the **shared dismiss helper** below; **note the macOS bash 3.x blocker**:
+Run after Step 5a actually force-pushed. Shared dismiss helper (with macOS bash-4 shim and inline REST fallback). Full helper bash: `references/pmm-act.md`.
 
-> ⚠️ **`dismiss-stale-bot-changes.sh` uses `mapfile` (bash 4+).** On macOS the default `/bin/bash` is 3.2, where `mapfile` is undefined and the script aborts. Until that script is fixed to be 3.x-safe, invoke it through a bash 4+ shim **or** use the inline REST fallback below. Linux CI/cloud agents ship bash 4+, so the direct call works there.
+### Step 5b′: Stale bot `CHANGES_REQUESTED` recovery (verdict `fixpr`, `STALE_BOT_CR > 0`)
 
-**Shared dismiss helper** (Steps 5b, 5b′, Step 2.5 post-push, and Step 5e inline completion all call this — pass `$N`, optional `$DISMISS_MSG` defaulting to `"Superseded by rebase onto main"` for 5b or `"Superseded — review was on a stale commit"` for 5b′/post-push):
+Run before Step 5c for `fixpr` PRs with `STALE_BOT_CR > 0`. Dismiss stale reviews + re-trigger owning bot (skip if Step 5.0 pre-flight already triggered this reviewer this tick — issue #576 guard). Re-gate: `MET == true` → treat as `wrap`; `CI_FAILING > 0 or UNRESOLVED > 0` → proceed to Step 5c; otherwise → `waiting`. Full bash (reviewer case-switch, CR hourly cap check): `references/pmm-act.md`.
 
-```bash
-DISMISS=""
-for c in "$HOME/.claude/skills-worktree/.claude/scripts/dismiss-stale-bot-changes.sh" \
-         "$HOME/.claude/scripts/dismiss-stale-bot-changes.sh" \
-         ".claude/scripts/dismiss-stale-bot-changes.sh"; do
-  [ -x "$c" ] && { DISMISS="$c"; break; }
-done
+### Step 5c: Parallel `phase-a-fixer` dispatch (verdict `fixpr`)
 
-BASH4=""; for b in bash /opt/homebrew/bin/bash /usr/local/bin/bash; do
-  v=$("$b" -c 'echo ${BASH_VERSINFO[0]}' 2>/dev/null || echo 0); [ "${v:-0}" -ge 4 ] && { BASH4="$b"; break; }
-done
-
-DISMISS_MSG="${DISMISS_MSG:-Superseded by rebase onto main}"
-
-if [ -n "$DISMISS" ] && [ -n "$BASH4" ]; then
-  "$BASH4" "$DISMISS" "$N"
-else
-  # Inline REST fallback (POSIX-safe, no mapfile) — same allowlist + semantics
-  # as the script: dismiss only Bot-authored CHANGES_REQUESTED whose commit_id
-  # != current HEAD. NEVER touches human reviews.
-  HEAD_SHA=$(gh pr view "$N" --json headRefOid --jq .headRefOid)
-  gh api --paginate "repos/$OWNER/$REPO/pulls/$N/reviews?per_page=100" | jq -s 'add // []' \
-   | jq -r --arg sha "$HEAD_SHA" '
-       ["coderabbitai[bot]","cursor[bot]","greptile-apps[bot]","codeant-ai[bot]","graphite-app[bot]"] as $allow
-       | .[] | select(.state=="CHANGES_REQUESTED")
-       | select((.commit_id//"")!="" and .commit_id!=$sha)
-       | select((.user.type//"")=="Bot")
-       | select(.user.login as $l | $allow|index($l)) | .id' \
-   | while read -r rid; do
-       [ -n "$rid" ] && gh api -X PUT \
-         "repos/$OWNER/$REPO/pulls/$N/reviews/$rid/dismissals" \
-         -f message="$DISMISS_MSG" >/dev/null 2>&1 \
-         && echo "[PMM] dismissed stale bot review_id=$rid on #$N"
-     done
-fi
-```
-
-### Step 5b′: Stale bot `CHANGES_REQUESTED` recovery (verdict `fixpr` — issue #514)
-
-Run **before Step 5c** for every PR whose Step 3 verdict is `fixpr` (or refined `fixpr`) **and** `STALE_BOT_CR > 0` from the tick's gate JSON. Do **not** run when the only bot signal is a **fresh** `CHANGES_REQUESTED` on the current HEAD (`STALE_BOT_CR == 0`) — that PR needs Step 5c fix work, not dismissal/re-trigger. This is **independent of whether Step 5a rebased** — Step 5b only runs after a force-push; without 5b′ a PR blocked *only* by a stale bot review would spawn a no-op `phase-a-fixer` every tick forever.
-
-**Dismiss** — run the shared dismiss helper with `DISMISS_MSG="Superseded — review was on a stale commit"`. Idempotent (already-`DISMISSED` counts as success). The helper only dismisses reviews whose `commit_id` ≠ current HEAD; never touches fresh bot CR on HEAD.
-
-**Re-trigger the owning bot** — post an **explicit** trigger for the owning reviewer on the current HEAD. Resolve via `.claude/scripts/reviewer-of.sh "$N"` (same mapping as `pr-preflight.sh`'s `reviewer_trigger()`).
-
-> **Since #576, Step 5.0's pre-flight already re-triggers a bot whose only activity is on a superseded commit** — which is exactly this step's situation (the review just dismissed was on a stale SHA). This step therefore **skips** any reviewer pre-flight already triggered on this tick; without that guard both would post for the same PR in the same tick, and for CodeRabbit that burns two of the ≤2/PR/hour explicit-trigger slots at once. It still runs when pre-flight was unavailable, skipped the PR, or reported the reviewer `already-present` / `skipped-rate-cap` — the case this step was written for.
-
-```bash
-REVIEWER=$(.claude/scripts/reviewer-of.sh "$N" 2>/dev/null || echo unknown)
-
-# Skip when Step 5.0's pre-flight already triggered this reviewer this tick
-# (issue #576) — it re-triggers stale-SHA bots itself now, so a second post here
-# would be a duplicate (and would double-spend CodeRabbit's per-PR cap).
-PF_KEY=""
-case "$REVIEWER" in
-  cr) PF_KEY="coderabbit" ;;   # gate-side name → pre-flight reviewer key
-  bugbot) PF_KEY="cursor" ;;
-  graphite) PF_KEY="graphite" ;;
-esac
-if [ -n "$PF_KEY" ] && [ -n "${PF_SUMMARY_BY_PR[$N]:-}" ] \
-   && [ "$(jq -r --arg k "$PF_KEY" '.reviewers[$k].status // ""' <<<"${PF_SUMMARY_BY_PR[$N]}" 2>/dev/null)" = "triggered" ]; then
-  echo "[PMM] pre-flight already re-triggered $REVIEWER on #$N this tick — skipping duplicate explicit trigger"
-  REVIEWER="__already_triggered__"
-fi
-CR_HOURLY=""
-for c in "$HOME/.claude/skills-worktree/.claude/scripts/cr-review-hourly.sh" \
-         "$HOME/.claude/scripts/cr-review-hourly.sh" \
-         ".claude/scripts/cr-review-hourly.sh"; do
-  [ -x "$c" ] && { CR_HOURLY="$c"; break; }
-done
-
-case "$REVIEWER" in
-  cr)
-    if [ -n "$CR_HOURLY" ] && "$CR_HOURLY" --check >/dev/null 2>&1 \
-       && "$CR_HOURLY" --peek-explicit "$N" >/dev/null 2>&1; then
-      if gh pr comment "$N" --body "@coderabbitai full review" >/dev/null 2>&1; then
-        "$CR_HOURLY" --record-explicit "$N" >/dev/null 2>&1 || true
-        echo "[PMM] re-triggered owning bot (cr) on #$N"
-      fi
-    else
-      echo "[PMM] CodeRabbit rate cap hit — skipping explicit re-trigger on #$N"
-    fi
-    ;;
-  bugbot)
-    gh pr comment "$N" --body "@cursor review" >/dev/null 2>&1 \
-      && echo "[PMM] re-triggered owning bot (bugbot) on #$N"
-    ;;
-  graphite)
-    gh pr comment "$N" --body "@graphite-app re-review" >/dev/null 2>&1 \
-      && echo "[PMM] re-triggered owning bot (graphite) on #$N"
-    ;;
-  greptile)
-    echo "[PMM] greptile owning reviewer on #$N — no auto-trigger per greptile.md"
-    ;;
-  __already_triggered__)
-    : # pre-flight covered it this tick (#576) — message already printed above
-    ;;
-  *)
-    echo "[PMM] unknown reviewer on #$N — skipping explicit re-trigger"
-    ;;
-esac
-```
-
-Never batch mention strings; never auto-trigger Greptile. Set `TICK_HAD_ACTION=true` when dismissal or re-trigger posts.
-
-**Re-gate and gate Step 5c** — re-run `.claude/scripts/merge-gate.sh "$N"`, stash in `GATE_BY_PR[$N]`, re-read `MET`, `CI_FAILING`, `STALE_BOT_CR`, `UNRESOLVED` (re-fetch unresolved thread count if needed). Then:
-   - **`MET == true`** → treat as `wrap` for Step 5d this tick (skip Step 5c spawn for this PR).
-   - **`CI_FAILING > 0` or `UNRESOLVED > 0`** → proceed to Step 5c spawn (real fix work remains).
-   - **Otherwise** (reviewer pending on fresh trigger, no CI/thread fix work) → skip Step 5c; verdict becomes `waiting` on the next tick when the bot lands.
-
-### Step 5c: Parallel `phase-a-fixer` dispatch (verdict `fixpr` — has-recoverable-blockers or merge-conflict)
-
-Fix work runs in **parallel** via one `phase-a-fixer` subagent per PR, capped at `$PMM_MAX_PARALLEL` (default 3). Merge dispatch stays sequential (Step 5d) — merges affect main and must not race.
-
-**Two fixer task types share this dispatch path:**
-
-1. **CR/CI/thread fix work** (`fixpr` from CI failing, unresolved threads, or stale bot CR) — standard Phase A fixer workflow per `.claude/agents/phase-a-fixer.md`.
-2. **Merge-conflict resolution** (`fixpr` with `merge-conflict` tag from `mergeable == CONFLICTING`, or from Step 5a rebase hitting conflicts) — same spawn shape, but the subagent prompt directs it to run the `/merge-conflict` skill workflow: rebase onto base → `resolve_merge_conflicts.py` for safe hunks → apply judgment to complex hunks → commit + force-push. Unresolvable conflicts exit with `OUTCOME: blocked` (see Step 2.5); the parent surfaces them as `BLOCKED:conflicts(needs-human)`.
-
-Conflict dispatches participate in the same parallel cap, batched `session-state.sh --set` write, and `pmm-fix-$N` tracking as CR/CI fixers. Set the Subagent column to `dispatched (merge-conflict)` when spawning for conflict resolution.
-
-**Idempotency and concurrency are already resolved in Step 3's refinement pass** (in-flight check + cap slot allocation), so the table printed in Step 4 already reflects which PRs will dispatch this tick. Step 5c dispatches every PR whose *refined* verdict is still `fixpr` **and** Step 5b′ did not re-gate it to `wrap`/`waiting` — it does not re-check `active_agents` or recompute slots. **Exception:** PRs whose Step 5a rebase aborted on conflicts override their refined verdict to `fixpr (merge-conflict)` in-place (see Step 5a) and are eligible for Step 5c dispatch in the same tick even though Step 4 already printed `rebase`. PRs refined to `awaiting fix subagent` or `queued (cap)` are skipped here with no further action; they are eligible again once Step 3 re-evaluates on a later tick.
-
-**CR hourly cap (fleet-wide).** Before spawning, snapshot the budget:
-
-```bash
-CR_BUDGET_OK=1
-.claude/scripts/cr-review-hourly.sh --check >/dev/null 2>&1 || CR_BUDGET_OK=0
-```
-
-If `$CR_BUDGET_OK == 0`, still spawn subagents but include `SKIP_CR_TRIGGER=1` in each prompt — subagents proceed without posting `@coderabbitai full review`. The skip surfaces in each subagent's exit report / handoff `notes`. Do **not** block spawn entirely when the cap is exhausted (unlike deferring all fix work).
-
-**Bulk spawn (one Agent call per PR, all in parallel up to the cap).** For each PR allocated a slot, read `VERDICTS_JSON[$N].tag` — when it is `merge-conflict` (from Step 3 `mergeable == CONFLICTING` **or** Step 5a rebase abort), set `TASK_TYPE=merge-conflict` even if GitHub still reports `BEHIND`/`MERGEABLE`. Otherwise use `TASK_TYPE=fixpr`. Invoke the Agent tool with:
-
-```text
-subagent_type: "phase-a-fixer"
-name: "pmm-fix-$N"
-mode: "bypassPermissions"
-model: "opus"
-isolation: "worktree"
-run_in_background: true
-```
-
-**Subagent prompt MUST include:**
-
-- PR number, branch name (`headRefName`), repo (`$OWNER/$REPO`), linked issue number (if any)
-- Current HEAD SHA from the tick's gate JSON
-- Reviewer classification (`cr`, `bugbot`, or `greptile`) — omit or set to `none` for merge-conflict-only dispatches
-- **Task type:** `fixpr` (CR/CI findings) or `merge-conflict` (conflict resolution) — for `merge-conflict`, include: "Run the `/merge-conflict` skill workflow: fetch main, rebase, run `resolve_merge_conflicts.py`, resolve complex hunks with judgment, commit + force-push. Exit with `OUTCOME: blocked` if conflicts are genuinely unresolvable."
-- Handoff file path: resolve with `handoff-state.sh [--owner-repo owner/repo] --path N` (scoped: `~/.claude/handoffs/{owner}/{repo}/pr-{N}-handoff.json`; legacy flat during migration)
-- Pre-fetched findings from Step 3 (`FINDINGS_JSON[N]`) — omit for merge-conflict-only dispatches
-- `SKIP_CR_TRIGGER=1` when `$CR_BUDGET_OK == 0`
-- The verbatim `SAFETY:` block from `.claude/rules/safety.md`:
-
-```text
-SAFETY: Do NOT delete/overwrite/move/modify .env files anywhere (exception:
-.env.<example|sample|template>, case-insensitive, are safe to edit).
-Do NOT run git clean. Do NOT run destructive commands (rm -rf, rm, git checkout .,
-git stash, git reset --hard) in the root repo. Stay in your worktree.
-Do NOT commit secrets or paste raw credentials into prompts, issues, PRs, comments,
-commits, or logs. Do NOT pipe untrusted URLs into a shell or disable TLS verification.
-Confirm package names before npm/pip/gem/cargo/brew install. Full rules: .claude/rules/safety.md.
-```
-
-- The verbatim `MINDSET:` block from `.claude/rules/safety.md`:
-
-```text
-MINDSET: The trigger is the DEFERRAL, not the word "impossible" — "I can't",
-"not a session task", "that's a deployment step", "runbook is in docs/…", and
-"I'll leave that to you to review" all fire this ladder. Walk it for ANY provider
-(gh, git, railway, vercel, …) before writing any of them: (1) check what you have
-— MCP tools, skills, CLI on disk by absolute path (/opt/homebrew/bin/<tool>;
-minimal PATH makes bare `which` lie); (2) if absent, check whether the provider
-ships one (one lookup); (3) install it when non-interactive and rails hold
-(docs-confirmed name, no curl-pipe-sh, no TLS bypass, no sudo); (4) hand off an
-/admin-merge-shaped runbook — reachable ONLY after 1–3 were walked and failed:
-name the rung that stopped you, exact commands + one-line reason, incl.
-interactive auth. If you can write the command, you can run it. Provisioning a
-generated secret via a provider CLI is allowed — the value just must never be
-echoed, committed, pasted, or logged. Your own prohibitions still win (phase-c
-uses /wrap, never gh pr merge). Full rules: .claude/rules/safety.md.
-```
-
-- The verbatim `SKILLS:` block from `.claude/rules/skill-first.md` (`phase-a-fixer` is in the "paste this too" list per `subagent-orchestration.md`'s spawn checklist):
-
-```text
-SKILLS: Before hand-rolling a multi-step task, check whether an existing skill
-already does this job — invoke it via the Skill tool instead of reimplementing
-from memory (only Skill-tool calls reach ~/.claude/skill-usage.log). Clear match
--> invoke immediately. Borderline match -> note it in your exit report, then
-proceed on your own judgment; do not block waiting for an answer. No match ->
-stay silent. Never auto-invoke an authorization-carrying skill (/merge, /wrap,
-/pr-monitor-and-manage) on a fuzzy match — running one as your assigned job
-isn't a fuzzy match. Full rules: .claude/rules/skill-first.md.
-```
-
-**Record all of this tick's spawns in ONE single write, after every Agent call has been issued — never one read-modify-write per PR.** `session-state.sh` has no cross-process lock (see `cr-review-hourly.sh`'s flock warning); if each parallel spawn ran its own independent `--get` → append → `--set` cycle, two spawns' read-modify-write windows can interleave and the second writer's `--set` clobbers the first writer's append (`session-state.sh`'s atomicity guarantees the single `mv` is atomic, not that concurrent read-modify-write sequences serialize). Since the parent is a single sequential thread even when it fires N Agent tool calls in one message, build every new entry first, then issue exactly one `session-state.sh` call for the whole batch:
-
-```bash
-NOW=$(date -u +%FT%TZ)
-NEW_ENTRIES='[]'
-IN_FLIGHT_SETS=()
-# ONE loop per spawned PR — build that PR's entry AND its --set argument together,
-# each using ONLY that PR's own head_sha. Never hoist head_sha into a shared
-# variable reused across iterations or across a second loop — the last PR's SHA
-# would silently overwrite every earlier PR's lock.
-for N in $SPAWNED_PR_NUMS; do
-  N_HEAD_SHA=$(jq -r '.head_sha' <<<"${GATE_BY_PR[$N]}")   # that PR's own tick-scoped $GATE
-  ISSUE_N=$(.claude/scripts/pr-issue-ref.sh "$N" 2>/dev/null || echo null)
-  AGENT_ID="pmm-fix-$N"
-  ENTRY=$(jq -n --arg id "$AGENT_ID" --arg task "PMM fix PR #$N" --argjson issue "$ISSUE_N" \
-    --argjson pr "$N" --arg launched "$NOW" --arg head_sha "$N_HEAD_SHA" \
-    '{id:$id, task:$task, issue:$issue, pr:$pr, phase:"A", status:"spawned", launched:$launched, head_sha:$head_sha}')
-  NEW_ENTRIES=$(jq --argjson entry "$ENTRY" '. + [$entry]' <<<"$NEW_ENTRIES")
-  IN_FLIGHT_SETS+=(--set ".pmm_in_flight.\"$N\"={\"skill\":\"phase-a-fixer\",\"status\":\"active\",\"dispatched_at\":\"$NOW\",\"head_sha\":\"$N_HEAD_SHA\",\"agent_id\":\"$AGENT_ID\"}")
-done
-
-# After the loop — ONE read of the current array, ONE append of the whole batch, ONE write:
-CURRENT_AGENTS=$(.claude/scripts/session-state.sh --get '.active_agents' 2>/dev/null || echo null)
-[ "$CURRENT_AGENTS" = "null" ] && CURRENT_AGENTS='[]'
-UPDATED_AGENTS=$(jq --argjson entries "$NEW_ENTRIES" '. + $entries' <<<"$CURRENT_AGENTS")
-.claude/scripts/session-state.sh --set ".active_agents=$UPDATED_AGENTS" "${IN_FLIGHT_SETS[@]}"
-```
-
-Set Subagent column to `spawned` immediately for every PR in this batch; transition to `working` once each subagent reports activity (first tool call or ~30s elapsed).
-
-**Safety boundaries for every subagent (non-negotiable):**
-
-- Never modify branch protection
-- Never dismiss human-authored reviews
-- Never resolve a review thread without code-verification (per `phase-a-fixer` Step 5)
+Cap `$PMM_MAX_PARALLEL`. Snapshot CR budget; include `SKIP_CR_TRIGGER=1` in prompts when cap exhausted but do **not** block spawn. Bulk-spawn in parallel; record all spawns in **ONE batched `session-state.sh` write** after all Agent calls — never per-spawn read-modify-write (race condition). Full prompt template, bulk-spawn bash, batch-write pattern: `references/pmm-act.md`.
 
 ### Step 5d: Sequential `/wrap` dispatch (verdict `wrap` — merge-ready)
 
-Merge-ready PRs get **sequential** `/wrap` dispatch — one at a time, never parallelized. Merges affect main branch state (main-sync, follow-up detection, lessons) and must not race. PMM never runs `gh pr merge` directly — landing always flows through the full `/wrap` workflow.
-
-**Deferral gate — check this FIRST, before any lock acquisition or `/wrap` execution below.** "Fix subagents active this tick" means spawned just now by Step 5c OR still running from a prior tick — check both: any Step 5c spawn this tick, **or** a **blocking** Phase A `active_agents` entry (per Step 5's shared gate idiom — any `id`, not just `pmm-fix-` prefixed; stale foreign entries with no progress evidence are non-blocking; this must match Step 5a's rebase-skip check exactly: a foreign, non-PMM Phase A agent can hold the same PR's branch in its own worktree, and `/wrap` checking out or pushing to that branch races it just as much as a rebase would). This matters because a `/pmm-stop`-then-resume, or a tick where Step 3's refinement pass left every `fixpr` PR at `awaiting fix subagent`/`queued (cap)` with zero *new* spawns, would otherwise slip past a "spawned this tick" check while a background fixer is still mid-flight on a shared branch/worktree.
-
-Process merge-ready PRs **only when no fix subagents are active this tick** (by the definition above) — run Step 5d sequentially before Step 5e. **If any fix subagents are active, stop here and defer all `/wrap` dispatches** until the Step 5e monitor loop has drained every active fix subagent — do not proceed to the idempotency check or lock acquisition below for any PR while the gate is closed. This keeps the parent out of concurrent parent work and honors dedicated monitor mode. **Foreign Phase A entries** blocking `/wrap` are drained by Step 5e's poll-based condition (entry disappearance from `active_agents`, terminal `status` flip, or `PMM_LOCK_STALE_SECS` staleness timeout with no progress evidence) — not by parsing an exit report — so the deferral gate always has a documented reopen path.
-
-**Merge-sequencing gate (issue #756) — apply after the deferral gate, before any lock.** Read each PR's Step 3.6 action from `SEQ`:
-
-- **`held(#A)`** → **skip this tick entirely.** No confirmation prompt, no lock write, no `/wrap`. The PR keeps its `wrap` readiness and is re-evaluated next tick, by which point `#A` has usually landed and this PR is `BEHIND` — one cheap rebase on the small PR instead of a conflict round on the big one. A hold is bounded by Step 3.6's stall counter, so it always has an exit.
-- **`batch(#A)`** → dispatch it in **this** tick, alongside every other `batch` member of the same anchor. They still merge **one at a time** (merges must not race), but all within this single tick's merge window — that is what bounds `#A` to one re-sync per batch rather than one per follower.
-- **`merge`** → dispatch normally.
-
-**Order within the tick:** anchors first (they are why the followers waited), then batch members in ascending PR number, then everything else. When Step 3.6 errored or was skipped, every PR reads `merge` and this gate is a no-op.
-
-**The merge-dispatch set is `wrap` ∪ `batch(#A)`, minus `held(#A)`** — define it explicitly before the loop below. Step 3.6 *replaces* a PR's `wrap` verdict with `batch(#A)` when it releases a hold, so a dispatch condition written as "`VERDICT == wrap`" alone would silently skip every released PR and they would never merge — the batch mechanism would be inert:
-
-```bash
-MERGE_SET=()
-for N in $PR_NUMS; do
-  case "${REFINED_VERDICT[$N]:-${VERDICT_BY_PR[$N]}}" in
-    wrap|batch\(*) MERGE_SET+=("$N") ;;   # both dispatch
-    held\(*)       ;;                      # held this tick — no lock, no /wrap
-  esac
-done
-```
-
-Sequencing never authorizes a merge — it only decides whether a PR is being held. Each dispatched PR still runs `/wrap`'s own gate re-check and AC verification below.
-
-**Idempotency-gated via `pmm_in_flight`** (only reached once the deferral gate above is open):
-
-```bash
-INFLIGHT=$(.claude/scripts/session-state.sh --get ".pmm_in_flight.\"$N\"" 2>/dev/null || echo null)
-```
-
-Decision:
-
-- `$INFLIGHT` has `status == "active"` → skip (verdict `awaiting prior /wrap`) unless stale per `PMM_LOCK_STALE_SECS` (default **3600s**) with no live progress evidence.
-- `$INFLIGHT` is `null` (or stale lock broken) → proceed to merge dispatch below.
-
-**Merge dispatch — no confirmation prompt by default.** For each `$N` in `MERGE_SET` (verdict `wrap` **or** `batch(#A)` — never `held(#A)`), in the order above:
-
-1. **When `PMM_CONFIRM_MERGES` is true:** emit a per-PR confirmation prompt ("Merge-ready: dispatch `/wrap` for #N?") **before** acquiring any lock. If declined, skip this PR this tick with **no** `pmm_in_flight` write — do not leave a stale lock.
-2. **When confirmed (or when `PMM_CONFIRM_MERGES` is false):** acquire the idempotency lock, then dispatch immediately:
-
-```bash
-NOW=$(date -u +%FT%TZ)
-HEAD_SHA=$(jq -r '.head_sha' <<<"${GATE_BY_PR[$N]}")
-.claude/scripts/session-state.sh --set \
-  ".pmm_in_flight.\"$N\"={\"skill\":\"wrap\",\"status\":\"active\",\"dispatched_at\":\"$NOW\",\"head_sha\":\"$HEAD_SHA\"}"
-```
-
-Default (`PMM_CONFIRM_MERGES` false): dispatch the **full** `/wrap` workflow inline (all 4 phases) immediately — silent merge per `CLAUDE.md` "PR MERGE AUTHORIZATION".
-
-Execute the **full** `/wrap` workflow inline (all 4 phases). PMM relies on `/wrap`'s own gate re-check (`merge-gate.sh`) and AC verification (`ac-checkboxes.sh`) — if the gate is no longer met (SHA moved, CI regressed) or AC fails, `/wrap` stops and returns a hard block; PMM records it and re-classifies on the next tick without re-authorizing or re-prompting.
-
-On completion:
-
-- `/wrap` merged the PR → clear `pmm_in_flight[N]`; append `#N` to `MERGED_THIS_TICK` and `MERGED_THIS_SESSION` (dedupe on append); PR drops from fleet on next `gh pr list`.
-- `/wrap` returned a hard block → clear in-flight and add `#N` to `HARD_BLOCK[]` for reporting (Step 4 next tick). Do **not** force-stop the fleet — the hard-blocked PR is dropped from actionable work and the idle counter handles convergence to Pause.
+Deferral gate: process merge-ready PRs **only when no fixing subagents are active** (spawned this tick by Step 5c OR still active from prior tick per the shared gate idiom). Merge-sequencing gate: `held(#A)` → skip tick; `batch(#A)` → dispatch in this tick's merge window; `merge` → dispatch normally. `--confirm-merges` prompt fires before lock acquisition. Idempotency via `pmm_in_flight` (skip if `status == "active"` and not stale per `PMM_LOCK_STALE_SECS`). Full deferral-gate detail, merge-set bash, lock-acquire/dispatch bash, lock-clear-on-completion: `references/pmm-act.md`.
 
 ### Step 5e: Dedicated monitor mode while fix subagents are active
 
-If any **blocking** fix subagents are active this tick (per Step 5's shared gate idiom and the deferral-gate definition in Step 5d — spawned now or carried over from a prior tick), **immediately enter an orchestration-only posture borrowing `monitor-mode.md`'s Dedicated Monitor Mode discipline** — the **parent's** ONLY job until every blocking fix subagent completes, fails, or is drained (foreign: disappearance / terminal `status` / `PMM_LOCK_STALE_SECS` staleness timeout) is orchestration (poll, verify, heartbeat); the parent does no direct feature-code edits, no local CR review, no substantive source analysis — but its subagents edit code, resolve conflicts, and push as designed. **PMM does NOT execute `monitor-mode.md`'s Monitor Loop Per-Cycle Checklist verbatim** — specifically, it never runs `phase-protocols.md`'s Phase Completion Protocols, which would otherwise auto-launch Phase B after Phase A. Step 2.5's aggregation fully replaces that: PMM fixes and pushes only, per Step 0's contract ("PMM does not launch Phase B/C after Phase A").
-
-**PMM's own monitor loop (~60s cadence — replaces, not layers on, `monitor-mode.md`'s checklist):**
-
-1. **Poll active subagent statuses — ownership-aware drain.** Each ~60s cycle, read `active_agents` and partition the Phase A entries gating deferred PRs into **PMM-owned** (`id` starts with `pmm-fix-`) and **foreign** (any other `id`) sets.
-
-   **PMM-owned entries:** Transition Subagent column: `spawned` → `working` → `complete` / `failed`. On completion (success, exhaustion, or crash), proceed to item 2 below.
-
-   **Foreign entries:** PMM has no exit report to parse and must never clean up or remove state it does not own — foreign agents drain by poll-based observation only (see below). While waiting, surface the PR's Subagent column as `deferred(foreign-agent)`.
-
-   For each foreign Phase A entry, the **drain signal** is:
-   - The entry **disappears** from `active_agents` (authoritative — the owning workflow removed it), **or**
-   - Its `status` flips to `complete` or `failed` (secondary/opportunistic — honored only if the owning workflow happens to set it).
-
-   PMM must **not** perform worktree cleanup, remove, or mutate the foreign entry or any foreign lock — the owning workflow cleans up under its own rules. PMM only observes and stops deferring once the entry is gone or terminal.
-
-   **Staleness fallback (foreign only):** Reuse `PMM_LOCK_STALE_SECS` (default 3600s), applied to the foreign entry's freshness timestamp (`last_seen_at` if present, else `launched`). When the entry exceeds the staleness window **and** there is no live evidence of progress on that PR (HEAD SHA unchanged since the timestamp, no new bot/CI activity since the timestamp), log the stale foreign agent, surface the Subagent column as `foreign-agent-stale`, and treat the entry as **non-blocking** per Step 5's shared gate idiom — the deferral gate reopens for that PR so `/wrap` may proceed after the monitor loop exits (rebase on the next tick also proceeds, since Step 5a uses the same idiom). Same conservatism as the existing lock-staleness idiom — the wide window and no-progress corroboration prevent pre-empting a healthy long-running foreign fixer; PMM still does not touch the foreign entry, it only stops waiting on it.
-
-   **Gate reopen:** Once a PR has no remaining **blocking** Phase A entry of either kind (PMM-owned or foreign — foreign entries past `PMM_LOCK_STALE_SECS` with no progress evidence count as non-blocking even if the row remains in `active_agents`), the deferral gate for that PR reopens and its deferred `/wrap` dispatch proceeds after the monitor loop exits, per existing Step 5d/5e ordering.
-
-2. **On PMM-owned completion** — success, exhaustion, or crash — **run Step 2.5's steps 1-3 in full** (parse exit report, worktree cleanup, remove this agent's own `active_agents` record + clear `pmm_in_flight[N]`) before branching on outcome. When OUTCOME is `pushed_fixes`, also run **Step 5b dismiss helper + Step 5b′ owning-bot re-trigger** on that PR (issue #514 — mirrors `/fixpr` 3a/3b; set `TICK_HAD_ACTION=true` if dismissal or re-trigger posts). This is unconditional, not just the success path — a failure that skips clearing `pmm_in_flight[N]` would otherwise leave a stale lock blocking Step 3's idempotency check until `PMM_LOCK_STALE_SECS` expires. Foreign entries are out of scope for this item — they drain per item 1's poll/staleness signal only.
-3. Branch on outcome for **PMM-owned** entries only (per Step 2.5's step 4, cleanup from item 2 above already done):
-   - **Crash / no exit report / stale >15 min:** mark `failed` in the table and add `#N` to `HARD_BLOCK[]` with reason `crashed(needs-approval)` — never re-dispatch silently. Reported once and dropped from the actionable fleet this tick (do **not** force-stop — see Step 3's `HARD_BLOCK[]` handling); the user can explicitly approve a respawn (`subagent-orchestration.md`: "Ask first only: ... respawning a crashed/no-handoff subagent").
-   - **`blocked` (unresolvable merge conflict or other fix blocker):** add `#N` to `HARD_BLOCK[]` with reason from the exit report (e.g. `conflicts(needs-human)`). Report once and drop from the actionable fleet — do not re-dispatch silently.
-   - **Token/turn exhaustion with a valid handoff file:** respawn immediately **using Step 5c's spawn pattern**, but with **freshly re-fetched** gate and findings data for this PR — do NOT reuse tick-start `GATE_BY_PR[$N]`/`FINDINGS_JSON[$N]` verbatim. Real time has passed since Step 3 computed them, and the exhausted subagent may have pushed partial progress before running out of tokens, moving the PR's actual HEAD SHA and review state past that tick-start snapshot; a respawn using the stale SHA/findings would hand the replacement outdated context. Re-run `.claude/scripts/merge-gate.sh "$N"` (and re-fetch findings from the three endpoints, same as Step 3's pre-fetch) immediately before building the replacement's spawn record, and use *that* fresh result — not the cached tick-start one — for its `head_sha`, `GATE_BY_PR[$N]` update, and prompt findings. This is an "Always do" action per `subagent-orchestration.md`'s Token/Turn Exhaustion Protocol — do not wait for the next tick, and do NOT defer to Step 2.5's exhaustion handling here (Step 2.5's deferral only works at tick-*start*, before Step 3 has run; Step 5e is mid-tick, after Step 3 already ran, so an inline respawn is possible here — it just needs fresh data, not the tick-start cache).
-4. Send heartbeat if >5 min since last user message (timestamp prefix required).
-5. Investigate stale **PMM-owned** agents (>15 min Phase A without progress). Foreign staleness is handled by item 1's `PMM_LOCK_STALE_SECS` fallback.
-
-**While subagents run:** do not start rebases, new spawns for other PRs, or `/wrap` dispatches. **Exception:** an exhaustion respawn (item 3 above) for a PR already in this tick's active-fixer set is a continuation of already-approved fix work, not a new spawn — it is exempt from this restriction and proceeds inline. Deferred merge-ready PRs from Step 5d run immediately after the monitor loop exits (all fix subagents — PMM-owned or foreign — complete, fail, or are drained via staleness timeout). The tick completes only after all spawned fix subagents return (or fail) and any deferred `/wrap` dispatches finish. Then proceed to Step 6.
-
-**#497 compatibility (idle auto-pause):** when all subagents exit and no parent dispatches remain in-flight, treat the tick as idle for digest/backoff purposes — the stable-state countdown in Step 6 applies as if the tick were a no-op dispatch tick.
-
-**Tick merge summary.** After all Step 5 actions complete, if `MERGED_THIS_TICK` is non-empty, print one line per merged PR (already recorded in `MERGED_THIS_SESSION` at `/wrap` completion — do not append again here):
-
-```text
-merged #N
-```
-
-Initialize `MERGED_THIS_SESSION='[]'` on the first tick in Step 0/Step 1.
+Enter orchestration-only posture (`monitor-mode.md` Dedicated Monitor Mode). PMM explicitly does **not** run `phase-protocols.md`'s Phase Completion Protocols — no Phase B/C auto-launch. Monitor loop (~60s): poll PMM-owned and foreign entries separately; drain foreign via disappearance/terminal status/staleness (never mutate); on PMM-owned completion run Steps 2.5.1–3 then branch on outcome (crash → `HARD_BLOCK[crashed(needs-approval)]`; `blocked` → `HARD_BLOCK[conflicts(needs-human)]`; exhaustion → respawn inline with **freshly re-fetched** gate data, not tick-start cache). Full drain-signal detail, staleness fallback, gate-reopen conditions: `references/pmm-act.md`.
 
 ---
 
 ## Step 6: Stable-state backoff + idle streak (per `scheduling-reliability.md`)
 
-Track a streak over the fleet digest so an idle fleet stops hammering the API. `DIGEST`/`PREV` and `ROW_DIGEST`/`ROW_PREV` were already computed in Step 4 this tick (hashed once) — reuse them, do not recompute. **Only the state digest feeds the streak**: `ROW_DIGEST` exists solely for Step 4's table decision, so a display-only change (verdict refinement, subagent cell) never resets backoff or the idle counter.
+`DIGEST`/`PREV` and `ROW_DIGEST`/`ROW_PREV` come from Step 4 — do not recompute. Only the state digest feeds the streak; `ROW_DIGEST` exists solely for Step 4's table decision.
 
 ```bash
-# DIGEST/PREV + ROW_DIGEST/ROW_PREV come from Step 4 (read pre-persist).
 STREAK=$(.claude/scripts/session-state.sh --get '.pmm_digest_streak' 2>/dev/null || echo 0)
 [ "$STREAK" = null ] && STREAK=0
 if [ "$DIGEST" = "$PREV" ]; then STREAK=$((STREAK+1)); else STREAK=0; fi
 .claude/scripts/session-state.sh --set ".pmm_digest=\"$DIGEST\"" --set ".pmm_digest_streak=$STREAK" \
   --set ".pmm_row_digest=\"$ROW_DIGEST\""
 
-# Resolve the effective cadence from the streak (used by Step 7's loop re-arm).
 if [ "$STREAK" -ge 3 ]; then EFFECTIVE_CADENCE="15m"; else EFFECTIVE_CADENCE="$PMM_CADENCE"; fi
 ```
 
-Backoff schedule (matches `scheduling-reliability.md` "Stable-State Backoff"):
-
+Backoff schedule:
 - **Streak ≥ 3** → `EFFECTIVE_CADENCE=15m`; re-arm with `/loop 15m /pr-monitor-and-manage <same args>`.
-- **Any digest change** (or a new user message) → streak resets to 0, so `EFFECTIVE_CADENCE` falls back to the configured base `$PMM_CADENCE`.
-- **Streak ≥ 9** → the fleet has been frozen for many ticks; print a suggestion to `/pmm-stop` (the user can re-invoke when something changes) but do not force-stop unless a hard block is also present.
+- **Any digest change** (or new user message) → streak resets to 0.
+- **Streak ≥ 9** → suggest `/pmm-stop`; do not force-stop unless a hard block is also present.
 
-A widened cadence is per-fleet here (one loop), but each PR keeps its own row in the digest tuple so a single PR changing state resets the whole loop to base cadence — the cheapest correct behavior for a single shared loop.
-
-**#497 idle auto-pause compatibility:** when a tick finishes with all fix subagents exited and no in-flight parent dispatches, the digest/backoff logic treats the tick as idle — a stable fleet with unchanged digest increments `pmm_digest_streak` normally, and after 3 idle ticks the cadence widens to 15m.
-
-### Idle tick definition + `pmm_idle_streak`
-
-An **idle tick** is one where **all** of the following hold:
-
-1. **No dispatch fired** — `TICK_HAD_ACTION=false` from Step 5 (no rebase, no fix subagent spawn, no `/wrap`, no reviewer trigger).
-2. **No state change vs prior tick** — fleet digest unchanged (`DIGEST == PREV` from above).
-3. **No active fix subagents** — no **blocking** Phase A `active_agents` entry (per Step 5's shared gate idiom — stale foreign entries with no progress evidence do not count). A tick can have `TICK_HAD_ACTION=false` and an unchanged digest while a long-running Phase A fixer from a prior tick is still working — that is not idle, and counting it as such risks auto-pausing mid-fix.
-4. **Nothing held by merge sequencing** — no PR carries Step 3.6's `held(#A)` verdict. A held PR is merge-ready work deliberately deferred one tick, which looks exactly like idleness (no dispatch, unchanged digest, no subagents). At the default `--stall-ticks 1` a hold resolves within one tick either way, so this can't reach the 3-tick pause threshold on its own — but making it explicit means raising `stall_ticks` later can never strand a ready fleet at Pause with its merges still queued.
-
-Maintain a dedicated **`pmm_idle_streak`** counter (flat, sibling to `pmm_digest_streak`):
+**Idle streak (`pmm_idle_streak`)** — an **idle tick** requires ALL of: (1) `TICK_HAD_ACTION=false`; (2) digest unchanged; (3) no blocking Phase A agents; (4) nothing held by merge sequencing. Orthogonal to cadence widening — widening must **not** reset the idle counter.
 
 ```bash
 IDLE_PREV=$(.claude/scripts/session-state.sh --get '.pmm_idle_streak' 2>/dev/null || echo 0)
 [ "$IDLE_PREV" = null ] && IDLE_PREV=0
 ACTIVE_FIXERS=$(jq '[.[] | select(.phase == "A" and (.status != "complete" and .status != "failed"))] | length' \
   <<<"$(.claude/scripts/session-state.sh --get '.active_agents' 2>/dev/null || echo '[]')")
-# Plain if-guard, NOT ${SEQ:-{}} — a brace-containing parameter-expansion
-# default terminates at its first literal `}` and would feed jq garbage.
 HELD_COUNT=0
-if [ -n "${SEQ:-}" ]; then
-  HELD_COUNT=$(jq '[.plan[]? | select(.action == "hold")] | length' <<<"$SEQ" 2>/dev/null || echo 0)
-fi
+[ -n "${SEQ:-}" ] && HELD_COUNT=$(jq '[.plan[]? | select(.action == "hold")] | length' <<<"$SEQ" 2>/dev/null || echo 0)
 if [ "$TICK_HAD_ACTION" = false ] && [ "$DIGEST" = "$PREV" ] && [ "$ACTIVE_FIXERS" -eq 0 ] && [ "$HELD_COUNT" -eq 0 ]; then
   IDLE_STREAK=$((IDLE_PREV + 1))
 else
@@ -951,29 +338,27 @@ fi
 .claude/scripts/session-state.sh --set ".pmm_idle_streak=$IDLE_STREAK"
 ```
 
-**`pmm_idle_streak` is orthogonal to cadence widening** — widening 5m→15m via `pmm_digest_streak` must **not** reset `pmm_idle_streak`. Only an action or digest change resets the idle counter. Three idle ticks at the widened 15-min cadence still counts toward auto-pause.
-
 ---
 
 ## Step 7: Stop routing, Pause routing, then establish / re-arm the polling loop
 
-**First, check the stop/pause conditions.** Routing order:
+**Check stop/pause conditions first:**
 
-1. **User command** — `/pmm-stop` (or "stop monitoring PRs"). See the companion `/pmm-stop` skill → **Stop & Clean Exit**.
-2. **Empty fleet** — `PR_COUNT == 0` from Step 2 → **immediate Pause** (Step 8) with reason `empty fleet` (no 3-tick wait).
-3. **Idle streak** — `pmm_idle_streak >= PMM_IDLE_PAUSE_AFTER` → **Pause** (Step 8) with reason `"$PMM_IDLE_PAUSE_AFTER idle ticks"`.
+1. **User command** — `/pmm-stop` (or "stop monitoring PRs"). See companion `/pr-monitor-and-manage-stop` skill → **Stop & Clean Exit**.
+2. **Empty fleet** — `PR_COUNT == 0` from Step 2 → **immediate Pause** with reason `empty fleet` (no 3-tick wait).
+3. **Idle streak** — `pmm_idle_streak >= PMM_IDLE_PAUSE_AFTER` → **Pause** with reason `"$PMM_IDLE_PAUSE_AFTER idle ticks"`.
 4. Otherwise → **re-arm the loop** (below).
 
-Hard-blocked PRs (`HARD_BLOCK[]`, including a crashed/no-handoff `phase-a-fixer` awaiting respawn approval — `crashed(needs-approval)`, Step 2.5/5e) do **not** trigger Stop or Pause by themselves — they are reported and dropped from the actionable fleet; the idle counter handles convergence when nothing actionable remains.
+Hard-blocked PRs do **not** trigger Stop or Pause — they are reported and dropped from the actionable fleet; the idle counter handles convergence when nothing actionable remains.
 
-Otherwise, **re-arm the loop.** `/loop` is the **canonical** primitive for this recurring poll — never a hand-rolled `ScheduleWakeup` chain (`scheduling-reliability.md`). On the first tick, establish it and state the cancel command in the same message:
+**Re-arm the loop.** `/loop` is the **canonical** primitive — never a hand-rolled `ScheduleWakeup` chain (`scheduling-reliability.md`). On the first tick, state the cancel command:
 
 ```text
 /loop <EFFECTIVE_CADENCE> /pr-monitor-and-manage <original args>
 To stop: say /pmm-stop (or "stop monitoring PRs"), or interrupt the loop.
 ```
 
-Record monitoring state every tick (preserve unknown fields — `session-state.sh` does this atomically):
+Record monitoring state every tick:
 
 ```bash
 NOW=$(date -u +%FT%TZ)
@@ -983,12 +368,11 @@ NOW=$(date -u +%FT%TZ)
   --set ".pmm_author=\"$PMM_AUTHOR\"" \
   --set ".pmm_last_tick_at=\"$NOW\"" \
   --set ".pmm_idle_streak=$IDLE_STREAK"
-# On the FIRST tick also set .pmm_started_at; every tick set the next-expected watermark.
 ```
 
 **Pre-exit checklist (run before ending every polling turn — `scheduling-reliability.md`):**
 
-1. **Next tick scheduled?** Confirm `/loop` is active/re-armed at `$EFFECTIVE_CADENCE` (or stopped/paused per the routing above).
+1. **Next tick scheduled?** Confirm `/loop` is active/re-armed (or stopped/paused per routing above).
 2. **Heartbeat sent?** The Step 4 timestamped line (plus the table when it carried news) is the heartbeat — never end a tick silently.
 3. **State recorded?** `pmm_active`, cadence, watermarks, `pmm_in_flight`, `active_agents`, `pmm_digest(_streak)`, `pmm_row_digest`, `pmm_idle_streak` written to `session-state.json`.
 
@@ -996,43 +380,11 @@ NOW=$(date -u +%FT%TZ)
 
 ## Pause (auto-pause — resumable)
 
-Reached from Step 7 when the fleet is empty or idle. Unlike Stop & Clean Exit, Pause preserves a resume marker so `/pr-monitor-and-manage-wake` or re-invoking this skill can pick up where it left off.
+Reached from Step 7 when the fleet is empty or idle. Preserves a resume marker so `/pr-monitor-and-manage-wake` or re-invoking this skill can pick up where it left off.
 
-### 1. Final heartbeat
+Full pause procedure (final heartbeat, loop cancel, fleet snapshot + config build, pause marker write, auto-wake cron registration, summary line): `references/pmm-lifecycle.md`.
 
-Print the **full** Step 4 status table one last time — terminal snapshots (Pause here, Stop & Clean Exit) are an explicit exception to Step 4's quiet-tick suppression, so the user always gets a final fleet snapshot even when the pause tick itself was quiet — then a one-line reason:
-
-```text
-[$TS] PMM pausing — reason: <empty fleet | N idle ticks>
-```
-
-### 2. Cancel the loop
-
-Cancel the recurring `/loop` (same guidance as Stop & Clean Exit):
-
-- If the runtime exposes a loop id / cancel handle, cancel it explicitly.
-- Otherwise interrupt the active loop. The next tick must not re-arm.
-
-### 3. Build fleet snapshot + config for the pause marker
-
-```bash
-NOW=$(date -u +%FT%TZ)
-# fleet_at_pause: array of {pr, head_sha, state} from Step 2 PR_LIST (headRefOid + mergeStateStatus)
-FLEET_AT_PAUSE=$(jq -c '[.[] | {pr: .number, head_sha: .headRefOid, state: .mergeStateStatus}]' <<<"$PR_LIST")
-CONFIG_AT_PAUSE=$(jq -nc \
-  --arg author "$PMM_AUTHOR" --arg repo "$OWNER_REPO" --arg cadence "$PMM_CADENCE" \
-  --argjson max_parallel "$PMM_MAX_PARALLEL" \
-  --argjson idle_pause_after "$PMM_IDLE_PAUSE_AFTER" \
-  --argjson auto_wake "$PMM_AUTO_WAKE" --arg auto_wake_cadence "$PMM_AUTO_WAKE_CADENCE" \
-  --argjson confirm_merges "$PMM_CONFIRM_MERGES" \
-  '{author:$author, repo:$repo, cadence:$cadence, max_parallel:$max_parallel, idle_pause_after:$idle_pause_after, auto_wake:$auto_wake, auto_wake_cadence:$auto_wake_cadence, confirm_merges:$confirm_merges}')
-```
-
-> **Wake coupling:** `/pr-monitor-and-manage-wake` Step 4b rebuilds `PMM_FLAGS` from this blob — including `--confirm-merges` when `confirm_merges` is true — before re-arming the loop.
-
-> **Schema note:** pause marker fields live under nested `.pmm.*` per the AC; existing runtime fields (`pmm_active`, `pmm_digest`, `pmm_idle_streak`, etc.) remain flat.
-
-### 4. Write pause marker (atomic batch)
+Key pause marker write:
 
 ```bash
 .claude/scripts/session-state.sh \
@@ -1043,85 +395,29 @@ CONFIG_AT_PAUSE=$(jq -nc \
   --set '.pmm_next_expected_tick_at=null'
 ```
 
-Preserve `pmm_digest`, `pmm_digest_streak`, and `pmm_idle_streak` as audit trail.
-
-### 5. Optional auto-wake cron (`--auto-wake`)
-
-When `$PMM_AUTO_WAKE` is true, register an hourly scan at pause time:
-
-> **Warning:** `CronCreate` is **session-only** — this job fires only while Claude is running in the current session. `durable: true` has no effect. `--auto-wake` does **not** survive session turnover. (Behavioral redesign tracked as a follow-up ticket.)
-
-```bash
-# Derive cadence minutes from PMM_AUTO_WAKE_CADENCE (e.g. 60m → 60)
-AW_CADENCE_MIN="${PMM_AUTO_WAKE_CADENCE%m}"
-if [ "$AW_CADENCE_MIN" -ge 60 ] && [ $((AW_CADENCE_MIN % 60)) -eq 0 ]; then
-  # off-peak-minute.sh's --every-n-min only accepts 1..59 (it builds a step-range
-  # within one hour) — for hourly-or-longer cadences (the 60m default), use the
-  # plain no-flag minute + a */H hour step instead, matching /pm's hourly pattern.
-  AW_HOURS=$((AW_CADENCE_MIN / 60))
-  AW_MINUTE=$(.claude/scripts/off-peak-minute.sh)
-  if [ "$AW_HOURS" -eq 1 ]; then
-    AW_CRON="$AW_MINUTE * * * *"
-  else
-    AW_CRON="$AW_MINUTE */$AW_HOURS * * *"
-  fi
-else
-  { read -r AW_MINUTE; read -r AW_CRON; } < <(.claude/scripts/off-peak-minute.sh --every-n-min "$AW_CADENCE_MIN")
-fi
-# CronCreate with prompt "/pr-monitor-and-manage-wake --auto-check", cron="$AW_CRON", recurring=true, durable=true
-# Persist returned job id to .pmm.auto_wake_cron_id and append to polling_jobs[]
-```
-
-Tell the user the cron job id and 7-day auto-expiry; note that the job is session-scoped (see `scheduling-reliability.md` contract note).
-
-### 6. Summary line
-
-```text
-PMM paused — <N> PR(s) waiting on reviewer, no changes for <idle window>. Wake with `/pr-monitor-and-manage-wake` or re-run `/pr-monitor-and-manage <flags>`.
-```
-
-If `--auto-wake` is set, add: `Auto-wake cron registered (<job_id>) — will scan hourly for fleet changes.`
-
-> **Post-merge symlink:** after this skill's `-wake` companion merges to `main`, symlink `~/.claude/skills/pr-monitor-and-manage-wake` → the skills-worktree copy per `skill-symlinks.md`.
+> **Session-only CronCreate warning (when `--auto-wake` is set):** `CronCreate` is **session-only** — this job fires only while Claude is running in the current session. `durable: true` has no effect. `--auto-wake` does **not** survive session turnover. (Behavioral redesign tracked as a separate ticket.)
 
 ---
 
 ## Stop & Clean Exit
 
-Reached from Step 7 when the **user** invokes `/pmm-stop`. Tear down and report (this is a terminal stop — no resume marker):
+Reached from Step 7 when the **user** invokes `/pmm-stop`. Tear down and report (terminal — no resume marker). Full summary format: `references/pmm-lifecycle.md`.
 
 ```bash
 .claude/scripts/session-state.sh --set '.pmm_active=false' --set '.pmm_next_expected_tick_at=null'
-# Best-effort: cancel the loop if a loop-id mechanism is available; otherwise the
-# user's /pmm-stop / interrupt drops it.
 ```
-
-Print a final summary:
-
-```text
-=== PR fleet monitoring ended ===
-Reason:   <user-stop>
-Fleet:    <final status table>
-Pre-flight: <per-PR draft→ready + reviewers triggered this session, from each PR's PREFLIGHT_SUMMARY; "clean" where no-op>
-Actions:  <rebases / phase-a-fixer subagents / /wrap dispatched this session, per PR — include Subagent outcomes>
-Merged:   <PR #s successfully merged this session via /wrap — e.g. "PR #1599, PR #1601"; "none" if none>
-Subagents: <per-PR spawn/complete/failed summary from active_agents audit>
-Blocked:  <PR # + reason for each HARD_BLOCK entry reported this session — e.g. "PR #123 human CHANGES_REQUESTED by @alice">
-```
-
-Hard-blocked PRs are reported here for visibility; the fleet may auto-pause afterward when idle.
 
 ---
 
 ## Safety boundaries (HARD STOPS — `safety.md`, `cr-merge-gate.md`)
 
-This skill is a **parent orchestrator**. The parent rebases/force-pushes (Step 5a), spawns parallel `phase-a-fixer` subagents for fix work (including merge conflicts), and dispatches `/wrap` sequentially for merges. Subagents edit code, resolve conflicts, fix findings, push, and reply/resolve threads — that is their purpose. The parent never reimplements fix/merge/resolve logic directly. The following are absolute:
+This skill is a **parent orchestrator**. The parent rebases/force-pushes (Step 5a), spawns parallel `phase-a-fixer` subagents for fix work including merge conflicts (Step 5c), and dispatches `/wrap` sequentially for merges (Step 5d). Subagents edit code, resolve conflicts, fix findings, push, and reply/resolve threads — that is their purpose. The following are absolute:
 
-- **Parent never edits feature code directly** — dispatch a `phase-a-fixer` subagent instead. Subagents are explicitly permitted and expected to edit feature code.
+- **Parent never edits feature code directly** — dispatch a `phase-a-fixer` subagent. Subagents are explicitly permitted and expected to edit feature code.
 - **Never modify branch protection** — no calls to `.../branches/.../protection`. Subagents inherit this prohibition.
-- **Never dismiss human reviews** — only Bot-allowlist `CHANGES_REQUESTED` on a stale `commit_id` (Steps 5b and 5b′, plus post-subagent dismiss in Step 2.5/5e after a push). Human CR is a hard block. Subagents must not dismiss human-authored reviews.
+- **Never dismiss human reviews** — only Bot-allowlist `CHANGES_REQUESTED` on a stale `commit_id` (Steps 5b and 5b′, plus post-subagent dismiss in Step 2.5/5e after a push). Human CR is a hard block.
 - **Never resolve a review thread without code-verification** — thread resolution happens only inside `phase-a-fixer` Step 5 after verifying the fix. This skill only *counts* unresolved threads.
-- **Never bypass AI-reviewer rate caps** — `cr-review-hourly.sh` gates every CR re-trigger; Greptile/CodeAnt caps are respected by subagents and `/wrap`. The Step 5.0 pre-flight (`pr-preflight.sh`, issue #493) is the sanctioned per-PR trigger path: it gates `@coderabbitai full review` on `cr-review-hourly.sh`, never triggers Greptile, never flips another user's draft, and is strictly per-PR (no shared accumulator — a flip/trigger on one PR never leaks to another).
+- **Never bypass AI-reviewer rate caps** — `cr-review-hourly.sh` gates every CR re-trigger; Greptile/CodeAnt caps are respected by subagents and `/wrap`. The Step 5.0 pre-flight (`pr-preflight.sh`, issue #493) is the sanctioned per-PR trigger path: it gates `@coderabbitai full review` on `cr-review-hourly.sh`, never triggers Greptile, never flips another user's draft, and is strictly per-PR (no shared accumulator).
 - **Never use GitHub's update-branch API** for `BEHIND` — only `git rebase origin/main` + `--force-with-lease`.
 - **Stay in the worktree; never run destructive commands in the root repo** — no `git clean`, `git reset --hard`, or `.env` edits anywhere.
 - **Never merge directly** — PMM never runs `gh pr merge` itself. It lands PRs only by dispatching the full `/wrap` workflow inline after gate + AC pass. No bypass path exists.

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -17,10 +17,6 @@ Thread-level **PR fleet manager**. This skill turns the current thread into a de
 
 > **Per-PR dispatch is inlined below.** `TODO: refactor to call /babysit-pr per discovered PR after #456 lands.` Until #456 merges, Step 3's decision tree is the single owner of per-PR logic. When `/babysit-pr` exists, replace Step 3's inline branches with one `/babysit-pr <PR>` dispatch per discovered PR — the table, discovery, idempotency, and backoff scaffolding here stay unchanged.
 
-This is a **set-and-monitor** command. Once invoked it acknowledges the mode, establishes a `/loop`, and at every tick reprints the fleet table and acts. The **parent thread** never edits feature code directly — it dispatches subagents to do that work — and never drifts into unrelated work.
-
-> **Scope vs `/pm`'s forgotten-PR triage (issue #657).** `/pm` runs a **one-shot** startup triage of *forgotten* PRs, recommends close/merge, and hands merges off to `/wrap` subagents — then it stops. This skill is the opposite: **continuous** fleet monitoring on a recurring `/loop`, driving *every* open PR to merge-ready or a named hard block tick after tick.
-
 Parent/subagent scope, prohibited actions, refusal template, and common misreads: `references/pmm-scope.md`.
 
 ---
@@ -42,8 +38,6 @@ fi
 ```
 
 After any resume (and on the **first** invocation in a thread), null the table digests — `session-state.sh --set '.pmm_digest=null' --set '.pmm_row_digest=null'` — so Step 4's first tick always prints the full table.
-
-Acknowledge mode up front so the constraints survive context compaction:
 
 > **PR-fleet-manager mode active.** My only job in **this parent thread** is to watch and manage your open PRs as a fleet — rediscover them each tick, print a status table, and dispatch rebase / parallel `phase-a-fixer` subagents (fix work, including merge conflicts) / sequential `/wrap` (merge-ready) per the decision tree. Merge-ready PRs are landed autonomously via inline `/wrap` dispatch (unless `--confirm-merges` is set). I will not edit feature code **directly in this thread**, start issues, or do unrelated work here — but I **will** dispatch subagents that edit code, resolve conflicts, fix findings, push, and reply/resolve threads.
 
@@ -126,9 +120,7 @@ When `READ_ONLY_FLEET=1`, skip every dispatch in the decision tree — display o
 
 Before Step 3 re-classifies the fleet, process any **PMM-owned** `phase-a-fixer` subagents (`id` starts with `pmm-fix-`) that completed since the last tick.
 
-**Initialize `EXHAUSTION_RESPAWN_PRS='[]'` at the start of this step, every tick — never carry it over.**
-
-**Load persisted hard blocks at tick start:**
+**Initialize `EXHAUSTION_RESPAWN_PRS='[]'` at the start of this step, every tick — never carry it over. Load persisted hard blocks:**
 
 ```bash
 HARD_BLOCK_JSON=$(.claude/scripts/session-state.sh --get '.pmm_hard_block // {}' 2>/dev/null || echo '{}')
@@ -153,8 +145,6 @@ Full protocol detail (handoff file isolation, tick-start refresh pattern): `refe
 ---
 
 ## Step 3: Gather per-PR state + classify (compute verdicts — NO actions)
-
-Refresh `HARD_BLOCK_JSON` before the per-PR loop:
 
 ```bash
 HARD_BLOCK_JSON=$(.claude/scripts/session-state.sh --get '.pmm_hard_block // {}' 2>/dev/null || echo '{}')
@@ -192,13 +182,9 @@ Read `merge_state` / `mergeable` **literally** from the gate JSON. **Do NOT infe
 
 `merge-gate.sh` exit `3` → `VERDICT=gone`, clear persisted block. Exit `2`/`4` → `VERDICT=error` (retry next tick).
 
-**Initialize `VERDICTS_JSON='{}'` once, before the per-PR loop — never via `${VERDICTS_JSON:-{}}`.** A brace-containing default terminates at its first literal `}` and appends a stray trailing brace, breaking every subsequent `jq` from the second PR onward.
+**Initialize `VERDICTS_JSON='{}'` before the per-PR loop — never via `${VERDICTS_JSON:-{}}` (brace default terminates at first `}`, stray brace breaks subsequent `jq` from PR 2 onward).** Collect hard blocks for reporting only — do not force-stop; idle counter handles convergence (Steps 6/7).
 
-**Collect hard blocks for reporting, but do not force-stop the fleet.** A fleet of only hard-blocked/waiting PRs converges to auto-Pause via the idle counter (Steps 6/7).
-
-**Pre-fetch findings for fix subagents (verdict `fixpr` only)** — stash in `FINDINGS_JSON[N]` for Step 5c.
-
-**Refine `fixpr` verdicts** for concurrency + idempotency: in-flight check → `awaiting fix subagent`; cap check → `queued (cap)`. Exhaustion respawn PRs hold slots unconditionally (tier 1); remaining slots go to fresh `fixpr` PRs by PR number (tier 2).
+**Pre-fetch findings for `fixpr` PRs** — stash in `FINDINGS_JSON[N]` for Step 5c. **Refine `fixpr` verdicts** for concurrency + idempotency: in-flight → `awaiting fix subagent`; cap → `queued (cap)`. Exhaustion respawn holds slots unconditionally (tier 1); fresh `fixpr` PRs by PR# (tier 2).
 
 Full per-row rationale, VERDICTS_JSON accumulation, findings pre-fetch, refinement-pass bash: `references/pmm-classify.md`.
 
@@ -318,10 +304,7 @@ if [ "$DIGEST" = "$PREV" ]; then STREAK=$((STREAK+1)); else STREAK=0; fi
 if [ "$STREAK" -ge 3 ]; then EFFECTIVE_CADENCE="15m"; else EFFECTIVE_CADENCE="$PMM_CADENCE"; fi
 ```
 
-Backoff schedule:
-- **Streak ≥ 3** → `EFFECTIVE_CADENCE=15m`; re-arm with `/loop 15m /pr-monitor-and-manage <same args>`.
-- **Any digest change** (or new user message) → streak resets to 0.
-- **Streak ≥ 9** → suggest `/pmm-stop`; do not force-stop unless a hard block is also present.
+Backoff: **streak ≥ 3** → `EFFECTIVE_CADENCE=15m`, re-arm `/loop 15m /pr-monitor-and-manage <args>`; digest change or user message → reset to 0; **streak ≥ 9** → suggest `/pmm-stop`.
 
 **Idle streak (`pmm_idle_streak`)** — an **idle tick** requires ALL of: (1) `TICK_HAD_ACTION=false`; (2) digest unchanged; (3) no blocking Phase A agents; (4) nothing held by merge sequencing. Orthogonal to cadence widening — widening must **not** reset the idle counter.
 
@@ -373,7 +356,6 @@ NOW=$(date -u +%FT%TZ)
 ```
 
 **Pre-exit checklist (run before ending every polling turn — `scheduling-reliability.md`):**
-
 1. **Next tick scheduled?** Confirm `/loop` is active/re-armed (or stopped/paused per routing above).
 2. **Heartbeat sent?** The Step 4 timestamped line (plus the table when it carried news) is the heartbeat — never end a tick silently.
 3. **State recorded?** `pmm_active`, cadence, watermarks, `pmm_in_flight`, `active_agents`, `pmm_digest(_streak)`, `pmm_row_digest`, `pmm_idle_streak` written to `session-state.json`.
@@ -385,8 +367,6 @@ NOW=$(date -u +%FT%TZ)
 Reached from Step 7 when the fleet is empty or idle. Preserves a resume marker so `/pr-monitor-and-manage-wake` or re-invoking this skill can pick up where it left off.
 
 Full pause procedure (final heartbeat, loop cancel, fleet snapshot + config build, pause marker write, auto-wake cron registration, summary line): `references/pmm-lifecycle.md`.
-
-Key pause marker write:
 
 ```bash
 .claude/scripts/session-state.sh \

--- a/.claude/skills/pr-monitor-and-manage/references/pmm-act.md
+++ b/.claude/skills/pr-monitor-and-manage/references/pmm-act.md
@@ -1,0 +1,354 @@
+# PMM Act: Per-Verdict Dispatch Detail
+
+Reference doc for `.claude/skills/pr-monitor-and-manage/SKILL.md`. Contains the
+full implementation detail for Steps 5a–5e: rebase, dismiss helper, stale-bot
+recovery, parallel fixer dispatch (including subagent prompt template), sequential
+`/wrap` dispatch, and dedicated monitor mode.
+
+---
+
+## Shared gate idiom (Steps 3, 5a, 5d, 5e, 6)
+
+An `active_agents` row with `phase == "A"` and `status` not in `{complete, failed}` blocks rebase, `/wrap`, and fix-dispatch gates unless drained. **PMM-owned** entries (`id` starts with `pmm-fix-`) are blocking until Step 2.5/5e drains them via exit report. **Foreign** entries (any other `id`) are blocking only while NOT stale: apply `PMM_LOCK_STALE_SECS` (default 3600s) to `last_seen_at` (or `launched`), and when the window is exceeded **and** there is no live progress evidence on that PR (HEAD SHA unchanged, no new bot/CI activity since the timestamp), treat the entry as **non-blocking** — PMM never mutates it, but stops deferring on it. All gate checks below use this idiom consistently.
+
+**Track actions this tick** for idle detection (Step 6). Initialize `TICK_HAD_ACTION=false` and `MERGED_THIS_TICK='[]'` at the start of Step 5; set `TICK_HAD_ACTION=true` whenever any of the following fire for any PR: rebase + force-push (Step 5a), stale-bot dismissal (Step 5b or 5b′), explicit owning-bot re-trigger from Step 5b′ (or post-subagent Step 2.5/5e), `phase-a-fixer` spawn (Step 5c), `/wrap` dispatch (Step 5d), or a reviewer trigger from `pr-preflight.sh` that actually posts (non-no-op output). Append PR numbers to `MERGED_THIS_TICK` when `/wrap` successfully merges a PR (Step 5d). Waiting, gone, error, `BLOCKED:*`, and no-op pre-flight do **not** set the flag.
+
+---
+
+## Step 5a: Rebase (verdict `rebase`, i.e. `merge_state == BEHIND`)
+
+**Skip if any Phase A agent is still active for this PR — not just PMM's own.** `BEHIND` is checked before `fixpr` in the decision tree (Step 3), so a PR with a fixer subagent still running from a prior tick can flip to verdict `rebase` if main advanced mid-fix — checking out that branch here would collide with that subagent's own worktree (git refuses to check out the same branch twice) and race its push. This check must match Step 3's in-flight check exactly (same reasoning: two Phase A fixers on one PR is risky regardless of which system spawned them) — checking only `pmm-fix-` entries would miss a foreign (non-PMM) Phase A agent sharing the same `active_agents` array, since `BEHIND`-verdict PRs never go through Step 3's `fixpr`-only refinement pass and so get no other protection. Before rebasing, check for any **blocking** Phase A `active_agents` entry for this PR (per the shared gate idiom above — includes PMM-owned and non-stale foreign entries; stale foreign entries with no progress evidence are non-blocking), or an active `pmm_in_flight[N]` lock **that is not stale** (same `PMM_LOCK_STALE_SECS`, default 3600s, staleness rule as Step 3's in-flight check — a stale lock is broken here too, not treated as blocking); if found, skip this PR this tick (verdict stays `rebase` for the table, but no action runs) — it becomes rebase-eligible once the agent completes and its worktree is cleaned up (Step 2.5 for PMM's own fixers; foreign agents clean up under their own workflow's rules). For foreign Phase A agents, PMM detects completion via Step 5e's poll/staleness signal (entry disappearance, terminal `status`, or `PMM_LOCK_STALE_SECS` timeout with no progress evidence) rather than waiting on cleanup or an exit report it cannot observe.
+
+**Use `git rebase origin/main` + `git push --force-with-lease` — NEVER GitHub's update-branch API.** The API creates bot merge commits that block CI; `auto-update-prs.yml` was removed for exactly this reason.
+
+```bash
+# Pre-flight: never rebase on a dirty tree. This skill runs from a worktree;
+# stay in it and never touch the root repo (safety.md).
+if [ -n "$(git status --porcelain)" ]; then
+  echo "[PMM] PR #$N BEHIND but working tree dirty — skipping rebase, surfacing"; # verdict downgrades to error
+else
+  git fetch origin main --quiet
+  git checkout "$HEADREF" 2>/dev/null || git switch "$HEADREF"
+  if git rebase origin/main; then
+    git push --force-with-lease
+    REBASED_SHA=$(git rev-parse HEAD)
+    # then run Step 5b (dismiss stale bot reviews on the new SHA)
+  else
+    git rebase --abort
+    echo "[PMM] PR #$N rebase hit conflicts — routing to merge-conflict fixer dispatch (Step 5c)"
+    # Override Step 3's `rebase` verdict so Step 5c includes this PR in the *same* tick
+    # (Step 5c only dispatches PRs whose refined verdict is `fixpr`, not `rebase`):
+    VERDICTS_JSON=$(jq --arg n "$N" '.[$n] = {verdict: "fixpr", tag: "merge-conflict", refined: "fixpr"}' <<<"$VERDICTS_JSON")
+    REFINED_VERDICT[$N]="fixpr"
+    # Do NOT add to HARD_BLOCK[] — spawn a phase-a-fixer subagent tasked with the
+    # /merge-conflict workflow instead. Step 5c dispatch runs later this tick.
+  fi
+fi
+```
+
+If the checkout/rebase cannot proceed (branch not present locally, multiple worktrees), surface the PR as `error` and leave it for the user rather than guessing.
+
+---
+
+## Step 5b: Dismiss stale bot reviews after a force-push
+
+Run only after Step 5a actually force-pushed. Uses the **shared dismiss helper** below; **note the macOS bash 3.x blocker**:
+
+> ⚠️ **`dismiss-stale-bot-changes.sh` uses `mapfile` (bash 4+).** On macOS the default `/bin/bash` is 3.2, where `mapfile` is undefined and the script aborts. Until that script is fixed to be 3.x-safe, invoke it through a bash 4+ shim **or** use the inline REST fallback below. Linux CI/cloud agents ship bash 4+, so the direct call works there.
+
+**Shared dismiss helper** (Steps 5b, 5b′, Step 2.5 post-push, and Step 5e inline completion all call this — pass `$N`, optional `$DISMISS_MSG` defaulting to `"Superseded by rebase onto main"` for 5b or `"Superseded — review was on a stale commit"` for 5b′/post-push):
+
+```bash
+DISMISS=""
+for c in "$HOME/.claude/skills-worktree/.claude/scripts/dismiss-stale-bot-changes.sh" \
+         "$HOME/.claude/scripts/dismiss-stale-bot-changes.sh" \
+         ".claude/scripts/dismiss-stale-bot-changes.sh"; do
+  [ -x "$c" ] && { DISMISS="$c"; break; }
+done
+
+BASH4=""; for b in bash /opt/homebrew/bin/bash /usr/local/bin/bash; do
+  v=$("$b" -c 'echo ${BASH_VERSINFO[0]}' 2>/dev/null || echo 0); [ "${v:-0}" -ge 4 ] && { BASH4="$b"; break; }
+done
+
+DISMISS_MSG="${DISMISS_MSG:-Superseded by rebase onto main}"
+
+if [ -n "$DISMISS" ] && [ -n "$BASH4" ]; then
+  "$BASH4" "$DISMISS" "$N"
+else
+  # Inline REST fallback (POSIX-safe, no mapfile) — same allowlist + semantics
+  # as the script: dismiss only Bot-authored CHANGES_REQUESTED whose commit_id
+  # != current HEAD. NEVER touches human reviews.
+  HEAD_SHA=$(gh pr view "$N" --json headRefOid --jq .headRefOid)
+  gh api --paginate "repos/$OWNER/$REPO/pulls/$N/reviews?per_page=100" | jq -s 'add // []' \
+   | jq -r --arg sha "$HEAD_SHA" '
+       ["coderabbitai[bot]","cursor[bot]","greptile-apps[bot]","codeant-ai[bot]","graphite-app[bot]"] as $allow
+       | .[] | select(.state=="CHANGES_REQUESTED")
+       | select((.commit_id//"")!="" and .commit_id!=$sha)
+       | select((.user.type//"")=="Bot")
+       | select(.user.login as $l | $allow|index($l)) | .id' \
+   | while read -r rid; do
+       [ -n "$rid" ] && gh api -X PUT \
+         "repos/$OWNER/$REPO/pulls/$N/reviews/$rid/dismissals" \
+         -f message="$DISMISS_MSG" >/dev/null 2>&1 \
+         && echo "[PMM] dismissed stale bot review_id=$rid on #$N"
+     done
+fi
+```
+
+---
+
+## Step 5b′: Stale bot `CHANGES_REQUESTED` recovery (verdict `fixpr` — issue #514)
+
+Run **before Step 5c** for every PR whose Step 3 verdict is `fixpr` (or refined `fixpr`) **and** `STALE_BOT_CR > 0` from the tick's gate JSON. Do **not** run when the only bot signal is a **fresh** `CHANGES_REQUESTED` on the current HEAD (`STALE_BOT_CR == 0`) — that PR needs Step 5c fix work, not dismissal/re-trigger. This is **independent of whether Step 5a rebased** — Step 5b only runs after a force-push; without 5b′ a PR blocked *only* by a stale bot review would spawn a no-op `phase-a-fixer` every tick forever.
+
+**Dismiss** — run the shared dismiss helper with `DISMISS_MSG="Superseded — review was on a stale commit"`. Idempotent (already-`DISMISSED` counts as success). The helper only dismisses reviews whose `commit_id` ≠ current HEAD; never touches fresh bot CR on HEAD.
+
+**Re-trigger the owning bot** — post an **explicit** trigger for the owning reviewer on the current HEAD. Resolve via `.claude/scripts/reviewer-of.sh "$N"` (same mapping as `pr-preflight.sh`'s `reviewer_trigger()`).
+
+> **Since #576, Step 5.0's pre-flight already re-triggers a bot whose only activity is on a superseded commit** — which is exactly this step's situation (the review just dismissed was on a stale SHA). This step therefore **skips** any reviewer pre-flight already triggered on this tick; without that guard both would post for the same PR in the same tick, and for CodeRabbit that burns two of the ≤2/PR/hour explicit-trigger slots at once. It still runs when pre-flight was unavailable, skipped the PR, or reported the reviewer `already-present` / `skipped-rate-cap` — the case this step was written for.
+
+```bash
+REVIEWER=$(.claude/scripts/reviewer-of.sh "$N" 2>/dev/null || echo unknown)
+
+# Skip when Step 5.0's pre-flight already triggered this reviewer this tick
+# (issue #576) — it re-triggers stale-SHA bots itself now, so a second post here
+# would be a duplicate (and would double-spend CodeRabbit's per-PR cap).
+PF_KEY=""
+case "$REVIEWER" in
+  cr) PF_KEY="coderabbit" ;;   # gate-side name → pre-flight reviewer key
+  bugbot) PF_KEY="cursor" ;;
+  graphite) PF_KEY="graphite" ;;
+esac
+if [ -n "$PF_KEY" ] && [ -n "${PF_SUMMARY_BY_PR[$N]:-}" ] \
+   && [ "$(jq -r --arg k "$PF_KEY" '.reviewers[$k].status // ""' <<<"${PF_SUMMARY_BY_PR[$N]}" 2>/dev/null)" = "triggered" ]; then
+  echo "[PMM] pre-flight already re-triggered $REVIEWER on #$N this tick — skipping duplicate explicit trigger"
+  REVIEWER="__already_triggered__"
+fi
+CR_HOURLY=""
+for c in "$HOME/.claude/skills-worktree/.claude/scripts/cr-review-hourly.sh" \
+         "$HOME/.claude/scripts/cr-review-hourly.sh" \
+         ".claude/scripts/cr-review-hourly.sh"; do
+  [ -x "$c" ] && { CR_HOURLY="$c"; break; }
+done
+
+case "$REVIEWER" in
+  cr)
+    if [ -n "$CR_HOURLY" ] && "$CR_HOURLY" --check >/dev/null 2>&1 \
+       && "$CR_HOURLY" --peek-explicit "$N" >/dev/null 2>&1; then
+      if gh pr comment "$N" --body "@coderabbitai full review" >/dev/null 2>&1; then
+        "$CR_HOURLY" --record-explicit "$N" >/dev/null 2>&1 || true
+        echo "[PMM] re-triggered owning bot (cr) on #$N"
+      fi
+    else
+      echo "[PMM] CodeRabbit rate cap hit — skipping explicit re-trigger on #$N"
+    fi
+    ;;
+  bugbot)
+    gh pr comment "$N" --body "@cursor review" >/dev/null 2>&1 \
+      && echo "[PMM] re-triggered owning bot (bugbot) on #$N"
+    ;;
+  graphite)
+    gh pr comment "$N" --body "@graphite-app re-review" >/dev/null 2>&1 \
+      && echo "[PMM] re-triggered owning bot (graphite) on #$N"
+    ;;
+  greptile)
+    echo "[PMM] greptile owning reviewer on #$N — no auto-trigger per greptile.md"
+    ;;
+  __already_triggered__)
+    : # pre-flight covered it this tick (#576) — message already printed above
+    ;;
+  *)
+    echo "[PMM] unknown reviewer on #$N — skipping explicit re-trigger"
+    ;;
+esac
+```
+
+Never batch mention strings; never auto-trigger Greptile. Set `TICK_HAD_ACTION=true` when dismissal or re-trigger posts.
+
+**Re-gate and gate Step 5c** — re-run `.claude/scripts/merge-gate.sh "$N"`, stash in `GATE_BY_PR[$N]`, re-read `MET`, `CI_FAILING`, `STALE_BOT_CR`, `UNRESOLVED` (re-fetch unresolved thread count if needed). Then:
+   - **`MET == true`** → treat as `wrap` for Step 5d this tick (skip Step 5c spawn for this PR).
+   - **`CI_FAILING > 0` or `UNRESOLVED > 0`** → proceed to Step 5c spawn (real fix work remains).
+   - **Otherwise** (reviewer pending on fresh trigger, no CI/thread fix work) → skip Step 5c; verdict becomes `waiting` on the next tick when the bot lands.
+
+---
+
+## Step 5c: Parallel `phase-a-fixer` dispatch (verdict `fixpr`)
+
+Fix work runs in **parallel** via one `phase-a-fixer` subagent per PR, capped at `$PMM_MAX_PARALLEL` (default 3). Merge dispatch stays sequential (Step 5d) — merges affect main and must not race.
+
+**Two fixer task types share this dispatch path:**
+
+1. **CR/CI/thread fix work** (`fixpr` from CI failing, unresolved threads, or stale bot CR) — standard Phase A fixer workflow per `.claude/agents/phase-a-fixer.md`.
+2. **Merge-conflict resolution** (`fixpr` with `merge-conflict` tag from `mergeable == CONFLICTING`, or from Step 5a rebase hitting conflicts) — same spawn shape, but the subagent prompt directs it to run the `/merge-conflict` skill workflow: rebase onto base → `resolve_merge_conflicts.py` for safe hunks → apply judgment to complex hunks → commit + force-push. Unresolvable conflicts exit with `OUTCOME: blocked` (see Step 2.5); the parent surfaces them as `BLOCKED:conflicts(needs-human)`.
+
+Conflict dispatches participate in the same parallel cap, batched `session-state.sh --set` write, and `pmm-fix-$N` tracking as CR/CI fixers. Set the Subagent column to `dispatched (merge-conflict)` when spawning for conflict resolution.
+
+**Idempotency and concurrency are already resolved in Step 3's refinement pass** — Step 5c dispatches every PR whose *refined* verdict is still `fixpr` **and** Step 5b′ did not re-gate it to `wrap`/`waiting`. PRs refined to `awaiting fix subagent` or `queued (cap)` are skipped here with no further action; they are eligible again once Step 3 re-evaluates on a later tick.
+
+**CR hourly cap (fleet-wide).** Before spawning, snapshot the budget:
+
+```bash
+CR_BUDGET_OK=1
+.claude/scripts/cr-review-hourly.sh --check >/dev/null 2>&1 || CR_BUDGET_OK=0
+```
+
+If `$CR_BUDGET_OK == 0`, still spawn subagents but include `SKIP_CR_TRIGGER=1` in each prompt. Do **not** block spawn entirely when the cap is exhausted.
+
+**Bulk spawn (one Agent call per PR, all in parallel up to the cap).** For each PR allocated a slot, read `VERDICTS_JSON[$N].tag` — when it is `merge-conflict`, set `TASK_TYPE=merge-conflict`. Otherwise use `TASK_TYPE=fixpr`. Invoke the Agent tool with:
+
+```text
+subagent_type: "phase-a-fixer"
+name: "pmm-fix-$N"
+mode: "bypassPermissions"
+model: "opus"
+isolation: "worktree"
+run_in_background: true
+```
+
+**Subagent prompt MUST include:**
+
+- PR number, branch name (`headRefName`), repo (`$OWNER/$REPO`), linked issue number (if any)
+- Current HEAD SHA from the tick's gate JSON
+- Reviewer classification (`cr`, `bugbot`, or `greptile`) — omit or set to `none` for merge-conflict-only dispatches
+- **Task type:** `fixpr` (CR/CI findings) or `merge-conflict` (conflict resolution) — for `merge-conflict`, include: "Run the `/merge-conflict` skill workflow: fetch main, rebase, run `resolve_merge_conflicts.py`, resolve complex hunks with judgment, commit + force-push. Exit with `OUTCOME: blocked` if conflicts are genuinely unresolvable."
+- Handoff file path: resolve with `handoff-state.sh [--owner-repo owner/repo] --path N` (scoped: `~/.claude/handoffs/{owner}/{repo}/pr-{N}-handoff.json`; legacy flat during migration)
+- Pre-fetched findings from Step 3 (`FINDINGS_JSON[N]`) — omit for merge-conflict-only dispatches
+- `SKIP_CR_TRIGGER=1` when `$CR_BUDGET_OK == 0`
+- The verbatim `SAFETY:` block from `.claude/rules/safety.md`
+- The verbatim `MINDSET:` block from `.claude/rules/safety.md`
+- The verbatim `SKILLS:` block from `.claude/rules/skill-first.md`
+
+**Record all of this tick's spawns in ONE single write, after every Agent call has been issued — never one read-modify-write per PR.** `session-state.sh` has no cross-process lock; if each parallel spawn ran its own independent `--get` → append → `--set` cycle, two spawns' read-modify-write windows can interleave and the second writer's `--set` clobbers the first writer's append. Since the parent is a single sequential thread even when it fires N Agent tool calls in one message, build every new entry first, then issue exactly one `session-state.sh` call for the whole batch:
+
+```bash
+NOW=$(date -u +%FT%TZ)
+NEW_ENTRIES='[]'
+IN_FLIGHT_SETS=()
+# ONE loop per spawned PR — build that PR's entry AND its --set argument together,
+# each using ONLY that PR's own head_sha. Never hoist head_sha into a shared
+# variable reused across iterations or across a second loop — the last PR's SHA
+# would silently overwrite every earlier PR's lock.
+for N in $SPAWNED_PR_NUMS; do
+  N_HEAD_SHA=$(jq -r '.head_sha' <<<"${GATE_BY_PR[$N]}")   # that PR's own tick-scoped $GATE
+  ISSUE_N=$(.claude/scripts/pr-issue-ref.sh "$N" 2>/dev/null || echo null)
+  AGENT_ID="pmm-fix-$N"
+  ENTRY=$(jq -n --arg id "$AGENT_ID" --arg task "PMM fix PR #$N" --argjson issue "$ISSUE_N" \
+    --argjson pr "$N" --arg launched "$NOW" --arg head_sha "$N_HEAD_SHA" \
+    '{id:$id, task:$task, issue:$issue, pr:$pr, phase:"A", status:"spawned", launched:$launched, head_sha:$head_sha}')
+  NEW_ENTRIES=$(jq --argjson entry "$ENTRY" '. + [$entry]' <<<"$NEW_ENTRIES")
+  IN_FLIGHT_SETS+=(--set ".pmm_in_flight.\"$N\"={\"skill\":\"phase-a-fixer\",\"status\":\"active\",\"dispatched_at\":\"$NOW\",\"head_sha\":\"$N_HEAD_SHA\",\"agent_id\":\"$AGENT_ID\"}")
+done
+
+# After the loop — ONE read of the current array, ONE append of the whole batch, ONE write:
+CURRENT_AGENTS=$(.claude/scripts/session-state.sh --get '.active_agents' 2>/dev/null || echo null)
+[ "$CURRENT_AGENTS" = "null" ] && CURRENT_AGENTS='[]'
+UPDATED_AGENTS=$(jq --argjson entries "$NEW_ENTRIES" '. + $entries' <<<"$CURRENT_AGENTS")
+.claude/scripts/session-state.sh --set ".active_agents=$UPDATED_AGENTS" "${IN_FLIGHT_SETS[@]}"
+```
+
+Set Subagent column to `spawned` immediately for every PR in this batch; transition to `working` once each subagent reports activity (first tool call or ~30s elapsed).
+
+**Safety boundaries for every subagent (non-negotiable):**
+- Never modify branch protection
+- Never dismiss human-authored reviews
+- Never resolve a review thread without code-verification (per `phase-a-fixer` Step 5)
+
+---
+
+## Step 5d: Sequential `/wrap` dispatch (verdict `wrap` — merge-ready)
+
+Merge-ready PRs get **sequential** `/wrap` dispatch — one at a time, never parallelized. Merges affect main branch state (main-sync, follow-up detection, lessons) and must not race. PMM never runs `gh pr merge` directly — landing always flows through the full `/wrap` workflow.
+
+**Deferral gate — check this FIRST, before any lock acquisition or `/wrap` execution below.** "Fix subagents active this tick" means spawned just now by Step 5c OR still running from a prior tick — check both: any Step 5c spawn this tick, **or** a **blocking** Phase A `active_agents` entry (per the shared gate idiom — any `id`, not just `pmm-fix-` prefixed; stale foreign entries with no progress evidence are non-blocking; this must match Step 5a's rebase-skip check exactly). This matters because a `/pmm-stop`-then-resume, or a tick where Step 3's refinement pass left every `fixpr` PR at `awaiting fix subagent`/`queued (cap)` with zero *new* spawns, would otherwise slip past a "spawned this tick" check while a background fixer is still mid-flight on a shared branch/worktree.
+
+Process merge-ready PRs **only when no fix subagents are active this tick** — run Step 5d sequentially before Step 5e. **If any fix subagents are active, stop here and defer all `/wrap` dispatches** until the Step 5e monitor loop has drained every active fix subagent.
+
+**Merge-sequencing gate (issue #756) — apply after the deferral gate, before any lock.** Read each PR's Step 3.6 action from `SEQ`:
+- **`held(#A)`** → skip this tick entirely. No confirmation prompt, no lock write, no `/wrap`. The PR keeps its `wrap` readiness and is re-evaluated next tick.
+- **`batch(#A)`** → dispatch it in **this** tick, alongside every other `batch` member of the same anchor. They still merge **one at a time**, but all within this single tick's merge window.
+- **`merge`** → dispatch normally.
+
+**Order within the tick:** anchors first, then batch members in ascending PR number, then everything else.
+
+**The merge-dispatch set is `wrap` ∪ `batch(#A)`, minus `held(#A)`** — define it explicitly before the loop below. Step 3.6 *replaces* a PR's `wrap` verdict with `batch(#A)` when it releases a hold, so a dispatch condition written as "`VERDICT == wrap`" alone would silently skip every released PR:
+
+```bash
+MERGE_SET=()
+for N in $PR_NUMS; do
+  case "${REFINED_VERDICT[$N]:-${VERDICT_BY_PR[$N]}}" in
+    wrap|batch\(*) MERGE_SET+=("$N") ;;   # both dispatch
+    held\(*)       ;;                      # held this tick — no lock, no /wrap
+  esac
+done
+```
+
+**Idempotency-gated via `pmm_in_flight`** (only reached once the deferral gate above is open):
+
+```bash
+INFLIGHT=$(.claude/scripts/session-state.sh --get ".pmm_in_flight.\"$N\"" 2>/dev/null || echo null)
+```
+
+- `$INFLIGHT` has `status == "active"` → skip (verdict `awaiting prior /wrap`) unless stale per `PMM_LOCK_STALE_SECS` (default **3600s**) with no live progress evidence.
+- `$INFLIGHT` is `null` (or stale lock broken) → proceed to merge dispatch below.
+
+**Merge dispatch — no confirmation prompt by default.** For each `$N` in `MERGE_SET` (verdict `wrap` **or** `batch(#A)` — never `held(#A)`), in the order above:
+
+1. **When `PMM_CONFIRM_MERGES` is true:** emit a per-PR confirmation prompt ("Merge-ready: dispatch `/wrap` for #N?") **before** acquiring any lock. If declined, skip this PR this tick with **no** `pmm_in_flight` write — do not leave a stale lock.
+2. **When confirmed (or when `PMM_CONFIRM_MERGES` is false):** acquire the idempotency lock:
+
+```bash
+NOW=$(date -u +%FT%TZ)
+HEAD_SHA=$(jq -r '.head_sha' <<<"${GATE_BY_PR[$N]}")
+.claude/scripts/session-state.sh --set \
+  ".pmm_in_flight.\"$N\"={\"skill\":\"wrap\",\"status\":\"active\",\"dispatched_at\":\"$NOW\",\"head_sha\":\"$HEAD_SHA\"}"
+```
+
+Execute the **full** `/wrap` workflow inline (all 4 phases). PMM relies on `/wrap`'s own gate re-check (`merge-gate.sh`) and AC verification (`ac-checkboxes.sh`) — if the gate is no longer met (SHA moved, CI regressed) or AC fails, `/wrap` stops and returns a hard block; PMM records it and re-classifies on the next tick without re-authorizing or re-prompting.
+
+On completion:
+- `/wrap` merged the PR → clear `pmm_in_flight[N]`; append `#N` to `MERGED_THIS_TICK` and `MERGED_THIS_SESSION` (dedupe on append); PR drops from fleet on next `gh pr list`.
+- `/wrap` returned a hard block → clear in-flight and add `#N` to `HARD_BLOCK[]` for reporting (Step 4 next tick). Do **not** force-stop the fleet.
+
+---
+
+## Step 5e: Dedicated monitor mode while fix subagents are active
+
+If any **blocking** fix subagents are active this tick (per the shared gate idiom and the deferral-gate definition in Step 5d — spawned now or carried over from a prior tick), **immediately enter an orchestration-only posture borrowing `monitor-mode.md`'s Dedicated Monitor Mode discipline** — the **parent's** ONLY job until every blocking fix subagent completes, fails, or is drained (foreign: disappearance / terminal `status` / `PMM_LOCK_STALE_SECS` staleness timeout) is orchestration (poll, verify, heartbeat); the parent does no direct feature-code edits, no local CR review, no substantive source analysis — but its subagents edit code, resolve conflicts, and push as designed. **PMM does NOT execute `monitor-mode.md`'s Monitor Loop Per-Cycle Checklist verbatim** — specifically, it never runs `phase-protocols.md`'s Phase Completion Protocols, which would otherwise auto-launch Phase B after Phase A. Step 2.5's aggregation fully replaces that: PMM fixes and pushes only, per Step 0's contract ("PMM does not launch Phase B/C after Phase A").
+
+**PMM's own monitor loop (~60s cadence — replaces, not layers on, `monitor-mode.md`'s checklist):**
+
+1. **Poll active subagent statuses — ownership-aware drain.** Each ~60s cycle, read `active_agents` and partition the Phase A entries gating deferred PRs into **PMM-owned** (`id` starts with `pmm-fix-`) and **foreign** (any other `id`) sets.
+
+   **PMM-owned entries:** Transition Subagent column: `spawned` → `working` → `complete` / `failed`. On completion (success, exhaustion, or crash), proceed to item 2 below.
+
+   **Foreign entries:** PMM has no exit report to parse and must never clean up or remove state it does not own — foreign agents drain by poll-based observation only (see below). While waiting, surface the PR's Subagent column as `deferred(foreign-agent)`.
+
+   For each foreign Phase A entry, the **drain signal** is:
+   - The entry **disappears** from `active_agents` (authoritative — the owning workflow removed it), **or**
+   - Its `status` flips to `complete` or `failed` (secondary/opportunistic).
+
+   PMM must **not** perform worktree cleanup, remove, or mutate the foreign entry or any foreign lock — the owning workflow cleans up under its own rules. PMM only observes and stops deferring once the entry is gone or terminal.
+
+   **Staleness fallback (foreign only):** Reuse `PMM_LOCK_STALE_SECS` (default 3600s), applied to the foreign entry's freshness timestamp (`last_seen_at` if present, else `launched`). When the entry exceeds the staleness window **and** there is no live evidence of progress on that PR (HEAD SHA unchanged since the timestamp, no new bot/CI activity since the timestamp), log the stale foreign agent, surface the Subagent column as `foreign-agent-stale`, and treat the entry as **non-blocking** per the shared gate idiom — the deferral gate reopens for that PR so `/wrap` may proceed after the monitor loop exits (rebase on the next tick also proceeds, since Step 5a uses the same idiom). Same conservatism as the existing lock-staleness idiom — the wide window and no-progress corroboration prevent pre-empting a healthy long-running foreign fixer; PMM still does not touch the foreign entry, it only stops waiting on it.
+
+   **Gate reopen:** Once a PR has no remaining **blocking** Phase A entry of either kind, the deferral gate for that PR reopens and its deferred `/wrap` dispatch proceeds after the monitor loop exits, per existing Step 5d/5e ordering.
+
+2. **On PMM-owned completion** — success, exhaustion, or crash — **run Step 2.5's steps 1-3 in full** (parse exit report, worktree cleanup, remove this agent's own `active_agents` record + clear `pmm_in_flight[N]`) before branching on outcome. When OUTCOME is `pushed_fixes`, also run **Step 5b dismiss helper + Step 5b′ owning-bot re-trigger** on that PR (issue #514 — mirrors `/fixpr` 3a/3b; set `TICK_HAD_ACTION=true` if dismissal or re-trigger posts). This is unconditional, not just the success path — a failure that skips clearing `pmm_in_flight[N]` would otherwise leave a stale lock blocking Step 3's idempotency check until `PMM_LOCK_STALE_SECS` expires.
+3. Branch on outcome for **PMM-owned** entries only (per Step 2.5's step 4, cleanup from item 2 above already done):
+   - **Crash / no exit report / stale >15 min:** mark `failed` in the table and add `#N` to `HARD_BLOCK[]` with reason `crashed(needs-approval)` — never re-dispatch silently. Reported once and dropped from the actionable fleet this tick; the user can explicitly approve a respawn.
+   - **`blocked` (unresolvable merge conflict or other fix blocker):** add `#N` to `HARD_BLOCK[]` with reason from the exit report (e.g. `conflicts(needs-human)`). Report once and drop from the actionable fleet.
+   - **Token/turn exhaustion with a valid handoff file:** respawn immediately **using Step 5c's spawn pattern**, but with **freshly re-fetched** gate and findings data for this PR — do NOT reuse tick-start `GATE_BY_PR[$N]`/`FINDINGS_JSON[$N]` verbatim. Real time has passed since Step 3 computed them, and the exhausted subagent may have pushed partial progress before running out of tokens, moving the PR's actual HEAD SHA and review state past that tick-start snapshot; a respawn using the stale SHA/findings would hand the replacement outdated context. Re-run `.claude/scripts/merge-gate.sh "$N"` (and re-fetch findings from the three endpoints, same as Step 3's pre-fetch) immediately before building the replacement's spawn record.
+4. Send heartbeat if >5 min since last user message (timestamp prefix required).
+5. Investigate stale **PMM-owned** agents (>15 min Phase A without progress). Foreign staleness is handled by item 1's `PMM_LOCK_STALE_SECS` fallback.
+
+**While subagents run:** do not start rebases, new spawns for other PRs, or `/wrap` dispatches. **Exception:** an exhaustion respawn for a PR already in this tick's active-fixer set is a continuation of already-approved fix work — it is exempt from this restriction and proceeds inline. Deferred merge-ready PRs from Step 5d run immediately after the monitor loop exits. The tick completes only after all spawned fix subagents return (or fail) and any deferred `/wrap` dispatches finish. Then proceed to Step 6.
+
+**#497 compatibility (idle auto-pause):** when all subagents exit and no parent dispatches remain in-flight, treat the tick as idle for digest/backoff purposes — the stable-state countdown in Step 6 applies as if the tick were a no-op dispatch tick.
+
+**Tick merge summary.** After all Step 5 actions complete, if `MERGED_THIS_TICK` is non-empty, print one line per merged PR (already recorded in `MERGED_THIS_SESSION` at `/wrap` completion — do not append again here):
+
+```text
+merged #N
+```
+
+Initialize `MERGED_THIS_SESSION='[]'` on the first tick in Step 0/Step 1.

--- a/.claude/skills/pr-monitor-and-manage/references/pmm-classify.md
+++ b/.claude/skills/pr-monitor-and-manage/references/pmm-classify.md
@@ -1,0 +1,256 @@
+# PMM Classification Detail
+
+Reference doc for `.claude/skills/pr-monitor-and-manage/SKILL.md`. Contains the
+verbose rationale for the per-PR decision tree, the VERDICTS_JSON/findings
+accumulation protocol, the Step 3 refinement pass, Step 3.6 merge-sequencing
+implementation, and the Step 4 heartbeat/quiet-tick definition.
+
+---
+
+## Step 3: Gather per-PR state + classify
+
+**Refresh `HARD_BLOCK_JSON` immediately before the per-PR loop** so Step 2.5 `blocked`/`crashed` persists from earlier in this same tick are visible to the decision tree (the Step 2.5 tick-start load is stale once Step 2.5 writes new entries):
+
+```bash
+HARD_BLOCK_JSON=$(.claude/scripts/session-state.sh --get '.pmm_hard_block // {}' 2>/dev/null || echo '{}')
+```
+
+This step performs no PR mutations or dispatches: it gathers state, computes verdicts, and may persist orchestration bookkeeping (e.g. Step 3.6's `.pmm_merge_holds`). PR mutations and dispatches happen in **Step 5**, after the heartbeat/table prints (Step 4). This ordering is required so the classification is always visible *before* any long-running dispatch.
+
+For **each** PR number, gather state. Run the per-PR fetches **in parallel across PRs** (one batch of background jobs, then collect), since they are independent network calls.
+
+For a single PR `$N` (with `$HEADREF` = its `headRefName` from the Step 2 `$PR_LIST`):
+
+```bash
+# Gate verdict — single source of truth for merge readiness, CI, merge_state,
+# review_decision, human_changes_requested, stale_bot_changes_requested_count.
+GATE=$(.claude/scripts/merge-gate.sh "$N"); GATE_EXIT=$?
+GATE_BY_PR[$N]="$GATE"   # retain per-PR — Step 5c/5d look up THIS PR's gate by
+                          # number rather than relying on a loop-scoped $GATE,
+                          # which is only valid for whichever PR Step 3 last
+                          # iterated and goes stale/wrong once other steps
+                          # iterate their own PR lists.
+# Linked issue for the Issue column (exit 1 = no link, expected).
+ISSUE=$(.claude/scripts/pr-issue-ref.sh "$N" 2>/dev/null || true)
+# Unresolved review threads (GraphQL — covers every bot/human author).
+UNRESOLVED=$(gh api graphql -f query='
+  query($owner:String!,$repo:String!,$n:Int!){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$n){
+        reviewThreads(first:100){ nodes { isResolved } } } } }' \
+  -F owner="$OWNER" -F repo="$REPO" -F n="$N" \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length' \
+  2>/dev/null || echo "?")
+```
+
+Pull the fields the table and decision tree need out of `$GATE`:
+
+```bash
+MET=$(jq -r '.met' <<<"$GATE")
+MERGE_STATE=$(jq -r '.merge_state' <<<"$GATE")          # CLEAN|BEHIND|BLOCKED|...
+MERGEABLE=$(jq -r '.mergeable' <<<"$GATE")              # MERGEABLE|CONFLICTING|UNKNOWN
+REVIEW_DECISION=$(jq -r '.review_decision' <<<"$GATE")  # APPROVED|CHANGES_REQUESTED|REVIEW_REQUIRED
+CI_FAILING=$(jq -r '.ci_status.failing' <<<"$GATE")
+CI_INPROG=$(jq -r '.ci_status.in_progress' <<<"$GATE")
+CI_PASSING=$(jq -r '.ci_status.passing' <<<"$GATE")
+HUMAN_CR=$(jq -r '.human_changes_requested | join(",")' <<<"$GATE")
+STALE_BOT_CR=$(jq -r '.stale_bot_changes_requested_count // 0' <<<"$GATE")
+```
+
+### Decision tree rationale (per row)
+
+Read `merge_state` / `mergeable` **literally** from the gate JSON. **Do NOT infer `BEHIND` from `BLOCKED`** — `BLOCKED` also covers missing checks/reviews, not just behind-base. Only the literal `BEHIND` triggers a rebase.
+
+| Condition (checked in order) | `VERDICT` | Rationale |
+|------------------------------|-----------|-----------|
+| PR in persisted `pmm_hard_block` | `BLOCKED:<reason>` | Overrides all other conditions including `CONFLICTING` — a prior-tick blocked/crashed exit already attempted resolution; do not re-dispatch silently |
+| `human_changes_requested` non-empty | `BLOCKED:human(@login)` | Human CR is a hard block — name each login; never auto-dismiss; requires human action to unblock |
+| `mergeable == CONFLICTING` | `fixpr` (`merge-conflict`) | Spawn `phase-a-fixer` tasked with `/merge-conflict` workflow; only `blocked` exit by the subagent turns it into `BLOCKED:conflicts(needs-human)` |
+| `merge_state == BEHIND` | `rebase` | Rebase + force-push is a parent-inline operation (Step 5a) — cheaper than a subagent spawn; rebase abort routes to `fixpr(merge-conflict)` in Step 5a |
+| `CI_FAILING > 0` **or** `UNRESOLVED > 0` | `fixpr` (`has-recoverable-blockers`) | Delegate fix work to Phase A fixer subagent |
+| `MET == false` and (`STALE_BOT_CR > 0` or `REVIEW_DECISION == CHANGES_REQUESTED` with no human CR) | `fixpr` (`has-recoverable-blockers`) | Step 5b′ dismisses stale bot reviews + re-triggers; spawn Phase A when fix work remains |
+| `MET == true` | `wrap` | Dispatch `/wrap` sequentially (Step 5d) |
+| Otherwise | `waiting` | CI in-progress, reviewer pending, `REVIEW_REQUIRED` with no bot signal yet, `UNKNOWN` — no-op |
+
+`merge-gate.sh` exit `3` (PR gone — merged/closed between Step 2 and now) → `VERDICT=gone`, clear persisted block (`.claude/scripts/session-state.sh --set ".pmm_hard_block.\"$N\"=null"`), drop from fleet. When the user explicitly approves respawn of a `crashed(needs-approval)` or `conflicts(needs-human)` PR, clear the same `pmm_hard_block` key before dispatch. Exit `2`/`4` (tooling/network) → `VERDICT=error` (do not act; retry next tick).
+
+### VERDICTS_JSON accumulation
+
+**Accumulate `VERDICTS_JSON` as each PR is classified — this is what Step 5.0's pre-flight gone/error skip reads.** Without this, `VERDICTS_JSON` stays an implicit empty object, the skip check never matches, and pre-flight runs against merged/errored PRs it should have skipped:
+
+**Initialize `VERDICTS_JSON='{}'` once, before the per-PR loop — never via a `${VERDICTS_JSON:-{}}` default.** A brace-containing parameter-expansion default terminates at its **first literal `}`**, so once the variable holds real content that form expands to the JSON *plus a stray trailing brace* (`{"618":{"verdict":"wrap"}}` + `}`) and every subsequent `jq` in the loop fails on invalid input. The bug only shows up from the second PR onward, which is exactly when it is hardest to spot.
+
+```bash
+VERDICTS_JSON='{}'   # once, before the loop — plain expansion everywhere below
+
+# ... per PR:
+TAG=""
+if [[ "$VERDICT" == "fixpr" && "$MERGEABLE" == "CONFLICTING" ]]; then
+  TAG="merge-conflict"
+fi
+if [[ -n "$TAG" ]]; then
+  VERDICTS_JSON=$(jq --arg n "$N" --arg v "$VERDICT" --arg tag "$TAG" \
+    '.[$n] = {verdict: $v, tag: $tag}' <<<"$VERDICTS_JSON")
+else
+  VERDICTS_JSON=$(jq --arg n "$N" --arg v "$VERDICT" '.[$n] = {verdict: $v}' <<<"$VERDICTS_JSON")
+fi
+```
+
+**Collect hard blocks for reporting, but do not force-stop the fleet.** Push every PR with a `BLOCKED:*` verdict onto a `HARD_BLOCK[]` list (with its reason). These PRs are **reported once and dropped from the actionable fleet** for this tick — they do not trigger Stop & Clean Exit. A fleet of only hard-blocked/waiting PRs converges to auto-Pause via the idle counter (Step 6/7). The `rebase`/`fixpr`/`wrap` verdicts are executed in Step 5.
+
+### Findings pre-fetch (verdict `fixpr` only)
+
+While gathering state, also fetch review findings from the three endpoints so Step 5c can embed them in each subagent prompt without a second round-trip:
+
+```bash
+# Per PR with fixpr verdict — stash in FINDINGS_JSON[N]
+gh api "repos/$OWNER/$REPO/pulls/$N/reviews?per_page=100"
+gh api "repos/$OWNER/$REPO/pulls/$N/comments?per_page=100"
+gh api "repos/$OWNER/$REPO/issues/$N/comments?per_page=100"
+```
+
+Filter to actionable bot findings (`coderabbitai[bot]`, `cursor[bot]`, `greptile-apps[bot]`, `codeant-ai[bot]`, `graphite-app[bot]`). Also record the **reviewer classification** (`cr`, `bugbot`, or `greptile`) from `reviewer-of.sh` or gate JSON for the subagent prompt.
+
+### Refinement pass: `fixpr` verdicts for concurrency + idempotency (still Step 3)
+
+Step 5c's parallel-dispatch decisions (skip-if-in-flight, cap slots) are pure reads against `session-state.json` — compute them here, **before Step 4 prints the table**, so the heartbeat never shows a stale `fixpr` for a PR that is actually already in flight or waiting on a slot.
+
+For every PR whose base verdict is `fixpr`:
+
+1. **In-flight check.** Refine to `awaiting fix subagent` if a **blocking** Phase A `active_agents` entry exists for this PR (per Step 5's shared gate idiom — foreign entries past `PMM_LOCK_STALE_SECS` with no progress evidence are non-blocking), OR if `pmm_in_flight[N]` has an active lock for the same PR **that is not stale** — apply the same `PMM_LOCK_STALE_SECS` (default 3600s) staleness rule Step 5d uses for `/wrap` locks. A stale lock (e.g. a `wrap` lock left over from a crashed parent, on a PR now reclassified `fixpr`) is broken here too, not just in Step 5d — otherwise a stale non-`phase-a-fixer` lock can block fix dispatch forever with no path to clear it.
+2. **Cap check.** Among the PRs still `fixpr` after step 1, count currently active **PMM-spawned** fix subagents (`id` prefixed `pmm-fix-` — excludes Phase A agents spawned by other workflows sharing the same `active_agents` array) and compute remaining slots:
+
+   ```bash
+   ACTIVE_COUNT=$(jq '[.[] | select(.phase == "A" and (.status != "complete" and .status != "failed")
+     and ((.id // "") | startswith("pmm-fix-")))] | length' \
+     <<<"$(.claude/scripts/session-state.sh --get '.active_agents' 2>/dev/null || echo '[]')")
+   SLOTS=$(( PMM_MAX_PARALLEL - ACTIVE_COUNT ))
+   (( SLOTS < 0 )) && SLOTS=0
+   ```
+
+   Allocate the `$SLOTS` available slots in two tiers, never by plain PR-number order alone: **tier 1** — every PR in `EXHAUSTION_RESPAWN_PRS` (populated by Step 2.5 this tick) keeps verdict `fixpr` unconditionally, even if it exceeds `$SLOTS` — an exhaustion-with-handoff respawn is mandatory per `subagent-orchestration.md`, not slot-competitive, so it must never lose to a fresh PR. **Tier 2** — remaining slots (`$SLOTS` minus tier-1 count, floored at 0) go to the rest of the still-`fixpr` PRs by PR number order, for determinism. Anything past that refines to `queued (cap)`. (A tick with more exhaustion respawns than `$PMM_MAX_PARALLEL` will transiently run over the nominal cap — acceptable, since these are already-approved in-flight fixes being continued, not new work.)
+
+Store the refined verdict per PR (`fixpr`, `awaiting fix subagent`, or `queued (cap)`) for both Step 4's table and Step 5c's dispatch loop — Step 5c dispatches only PRs still refined to `fixpr` and does not repeat this check.
+
+---
+
+## Step 3.6: Overlap-aware merge sequencing
+
+First-ready-first-merged is backwards when one PR's diff dwarfs its siblings' in a shared file: every small PR that lands first forces the big one into another conflict round. Before Step 4 prints and Step 5d dispatches, compute a **merge order** over the fleet so the largest footprint in a contested file lands first and the smaller ones wait.
+
+This step is **side-effect-free** — `merge-sequence.sh` reads `pulls/{N}/files` and prints a plan; it never merges, rebases, or comments. Mechanism, state machine, and rationale: `.claude/reference/merge-sequencing.md`.
+
+```bash
+# Prior tick's hold state — this is what makes stall detection work across ticks.
+PRIOR_HOLDS=$(.claude/scripts/session-state.sh --get '.pmm_merge_holds // {}' 2>/dev/null || echo '{}')
+
+# Flatten Step 3's VERDICTS_JSON ({"<n>":{verdict,tag}}) to {"<n>":"<verdict>"},
+# then overwrite each entry with the REFINED verdict where Step 3's refinement
+# pass produced one (`awaiting fix subagent`, `queued (cap)`, `held(#A)` from a
+# prior tick). Pass the WHOLE fleet, not just the `wrap` PRs: the planner needs a
+# non-`wrap` anchor's verdict to tell "progressing" from "hard-blocked", and that
+# is exactly what decides whether its followers hold or release.
+VERDICTS_MAP=$(jq -c 'map_values(.verdict)' <<<"$VERDICTS_JSON")
+HEADS_MAP='{}'   # plain init — never a ${HEADS_MAP:-{}} default (see Step 3 above)
+for N in $PR_NUMS; do
+  VERDICTS_MAP=$(jq -c --arg n "$N" --arg v "${REFINED_VERDICT[$N]:-}" \
+    'if $v == "" then . else .[$n] = $v end' <<<"$VERDICTS_MAP")
+  HEADS_MAP=$(jq -c --arg n "$N" --arg sha "$(jq -r '.head_sha // ""' <<<"${GATE_BY_PR[$N]}")" \
+    'if $sha == "" then . else .[$n] = $sha end' <<<"$HEADS_MAP")
+done
+
+# Sequence only PRs that still exist. A PR classified `gone` (merged/closed
+# between Step 2 and now) would 404 in the planner and, without --skip-missing,
+# take the WHOLE fleet's plan down with exit 3. Filter the known-gone ones here,
+# and pass --skip-missing so a PR that merges during this very step is demoted to
+# an excluded_prs[] entry instead of failing the run.
+SEQ_PRS=$(for N in $PR_NUMS; do
+  V=$(jq -r --arg n "$N" '.[$n] // ""' <<<"$VERDICTS_MAP")
+  [[ "$V" == "gone" || "$V" == "error" ]] || echo "$N"
+done | tr '\n' ',' | sed 's/,$//')
+
+SEQ=""; SEQ_RC=1
+if [[ -n "$SEQ_PRS" ]]; then
+  SEQ=$(.claude/scripts/merge-sequence.sh --prs "$SEQ_PRS" --skip-missing \
+    --verdicts "$VERDICTS_MAP" --heads "$HEADS_MAP" --holds "$PRIOR_HOLDS")
+  SEQ_RC=$?
+fi
+```
+
+`HEADS_MAP` comes from the gate JSON you already fetched, so passing it saves one `gh pr view` per PR. Both maps are plain in-memory tick state — initialize `HEADS_MAP='{}'` at the top of this step every tick, never carried across ticks.
+
+`SEQ_RC` is `0` when sequencing applies (≥1 hold or batch), `1` when the fleet has no overlap (plan still printed, every PR reads `merge`, dispatch unchanged), and `2`/`3`/`4` on usage/not-found/gh errors. **On any error exit, log one line and continue the tick with sequencing disabled** — treat every PR as `merge`. A planner failure must never block the fleet; the merge gate is still the authority on whether anything lands.
+
+**Refine the verdicts once more** from `SEQ`'s per-PR action, for PRs currently verdicted `wrap`:
+
+| `plan[N].action` | Refined verdict | Step 5d does |
+|------------------|-----------------|--------------|
+| `merge` | `wrap` (unchanged) | dispatch normally |
+| `hold` | `held(#A)` | skip this tick — `#A` is landing ahead of it |
+| `batch` | `batch(#A)` | dispatch in this tick's single batch window |
+| `not_merge_ready` | unchanged | n/a — it was never a merge candidate |
+
+**Persist the returned hold state — only on a successful run** (`SEQ_RC` `0` or `1`) so the next tick's stall counter advances. **Never persist after an error exit:** `$SEQ` is empty or partial then, `.holds` evaluates to `null`, and writing it would *wipe* the prior tick's stall counters — turning a transient planner failure into a silent reset that re-holds already-released PRs:
+
+```bash
+if [[ "$SEQ_RC" -eq 0 || "$SEQ_RC" -eq 1 ]]; then
+  NEW_HOLDS=$(jq -c '.holds // {}' <<<"$SEQ")
+  .claude/scripts/session-state.sh --set ".pmm_merge_holds=$NEW_HOLDS"
+else
+  echo "[PMM] merge-sequence.sh failed (exit $SEQ_RC) — sequencing disabled this tick; prior holds left intact"
+  SEQ=""   # every PR falls through to `merge`; Step 4 prints no annotation
+fi
+```
+
+Evaluate the `jq` first and pass the resulting JSON as the value — never a raw filter expression (`handoff-files.md` field-type contract). Keep `SEQ` for Step 4's annotation and Step 5d's dispatch order; an empty `SEQ` means "no sequencing this tick", which every consumer below already treats as `merge`.
+
+> **Authorship is enforced inside the planner** (`pr-authorship.sh`, fail-closed): a collaborator's PR touching the same file is excluded before grouping, so it can never become an anchor holding your PRs behind a merge you have no authority to perform. Under `READ_ONLY_FLEET=1` this step still runs — the plan is display-only context, like the rest of the table.
+
+---
+
+## Step 4: Heartbeat / quiet-tick definition and table format
+
+### Quiet-tick logic
+
+Print the **full table** (below the lead line) when ANY of:
+
+- (a) this is the first tick of a fresh invocation (Step 0 mode entry) or the first tick after a resume (Step 0a) — both null `.pmm_digest`/`.pmm_row_digest`, so (b) also fires mechanically;
+- (b) `DIGEST != PREV` or `ROW_DIGEST != ROW_PREV` (or either previous value is null);
+- (c) any PR's verdict this tick is actionable — `rebase`, `fixpr`, `wrap`, or `batch(#A)` — so the classification is always visible before Step 5 acts;
+- (d) Step 2.5 processed any subagent outcome, or `HARD_BLOCK[]` gained a new entry this tick;
+- (e) Step 3.6 held or batched anything (the merge-sequence annotation must stay visible).
+
+**Quiet tick** (none of a–e): append `— no change` plus the PR numbers to the lead line; when `HARD_BLOCK[]` is non-empty append the standing blocks with reasons, and when any PR is refined `queued (cap)` or `held(#A)` append those too (e.g. `… (author:x) — no change (#101 #102; hard-blocked: #99 human-CR; queued (cap): #103)`); print **only that line** — no table. **New** hard blocks, gate failures, and terminations always get the full table on the tick they appear ((b)/(c)/(d)); already-reported blocks stay visible via the hard-blocked suffix on every quiet line — never silently dropped. Terminal snapshots (Pause / Stop & Clean Exit) always print the full table regardless of quiet-tick status.
+
+### Table format
+
+| Issue | PR | State | Reviews | CI | Unresolved Threads | Verdict | Subagent |
+|-------|----|-------|---------|----|--------------------|---------|----------|
+| #<issue or —> | #<N> | <merge_state> | <review_decision> | <pass>/<fail>/<prog> | <count> | <VERDICT from Step 3> | <SUBAGENT_STATUS> |
+
+- **Issue** — from `pr-issue-ref.sh`, or `—` when the PR body has no closing keyword.
+- **State** — literal `merge_state` (`CLEAN`/`BEHIND`/`BLOCKED`/`UNKNOWN`); when `mergeable == CONFLICTING`, append `(CONFLICTING)` to the State cell so the conflict signal is visible (CONFLICTING is a `mergeable` value, not a `merge_state` value).
+- **Reviews** — literal `review_decision` (`APPROVED`/`CHANGES_REQUESTED`/`REVIEW_REQUIRED`).
+- **CI** — `passing`/`failing`/`in_progress` counts from the gate.
+- **Unresolved Threads** — count of `isResolved == false` (or `?` if the GraphQL fetch failed).
+- **Verdict** — the Step 3 verdict: `rebase`, `fixpr`, `wrap`, `waiting`, `awaiting fix subagent`, `queued (cap)`, `rate-limited`, `BLOCKED:human(@x)`, `BLOCKED:conflicts(needs-human)`, `gone`, `error`, plus Step 3.6's merge-sequencing refinements `held(#A)` and `batch(#A)`.
+- **Subagent** — per-PR agent state for fix work: `—` (not spawned / no fix dispatch this tick), `dispatched (merge-conflict)` (conflict-resolution fixer spawned this tick — transitions to `spawned`/`working`/`complete`/`failed` as the subagent runs), `spawned`, `working`, `complete`, `failed`, `deferred(foreign-agent)` (Step 5d/5e deferral gate closed because a foreign Phase A entry blocks this PR), `foreign-agent-stale` (Step 5e staleness timeout fired on a silent foreign entry — gate treated as drained). Populated from `active_agents` + Step 2.5 outcomes (PMM-owned only) + Step 5e foreign-drain polling. Merge-ready `/wrap` dispatches show `—` (wrap is parent-inline, not a subagent).
+
+A PR merged this tick is reported via the per-tick `merged #N` line (Step 5d) and then naturally disappears from the fleet on the next `gh pr list` discovery — no table row lingers.
+
+### Merge-sequence annotation
+
+Print this whenever Step 3.6 held or batched anything. Emit `SEQ`'s `summary` verbatim on the line directly under the table:
+
+```bash
+jq -e '[.plan[] | select(.action == "hold" or .action == "batch")] | length > 0' >/dev/null <<<"$SEQ" \
+  && echo "Merge sequence: $(jq -r .summary <<<"$SEQ")"
+```
+
+```text
+Merge sequence: holding #101, #102 until #100 lands — they share `.claude/skills/pm/SKILL.md`
+```
+
+Omit the line entirely when nothing is held or batched — a fleet with no overlap gets no annotation and no behavioural change. When `SEQ`'s `excluded_prs[]` is non-empty, add one short line naming the count and reason (e.g. "1 PR excluded from sequencing: not yours") so a collaborator's PR silently sitting out is visible rather than invisible.
+
+Only after the heartbeat (and the table, when any of a–e fired) is printed does Step 5 execute the actions. A quiet tick has no actionable verdicts by construction (condition c); if Step 5.0 pre-flight nonetheless acts on a quiet tick (draft flip, reviewer trigger), its own timestamped output lines report it.

--- a/.claude/skills/pr-monitor-and-manage/references/pmm-lifecycle.md
+++ b/.claude/skills/pr-monitor-and-manage/references/pmm-lifecycle.md
@@ -1,0 +1,198 @@
+# PMM Lifecycle: Resume, Pause, and Stop
+
+Reference doc for `.claude/skills/pr-monitor-and-manage/SKILL.md`. Contains
+the full Step 0a resume logic, Pause state machine (steps 1–6), pause-marker
+schema, and Stop & Clean Exit procedure.
+
+---
+
+## Pause-marker schema
+
+Pause marker fields live under nested `.pmm.*`. Existing runtime fields
+(`pmm_active`, `pmm_digest`, `pmm_idle_streak`, etc.) remain flat.
+
+| Field | Type | Written by | Read by |
+|-------|------|-----------|---------|
+| `.pmm.paused_at` | ISO-8601 string | Main skill Pause step 4 | Step 0a, `-wake` Step 2 |
+| `.pmm.fleet_at_pause` | `[{pr, head_sha, state}]` | Main skill Pause step 3 | `-wake` Step 4a |
+| `.pmm.config_at_pause` | object | Main skill Pause step 3 | Step 0a, `-wake` Step 4b |
+| `.pmm.auto_wake_cron_id` | string or null | Main skill Pause step 5 | `-stop` Step 3, `-wake` Step 3 |
+
+`config_at_pause` fields: `author`, `repo`, `cadence`, `max_parallel`, `idle_pause_after`, `auto_wake`, `auto_wake_cadence`, `confirm_merges`.
+
+> **Wake coupling:** `/pr-monitor-and-manage-wake` Step 4b rebuilds `PMM_FLAGS` from the `config_at_pause` blob — including `--confirm-merges` when `confirm_merges` is true — before re-arming the loop. The main skill's Step 0a uses the same blob for flag merging on direct re-invocation.
+
+---
+
+## Step 0a: Resume from pause
+
+On **every** invocation, before Step 1, check for a pause marker. If present, this invocation is a **resume** — tear down any auto-wake cron, clear the marker, merge config, and continue into normal ticking:
+
+```bash
+PAUSED_AT=$(.claude/scripts/session-state.sh --get '.pmm.paused_at' 2>/dev/null || echo null)
+if [ "$PAUSED_AT" != null ] && [ -n "$PAUSED_AT" ]; then
+  # 1. Read saved config into the $SAVED shell variable (fallback defaults if missing) —
+  #    step 3 below clears .pmm.config_at_pause in session-state, so step 4 MUST use this
+  #    already-captured $SAVED variable, never re-read .pmm.config_at_pause from
+  #    session-state after step 3 has run (it will be null by then).
+  SAVED=$(.claude/scripts/session-state.sh --get '.pmm.config_at_pause' 2>/dev/null || echo '{}')
+  # 2. Delete auto-wake cron (fail-closed — see pr-monitor-and-manage-wake Step 3)
+  CRON_ID=$(.claude/scripts/session-state.sh --get '.pmm.auto_wake_cron_id' 2>/dev/null || echo null)
+  if [[ -n "$CRON_ID" && "$CRON_ID" != "null" ]]; then
+    CronDelete "$CRON_ID" || {
+      echo "ERROR: CronDelete failed for $CRON_ID — NOT clearing pause marker; cron may still fire, retry." >&2
+      exit 1
+    }
+    JOBS=$(.claude/scripts/session-state.sh --get '.polling_jobs' 2>/dev/null || echo '[]')
+    if [[ "$JOBS" != "null" && -n "$JOBS" ]]; then
+      NEW_JOBS=$(jq -c --arg id "$CRON_ID" 'map(select(.id != $id))' <<<"$JOBS")
+    else
+      NEW_JOBS='[]'
+    fi
+    .claude/scripts/session-state.sh --set ".polling_jobs=$NEW_JOBS" --set '.pmm.auto_wake_cron_id=null'
+  fi
+  # 3. Clear pause marker + reset pmm_idle_streak=0 + set pmm_active=true
+  #    + null .pmm_digest and .pmm_row_digest (atomic batch) — the digest reset
+  #    forces Step 4's full table on the first post-resume tick (condition a/b)
+  .claude/scripts/session-state.sh \
+    --set '.pmm.paused_at=null' \
+    --set '.pmm.fleet_at_pause=null' \
+    --set '.pmm.config_at_pause=null' \
+    --set '.pmm_idle_streak=0' \
+    --set '.pmm_active=true' \
+    --set '.pmm_digest=null' \
+    --set '.pmm_row_digest=null'
+  # 4. Merge flags: explicit $ARGUMENTS override $SAVED (the step-1 variable, not
+  #    session-state — that field is already cleared by step 3 at this point)
+  echo "[PMM] Resuming from pause (paused_at=$PAUSED_AT) — flags on this invocation override saved config."
+fi
+```
+
+Resume logic is shared with `/pr-monitor-and-manage-wake` — see `.claude/skills/pr-monitor-and-manage-wake/SKILL.md` Step 2 (cron teardown) and Step 3 (marker clear + loop re-arm). When resuming via re-invoking this skill (not `-wake`), apply the precedence rule in Step 1 after parsing `$ARGUMENTS`: any flag explicitly supplied on this invocation wins; omitted flags inherit from `.pmm.config_at_pause`. After resume, continue with Step 1 using the merged config and run a full discovery tick at **base** cadence (not the widened backoff cadence).
+
+A stale marker left by a killed session is safely reconciled here: the next `/pr-monitor-and-manage` invocation reads it, resumes (or the user runs `/pmm-stop`), and re-runs discovery from scratch.
+
+---
+
+## Pause (auto-pause — resumable)
+
+Reached from Step 7 when the fleet is empty or idle. Unlike Stop & Clean Exit, Pause preserves a resume marker so `/pr-monitor-and-manage-wake` or re-invoking this skill can pick up where it left off.
+
+### 1. Final heartbeat
+
+Print the **full** Step 4 status table one last time — terminal snapshots (Pause here, Stop & Clean Exit) are an explicit exception to Step 4's quiet-tick suppression, so the user always gets a final fleet snapshot even when the pause tick itself was quiet — then a one-line reason:
+
+```text
+[$TS] PMM pausing — reason: <empty fleet | N idle ticks>
+```
+
+### 2. Cancel the loop
+
+Cancel the recurring `/loop`:
+- If the runtime exposes a loop id / cancel handle, cancel it explicitly.
+- Otherwise interrupt the active loop. The next tick must not re-arm.
+
+### 3. Build fleet snapshot + config for the pause marker
+
+```bash
+NOW=$(date -u +%FT%TZ)
+# fleet_at_pause: array of {pr, head_sha, state} from Step 2 PR_LIST (headRefOid + mergeStateStatus)
+FLEET_AT_PAUSE=$(jq -c '[.[] | {pr: .number, head_sha: .headRefOid, state: .mergeStateStatus}]' <<<"$PR_LIST")
+CONFIG_AT_PAUSE=$(jq -nc \
+  --arg author "$PMM_AUTHOR" --arg repo "$OWNER_REPO" --arg cadence "$PMM_CADENCE" \
+  --argjson max_parallel "$PMM_MAX_PARALLEL" \
+  --argjson idle_pause_after "$PMM_IDLE_PAUSE_AFTER" \
+  --argjson auto_wake "$PMM_AUTO_WAKE" --arg auto_wake_cadence "$PMM_AUTO_WAKE_CADENCE" \
+  --argjson confirm_merges "$PMM_CONFIRM_MERGES" \
+  '{author:$author, repo:$repo, cadence:$cadence, max_parallel:$max_parallel, idle_pause_after:$idle_pause_after, auto_wake:$auto_wake, auto_wake_cadence:$auto_wake_cadence, confirm_merges:$confirm_merges}')
+```
+
+### 4. Write pause marker (atomic batch)
+
+```bash
+.claude/scripts/session-state.sh \
+  --set ".pmm.paused_at=\"$NOW\"" \
+  --set ".pmm.fleet_at_pause=$FLEET_AT_PAUSE" \
+  --set ".pmm.config_at_pause=$CONFIG_AT_PAUSE" \
+  --set '.pmm_active=false' \
+  --set '.pmm_next_expected_tick_at=null'
+```
+
+Preserve `pmm_digest`, `pmm_digest_streak`, and `pmm_idle_streak` as audit trail.
+
+### 5. Optional auto-wake cron (`--auto-wake`)
+
+When `$PMM_AUTO_WAKE` is true, register an hourly scan at pause time:
+
+> **Warning:** `CronCreate` is **session-only** — this job fires only while Claude is running in the current session. `durable: true` has no effect. `--auto-wake` does **not** survive session turnover. (Behavioral redesign tracked as a follow-up ticket.)
+
+```bash
+# Derive cadence minutes from PMM_AUTO_WAKE_CADENCE (e.g. 60m → 60)
+AW_CADENCE_MIN="${PMM_AUTO_WAKE_CADENCE%m}"
+if [ "$AW_CADENCE_MIN" -ge 60 ] && [ $((AW_CADENCE_MIN % 60)) -eq 0 ]; then
+  # off-peak-minute.sh's --every-n-min only accepts 1..59 (it builds a step-range
+  # within one hour) — for hourly-or-longer cadences (the 60m default), use the
+  # plain no-flag minute + a */H hour step instead, matching /pm's hourly pattern.
+  AW_HOURS=$((AW_CADENCE_MIN / 60))
+  AW_MINUTE=$(.claude/scripts/off-peak-minute.sh)
+  if [ "$AW_HOURS" -eq 1 ]; then
+    AW_CRON="$AW_MINUTE * * * *"
+  else
+    AW_CRON="$AW_MINUTE */$AW_HOURS * * *"
+  fi
+else
+  { read -r AW_MINUTE; read -r AW_CRON; } < <(.claude/scripts/off-peak-minute.sh --every-n-min "$AW_CADENCE_MIN")
+fi
+# CronCreate with prompt "/pr-monitor-and-manage-wake --auto-check", cron="$AW_CRON", recurring=true, durable=true
+# Persist returned job id to .pmm.auto_wake_cron_id and append to polling_jobs[]
+```
+
+Tell the user the cron job id and 7-day auto-expiry; note that the job is session-scoped (see `scheduling-reliability.md` contract note).
+
+### 6. Summary line
+
+```text
+PMM paused — <N> PR(s) waiting on reviewer, no changes for <idle window>. Wake with `/pr-monitor-and-manage-wake` or re-run `/pr-monitor-and-manage <flags>`.
+```
+
+If `--auto-wake` is set, add: `Auto-wake cron registered (<job_id>) — will scan hourly for fleet changes.`
+
+> **Post-merge symlink:** after this skill's `-wake` companion merges to `main`, symlink `~/.claude/skills/pr-monitor-and-manage-wake` → the skills-worktree copy per `skill-symlinks.md`.
+
+---
+
+## Stop & Clean Exit
+
+Reached from Step 7 when the **user** invokes `/pmm-stop`. Tear down and report (this is a terminal stop — no resume marker):
+
+```bash
+.claude/scripts/session-state.sh --set '.pmm_active=false' --set '.pmm_next_expected_tick_at=null'
+# Best-effort: cancel the loop if a loop-id mechanism is available; otherwise the
+# user's /pmm-stop / interrupt drops it.
+```
+
+Print a final summary:
+
+```text
+=== PR fleet monitoring ended ===
+Reason:   <user-stop>
+Fleet:    <final status table>
+Pre-flight: <per-PR draft→ready + reviewers triggered this session, from each PR's PREFLIGHT_SUMMARY; "clean" where no-op>
+Actions:  <rebases / phase-a-fixer subagents / /wrap dispatched this session, per PR — include Subagent outcomes>
+Merged:   <PR #s successfully merged this session via /wrap — e.g. "PR #1599, PR #1601"; "none" if none>
+Subagents: <per-PR spawn/complete/failed summary from active_agents audit>
+Blocked:  <PR # + reason for each HARD_BLOCK entry reported this session — e.g. "PR #123 human CHANGES_REQUESTED by @alice">
+```
+
+Hard-blocked PRs are reported here for visibility; the fleet may auto-pause afterward when idle.
+
+---
+
+## Deferred follow-ups (bounded refactor scope)
+
+The following were intentionally left out of this PR (scope: bounded dedup + reference-extraction per Issue #815 / Issue #778 Option 2):
+
+- **`resolve_script()` dedup across `-stop`/`-wake` family** — the same three-candidate lookup appears verbatim in `-stop/SKILL.md` and `-wake/SKILL.md`. A shared canonical location would prevent drift, but touching companion skills is out of scope here. Tracked for a future PR.
+- **`pmm_delete_auto_wake_cron` helper** — the cron teardown block is duplicated in `-stop/SKILL.md`, `-wake/SKILL.md`, and now this file (Step 0a). A single shared helper (bash script or reference) would prevent lock-step edits. Tracked for a future PR.
+- **Full FU-2 ≤150-line dispatcher collapse** — this bounded refactor brings SKILL.md to ~400 lines. The full collapse to ≤150 lines (with a script-side no-change short-circuit) remains deferred until the `/babysit-pr` delegation contract (#456/#460) is settled, per `token-efficiency-audit-2026-07.md` FU-2.
+- **Per-PR `/babysit-pr` delegation** (#456/#460) — replacing Step 3's inline per-PR decision tree with one `/babysit-pr <PR>` dispatch per PR. The table, discovery, idempotency, and backoff scaffolding in SKILL.md stay unchanged until this lands.

--- a/.claude/skills/pr-monitor-and-manage/references/pmm-scope.md
+++ b/.claude/skills/pr-monitor-and-manage/references/pmm-scope.md
@@ -43,3 +43,9 @@ The parent is orchestration-only with respect to source edits: the only direct w
 `--repo` scopes **discovery** (`gh pr list`) and the GraphQL/REST reads. But the per-PR helpers (`merge-gate.sh`, `pr-issue-ref.sh`, `cr-review-hourly.sh`, `dismiss-stale-bot-changes.sh`) and all git actions (rebase, force-push, fix subagents, `/wrap`) operate on the **current checkout** — they resolve the repo via `gh repo view`, not a flag. So managing a repo requires running this skill from a worktree of **that** repo. If `--repo` names a repo other than the current checkout, **stop and reconcile** (same multi-repo hazard guard as `cr-github-review.md`) rather than acting against the wrong repo.
 
 **Invoking-repo scope (issue #687).** The `--repo` constraint above already keeps discovery + actions in one repo's lane. The one shared-state read that spans repos is the global `.active_agents` array; PMM already scopes its own work by `id` prefix (`pmm-fix-`) and treats foreign entries as read-only. When a broader, repo-scoped view of session state is needed, prefer `session-state.sh --session-view` (drops other repos' PRs and their agents) over `--get .`. Cross-repo fleet management is never implicit — point it at one repo per invocation.
+
+---
+
+## Scope vs `/pm` (issue #657)
+
+`/pm` runs a **one-shot** startup triage of *forgotten* PRs, recommends close/merge, and hands merges off to `/wrap` subagents — then it stops. `/pr-monitor-and-manage` is the opposite: **continuous** fleet monitoring on a recurring `/loop`, driving *every* open PR to merge-ready or a named hard block tick after tick.

--- a/.claude/skills/pr-monitor-and-manage/references/pmm-scope.md
+++ b/.claude/skills/pr-monitor-and-manage/references/pmm-scope.md
@@ -1,0 +1,45 @@
+# PMM Scope, Prohibitions, and Anti-patterns
+
+Reference doc for `.claude/skills/pr-monitor-and-manage/SKILL.md`. Contains the
+parent/subagent scope table, prohibited actions, refusal template, and common
+misreads that are too verbose to keep in the main dispatcher body.
+
+---
+
+## Parent vs Subagent scope
+
+| Scope | Role | Allowed | Disallowed |
+|-------|------|---------|------------|
+| **Parent (this thread)** | Fleet orchestrator | Discover PRs, classify state, dispatch subagents, aggregate exit reports, update the fleet table, decide next tick; git rebase/force-push for `BEHIND` (Step 5a); stale-bot dismiss + re-trigger (Steps 5b/5b′); inline `/wrap` for merge-ready PRs | Direct code edits; direct git beyond discovery/rebase/dismiss; direct merges (`gh pr merge`); starting new issues; unrelated work |
+| **Subagents (spawned per PR)** | Fix worker | Edit files, resolve merge conflicts, fix CR/CI findings, push commits, reply to threads, resolve bot threads — one PR each, per `.claude/rules/subagent-orchestration.md` and #509 (parallel subagents) | Modify branch protection; dismiss human reviews; bypass SAFETY rules |
+
+Spawn pattern reference: `.claude/rules/subagent-orchestration.md` (Phase A fixer / Phase C merger). Every spawn includes the verbatim `SAFETY:` block from `.claude/rules/safety.md`.
+
+---
+
+## Prohibited for the parent thread (refuse and redirect)
+
+- Writing or editing **feature code directly** — dispatch a `phase-a-fixer` subagent instead (merge conflicts, CR findings, CI failures are all dispatch cases, not refusal cases).
+- Invoking `/start-issue`, `/prompt`, or spawning subagents for **new work unrelated to the discovered fleet**.
+- Creating issues or PRs (other than the follow-ups `/wrap` itself creates on merge).
+- Any task unrelated to managing the discovered PR fleet.
+
+**Refusal template** when asked for genuinely out-of-scope *parent* work (not dispatchable fleet fix work):
+
+> That's outside PR-fleet-manager mode. I'm keeping this thread focused on monitoring your open PRs. Start a separate thread (e.g. `/start-issue`) for that work — say `/pmm-stop` first if you want me to stop monitoring here.
+
+---
+
+## Common misreads / Anti-patterns
+
+> If you catch yourself telling the user "I can't edit code in this thread" as a reason to **stop** rather than **dispatch**, that's wrong — the parent doesn't edit code, but its subagents do, and that's the whole point. Merge conflicts, CR findings, and CI failures are all handled by spawning fix subagents, not by refusing or hard-blocking pre-dispatch.
+
+The parent is orchestration-only with respect to source edits: the only direct writes it performs are git rebase/force-push (Step 5a), stale-bot review dismissal + owning-bot re-trigger (Steps 5b/5b′), and the bounded mutations that `phase-a-fixer` subagents and `/wrap` already own. Fix work — including merge-conflict resolution — is delegated to parallel `phase-a-fixer` subagents (`.claude/agents/phase-a-fixer.md`); merge work stays sequential via `/wrap`. The parent never reimplements fix/merge logic beyond the shared dismiss/re-trigger helpers that `/fixpr` also uses.
+
+---
+
+## `--repo` constraint (load-bearing)
+
+`--repo` scopes **discovery** (`gh pr list`) and the GraphQL/REST reads. But the per-PR helpers (`merge-gate.sh`, `pr-issue-ref.sh`, `cr-review-hourly.sh`, `dismiss-stale-bot-changes.sh`) and all git actions (rebase, force-push, fix subagents, `/wrap`) operate on the **current checkout** — they resolve the repo via `gh repo view`, not a flag. So managing a repo requires running this skill from a worktree of **that** repo. If `--repo` names a repo other than the current checkout, **stop and reconcile** (same multi-repo hazard guard as `cr-github-review.md`) rather than acting against the wrong repo.
+
+**Invoking-repo scope (issue #687).** The `--repo` constraint above already keeps discovery + actions in one repo's lane. The one shared-state read that spans repos is the global `.active_agents` array; PMM already scopes its own work by `id` prefix (`pmm-fix-`) and treats foreign entries as read-only. When a broader, repo-scoped view of session state is needed, prefer `session-state.sh --session-view` (drops other repos' PRs and their agents) over `--get .`. Cross-repo fleet management is never implicit — point it at one repo per invocation.


### PR DESCRIPTION
## Summary

Closes #815
Closes #778

SKILL.md shrinks from **1127 → 423 lines** (-62%). Heavy prose and full bash implementations extracted to four per-skill reference docs under `.claude/skills/pr-monitor-and-manage/references/`:

- **`pmm-scope.md`** — parent/subagent scope table, prohibited actions, refusal template, anti-patterns, `--repo` constraint detail
- **`pmm-classify.md`** — decision-tree row rationale, VERDICTS_JSON accumulation (brace-trap warning), findings pre-fetch, refinement pass, Step 3.6 full merge-sequencing bash, quiet-tick conditions, table column definitions
- **`pmm-act.md`** — Steps 5a–5e full detail: rebase bash, dismiss helper (bash-4 shim + REST fallback), stale-bot recovery, parallel fixer dispatch (full prompt template + batch-write pattern), `/wrap` dispatch, dedicated monitor mode
- **`pmm-lifecycle.md`** — Step 0a full resume bash (cron teardown, digest null), Pause steps 1–6 (auto-wake cron derivation, session-only CronCreate warning), Stop & Clean Exit, deferred follow-ups list

SKILL.md keeps: frontmatter unchanged, decision tree TABLE verbatim (load-bearing), `--confirm-merges` flag semantics, session-only CronCreate warning, all arg defaults, authorship guard, `/loop` canonical re-arm, pre-exit checklist, safety boundaries.

**Deferred** (noted in `pmm-lifecycle.md`): full FU-2 ≤150-line dispatcher collapse (Issue #778 Option 3), `resolve_script()` dedup across `-stop`/`-wake` family (separate PR), `/babysit-pr` per-PR delegation (#456/#460).

**Touch scope:** Only `.claude/skills/pr-monitor-and-manage/`. No other skills, `.claude/scripts/`, `.claude/rules/`, or `CLAUDE.md` touched.

[COVERAGE] none (CR rate-limited free OSS tier; CodeAnt 403 daily cap); self-review performed; GitHub App review gates the merge.

## Test plan

- [x] `SKILL.md` contains the frontmatter unchanged (name, description, triggers, argument-hint)
- [x] `SKILL.md` decision tree TABLE is verbatim (all 8 rows with exact verdict names)
- [x] `SKILL.md` contains `--confirm-merges` flag description with "never overrides hard stops" language
- [x] `SKILL.md` Pause section contains the session-only CronCreate warning
- [x] `references/pmm-scope.md` exists and contains parent/subagent scope table + refusal template
- [x] `references/pmm-classify.md` exists and contains VERDICTS_JSON brace-trap warning + Step 3.6 merge-sequencing bash
- [x] `references/pmm-act.md` exists and contains Steps 5a–5e implementations including full dismiss helper bash
- [x] `references/pmm-lifecycle.md` exists and contains Step 0a resume bash + Pause steps 1–6 + session-only CronCreate warning
- [x] No files outside `.claude/skills/pr-monitor-and-manage/` were modified
- [x] `SKILL.md` is ≤450 lines (target ~400); all 4 reference files are non-empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded PR monitoring guidance with clearer lifecycle, scope, safety, and orchestration rules.
  * Documented reliable pause, resume, auto-wake, and clean-stop behavior.
  * Added clearer handling for merge conflicts, stale reviews, rebasing, hard blocks, and queued fixes.
  * Documented overlap-aware merge sequencing and safer merge deferrals.
  * Improved status reporting with concise quiet-tick updates, detailed tables, and merge annotations.
  * Added guidance for concurrency limits, recovery from interrupted fixes, and cross-repository safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->