### PR TITLE
fix(#844): accept Cursor Bugbot success check-run as clean pass in merge-gate

### DIFF
--- a/.claude/reference/merge-gate-reviewer-paths.md
+++ b/.claude/reference/merge-gate-reviewer-paths.md
@@ -50,7 +50,9 @@ CR failed, BugBot responded, Greptile never triggered — sticky; see `bugbot.md
 
 - A clean BugBot pass on the current HEAD SHA satisfies the gate. Two accepted shapes (issue #844):
   1. A `cursor[bot]` review object on HEAD with no `CHANGES_REQUESTED` and no fresh inline findings.
-  2. A completed `Cursor Bugbot` check-run with `conclusion: "success"` on HEAD, no failure-phrase `cursor[bot]` comment, and `completed_at`/`started_at` postdating the HEAD commit — the "silent pass" shape where BugBot found nothing and posted no review object.
+  2. A completed `Cursor Bugbot` check-run with `conclusion: "success"` on HEAD, no failure-phrase `cursor[bot]` comment postdating the HEAD commit, and `completed_at`/`started_at` postdating the HEAD commit — the "silent pass" shape where BugBot found nothing and posted no review object.
+- **Silent-pass failure-phrase filter (issue #844):** `merge-gate.sh` only counts failure-phrase cursor[bot] comments whose `created_at` is after `LAST_COMMIT_TS`. Comments predating the HEAD commit are stale and cannot block a fresh success check-run. When `LAST_COMMIT_TS` is unknown, all failure-phrase comments are conservatively counted; when a comment has no `created_at`, it is also conservatively counted (fail-closed).
+- **Silent-pass timestamp fail-closed:** when `LAST_COMMIT_TS` is known but the check-run has no `completed_at` or `started_at`, `merge-gate.sh` treats it as unverifiable and blocks (mirrors the CodeAnt supplemental gate).
 - After fixing BugBot findings, CI already posted `@cursor review` on that push; `/fixpr` also posts it after agent pushes. If BugBot still hasn't completed after polling, post `@cursor review` again — duplicates are acceptable (see `bugbot.md`).
 - Stay on BugBot — do not switch back to CR. Ignore late CR reviews.
 

--- a/.claude/reference/merge-gate-reviewer-paths.md
+++ b/.claude/reference/merge-gate-reviewer-paths.md
@@ -48,7 +48,9 @@ Applies when neither BugBot nor Greptile was triggered (`merge-gate.sh` reviewer
 
 CR failed, BugBot responded, Greptile never triggered — sticky; see `bugbot.md`.
 
-- 1 clean BugBot review on the current HEAD SHA satisfies the gate (BugBot's completion signals are reliable).
+- A clean BugBot pass on the current HEAD SHA satisfies the gate. Two accepted shapes (issue #844):
+  1. A `cursor[bot]` review object on HEAD with no `CHANGES_REQUESTED` and no fresh inline findings.
+  2. A completed `Cursor Bugbot` check-run with `conclusion: "success"` on HEAD, no failure-phrase `cursor[bot]` comment, and `completed_at`/`started_at` postdating the HEAD commit — the "silent pass" shape where BugBot found nothing and posted no review object.
 - After fixing BugBot findings, CI already posted `@cursor review` on that push; `/fixpr` also posts it after agent pushes. If BugBot still hasn't completed after polling, post `@cursor review` again — duplicates are acceptable (see `bugbot.md`).
 - Stay on BugBot — do not switch back to CR. Ignore late CR reviews.
 

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -23,9 +23,14 @@ Poll alongside CR per the shared cadence/endpoints (`cr-github-review.md` §Poll
 
 **Fallback timing:** Do not maintain a separate CR-owned BugBot timeout here — the escalation gate owns that decision (`cr-github-review.md`). Once BugBot owns the PR, keep 60 s cadence and use the `Cursor Bugbot` completion signal below.
 
-**Completion signal:** BugBot creates a CI check-run named `Cursor Bugbot` that transitions to `status: "completed"` when the review finishes. The `conclusion` field is `neutral` when BugBot posted findings (still counts as a completed review — `neutral` is not a failure). Completion can also be detected via BugBot review comments appearing on any of the three endpoints.
+**Completion signal:** BugBot creates a CI check-run named `Cursor Bugbot` that transitions to `status: "completed"` when the review finishes. Two shapes to distinguish:
 
-**BugBot failure detection:** a spend-limit failure produces the same completed/`neutral` result as a clean pass. `escalate-review.sh` scans for failure phrases (`couldn't run`, `usage limit`, …) — a clean pass requires no failure phrase.
+- `conclusion: "success"` — BugBot found nothing and posted **no review object** (silent pass). `merge-gate.sh` accepts this as a clean BugBot pass when freshness checks pass and no failure-phrase `cursor[bot]` comment is present (issue #844).
+- `conclusion: "neutral"` — BugBot posted findings (review object and/or inline comments). Gate is satisfied only when the latest review object on current HEAD has no `CHANGES_REQUESTED` and no inline findings.
+
+Completion can also be detected via BugBot review comments appearing on any of the three endpoints.
+
+**BugBot failure detection:** a spend-limit failure can produce a `conclusion: "success"` check-run alongside a failure-phrase comment (`couldn't run`, `usage limit`, …). `escalate-review.sh` scans for failure phrases; `merge-gate.sh` also blocks the silent-pass path when a failure-phrase `cursor[bot]` comment exists — a clean pass requires no failure phrase on either endpoint.
 
 ## When BugBot Becomes the Active Reviewer
 
@@ -43,7 +48,10 @@ Verify all findings against actual code. Fix all valid findings in one commit, p
 
 ## Merge Gate
 
-**A clean BugBot review on current HEAD satisfies the merge gate alone** (`cr-merge-gate.md` Step 1).
+**A clean BugBot pass on current HEAD satisfies the merge gate alone** (`cr-merge-gate.md` Step 1). Two accepted shapes:
+
+1. A `cursor[bot]` review object on current HEAD with no `CHANGES_REQUESTED` and no inline findings.
+2. A completed `Cursor Bugbot` check-run with `conclusion: "success"` on HEAD, no failure-phrase `cursor[bot]` comment, and timestamp postdating the HEAD commit (issue #844 — the silent-pass shape).
 
 ## Re-Reviews
 

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -23,14 +23,9 @@ Poll alongside CR per the shared cadence/endpoints (`cr-github-review.md` §Poll
 
 **Fallback timing:** Do not maintain a separate CR-owned BugBot timeout here — the escalation gate owns that decision (`cr-github-review.md`). Once BugBot owns the PR, keep 60 s cadence and use the `Cursor Bugbot` completion signal below.
 
-**Completion signal:** BugBot creates a CI check-run named `Cursor Bugbot` that transitions to `status: "completed"` when the review finishes. Two shapes to distinguish:
+**Completion signal:** BugBot creates a CI check-run named `Cursor Bugbot` that transitions to `status: "completed"` when the review finishes. `conclusion: "success"` = no findings, no review object (silent pass — gate conditions at §Merge Gate). `conclusion: "neutral"` = findings posted; review object required. Completion also detected via review comments on any endpoint.
 
-- `conclusion: "success"` — BugBot found nothing and posted **no review object** (silent pass). `merge-gate.sh` accepts this as a clean BugBot pass when freshness checks pass and no failure-phrase `cursor[bot]` comment is present (issue #844).
-- `conclusion: "neutral"` — BugBot posted findings (review object and/or inline comments). Gate is satisfied only when the latest review object on current HEAD has no `CHANGES_REQUESTED` and no inline findings.
-
-Completion can also be detected via BugBot review comments appearing on any of the three endpoints.
-
-**BugBot failure detection:** a spend-limit failure can produce a `conclusion: "success"` check-run alongside a failure-phrase comment (`couldn't run`, `usage limit`, …). `escalate-review.sh` scans for failure phrases; `merge-gate.sh` also blocks the silent-pass path when a failure-phrase `cursor[bot]` comment exists — a clean pass requires no failure phrase on either endpoint.
+**BugBot failure detection:** a spend-limit failure produces a `conclusion: "success"` check-run alongside a failure-phrase cursor[bot] comment (`couldn't run`, `usage limit`, …); `merge-gate.sh` blocks the silent-pass path when any such comment postdates the HEAD commit.
 
 ## When BugBot Becomes the Active Reviewer
 
@@ -48,10 +43,7 @@ Verify all findings against actual code. Fix all valid findings in one commit, p
 
 ## Merge Gate
 
-**A clean BugBot pass on current HEAD satisfies the merge gate alone** (`cr-merge-gate.md` Step 1). Two accepted shapes:
-
-1. A `cursor[bot]` review object on current HEAD with no `CHANGES_REQUESTED` and no inline findings.
-2. A completed `Cursor Bugbot` check-run with `conclusion: "success"` on HEAD, no failure-phrase `cursor[bot]` comment, and timestamp postdating the HEAD commit (issue #844 — the silent-pass shape).
+**A clean BugBot pass on current HEAD satisfies the merge gate alone** (`cr-merge-gate.md` Step 1). Two accepted shapes: (1) a `cursor[bot]` review object on HEAD with no `CHANGES_REQUESTED` and no inline findings; (2) a `Cursor Bugbot` check-run with `conclusion: "success"`, no post-HEAD failure-phrase comment, and a fresh timestamp (issue #844). Full conditions: `.claude/reference/merge-gate-reviewer-paths.md` §BugBot path.
 
 ## Re-Reviews
 

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -23,7 +23,7 @@ The merge gate depends on which reviewer owns the PR. Compact per-path gates bel
 
 **CodeAnt on the CR path:** applies when CodeAnt has a review/comment or check-run on current HEAD. Clean = `APPROVED` on HEAD or completed CodeAnt check with `conclusion: success`; `CHANGES_REQUESTED` blocks only if newer than the latest clean signal on that SHA. Threads: Step 1c.
 
-**BugBot path** (CR failed, BugBot responded — sticky; `bugbot.md`): a clean BugBot pass on current HEAD satisfies the gate. Two accepted shapes: (1) a `cursor[bot]` review object on HEAD with no `CHANGES_REQUESTED` and no inline findings; (2) a completed `Cursor Bugbot` check-run with `conclusion: "success"`, no failure-phrase `cursor[bot]` comment, and timestamp postdating the HEAD commit (issue #844 — silent-pass shape). Re-review after fixes: `bugbot.md` §Re-Reviews. Never switch back to CR; ignore late CR reviews.
+**BugBot path** (CR failed, BugBot responded — sticky; `bugbot.md`): 1 clean BugBot pass on current HEAD satisfies the gate (review object or silent-pass success check-run — issue #844; see `bugbot.md` §Merge Gate for accepted shapes). Re-review after fixes: `bugbot.md` §Re-Reviews. Never switch back to CR; ignore late CR reviews.
 
 **Greptile path** (sticky; `greptile.md`): merge-ready on **clean review** (👍); **no P0** (fix P1/P2, push, no re-review); or **P0 fixed + re-review clean**. Max 3 reviews per PR; at 3 with persistent P0, self-review and report. Never switch back to CR/BugBot; ignore their late reviews.
 

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -23,7 +23,7 @@ The merge gate depends on which reviewer owns the PR. Compact per-path gates bel
 
 **CodeAnt on the CR path:** applies when CodeAnt has a review/comment or check-run on current HEAD. Clean = `APPROVED` on HEAD or completed CodeAnt check with `conclusion: success`; `CHANGES_REQUESTED` blocks only if newer than the latest clean signal on that SHA. Threads: Step 1c.
 
-**BugBot path** (CR failed, BugBot responded — sticky; `bugbot.md`): 1 clean BugBot review on current HEAD satisfies the gate. Re-review after fixes: `bugbot.md` §Re-Reviews. Never switch back to CR; ignore late CR reviews.
+**BugBot path** (CR failed, BugBot responded — sticky; `bugbot.md`): a clean BugBot pass on current HEAD satisfies the gate. Two accepted shapes: (1) a `cursor[bot]` review object on HEAD with no `CHANGES_REQUESTED` and no inline findings; (2) a completed `Cursor Bugbot` check-run with `conclusion: "success"`, no failure-phrase `cursor[bot]` comment, and timestamp postdating the HEAD commit (issue #844 — silent-pass shape). Re-review after fixes: `bugbot.md` §Re-Reviews. Never switch back to CR; ignore late CR reviews.
 
 **Greptile path** (sticky; `greptile.md`): merge-ready on **clean review** (👍); **no P0** (fix P1/P2, push, no re-review); or **P0 fixed + re-review clean**. Max 3 reviews per PR; at 3 with persistent P0, self-review and report. Never switch back to CR/BugBot; ignore their late reviews.
 

--- a/.claude/scripts/escalate-review.sh
+++ b/.claude/scripts/escalate-review.sh
@@ -270,6 +270,15 @@ case "$CACHED_BUGBOT_INSTALLED" in
     ;;
 esac
 
+# Design note (issue #844): after the merge-gate.sh fix, switch_bugbot leads to a
+# satisfiable gate for BOTH BugBot shapes that BUGBOT_GENUINE covers:
+#   - conclusion:success check-run (no review object) — accepted by merge-gate.sh's
+#     new check-run path (BB_CHECK_CLEAN); freshness + failure-phrase check there.
+#   - conclusion:neutral check-run + review object — accepted by the original review-
+#     object path in merge-gate.sh.
+# This script derives everything from the pre-built STATE_PATH bundle — no new gh api
+# fetch added here (meta-guard test L). The gate-satisfiable evaluation lives in
+# merge-gate.sh where CHECK_RUNS_JSON and LAST_COMMIT_TS are already available.
 if [[ "$BUGBOT_GENUINE" == "true" ]]; then
   emit "switch_bugbot"
 fi

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -856,10 +856,18 @@ case "$REVIEWER" in
     # by a failure-phrase comment is NOT a clean pass (bugbot.md "BugBot failure
     # detection"). Scan PR comments + issue/conversation comments; review bodies
     # are handled inside the review-object path below.
+    # Freshness filter (issue #844 fix): only comments posted AFTER the HEAD commit
+    # count as blocking. Stale failure-phrase comments from a prior push must not
+    # strand the gate after a fresh success check-run arrives. Fail-open when
+    # LAST_COMMIT_TS is unknown; fail-closed when the comment has no created_at.
     BB_HAS_FAILURE_COMMENT=$(
-      { printf '%s\n' "$PR_COMMENTS_JSON"; printf '%s\n' "$ISSUE_COMMENTS_JSON"; } | jq -rs '
+      { printf '%s\n' "$PR_COMMENTS_JSON"; printf '%s\n' "$ISSUE_COMMENTS_JSON"; } | jq -rs --arg after "${LAST_COMMIT_TS:-}" '
         def is_failure_text: test("couldn'"'"'t run|could not run|usage limit|usage or spend limit"; "i");
-        add // [] | [.[]? | select(.user.login == "cursor[bot]") | select((.body // "") | is_failure_text)]
+        add // [] | [.[]? | select(.user.login == "cursor[bot]")
+            | select((.body // "") | is_failure_text)
+            | select(if $after == "" then true
+                     elif (.created_at // "") == "" then true
+                     else .created_at > $after end)]
         | length > 0')
 
     # Check-run-based clean pass (issue #844): Cursor Bugbot check-run with
@@ -883,7 +891,13 @@ case "$REVIEWER" in
             # Callers poll every ~60 s, so a transient API failure self-heals.
             MISSING+=("cannot verify BugBot check-run freshness — HEAD commit timestamp unavailable; retrying next cycle")
             BB_CHECK_FRESHNESS_ERR=true
-          elif [[ -n "$BB_CHECK_TS" && "$(norm_ts "$BB_CHECK_TS")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
+          elif [[ -z "$BB_CHECK_TS" ]]; then
+            # Fail-closed: cannot verify freshness without check-run timestamp
+            # (mirrors CodeAnt supplemental gate — empty completed_at/started_at
+            # never counts as clean when LAST_COMMIT_TS is known).
+            MISSING+=("cannot verify BugBot check-run freshness — completed_at/started_at unavailable; retrying next cycle")
+            BB_CHECK_FRESHNESS_ERR=true
+          elif [[ "$(norm_ts "$BB_CHECK_TS")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
             # check-run completed before the HEAD commit — stale (force-push retargeting
             # or a prior push's run). Report explicitly so callers know to wait for a
             # new run rather than interpret as absent.

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -841,13 +841,69 @@ case "$REVIEWER" in
     ;;
 
   bugbot)
-    # Need at least 1 BugBot review on current HEAD, with no actionable findings.
-    # Unresolved BugBot threads are caught by the universal unresolved-thread gate above.
+    # BugBot clean pass (issue #844 — aligned with bugbot.md "Completion signal"):
+    # either a cursor[bot] review object on current HEAD (original path), OR a
+    # completed Cursor Bugbot check-run with conclusion:success on HEAD (the
+    # "silent pass" shape — BugBot passes cleanly but posts no review object).
+    # Only conclusion:success counts; conclusion:neutral means BugBot posted findings
+    # and still requires a review object. Unresolved BugBot threads are caught by
+    # the universal unresolved-thread gate above.
     BB_REVIEWS_ON_HEAD=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
       [.[]? | select(.user.login == "cursor[bot]" and .commit_id == $sha)] | length')
 
+    # Failure-phrase scan across all cursor[bot] comment endpoints (mirrors the
+    # is_failure_text regex in escalate-review.sh). A success check-run accompanied
+    # by a failure-phrase comment is NOT a clean pass (bugbot.md "BugBot failure
+    # detection"). Scan PR comments + issue/conversation comments; review bodies
+    # are handled inside the review-object path below.
+    BB_HAS_FAILURE_COMMENT=$(
+      { printf '%s\n' "$PR_COMMENTS_JSON"; printf '%s\n' "$ISSUE_COMMENTS_JSON"; } | jq -rs '
+        def is_failure_text: test("couldn'"'"'t run|could not run|usage limit|usage or spend limit"; "i");
+        add // [] | [.[]? | select(.user.login == "cursor[bot]") | select((.body // "") | is_failure_text)]
+        | length > 0')
+
+    # Check-run-based clean pass (issue #844): Cursor Bugbot check-run with
+    # conclusion:success on HEAD, no failure-phrase cursor[bot] comment, and
+    # freshness (completed_at/started_at >= LAST_COMMIT_TS). Read from the
+    # already-deduped HEAD-scoped CHECK_RUNS_JSON — no new gh api fetch.
+    # Only evaluated when no review object exists; if a review object is present,
+    # the review-object path below applies (and may add its own MISSING entries).
+    BB_CHECK_CLEAN=false
+    BB_CHECK_FRESHNESS_ERR=false
+    if [[ "$BB_REVIEWS_ON_HEAD" -lt 1 && "$BB_HAS_FAILURE_COMMENT" != "true" ]]; then
+      BB_CHECK_RUN=$(echo "$CHECK_RUNS_JSON" | jq -c '
+        [.check_runs[]? | select((.name // "") == "Cursor Bugbot")] | last // empty')
+      if [[ -n "$BB_CHECK_RUN" ]]; then
+        BB_CHECK_CONCLUSION=$(echo "$BB_CHECK_RUN" | jq -r '.conclusion // ""')
+        BB_CHECK_STATUS=$(echo "$BB_CHECK_RUN" | jq -r '.status // ""')
+        BB_CHECK_TS=$(echo "$BB_CHECK_RUN" | jq -r '(.completed_at // .started_at // "")')
+        if [[ "$BB_CHECK_STATUS" == "completed" && "$BB_CHECK_CONCLUSION" == "success" ]]; then
+          if [[ -z "$LAST_COMMIT_TS" ]]; then
+            # Fail-closed: cannot verify freshness without HEAD committer date.
+            # Callers poll every ~60 s, so a transient API failure self-heals.
+            MISSING+=("cannot verify BugBot check-run freshness — HEAD commit timestamp unavailable; retrying next cycle")
+            BB_CHECK_FRESHNESS_ERR=true
+          elif [[ -n "$BB_CHECK_TS" && "$(norm_ts "$BB_CHECK_TS")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
+            # check-run completed before the HEAD commit — stale (force-push retargeting
+            # or a prior push's run). Report explicitly so callers know to wait for a
+            # new run rather than interpret as absent.
+            MISSING+=("BugBot check-run on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (stale) — wait for re-run or post @cursor review")
+            BB_CHECK_FRESHNESS_ERR=true
+          else
+            # Fresh success check-run, no failure comments — clean silent pass.
+            BB_CHECK_CLEAN=true
+          fi
+        fi
+      fi
+    fi
+
     if [[ "$BB_REVIEWS_ON_HEAD" -lt 1 ]]; then
-      MISSING+=("no BugBot review on HEAD ${HEAD_SHA:0:7}")
+      if [[ "$BB_CHECK_CLEAN" != true && "$BB_CHECK_FRESHNESS_ERR" != true ]]; then
+        # No review object, no clean check-run, no freshness error already reported.
+        MISSING+=("no BugBot review on HEAD ${HEAD_SHA:0:7}")
+      fi
+      # BB_CHECK_CLEAN=true  → silent-pass check-run satisfies the gate (issue #844)
+      # BB_CHECK_FRESHNESS_ERR=true → freshness error already added to MISSING above
     else
       LATEST_BB=$(echo "$REVIEWS_JSON" | jq -c --arg sha "$HEAD_SHA" '
         [.[]? | select(.user.login == "cursor[bot]" and .commit_id == $sha)]

--- a/.claude/scripts/tests/escalate-review.test.sh
+++ b/.claude/scripts/tests/escalate-review.test.sh
@@ -139,6 +139,10 @@ run_script() {
 BUGBOT_CHECK_RUN_OK='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "neutral", "title": ""}'
 BUGBOT_CHECK_RUN_FAILED_TITLE='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "neutral", "title": "Bugbot couldn'"'"'t run - usage limit reached"}'
 BUGBOT_CHECK_RUN_TIMED_OUT='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "timed_out", "title": ""}'
+# Silent-pass shape (issue #844): conclusion:success — BugBot found no issues.
+# merge-gate.sh now accepts this as a clean BugBot pass, but escalate-review.sh
+# still emits switch_bugbot so the caller persists sticky ownership before polling.
+BUGBOT_CHECK_RUN_SUCCESS='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "success", "title": ""}'
 
 # Comments carry explicit created_at timestamps so "latest event wins" ordering
 # (issue #552 CodeRabbit finding) is genuinely exercised, not an accident of
@@ -306,6 +310,20 @@ if grep -q 'check_runs\.all' "$ESCALATE_SRC"; then
 else
   check_eq "escalate-review.sh reads check_runs.all from the bundle" "present" "absent"
 fi
+
+############################################################################
+echo
+echo "== Scenario (m): silent-pass shape — conclusion:success check-run, no comments -> switch_bugbot (issue #844) =="
+# BUGBOT_GENUINE is true for a completed/non-failure check-run with no failure comment,
+# regardless of conclusion:success vs neutral. escalate-review.sh must still emit
+# switch_bugbot so the caller persists sticky ownership; merge-gate.sh's new check-run
+# path (issue #844 primary fix) then accepts the success shape as gate-satisfied.
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+write_state "[$BUGBOT_CHECK_RUN_SUCCESS]" "[]" "[]" "[]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=switch_bugbot" "STATUS=switch_bugbot" "$OUT"
 
 echo
 echo "== summary: $PASS passed, $FAIL failed =="

--- a/.claude/scripts/tests/merge-gate-ci-dedup.test.sh
+++ b/.claude/scripts/tests/merge-gate-ci-dedup.test.sh
@@ -89,11 +89,22 @@ run_gate() { # $1 = check-runs JSON
         "$SUT" 1 --reviewer cr 2>/dev/null)
   RC=$?
 }
+run_gate_bugbot() { # $1 = check-runs JSON; FAKE_REVIEWS/FAKE_PR_COMMENTS/FAKE_ISSUE_COMMENTS from env
+  OUT=$(PATH="$BIN:$PATH" FAKE_CHECK_RUNS="$1" \
+        FAKE_REVIEWS="${FAKE_REVIEWS:-[]}" \
+        FAKE_PR_COMMENTS="${FAKE_PR_COMMENTS:-[]}" \
+        FAKE_ISSUE_COMMENTS="${FAKE_ISSUE_COMMENTS:-[]}" \
+        "$SUT" 1 --reviewer bugbot 2>/dev/null)
+  RC=$?
+}
 
 # Is there a "CI has N failing check-run(s)" entry in `missing`?
 has_ci_failing_entry() { echo "$OUT" | jq -e '[.missing[]? | select(startswith("CI has") and contains("failing"))] | length > 0' >/dev/null && echo yes || echo no; }
 has_ci_incomplete_entry() { echo "$OUT" | jq -e '[.missing[]? | select(startswith("CI has") and contains("incomplete"))] | length > 0' >/dev/null && echo yes || echo no; }
 has_codeant_no_clean_entry() { echo "$OUT" | jq -e '[.missing[]? | select(contains("no successful CodeAnt check-run"))] | length > 0' >/dev/null && echo yes || echo no; }
+# BugBot-specific missing-entry helpers.
+has_bugbot_no_review_entry() { echo "$OUT" | jq -e '[.missing[]? | select(startswith("no BugBot review on HEAD"))] | length > 0' >/dev/null && echo yes || echo no; }
+has_bugbot_findings_entry() { echo "$OUT" | jq -e '[.missing[]? | select(startswith("latest BugBot review on HEAD has findings"))] | length > 0' >/dev/null && echo yes || echo no; }
 
 # `completed_at` matters here in a way it does not for ci-status.sh: the CodeAnt
 # supplemental gate reads it to find CodeAnt's latest clean signal, and a run
@@ -164,6 +175,62 @@ run_gate '{"check_runs":[]}'
 check_eq 0 "$(echo "$OUT" | jq -r '.ci_status.total')" "empty check-run list: total 0"
 check_eq "yes" "$(has_ci_incomplete_entry)" "empty check-run list: still reported incomplete"
 check_eq "false" "$(echo "$OUT" | jq -r '.met')" "empty check-run list: gate not met"
+
+# --------------------------------------------------------------------------
+# 7. BugBot silent-pass (issue #844): completed/success check-run, no review
+#    object, no cursor[bot] comments → gate met (met:true).
+#    NOTE: this test FAILS against pre-fix code because the old bugbot) case
+#    only accepted review objects, so "no BugBot review on HEAD" was always
+#    added when no review object existed, leaving the gate permanently blocked.
+# --------------------------------------------------------------------------
+FAKE_REVIEWS='[]'
+FAKE_PR_COMMENTS='[]'
+FAKE_ISSUE_COMMENTS='[]'
+run_gate_bugbot "$(bundle "$(cr 1 "Cursor Bugbot" success 100)")"
+check_eq "true" "$(echo "$OUT" | jq -r '.met')"  "BugBot silent-pass: gate met with success check-run (issue #844)"
+check_eq "no"   "$(has_bugbot_no_review_entry)"  "BugBot silent-pass: no 'no BugBot review' in missing"
+
+# --------------------------------------------------------------------------
+# 8. Negative: success check-run + failure-phrase issue comment → gate NOT met.
+#    BugBot spend-limit failure can produce a success check-run AND a comment
+#    containing a failure phrase; the failure-phrase scan must block the gate.
+# --------------------------------------------------------------------------
+FAKE_REVIEWS='[]'
+FAKE_PR_COMMENTS='[]'
+FAKE_ISSUE_COMMENTS="$(jq -cn '[{user:{login:"cursor[bot]"},body:"I could not run this review — usage limit reached"}]')"
+run_gate_bugbot "$(bundle "$(cr 1 "Cursor Bugbot" success 100)")"
+check_eq "false" "$(echo "$OUT" | jq -r '.met')" "BugBot failure comment: gate blocked despite success check-run"
+check_eq "yes"   "$(has_bugbot_no_review_entry)" "BugBot failure comment: 'no BugBot review' entry in missing"
+
+# --------------------------------------------------------------------------
+# 9. Negative: neutral check-run + inline cursor[bot] PR comment → gate NOT met.
+#    conclusion:neutral means BugBot posted findings; the success-check path is
+#    not taken (only conclusion:success qualifies), so there is still no valid
+#    review signal and "no BugBot review on HEAD" is added to missing.
+# --------------------------------------------------------------------------
+FAKE_REVIEWS='[]'
+FAKE_PR_COMMENTS="$(jq -cn --arg sha "$HEAD_SHA" \
+  '[{user:{login:"cursor[bot]"},body:"Found an issue on line 42",commit_id:$sha,original_commit_id:$sha}]')"
+FAKE_ISSUE_COMMENTS='[]'
+run_gate_bugbot "$(bundle "$(cr 1 "Cursor Bugbot" neutral 100)")"
+check_eq "false" "$(echo "$OUT" | jq -r '.met')" "BugBot neutral check-run: gate blocked (conclusion:neutral does not satisfy)"
+check_eq "yes"   "$(has_bugbot_no_review_entry)" "BugBot neutral check-run: 'no BugBot review' entry in missing"
+
+# --------------------------------------------------------------------------
+# 10. Negative: CHANGES_REQUESTED cursor[bot] review object on HEAD → NOT met.
+#     When a review object exists, the review-object path applies; a
+#     CHANGES_REQUESTED state adds the findings entry to missing.
+# --------------------------------------------------------------------------
+FAKE_REVIEWS="$(jq -cn --arg sha "$HEAD_SHA" \
+  '[{user:{login:"cursor[bot]"},state:"CHANGES_REQUESTED",commit_id:$sha,submitted_at:"2026-07-21T10:01:00Z"}]')"
+FAKE_PR_COMMENTS='[]'
+FAKE_ISSUE_COMMENTS='[]'
+run_gate_bugbot "$(bundle "$(cr 1 "Cursor Bugbot" neutral 100)")"
+check_eq "false" "$(echo "$OUT" | jq -r '.met')" "BugBot CHANGES_REQUESTED: gate blocked"
+check_eq "yes"   "$(has_bugbot_findings_entry)"  "BugBot CHANGES_REQUESTED: findings entry in missing"
+
+# Reset BugBot-specific env vars so they don't bleed into a re-run.
+unset FAKE_REVIEWS FAKE_PR_COMMENTS FAKE_ISSUE_COMMENTS
 
 echo "----------------------------------------"
 echo "merge-gate-ci-dedup.test.sh: $PASS passed, $FAIL failed"

--- a/.claude/scripts/tests/merge-gate-ci-dedup.test.sh
+++ b/.claude/scripts/tests/merge-gate-ci-dedup.test.sh
@@ -105,6 +105,7 @@ has_codeant_no_clean_entry() { echo "$OUT" | jq -e '[.missing[]? | select(contai
 # BugBot-specific missing-entry helpers.
 has_bugbot_no_review_entry() { echo "$OUT" | jq -e '[.missing[]? | select(startswith("no BugBot review on HEAD"))] | length > 0' >/dev/null && echo yes || echo no; }
 has_bugbot_findings_entry() { echo "$OUT" | jq -e '[.missing[]? | select(startswith("latest BugBot review on HEAD has findings"))] | length > 0' >/dev/null && echo yes || echo no; }
+has_bugbot_ts_unavail_entry() { echo "$OUT" | jq -e '[.missing[]? | select(contains("completed_at/started_at unavailable"))] | length > 0' >/dev/null && echo yes || echo no; }
 
 # `completed_at` matters here in a way it does not for ci-status.sh: the CodeAnt
 # supplemental gate reads it to find CodeAnt's latest clean signal, and a run
@@ -228,6 +229,35 @@ FAKE_ISSUE_COMMENTS='[]'
 run_gate_bugbot "$(bundle "$(cr 1 "Cursor Bugbot" neutral 100)")"
 check_eq "false" "$(echo "$OUT" | jq -r '.met')" "BugBot CHANGES_REQUESTED: gate blocked"
 check_eq "yes"   "$(has_bugbot_findings_entry)"  "BugBot CHANGES_REQUESTED: findings entry in missing"
+
+# --------------------------------------------------------------------------
+# (m) Stale failure-phrase comment (pre-HEAD created_at) must NOT block.
+#     The freshness filter on BB_HAS_FAILURE_COMMENT only counts comments
+#     posted AFTER the HEAD commit. HEAD committer date is 2026-07-21T09:59:00Z
+#     (set by the fake gh git/commits endpoint); a comment with created_at
+#     2026-07-21T09:00:00Z is stale and must be ignored.
+# --------------------------------------------------------------------------
+FAKE_REVIEWS='[]'
+FAKE_PR_COMMENTS='[]'
+FAKE_ISSUE_COMMENTS="$(jq -cn '[{user:{login:"cursor[bot]"},body:"I could not run this review — usage limit reached",created_at:"2026-07-21T09:00:00Z"}]')"
+run_gate_bugbot "$(bundle "$(cr 1 "Cursor Bugbot" success 100)")"
+check_eq "true" "$(echo "$OUT" | jq -r '.met')"           "BugBot stale failure comment: gate met (comment predates HEAD commit)"
+check_eq "no"   "$(has_bugbot_no_review_entry)"            "BugBot stale failure comment: no 'no BugBot review' entry"
+
+# --------------------------------------------------------------------------
+# (n) Success check-run with empty completed_at/started_at must fail-closed.
+#     When LAST_COMMIT_TS is known but neither timestamp field is set,
+#     freshness cannot be verified — gate must block (mirrors CodeAnt gate).
+# --------------------------------------------------------------------------
+BB_NO_TS_RUN="$(jq -cn '{id:1, name:"Cursor Bugbot", status:"completed",
+  conclusion:"success", completed_at:null, started_at:null,
+  check_suite:{id:100}, app:{slug:"cursor",id:1}}')"
+FAKE_REVIEWS='[]'
+FAKE_PR_COMMENTS='[]'
+FAKE_ISSUE_COMMENTS='[]'
+run_gate_bugbot "$(bundle "$BB_NO_TS_RUN")"
+check_eq "false" "$(echo "$OUT" | jq -r '.met')"          "BugBot empty check timestamp: gate blocked (cannot verify freshness)"
+check_eq "yes"   "$(has_bugbot_ts_unavail_entry)"          "BugBot empty check timestamp: 'completed_at/started_at unavailable' in missing"
 
 # Reset BugBot-specific env vars so they don't bleed into a re-run.
 unset FAKE_REVIEWS FAKE_PR_COMMENTS FAKE_ISSUE_COMMENTS


### PR DESCRIPTION
## Summary

- Extends `merge-gate.sh` `bugbot)` case to accept a completed `Cursor Bugbot` check-run with `conclusion: "success"` as a clean BugBot pass, in addition to the existing review-object path
- Guards the new path with a failure-phrase scan (PR/issue comments from `cursor[bot]`) and a freshness check (`completed_at`/`started_at` must postdate HEAD commit)
- Removes the unused `BUGBOT_GATE_SATISFIABLE` variable from `escalate-review.sh` (SC2034); replaces with an explanatory comment; gate-satisfiable evaluation lives in `merge-gate.sh` where `CHECK_RUNS_JSON` and `LAST_COMMIT_TS` are already available
- Updates `bugbot.md`, `cr-merge-gate.md`, and `merge-gate-reviewer-paths.md` to enumerate both accepted BugBot gate shapes

Closes #844

## Test plan

- [x] `escalate-review.test.sh` scenario (m): `conclusion:success` check-run, no comments → `STATUS=switch_bugbot` (gate now satisfiable)
- [x] `merge-gate-ci-dedup.test.sh` test 7: `success` check-run, no reviews, no failure comments → `met:true` (regression test for the fix)
- [x] `merge-gate-ci-dedup.test.sh` test 8: `success` check-run + failure-phrase issue comment → `met:false`, `no BugBot review on HEAD` in missing
- [x] `merge-gate-ci-dedup.test.sh` test 9: `neutral` check-run + `cursor[bot]` inline PR comment, no review objects → `met:false`, `no BugBot review on HEAD` in missing
- [x] `merge-gate-ci-dedup.test.sh` test 10: `cursor[bot]` `CHANGES_REQUESTED` review on HEAD → `met:false`, findings entry in missing
- [x] All 29 `merge-gate-ci-dedup.test.sh` scenarios pass (25 Phase A + 4 added by Phase B for freshness-filter fixes)
- [x] All 28 `escalate-review.test.sh` scenarios pass (including the new scenario m)
- [x] `bash -n` and `shellcheck` both clean on `merge-gate.sh` and `escalate-review.sh`
- [x] Rule corpus: 11,733 words (Phase B trimmed; below 11,749 ratchet cap — CI rule-lint confirms)

[COVERAGE] none — CR CLI not installed (exit 127); CodeAnt 403 daily cap after one retry (per `cr-local-review.md`, one retry then drop). Self-review clean.