### PR TITLE
refactor(#818): slim issue-maker/SKILL.md — extract tier table and set-log to skill-local files

### DIFF
--- a/.claude/skills/issue-maker/SKILL.md
+++ b/.claude/skills/issue-maker/SKILL.md
@@ -103,21 +103,16 @@ Every `gh issue …` call below passes `--repo "$REPO"`.
 
 ### Writing to the session log (one canonical helper)
 
-Every mutation of `$LOG` — recording a created issue, switching mode, marking an issue closed, saving the target repo — goes through one atomic read-modify-write helper so no snippet ever leaves the log stale. Define it once per invocation and reuse it everywhere below:
+Every mutation of `$LOG` goes through `scripts/set-log.sh` (skill-local) — an atomic read-modify-write helper. Resolve and bind it once per invocation:
 
 ```bash
-# set_log <jq-filter> [--argjson|--arg NAME VALUE ...]
-# Applies <jq-filter> to $LOG and refreshes .last_updated_at, atomically.
-set_log() {
-  local filter="$1"; shift
-  local now; now=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-  local tmp; tmp=$(mktemp)
-  if jq "$@" --arg __now "$now" "$filter | .last_updated_at = \$__now" "$LOG" > "$tmp"; then
-    mv "$tmp" "$LOG"
-  else
-    rm -f "$tmp"; echo "WARN: failed to update session log ($filter)" >&2; return 1
-  fi
-}
+SET_LOG=""
+for candidate in \
+  "$HOME/.claude/skills-worktree/.claude/skills/issue-maker/scripts/set-log.sh" \
+  "$HOME/.claude/skills/issue-maker/scripts/set-log.sh"; do
+  [ -x "$candidate" ] && { SET_LOG="$candidate"; break; }
+done
+set_log() { "$SET_LOG" "$LOG" "$@"; }
 ```
 
 Examples used below: `set_log '.target_repo = $v' --arg v "$REPO"`, `set_log '.mode = $v' --arg v rapid-fire`, and the create/close updates in Steps 9 and 12.
@@ -174,7 +169,7 @@ fi
 
 - **Guard:** if no significant keywords remain, skip the dedup search.
 - **Helper missing, or `DEDUP_RC` ≥ 2:** fall back to the title-only `gh issue list --search "$KEYWORDS in:title"` over open and recently-closed issues, and say the check was degraded when surfacing results.
-- **Interpreting matches:** `/issue-maker` always has a human in the loop, so it only ever *surfaces* candidates — it never auto-comments in place of filing. Use the strong/weak/none thresholds in `.claude/reference/autofile-dedup.md` to classify the **top** candidate: a **strong match** (an open issue naming the same primary artifact, with a body sentence or acceptance criterion that already covers this) or an **exact title match** is a genuine pause point; weak/ambiguous matches are not.
+- **Interpreting matches:** `/issue-maker` always has a human in the loop, so it only ever *surfaces* candidates — it never auto-comments in place of filing. Use the strong/weak/none thresholds in `.claude/reference/autofile-dedup.md` to classify the **top** candidate: a **strong match** or an **exact title match** is a genuine pause point; weak/ambiguous matches are not.
 - **Default mode — pause only on a strong or exact match:** if the top candidate clears that bar, surface it and ask *"Looks like a duplicate of #N — file anyway? (y/N)"* before creating. On a weak/ambiguous match, **do not block** — file, and name the near-duplicate as a decision point (Step 9a: "possibly overlaps #N"). No match → file normally.
 - **Rapid-fire:** show any matches but proceed unless there is an **exact title match** (then block and ask).
 
@@ -296,27 +291,15 @@ Tone precedent: `/wrap`'s terse "here's what I decided — flag anything wrong" 
 
 ### Step 9b: Infer a coding tier (for the chip's Model and Effort lines)
 
-`/issue-maker` does no tier classification during capture, but the chip requires a `**Model:** {MODEL} — {REASON}` line **and** an `**Effort:** {LEVEL} — {REASON}` line (`chip-launching.md`). Rather than invoking `/prompt` for two lines, infer the tier directly from the body just drafted in Step 5, using a trimmed, single-issue version of `/prompt`'s Heavy/Standard/Light mapping (`prompt/SKILL.md` Steps 4–5) — no batch aggregation, no dependency counting, no Fable step-up:
+`/issue-maker` does no tier classification during capture, but the chip requires a `**Model:** {MODEL} — {REASON}` line **and** an `**Effort:** {LEVEL} — {REASON}` line (`chip-launching.md`). Rather than invoking `/prompt` for two lines, infer the tier directly from the body just drafted in Step 5. Full signal definitions, tier table, and evaluation rules: `references/tier-inference.md`. Summary:
 
-- `file_count` — paths under `## Related Files` plus backticked paths in the body containing `/` and a file extension
-- `ac_count` — count of `- [ ]` lines under `## Acceptance Criteria`
-- `touches_rules` / `touches_claude_md` / `touches_skill` — any counted path matches `.claude/rules/`, `CLAUDE.md`, or `.claude/skills/`
-- `has_orchestration_keywords` — body mentions "subagent", "Phase A/B/C", "multi-phase", "orchestration", "monitor mode", "handoff"
-- `scope_keywords` — title/body mentions "typo", "rename", "comment", "config", "doc update", "README", "formatting"
+| Tier | Trigger (any is sufficient) | Model / effort |
+|------|-----------------------------|----------------|
+| **Heavy** | `touches_rules`, `touches_claude_md`, `has_orchestration_keywords`, or `file_count > 5` | Opus, Extra |
+| **Standard** | not Heavy, and (`file_count` 2–5, `ac_count > 3`, or `touches_skill`) | Opus, High |
+| **Light** | not Heavy/Standard, **and** a positive Light signal (`scope_keywords` or `file_count ≤ 1` with clear scope) | Sonnet, Low |
 
-| Tier | Trigger | Model / effort |
-|------|---------|-----------------|
-| **Heavy** | `touches_rules`, `touches_claude_md`, `has_orchestration_keywords`, or `file_count > 5` | Opus, effort Extra (step up to Max for correctness-critical work — see `prompt/SKILL.md` Step 5) |
-| **Standard** | not Heavy, and `file_count` 2–5, `ac_count > 3`, or `touches_skill` | Opus, effort High |
-| **Light** | not Heavy/Standard, **and** a positive Light signal: any `scope_keywords` present, or `file_count ≤ 1` with a clear single-file scope | Sonnet, effort Low |
-
-**Evaluate in table order and stop at the first match** — Heavy, then Standard, then Light — matching `/prompt`'s "when signals conflict, choose the higher tier" rule. A `touches_rules` or orchestration trigger therefore wins over a `scope_keywords` hit on the same issue.
-
-Light requires a **positive** signal, not merely the absence of the other two. Were it the plain complement of Heavy/Standard it would match every remaining issue, and the Standard default below could never fire — a thin, unclassifiable body would silently land on the cheapest tier instead of the safe one.
-
-Model values are bare family names and effort values are picker labels — never a version number, never a bare API token (`chip-launching.md` "Model and effort lines").
-
-Default to **Standard** when signals are too sparse to classify confidently (thin bodies, terse rapid-fire captures) — it's the safer default absent a strong signal either way.
+Default to **Standard** when signals are sparse. Values are bare family names / picker labels — never version numbers or API tokens (`chip-launching.md` "Model and effort lines").
 
 **Both values from this step reach Step 9c** — the model on the `**Model:**` line and the effort on the `**Effort:**` line, in the chip `prompt` and in the visible short summary. A tier computed here and then dropped is the defect #791 fixed.
 
@@ -351,8 +334,6 @@ Run `/start-issue {ISSUE_NUMBER}`. It polls for CodeRabbit's implementation plan
 ```
 
 The merge-authority bullet is the shared contract from `chip-launching.md` "Merge-authority line" — reproduce it **verbatim**, never softened into an approval request.
-
-Why delegate to `/start-issue` instead of a fuller inline template (like `/pm`'s or `/prompt`'s): at the moment this chip is offered the issue has no CR plan yet (it posts asynchronously) and no codebase exploration has happened — `/issue-maker` never does that by design (Step 2). `/start-issue` already owns exactly that sequencing; duplicating it here would drift out of sync with its own logic.
 
 - **Chip mode** (`mcp__ccd_session__spawn_task` present): call `spawn_task` with `title` (verb-first, ≤60 chars, includes the issue number, e.g. `Fix #42 stale worktree warning`), `prompt` (the block above, verbatim), `tldr` (1–2 plain sentences from `TITLE`), `cwd` (repo root — no worktree exists yet at capture time, unlike `/start-issue`'s own chip, which points at the worktree it just created). On success, **record the returned `task_id` immediately** — before printing anything else:
 

--- a/.claude/skills/issue-maker/SKILL.md
+++ b/.claude/skills/issue-maker/SKILL.md
@@ -112,6 +112,7 @@ for candidate in \
   "$HOME/.claude/skills/issue-maker/scripts/set-log.sh"; do
   [ -x "$candidate" ] && { SET_LOG="$candidate"; break; }
 done
+[[ -n "$SET_LOG" ]] || { echo "FATAL: scripts/set-log.sh not found — is the issue-maker skill installed?" >&2; exit 1; }
 set_log() { "$SET_LOG" "$LOG" "$@"; }
 ```
 

--- a/.claude/skills/issue-maker/references/tier-inference.md
+++ b/.claude/skills/issue-maker/references/tier-inference.md
@@ -1,0 +1,41 @@
+# Tier Inference — issue-maker single-issue subset
+
+Consumed by Step 9b to produce the `**Model:**` and `**Effort:**` lines for the
+coding chip. This is a **trimmed single-issue** version of `/prompt`'s
+Heavy/Standard/Light mapping (`prompt/SKILL.md` Steps 4–5): no batch
+aggregation, no dependency counting, no Fable step-up.
+
+## Signals to compute from the body drafted in Step 5
+
+| Signal | How to compute |
+|--------|----------------|
+| `file_count` | Paths under `## Related Files` plus backticked paths in the body containing `/` and a file extension |
+| `ac_count` | Count of `- [ ]` lines under `## Acceptance Criteria` |
+| `touches_rules` | Any counted path matches `.claude/rules/` |
+| `touches_claude_md` | Any counted path matches `CLAUDE.md` |
+| `touches_skill` | Any counted path matches `.claude/skills/` |
+| `has_orchestration_keywords` | Body mentions "subagent", "Phase A/B/C", "multi-phase", "orchestration", "monitor mode", "handoff" |
+| `scope_keywords` | Title/body mentions "typo", "rename", "comment", "config", "doc update", "README", "formatting" |
+
+## Classification table (evaluate top to bottom, stop at first match)
+
+| Tier | Trigger (any is sufficient) | Model / effort |
+|------|-----------------------------|----------------|
+| **Heavy** | `touches_rules`, `touches_claude_md`, `has_orchestration_keywords`, or `file_count > 5` | Opus, Extra (step up to Max for correctness-critical work — see `prompt/SKILL.md` Step 5) |
+| **Standard** | not Heavy, and (`file_count` 2–5, `ac_count > 3`, or `touches_skill`) | Opus, High |
+| **Light** | not Heavy/Standard, **and** a positive Light signal: any `scope_keywords` present, or `file_count ≤ 1` with a clear single-file scope | Sonnet, Low |
+
+**Evaluate in table order and stop at the first match.** A `touches_rules` or
+orchestration trigger wins over a `scope_keywords` hit on the same issue.
+
+**Light requires a positive signal**, not merely the absence of the other two.
+Were it the plain complement of Heavy/Standard, a thin unclassifiable body would
+silently land on the cheapest tier instead of the safe Standard default.
+
+**Default to Standard** when signals are too sparse to classify confidently
+(thin bodies, terse rapid-fire captures) — the safer choice absent a strong
+signal either way.
+
+Model values are bare family names; effort values are picker labels — never a
+version number, never a bare API token (`chip-launching.md` "Model and effort
+lines").

--- a/.claude/skills/issue-maker/scripts/set-log.sh
+++ b/.claude/skills/issue-maker/scripts/set-log.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Atomically apply a jq filter to an issue-maker session log,
+# refreshing .last_updated_at in the same operation.
+#
+# Usage: set-log.sh LOG_FILE JQ_FILTER [jq-args...]
+#
+# All jq-args are forwarded verbatim to jq (e.g. --arg, --argjson).
+# Exits 1 if the write fails; leaves LOG_FILE unchanged on failure.
+#
+# Example:
+#   set-log.sh "$LOG" '.mode = $v' --arg v rapid-fire
+#   set-log.sh "$LOG" '.target_repo = $v' --arg v "owner/repo"
+
+set -euo pipefail
+
+if (( $# < 2 )); then
+  echo "Usage: set-log.sh LOG_FILE JQ_FILTER [jq-args...]" >&2
+  exit 2
+fi
+
+LOG="$1"; shift
+FILTER="$1"; shift
+NOW=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+TMP=$(mktemp)
+
+if jq "$@" --arg __now "$NOW" "$FILTER | .last_updated_at = \$__now" "$LOG" > "$TMP"; then
+  mv "$TMP" "$LOG"
+else
+  rm -f "$TMP"
+  echo "WARN: failed to update session log ($FILTER)" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Zero-behavior-change refactor of the issue-maker churn hotspot. Extracts inline content that was restated from canonical sources, moving it to skill-local files.

- **`scripts/set-log.sh`** (new, executable): atomic session-log writer; replaces the 15-line inline `set_log()` bash function definition in Step 1. Call sites unchanged (function name preserved via resolver).
- **`references/tier-inference.md`** (new): full signal definitions and Heavy/Standard/Light tier table; replaces the ~25-line inline table in Step 9b. SKILL.md retains a compact 4-row summary table with a pointer.
- **Step 4**: trimmed inline strong-match parenthetical that restated `.claude/reference/autofile-dedup.md` thresholds.
- **Step 9c**: removed the "Why delegate to /start-issue" rationale paragraph (pure prose, no behavioral content).

Net: ~35 lines removed from SKILL.md, split into 2 skill-local files. All chip contracts, lint-required verbatim blocks, and behavioral semantics identical.

## Test plan

- [x] `chip-model-guard-lint.sh` passes (6 emitters, all contracts present)
- [x] `merge-authority-lint.sh` passes (5 emitters, verbatim bullet intact)
- [x] `verbatim-block-lint.sh` passes (6 copy surfaces)
- [x] `rule-lint.sh` passes (word count 11680 / 12000 soft cap; all fixture tests pass)
- [x] CodeRabbit local CLI: clean pass (0 findings, `cr-only` coverage — CodeAnt 403 daily cap, dropped per `cr-local-review.md`)
- [x] `scripts/set-log.sh` is executable, passes `bash -n` and `shellcheck`
- [x] All SKILL.md call sites for `set_log` remain valid (function name preserved via resolver pattern)
- [x] `references/tier-inference.md` contains full signal table matching what was inline in Step 9b

[COVERAGE: cr-only — CodeAnt 403 daily cap hit, dropped per cr-local-review.md]

Closes #818