### PR TITLE
feat(#851): cut agent chatter to heartbeat + decision points

### DIFF
--- a/.claude/reference/issue-162-phase-protocol-verification.md
+++ b/.claude/reference/issue-162-phase-protocol-verification.md
@@ -26,6 +26,8 @@
 
 **Note on issue #162 wording:** Test scenarios asked for a “fenced” block; agent instructions use a ```text fence in markdown for readability. The runtime contract is the plain `EXIT_REPORT` header plus colon-separated lines (see `exit-report-format.md`).
 
+> **Superseded in part (issue #851).** The step *counts* below are a snapshot of `phase-protocols.md` as it stood at this verification. Issue #851 removed the routine "Report to user" steps — Phase A now ends at step 7, Phase B at step 5, Phase C at step 4 — because routine completion reports are suppressed under `CLAUDE.md` #3. Every other finding here still holds.
+
 ## 2. Phase B Completion Protocol (6-step checklist)
 
 **Source:** `.claude/rules/phase-protocols.md` — “Phase B Completion Protocol (MANDATORY)”, numbered steps 1–6:
@@ -35,7 +37,7 @@
 3. Verify review state via GitHub API before Phase C  
 4. Launch Phase C within 60s — auto `/wrap`, no approval pause
 5. Update `session-state.json`  
-6. Report to user (with timestamp)  
+6. ~~Report to user (with timestamp)~~ — **removed by issue #851**; Phase B now ends at step 5.  
 
 **Verification:** Checklist is explicit and ordered; “Phase C launch is top priority after Phase B reports `merge_ready`” is stated immediately after the list. **Behavioral enforcement** in-repo is via parent-agent rules (`phase-protocols.md`, `subagent-orchestration.md`); this pass did not execute a live parent loop.
 
@@ -43,7 +45,7 @@
 
 ## 3. Phase C Completion Protocol
 
-**Source:** `.claude/rules/phase-protocols.md` — “Phase C Completion Protocol (MANDATORY)” lists **five** numbered steps (parse → branch on OUTCOME → update session-state → handoff cleanup after confirmed merge → report). Issue #162 AC called this “4-step”; the committed rule file has five numbered items — align AC with the file or renumber in a follow-up doc edit.
+**Source:** `.claude/rules/phase-protocols.md` — “Phase C Completion Protocol (MANDATORY)” listed **five** numbered steps at the time of this pass (parse → branch on OUTCOME → update session-state → handoff cleanup after confirmed merge → report). Issue #162 AC called this “4-step”. **Resolved by issue #851:** the trailing report step is gone, so the file now lists four steps and matches the AC.
 
 **Merge / handoff:** Phase C agent template (`phase-c-merger.md`) states the parent deletes the handoff only after `OUTCOME: merged` and GitHub confirms merge — consistent with `phase-protocols.md` Phase C step 4.
 

--- a/.claude/rules/cr-github-review.md
+++ b/.claude/rules/cr-github-review.md
@@ -78,7 +78,7 @@ Verdicts: `gate_met`, `polling_cr`, `switch_bugbot`, `trigger_greptile`, `budget
 
 ### CI Health Check (MANDATORY — every poll cycle)
 
-**Check ALL check-runs:** `repos/{owner}/{repo}/commits/{SHA}/check-runs?per_page=100` (full command: `.claude/reference/cr-polling-commands.md`). Any blocking conclusion → **invoke `/fixpr` immediately** (`cancelled`/`neutral`/`skipped` are non-blocking). CI failures block merge independently of CR; report a pass/fail summary.
+**Check ALL check-runs:** `repos/{owner}/{repo}/commits/{SHA}/check-runs?per_page=100` (full command: `.claude/reference/cr-polling-commands.md`). Any blocking conclusion → **invoke `/fixpr` immediately** (`cancelled`/`neutral`/`skipped` are non-blocking). CI failures block merge independently of CR.
 
 ### Timeout & Fallback — Three-Tier Review Chain
 

--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -1,8 +1,8 @@
 # Issue Flow
 
-> **Always:** Create a GitHub issue before any code work. Merge CR's plan into the issue body before coding. A skill may open issues autonomously — provided it reports each one in-thread with number, title, one-line rationale, and clickable link (`/issue-maker`'s closing-URL convention).
+> **Always:** Create a GitHub issue before any code work. Merge CR's plan into the issue body before coding. A skill may open issues autonomously — reported in-thread only when filing is the ask (`/issue-maker`: number, title, rationale, link); incidental filings are recorded, not narrated.
 > **Ask first:** Never — issue creation and planning are autonomous. Filing is reversible; closing an unwanted issue is the escape hatch, not a confirmation prompt.
-> **Never:** Skip the issue. Start coding without a plan. Post the plan as scattered comments instead of editing the issue body. Open an issue without reporting it.
+> **Never:** Skip the issue. Start coding without a plan. Post the plan as scattered comments instead of editing the issue body. Open an issue without recording it.
 
 ## Issue Planning Flow — Procedural Checklist
 

--- a/.claude/rules/monitor-mode.md
+++ b/.claude/rules/monitor-mode.md
@@ -25,13 +25,13 @@ Every ~60s, in order:
 
 ## Subagent Health Monitoring (MANDATORY)
 
-Poll every cycle; never fire-and-forget. Report successes and failures immediately, naming PR/issue, phase, failure mode, and remaining work. Verify outputs before marking complete (`gh pr view` for pushes, comments/replies for feedback handling).
+Poll every cycle; never fire-and-forget. Report failures and blockers immediately — PR/issue, phase, failure mode, remaining work; successes fold into the heartbeat. Verify outputs before marking complete (`gh pr view` for pushes, comments/replies for feedback handling).
 
 Respawn permissions: crash asks, exhaustion auto (`phase-protocols.md`).
 
 ## User Heartbeat (MANDATORY)
 
-CLAUDE.md #3 is canonical for the one-line default and for when full detail is owed. Routine-beat format:
+CLAUDE.md #3 is canonical. Routine-beat format:
 
 `[<ET timestamp>] <state / what's running> · next: <action or cadence> — monitoring N PR(s) (#a, #b)`
 
@@ -49,14 +49,14 @@ If a summary block references prior work you do not remember, recover before all
 1. Timestamp; rerun session-start checks.
 2. Read `session-state.json` + handoffs; reconcile each open PR on GitHub (all 3 endpoints per `cr-github-review.md`).
 3. Per polled PR: `polling-state-gate.sh <N> --verify-state` (optional `--root-repo`), then resume with `polling-state-gate.sh <N>` (shells `merge-gate.sh`).
-4. Dashboard (PR, HEAD, reviewer, pending); verify stale agents and stalled transitions; launch as needed.
-5. Report: "Resuming after context compaction. Reconstructed state from GitHub." then resume monitoring.
+4. Reconcile state (PR, HEAD, reviewer, pending); verify stale agents and stalled transitions; launch as needed.
+5. Resume monitoring — one heartbeat line, no report.
 
 ## PM Monitoring Recovery
 
 If `monitoring_active=true` or passive mode with non-empty `prs`/`active_agents`, rebuild from `prs`, `active_agents`, handoffs, and GitHub before continuing.
 
-- No workers left → `monitoring_active=false`, report done.
+- No workers left → `monitoring_active=false`.
 - `/pm`-owned monitoring is always passive — never restart a `/loop`/`CronCreate` on `/pm`'s behalf; point fleet monitoring at `/pr-monitor-and-manage`.
 - Jobs in `polling_jobs[]` → recover per that skill's contract (`pm-monitoring-decision.md`); log drops in `polling_failures[]`.
 

--- a/.claude/rules/phase-protocols.md
+++ b/.claude/rules/phase-protocols.md
@@ -2,7 +2,7 @@
 
 > **Always:** Print a Structured Exit Report as the final output before every subagent exits. Execute the appropriate Completion Protocol immediately when a subagent returns. Verify outputs before marking complete.
 > **Ask first:** Crashed/no-handoff respawns — tell the user first; exhaustion with valid handoff auto-respawns ("Always do").
-> **Never:** Skip the exit report. Launch the next phase without verifying the previous phase's outputs. Do NOT ask permission for autonomous phase transitions — including Phase C after `merge_ready`.
+> **Never:** Skip the exit report. Launch the next phase without verifying the previous phase's outputs. Do NOT ask permission for autonomous phase transitions — including Phase C after `merge_ready`. Emit routine completion reports; blockers and failures still surface (`CLAUDE.md` #3).
 
 ## Structured Exit Report (MANDATORY — all phases)
 
@@ -15,13 +15,12 @@ Every subagent MUST print an `EXIT_REPORT` block as its **final output** — one
 1. **Parse the exit report.** Extract `PR_NUMBER`, `HEAD_SHA`, `OUTCOME`, `REVIEWER`, `NEXT_PHASE`. No exit report = silent failure — report to user, check GitHub.
 2. **Branch on OUTCOME:**
    - `pushed_fixes` or `no_findings` → proceed to step 3
-   - `exhaustion` → **run step 4 (worktree cleanup) now**, then launch replacement Phase A within 60s. Report to user. **STOP — do not execute steps 3, 5-8** (skipping cleanup makes the replacement hit "branch already checked out").
+   - `exhaustion` → **run step 4 (worktree cleanup) now**, then launch replacement Phase A within 60s. Report to user. **STOP — do not execute steps 3, 5-7** (skipping cleanup makes the replacement hit "branch already checked out").
 3. **Verify the push.** `gh pr view N --json commits --jq '.commits[-1].oid'` — confirm SHA matches. Mismatch = silent failure.
 4. **Clean up the Phase A worktree:** `git worktree remove <path> --force` (or `git worktree prune` on failure). Releases the branch lock for Phase B.
 5. **Verify handoff file.** Resolve path with `handoff-state.sh [--owner-repo owner/repo] --path N` and confirm the file exists with `phase_completed: "A"`. If missing, reconstruct and write it yourself.
 6. **Launch Phase B within 60 seconds.** Check all 3 comment endpoints; include findings and handoff path.
 7. **Update `session-state.json`.** Record phase transition and HEAD SHA.
-8. **Report to user.** "Phase A complete for PR #N — fixes pushed (SHA `abc1234`). Phase B launched."
 
 ## Phase B Completion Protocol (MANDATORY)
 
@@ -30,11 +29,10 @@ Every subagent MUST print an `EXIT_REPORT` block as its **final output** — one
 1. **Parse the exit report.** No exit report = silent failure.
 2. **Branch on OUTCOME:**
    - `merge_ready` → proceed to step 3 (launch Phase C). This is the single Phase-C-advancing terminal.
-   - `clean`, `fixes_pushed`, or `exhaustion` → launch replacement Phase B within 60s, update `session-state.json` (keep phase B; record new SHA/remaining work as applicable), report with timestamp, and **STOP**.
+   - `clean`, `fixes_pushed`, or `exhaustion` → launch replacement Phase B within 60s, update `session-state.json` (keep phase B; record new SHA/remaining work as applicable), and **STOP**.
 3. **Verify review state via GitHub API.** Confirm the merge gate per `cr-merge-gate.md` Step 1. If verification fails, launch replacement Phase B instead of Phase C — STOP.
 4. **Launch Phase C within 60 seconds.** No merge-approval pause — Phase C runs `/wrap` silently once gate + AC pass. Include the handoff path.
 5. **Update `session-state.json`.** Record phase transition and HEAD SHA.
-6. **Report to user (with timestamp).**
 
 ## Phase C Completion Protocol (MANDATORY)
 
@@ -45,8 +43,7 @@ Every subagent MUST print an `EXIT_REPORT` block as its **final output** — one
    - `merged` → verify GitHub confirms the PR is merged (`merged == true`), then proceed to cleanup.
    - `blocked` → report blocker details to user. Do NOT merge.
 3. **Update `session-state.json`.** Mark Phase C complete, remove from `active_agents`.
-4. **Handoff cleanup (after successful merge only).** Delete the handoff file (`handoff-state.sh [--owner-repo owner/repo] --delete N`) after `OUTCOME: merged` confirmed by GitHub. If merge fails or is aborted, do NOT delete.
-5. **Report to user (with timestamp).**
+4. **Handoff cleanup (after successful merge only).** Delete the handoff file (`handoff-state.sh [--owner-repo owner/repo] --delete N`) after `OUTCOME: merged` confirmed by GitHub. If merge fails or is aborted, do NOT delete. A clean merge is silent.
 
 ## `/wrap` → `/fixpr` Delegation Contract
 

--- a/.claude/rules/phase-protocols.md
+++ b/.claude/rules/phase-protocols.md
@@ -2,7 +2,7 @@
 
 > **Always:** Print a Structured Exit Report as the final output before every subagent exits. Execute the appropriate Completion Protocol immediately when a subagent returns. Verify outputs before marking complete.
 > **Ask first:** Crashed/no-handoff respawns — tell the user first; exhaustion with valid handoff auto-respawns ("Always do").
-> **Never:** Skip the exit report. Launch the next phase without verifying the previous phase's outputs. Do NOT ask permission for autonomous phase transitions — including Phase C after `merge_ready`. Emit routine completion reports; blockers and failures still surface (`CLAUDE.md` #3).
+> **Never:** Skip the exit report. Launch the next phase without verifying the previous phase's outputs. Do NOT ask permission for autonomous phase transitions — including Phase C after `merge_ready`.
 
 ## Structured Exit Report (MANDATORY — all phases)
 
@@ -29,7 +29,7 @@ Every subagent MUST print an `EXIT_REPORT` block as its **final output** — one
 1. **Parse the exit report.** No exit report = silent failure.
 2. **Branch on OUTCOME:**
    - `merge_ready` → proceed to step 3 (launch Phase C). This is the single Phase-C-advancing terminal.
-   - `clean`, `fixes_pushed`, or `exhaustion` → launch replacement Phase B within 60s, update `session-state.json` (keep phase B; record new SHA/remaining work as applicable), and **STOP**.
+   - `clean`, `fixes_pushed`, or `exhaustion` → launch replacement Phase B within 60s, update `session-state.json` (keep phase B; record new SHA/remaining work as applicable), and **STOP**. Report `exhaustion` (a failure); `clean`/`fixes_pushed` are silent (`CLAUDE.md` #3).
 3. **Verify review state via GitHub API.** Confirm the merge gate per `cr-merge-gate.md` Step 1. If verification fails, launch replacement Phase B instead of Phase C — STOP.
 4. **Launch Phase C within 60 seconds.** No merge-approval pause — Phase C runs `/wrap` silently once gate + AC pass. Include the handoff path.
 5. **Update `session-state.json`.** Record phase transition and HEAD SHA.

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -225,7 +225,7 @@ TS=$(TZ='America/New_York' date +'%a %b %-d %I:%M %p ET')
 echo "[$TS] PMM tick — $PR_COUNT PR(s) in fleet (author:$PMM_AUTHOR)"
 ```
 
-Print the **full table** when any of: (a) first tick / post-resume (digests are null), or the user asks for it; (b) `DIGEST != PREV` or `ROW_DIGEST != ROW_PREV` **and** the delta is decision-relevant — a new hard block, a gate failure, a termination, or a PR entering/leaving the fleet. A purely informational delta (a new bot comment, a CI count, a display-only change) takes the quiet line instead (issue #851); the digests still drive backoff and Step 6 persistence either way. (c) any PR's verdict is actionable (`rebase`, `fixpr`, `wrap`, `batch(#A)`); (d) Step 2.5 processed subagent outcomes or `HARD_BLOCK[]` gained an entry; (e) Step 3.6 held or batched anything.
+Print the **full table** when any of: (a) first tick / post-resume (digests are null), or the user asks for it; (b) a digest change — `DIGEST != PREV` **or** `ROW_DIGEST != ROW_PREV` — **that is also** decision-relevant: a new hard block, a gate failure, a termination, or a PR entering/leaving the fleet. Both halves must hold; a digest change on its own does not fire (b). A purely informational delta (a new bot comment, a CI count, a display-only change) takes the quiet line instead (issue #851); the digests still drive backoff and Step 6 persistence either way. (c) any PR's verdict is actionable (`rebase`, `fixpr`, `wrap`, `batch(#A)`); (d) Step 2.5 processed subagent outcomes or `HARD_BLOCK[]` gained an entry; (e) Step 3.6 held or batched anything.
 
 **Quiet tick** (none of a–e): one line: `[$TS] PMM tick — N PR(s) (author:x) — no change (#N1 #N2; hard-blocked: #N3 human-CR; queued (cap): #N4)`.
 

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-monitor-and-manage
-description: Thread-level PR fleet manager. Rediscovers your open PRs every tick, prints a delta-aware status table (one-line heartbeat when nothing changed), and auto-dispatches the per-PR decision tree (rebase / parallel phase-a-fixer / sequential /wrap) until the fleet is clean, hard-blocked, or idle. Auto-pauses when idle; resume with /pr-monitor-and-manage-wake. Triggers on "/pr-monitor-and-manage", "/pmm", "manage PRs", "PR fleet", "watch PRs".
+description: Thread-level PR fleet manager. Rediscovers your open PRs every tick, prints a status table on the first tick, after a resume, at pause/stop, and whenever a decision is needed or you ask (one-line heartbeat otherwise), and auto-dispatches the per-PR decision tree (rebase / parallel phase-a-fixer / sequential /wrap) until the fleet is clean, hard-blocked, or idle. Auto-pauses when idle; resume with /pr-monitor-and-manage-wake. Triggers on "/pr-monitor-and-manage", "/pmm", "manage PRs", "PR fleet", "watch PRs".
 triggers:
   - pr-monitor-and-manage
   - pmm
@@ -225,7 +225,7 @@ TS=$(TZ='America/New_York' date +'%a %b %-d %I:%M %p ET')
 echo "[$TS] PMM tick — $PR_COUNT PR(s) in fleet (author:$PMM_AUTHOR)"
 ```
 
-Print the **full table** when any of: (a) first tick / post-resume (digests are null); (b) `DIGEST != PREV` or `ROW_DIGEST != ROW_PREV`; (c) any PR's verdict is actionable (`rebase`, `fixpr`, `wrap`, `batch(#A)`); (d) Step 2.5 processed subagent outcomes or `HARD_BLOCK[]` gained an entry; (e) Step 3.6 held or batched anything.
+Print the **full table** when any of: (a) first tick / post-resume (digests are null), or the user asks for it; (b) `DIGEST != PREV` or `ROW_DIGEST != ROW_PREV` **and** the delta is decision-relevant — a new hard block, a gate failure, a termination, or a PR entering/leaving the fleet. A purely informational delta (a new bot comment, a CI count, a display-only change) takes the quiet line instead (issue #851); the digests still drive backoff and Step 6 persistence either way. (c) any PR's verdict is actionable (`rebase`, `fixpr`, `wrap`, `batch(#A)`); (d) Step 2.5 processed subagent outcomes or `HARD_BLOCK[]` gained an entry; (e) Step 3.6 held or batched anything.
 
 **Quiet tick** (none of a–e): one line: `[$TS] PMM tick — N PR(s) (author:x) — no change (#N1 #N2; hard-blocked: #N3 human-CR; queued (cap): #N4)`.
 

--- a/.claude/skills/pr-monitor-and-manage/references/pmm-classify.md
+++ b/.claude/skills/pr-monitor-and-manage/references/pmm-classify.md
@@ -215,7 +215,7 @@ Evaluate the `jq` first and pass the resulting JSON as the value — never a raw
 Print the **full table** (below the lead line) when ANY of:
 
 - (a) this is the first tick of a fresh invocation (Step 0 mode entry) or the first tick after a resume (Step 0a) — both null `.pmm_digest`/`.pmm_row_digest`; (a) is independently sufficient, so the table prints regardless of (b). The user asking for the table also fires (a);
-- (b) `DIGEST != PREV` or `ROW_DIGEST != ROW_PREV` (or either previous value is null) **and** the delta is decision-relevant — a new hard block, a gate failure, a termination, or a PR entering/leaving the fleet. A purely informational delta (a new bot comment, a CI count, a display-only change) does **not** print the table (issue #851); the digests are still computed and persisted for backoff;
+- (b) a digest change — `DIGEST != PREV` **or** `ROW_DIGEST != ROW_PREV` **or** either previous value is null — **that is also** decision-relevant: a new hard block, a gate failure, a termination, or a PR entering/leaving the fleet. Both halves must hold; a digest change on its own does not fire (b). A purely informational delta (a new bot comment, a CI count, a display-only change) does **not** print the table (issue #851); the digests are still computed and persisted for backoff;
 - (c) any PR's verdict this tick is actionable — `rebase`, `fixpr`, `wrap`, or `batch(#A)` — so the classification is always visible before Step 5 acts;
 - (d) Step 2.5 processed any subagent outcome, or `HARD_BLOCK[]` gained a new entry this tick;
 - (e) Step 3.6 held or batched anything (the merge-sequence annotation must stay visible).

--- a/.claude/skills/pr-monitor-and-manage/references/pmm-classify.md
+++ b/.claude/skills/pr-monitor-and-manage/references/pmm-classify.md
@@ -214,8 +214,8 @@ Evaluate the `jq` first and pass the resulting JSON as the value — never a raw
 
 Print the **full table** (below the lead line) when ANY of:
 
-- (a) this is the first tick of a fresh invocation (Step 0 mode entry) or the first tick after a resume (Step 0a) — both null `.pmm_digest`/`.pmm_row_digest`, so (b) also fires mechanically;
-- (b) `DIGEST != PREV` or `ROW_DIGEST != ROW_PREV` (or either previous value is null);
+- (a) this is the first tick of a fresh invocation (Step 0 mode entry) or the first tick after a resume (Step 0a) — both null `.pmm_digest`/`.pmm_row_digest`; (a) is independently sufficient, so the table prints regardless of (b). The user asking for the table also fires (a);
+- (b) `DIGEST != PREV` or `ROW_DIGEST != ROW_PREV` (or either previous value is null) **and** the delta is decision-relevant — a new hard block, a gate failure, a termination, or a PR entering/leaving the fleet. A purely informational delta (a new bot comment, a CI count, a display-only change) does **not** print the table (issue #851); the digests are still computed and persisted for backoff;
 - (c) any PR's verdict this tick is actionable — `rebase`, `fixpr`, `wrap`, or `batch(#A)` — so the classification is always visible before Step 5 acts;
 - (d) Step 2.5 processed any subagent outcome, or `HARD_BLOCK[]` gained a new entry this tick;
 - (e) Step 3.6 held or batched anything (the merge-sequence annotation must stay visible).

--- a/.claude/skills/pr-monitor-and-manage/references/pmm-lifecycle.md
+++ b/.claude/skills/pr-monitor-and-manage/references/pmm-lifecycle.md
@@ -53,7 +53,7 @@ if [ "$PAUSED_AT" != null ] && [ -n "$PAUSED_AT" ]; then
   fi
   # 3. Clear pause marker + reset pmm_idle_streak=0 + set pmm_active=true
   #    + null .pmm_digest and .pmm_row_digest (atomic batch) — the digest reset
-  #    forces Step 4's full table on the first post-resume tick (condition a/b)
+  #    forces Step 4's full table on the first post-resume tick (condition a)
   .claude/scripts/session-state.sh \
     --set '.pmm.paused_at=null' \
     --set '.pmm.fleet_at_pause=null' \

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wrap
-description: End-of-session command — verify no unresolved findings, squash merge, sync main, detect per-PR follow-ups, run a full-session loose-ends sweep, and extract lessons. Terse by default — output is a concise merged + follow-ups summary; pass `--verbose` for the full per-phase report. Accepts an optional PR reference (`/wrap <URL>`, `/wrap #N`, `/wrap N`); with no argument it infers the PR from the current branch, then thread context, then session-state.
+description: End-of-session command — verify no unresolved findings, squash merge, sync main, detect per-PR follow-ups, run a full-session loose-ends sweep, and extract lessons. Silent by default — a clean merge prints nothing but items needing your decision; pass `--verbose` (or just ask) for the merged + follow-ups summary and the full per-phase report. Accepts an optional PR reference (`/wrap <URL>`, `/wrap #N`, `/wrap N`); with no argument it infers the PR from the current branch, then thread context, then session-state.
 argument-hint: "[URL | #N | N] [--verbose]"
 ---
 
@@ -29,9 +29,9 @@ Wrap up the current PR and session. This is the "we're done here" command that h
 
 ### Follow-up filing is autonomous (issue #633)
 
-Both Phase 3 passes — **Part A** (per-PR follow-ups) and **Part B** (full-session sweep) — file every novel candidate as a GitHub issue **without asking**. There is no opt-out flag and no "file as new issue?" prompt anywhere in this skill. The deal is two-sided: filing is unconditional, and **every** filed issue is reported in the closing message (Step 4.3) with number, title, one-line rationale, and clickable link. Retraction (`gh issue close`) is the escape hatch, not a confirmation round-trip. The norm is stated once for all skills in `.claude/rules/issue-planning.md`.
+Both Phase 3 passes — **Part A** (per-PR follow-ups) and **Part B** (full-session sweep) — file every novel candidate as a GitHub issue **without asking**. There is no opt-out flag and no "file as new issue?" prompt anywhere in this skill. The deal is two-sided: filing is unconditional, and **every** filed issue is durably **recorded** — the GitHub issue itself, the run-scoped `WRAP_FILED_ISSUES` registry, and `session-state.json` `wrap_sweep.filed_issues` (Step 3.13). **Recording is not narrating (issue #851):** filings do *not* print on the default path. They are listed with number, title, one-line rationale, and clickable link under `--verbose` or on request, and any filing that needs a decision — a failed `gh issue create`, or one carrying a `Possibly duplicates #{N}` caveat — surfaces immediately in either mode. Retraction (`gh issue close`) is the escape hatch, not a confirmation round-trip. The norm is stated once for all skills in `.claude/rules/issue-planning.md`.
 
-Autonomy does not mean filing blind: every candidate goes through the body-aware duplicate check in **Step 3.0** first (issue #652). That check can only ever *redirect* a filing onto an existing issue or *annotate* it — it never drops a finding, and every filing it suppresses is named in the closing report alongside the issue it deferred to.
+Autonomy does not mean filing blind: every candidate goes through the body-aware duplicate check in **Step 3.0** first (issue #652). That check can only ever *redirect* a filing onto an existing issue or *annotate* it — it never drops a finding, and every filing it suppresses is named in the `--verbose` report alongside the issue it deferred to.
 
 ### Wrap-Internal Phase Transitions
 
@@ -55,19 +55,19 @@ Autonomy does not mean filing blind: every candidate goes through the body-aware
 
 ## Output modes
 
-`/wrap` is **terse by default**: it runs all four phases in full but collapses its human-facing output to a short merged + follow-ups summary. Pass `--verbose` for the complete per-phase narration and the detailed final report.
+`/wrap` is **silent by default** (issue #851): it runs all four phases in full and says nothing about a clean merge — only items that need an explicit decision from you. Pass `--verbose`, or simply ask ("what did you just do?", "summarize"), for the merged + follow-ups summary, the per-phase narration, and the detailed final report. This implements `CLAUDE.md` #3 for this skill.
 
 | Mode | Flag | Effect |
 |------|------|--------|
-| **Terse** | *(default)* | Two concise blocks — **Merged** (≤3 sentences) and **Follow-ups** (≤3 sentences, or "No follow-ups opened.") — plus a one-line lessons ack and, only when the sweep left decisions pending, a one-line verdict. Per-phase narration is suppressed. |
-| **Verbose** | `--verbose` | The full report: per-cycle recovery heartbeats, the Session Lessons block, and the multi-section "Wrap-Up Complete" report (Issues filed, Filings suppressed as duplicates, Session sweep, Verdict, Lessons). Full template: `references/wrap-report-templates.md`. |
+| **Silent** | *(default)* | Nothing on a clean run — no merge line, no follow-up list, no lessons ack, no sweep summary. Only decision-requiring items print, one terse line each (Step 4.3 **Silent default**). |
+| **Verbose** | `--verbose` *(or an explicit request)* | The full report: the `## Wrapped up` merged + follow-ups block, per-cycle recovery heartbeats, the Session Lessons block, and the multi-section "Wrap-Up Complete" report (Issues filed, Filings suppressed as duplicates, Session sweep, Verdict, Lessons). Full template: `references/wrap-report-templates.md`. |
 
-**Verbosity is additive and human-facing only.** Every phase executes **identically** in both modes; only narration differs. Four things always print regardless of mode:
+**Verbosity is additive and human-facing only.** Every phase executes **identically** in both modes; only narration differs. Suppression is never deletion — the merge, the filings, the sweep, and the lessons are all recorded (GitHub, `WRAP_FILED_ISSUES`, `session-state.json` `wrap_sweep`, memory), so an explicit request re-renders the verbose report in full from that state. Four things always print regardless of mode:
 
-- **State-changing blockers and stop conditions** — a merge that can't proceed, `CONFLICTING`, human `CHANGES_REQUESTED`, no PR found, the recovery cap — surface as a short one-line reason even in terse mode (Step 4.3 **Blocker path**).
+- **State-changing blockers and stop conditions** — a merge that can't proceed, `CONFLICTING`, human `CHANGES_REQUESTED`, no PR found, the recovery cap — surface as a short one-line reason even on the silent default (Step 4.3 **Blocker path**).
 - **The `[INFERRED]` merge-safety checkpoint** (Step 1.1). Prints only on the inference path, never on the normal branch path.
-- **The CLAUDE.md 5-minute heartbeat** during long `/fixpr` waits.
-- **`[COVERAGE]` when local review was degraded** (`cr-only`, `codeant-only`, or `none`). Full coverage (`both`) is terse-suppressible.
+- **The CLAUDE.md 5-minute heartbeat** during long `/fixpr` waits. Silence never extends past the heartbeat — that is what keeps a suppressed run distinguishable from a stalled one (issue #803).
+- **`[COVERAGE]` when local review was degraded** (`cr-only`, `codeant-only`, or `none`). Full coverage (`both`) is suppressible.
 
 When `/wrap` is invoked by a phase-C subagent, the machine **`EXIT_REPORT`** block (per `phase-protocols.md`) is emitted **identically regardless of verbosity**.
 
@@ -189,7 +189,7 @@ if [ "$WRAP_VERBOSE" = "1" ]; then
 fi
 ```
 
-**Terse mode keeps two non-negotiable signals:** (a) the CLAUDE.md 5-minute heartbeat during `/fixpr` waits, and (b) dispatch/blocker transitions always print.
+**The silent default keeps two non-negotiable signals:** (a) the CLAUDE.md 5-minute heartbeat during `/fixpr` waits, and (b) dispatch/blocker transitions always print.
 
 After each action, append to **`WRAP_RECOVERY_AUDIT`**: cycle number, blocker summary, action taken, result. Always built; rendered to the user only under `--verbose`.
 
@@ -425,7 +425,7 @@ For each follow-up item (the HHG pair or the generic list):
 {context from detection}${LINKED_SOURCE}
 
 _Filed via /wrap._"
-  # Surface title+body before filing (visible in --verbose mode only; all filings announced in Step 4.3 regardless):
+  # Surface title+body before filing (--verbose only; the silent default records without printing):
   if [ "$WRAP_VERBOSE" = "1" ]; then
     echo "Filing follow-up: $ISSUE_TITLE"
     echo "$ISSUE_BODY"
@@ -446,13 +446,13 @@ _Filed via /wrap._"
 
 ### Step 3.4: Carry Part A results into the unified report
 
-Part A does **not** print its own "Created" list — every issue it filed is in `WRAP_FILED_ISSUES` and announced once in Step 4.3. Carry forward: filed issues (already in registry), suppressed-as-duplicates, filed-with-caveat, and failures. If nothing detected and nothing filed, Step 4.3 reads "No follow-up items detected." Proceed immediately to Part B.
+Part A does **not** print its own "Created" list — every issue it filed is in `WRAP_FILED_ISSUES` and rendered once in Step 4.3's verbose report. Carry forward: filed issues (already in registry), suppressed-as-duplicates, filed-with-caveat, and failures. Filed-with-caveat entries and creation failures are the two that also print on the silent default. If nothing detected and nothing filed, the verbose report reads "No follow-up items detected." Proceed immediately to Part B.
 
 ### Part B — Full-session sweep
 
 Part B sweeps the **whole session** for loose ends the per-PR detection in Part A cannot see. It produces two buckets — **Auto-handled** and **Needs your decision** — and a one-line **verdict**.
 
-**Safety boundaries (non-negotiable — issue #471):** never auto-file without surfacing the body; never auto-act on anything affecting shared state (live crons, active subagents, human-owned issues/PRs, recovery branches); auto-handling limited to: stopping a **dead** session `/loop` job and deleting a **stale** handoff file.
+**Safety boundaries (non-negotiable — issue #471):** never auto-file without recording the full body (rendered under `--verbose` or on request — issue #851); never auto-act on anything affecting shared state (live crons, active subagents, human-owned issues/PRs, recovery branches); auto-handling limited to: stopping a **dead** session `/loop` job and deleting a **stale** handoff file.
 
 #### Step 3.5: Sweep setup & idempotency guard
 
@@ -465,7 +465,7 @@ if [[ -n "$SESSION_STATE_SH" ]]; then
 fi
 ```
 
-Initialize `SWEEP_AUTO_HANDLED` and `SWEEP_NEEDS_DECISION` (free-form bullet lists). Cap each rendered section at 3–5 bullets (overflow → "+ N more" summary); auto-filed tickets are **exempt** from the cap — every created issue's title + body is surfaced in full.
+Initialize `SWEEP_AUTO_HANDLED` and `SWEEP_NEEDS_DECISION` (free-form bullet lists). Cap each rendered section at 3–5 bullets (overflow → "+ N more" summary); auto-filed tickets are **exempt** from the cap — every created issue's title + body is surfaced in full under `--verbose`.
 
 #### Step 3.6: Category 1 — Session loose ends (transcript introspection)
 
@@ -491,7 +491,7 @@ Classify per `.claude/reference/autofile-dedup.md` and take exactly one path:
 - **Weak / closed** → set `WEAK_DUP_NUM` and file with `Possibly duplicates #{DUP_NUM}` body line; add to `SWEEP_NEEDS_DECISION`.
 - **None** → file.
 
-On filing: create immediately, **surface title + body**, append to `WRAP_FILED_ISSUES` (rationale `loose end: <summary>`), append number to `DEDUP_EXCLUDE`, add to `SWEEP_AUTO_HANDLED`. Use same `gh issue create` guard as Step 3.3 (validate parsed number; on failure record and continue):
+On filing: create immediately, **surface title + body under `--verbose`**, append to `WRAP_FILED_ISSUES` (rationale `loose end: <summary>`), append number to `DEDUP_EXCLUDE`, add to `SWEEP_AUTO_HANDLED`. Use same `gh issue create` guard as Step 3.3 (validate parsed number; on failure record and continue):
 
 ```bash
 POSSIBLE_DUP=""
@@ -671,13 +671,28 @@ For each actionable, novel lesson:
 - Write memory files with proper frontmatter (`feedback`, `project`, or `user` type)
 - Add pointers to `MEMORY.md`
 
-Memory writes happen in both modes. Record `WRAP_LESSONS_COUNT`. Verbose mode prints the full `## Session Lessons` block; terse carries only a one-line ack into Step 4.3.
+Memory writes happen in both modes. Record `WRAP_LESSONS_COUNT`. Verbose mode prints the full `## Session Lessons` block; the silent default prints no lessons ack at all — the memory files are the record.
 
 ### Step 4.3: Final report
 
-`/wrap` renders one of two **success** reports based on the output mode; the **Blocker path** prints in *both* modes.
+`/wrap` has three output paths: the **silent default**, the **verbose report**, and the **Blocker path** (prints in *both* modes).
 
-#### Terse report (default)
+#### Silent default
+
+On a clean run, print **nothing** — no merge line, no follow-up list, no lessons ack, no sweep summary. All of it is already recorded (GitHub, `WRAP_FILED_ISSUES`, `session-state.json` `wrap_sweep`, memory) and re-renders in full under `--verbose` or on request.
+
+Print **only** items that need an explicit decision from the user, one terse line each:
+
+- **Blocker or stop condition** → the Blocker path below. Mandatory — silence must never swallow a stop.
+- **A filing that needs your judgment** → `gh issue create` failed, or the issue was filed with a `Possibly duplicates #{N}` caveat: `Filed [#{a}](url) — possibly duplicates #{b}.` A filing with no caveat is recorded silently.
+- **Sweep verdict, only when items are pending** → `{N} item(s) pending your decision — run /wrap --verbose for detail.` Omit entirely on `Clear to archive`.
+- **`[COVERAGE]` degraded** and the **`[INFERRED]` checkpoint** — per the always-print list in **Output modes**.
+
+When none of those apply, `/wrap` produces no output at all. A clean merge is silent (`CLAUDE.md` #3).
+
+#### Verbose report (`--verbose`, or on explicit request)
+
+Print this block first:
 
 ```
 ## Wrapped up
@@ -692,6 +707,8 @@ Memory writes happen in both modes. Record `WRAP_LESSONS_COUNT`. Verbose mode pr
 
 Rules: **Merged ≤3 sentences; Follow-ups ≤3 sentences.** Every opened issue is listed (number + one-line + clickable link) — an issue not listed is indistinguishable from one silently dropped. Suppressed-as-duplicate findings: never silently dropped (surface count). Sweep verdict: appears only when decisions are pending.
 
+Then the full `## Wrap-Up Complete` multi-section template, rendering rules, section caps, and exemptions: **`references/wrap-report-templates.md`**.
+
 #### Blocker path (both modes)
 
 Print a **single short line** naming the reason. Under `--verbose`, also append the full `WRAP_RECOVERY_AUDIT` / `missing` detail:
@@ -703,10 +720,6 @@ Print a **single short line** naming the reason. Under `--verbose`, also append 
 - **`/fixpr` delegation failure (Step 2.1 Branch B)** → `Merge blocked: /fixpr could not resolve {blocker} — {FIXPR_WRAP_STATUS}.`
 - **No PR found** → the Step 1.1f message verbatim.
 
-The blocker line is **mandatory in terse mode** — terseness must never swallow a stop.
-
-#### Verbose report (`--verbose`)
-
-Full `## Wrap-Up Complete` multi-section template, rendering rules, section caps, and exemptions: **`references/wrap-report-templates.md`**.
+The blocker line is **mandatory on the silent default** — silence must never swallow a stop.
 
 The worktree and feature branch are intentionally left in place, reaped out-of-band by `/pm-update`'s stale-cleanup pass. See `.claude/scripts/stale-cleanup.sh --help`.

--- a/.claude/skills/wrap/references/wrap-report-templates.md
+++ b/.claude/skills/wrap/references/wrap-report-templates.md
@@ -1,8 +1,8 @@
 # `/wrap` Step 4.3 — Verbose Report Template
 
-Referenced from `wrap/SKILL.md` Step 4.3. The SKILL.md keeps the terse block, the blocker path strings, and the selector logic; this file holds the full verbose template and its rendering rules.
+Referenced from `wrap/SKILL.md` Step 4.3. The SKILL.md keeps the silent-default rules, the `## Wrapped up` block, the blocker path strings, and the selector logic; this file holds the full verbose template and its rendering rules. Nothing here prints on the silent default (issue #851) — it renders only under `--verbose` or on an explicit request.
 
-## Verbose report (`--verbose`)
+## Verbose report (`--verbose`, or on explicit request)
 
 ```
 ## Wrap-Up Complete

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # PR MERGE AUTHORIZATION
 
-When the merge gate passes (`cr-merge-gate.md` Steps 1–1d, 1b) and every Test Plan box verifies (Step 2), **auto-run full `/wrap`** (squash-merge, sync main, follow-ups, session sweep, lessons) — **no approval pause, no pre-merge message**. Post-merge report is the user's first signal.
+When the merge gate passes (`cr-merge-gate.md` Steps 1–1d, 1b) and every Test Plan box verifies (Step 2), **auto-run full `/wrap`** (squash-merge, sync main, follow-ups, session sweep, lessons) — **no approval pause, no pre-merge message**. A clean merge is silent (item #3).
 
 **Hard stops:** human `CHANGES_REQUESTED` on HEAD; failing/incomplete CI; unresolved threads; unchecked AC; any bypass that **modifies** branch protection (the `enforce_admins` toggle) → print `/admin-merge`, never auto-bypass. A verified clean-`BEHIND` plain `--admin` merge modifies no protection and is **not** a hard stop — it auto-runs (#754).
 
@@ -16,11 +16,11 @@ These apply to EVERY parent-agent message. No exceptions, no degradation, no ski
 
 1. **Timestamp prefix.** Start every message with Eastern time (`Mon Mar 16 02:34 AM ET`). **Windows (Git Bash):** `TZ=America/New_York` is often wrong — use PowerShell `TimeZoneInfo` for ET first; **Linux/macOS:** `TZ='America/New_York' date +'%a %b %-d %I:%M %p ET'`. Never estimate — run a command; for elapsed time, compare two outputs.
 2. **Active monitoring declaration.** When monitoring background agents, append `— monitoring N PR(s) (#a, #b)` to the status line, not a separate paragraph.
-3. **5-minute heartbeat — one line by default.** Never go >5 min without a status message; routine format: `monitor-mode.md` "User Heartbeat". Multi-line only for state changes, blockers, failures, and final reports — hard stops always in full. During operations touching 4+ files, emit one-line status every 3 writes/edits (`monitor-mode.md`).
+3. **Output = heartbeat + decision points only (canonical).** Never go >5 min without a one-line status message (`monitor-mode.md` "User Heartbeat") — the only routine output, never suppressed. Blockers, ambiguous calls, and permission requests surface immediately and tersely — multi-line only for those and hard stops. Everything else is suppressed: progress narration, file lists, per-phase status, completion reports, end-of-run summaries. Suppressed, not lost — work is still recorded (PR bodies, issues, state, memory). Summaries are opt-in: `--verbose`, "summarize", `/recap`, `/standup`. File-write status updates: `monitor-mode.md`.
 4. **`/loop` for recurring polls.** Back any "poll/check/watch every N" request with `/loop` (or `CronCreate` for ≥3 concurrent polls / wall-clock-cadence fleet ticks — **session-only**, see `scheduling-reliability.md` contract note) — never a hand-rolled chain of one-shot wake-ups. Decision tree + pre-exit checklist: `scheduling-reliability.md`.
 5. **Dedicated monitor mode.** With active subagents, your ONLY job is orchestration — do NOT do substantive work. See `monitor-mode.md` "Dedicated Monitor Mode" for full rules.
 
-After context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `monitor-mode.md`) and report it WITH a timestamp.
+After context compaction, your FIRST action is to reconstruct monitoring state (see "Post-Compaction Recovery" in `monitor-mode.md`) and confirm it in one timestamped line.
 
 ## Thread title — `[#issue]` prefix
 


### PR DESCRIPTION
## What changed

Makes silence the default and decisions the exception, per Issue #851.

`CLAUDE.md` "EVERY MESSAGE" **#3** becomes the single canonical output-verbosity policy. Every other reporting surface now defers to it instead of adding its own "report to user" obligation on top — which is what made chat volume compound per phase and per PR.

**The policy (`CLAUDE.md` #3):** the one-line heartbeat is the *only* routine output and is never suppressed. Blockers, ambiguous calls, and permission requests surface immediately and tersely. Everything else — progress narration, file lists, per-phase status, completion reports, end-of-run summaries — is suppressed. Suppressed is not lost: the work is still recorded (PR bodies, issues, `session-state.json`, memory), and summaries are opt-in (`--verbose`, "summarize", `/recap`, `/standup`).

**Surfaces reconciled**

| File | Change |
|------|--------|
| `CLAUDE.md` | #3 rewritten as the canonical policy; escalation list narrowed to blockers/decisions/hard-stops. Merge authorization now says a clean merge is silent (was "post-merge report is the user's first signal"). |
| `.claude/rules/monitor-mode.md` | Only failures and blockers report; successes fold into the heartbeat. Compaction recovery and PM recovery stop narrating. |
| `.claude/rules/phase-protocols.md` | Routine "Report to user" steps removed (Phase A step 8, Phase B step 6, Phase C step 5). Blocker, failure and exhaustion reporting all retained. |
| `.claude/rules/issue-planning.md` | Issues report in-thread when filing *is* the ask (`/issue-maker`); incidental filings are recorded, not narrated. Required for AC6. |
| `.claude/rules/cr-github-review.md` | A passing CI run is no longer reported; failures still block and surface. |
| `.claude/skills/wrap/SKILL.md` | **Silent by default** — a clean merge prints nothing beyond decision-requiring items. The `## Wrapped up` block moves behind the existing `--verbose` flag. |
| `.claude/skills/pr-monitor-and-manage/` | A purely informational digest delta no longer prints the full table; first tick, resume, pause/stop, actionable verdicts, and explicit requests still do. |

`/pm` is deliberately untouched: its board is user-invoked output, which the policy already exempts as opt-in.

## Decision flagged (from the issue's open questions)

**"Does 'done' deserve a signal?"** — implemented as the issue assumed: **a clean merge produces no chat output at all**. If you'd rather have a bare `merged #N` one-liner, it is a one-clause edit in `CLAUDE.md` #3 and the `/wrap` Silent-default section. Say the word and I'll flip it.

The other two open questions were resolved without a behavior change: heartbeat content keeps its existing one-line format (Issue #803's silence backstop references it, and stripping the task/next fields would make a stall harder to spot), and `/pm` tables stay available on request.

## Local review coverage

`[COVERAGE] none` — both local CLIs were unavailable this session:

- **CodeAnt CLI:** HTTP 403 on every file (the undocumented daily agent-review cap). Per `cr-local-review.md`, dropped for the session; the CodeAnt GitHub App is unaffected and still gates the merge.
- **CodeRabbit CLI:** ran ~22 minutes emitting heartbeats but stalled after its first 3 findings; terminated per the hang rule. **All 3 findings it did emit were resolved** before commit — two accepted as suggested (stale step counts in `.claude/reference/issue-162-phase-protocol-verification.md`; incomplete PMM `description`), one accepted in part: CodeRabbit asked to delete the new `Never: emit routine completion reports` clause, which is the core of AC4 — kept, with its ambiguity fixed instead (`; blockers and failures still surface`).

Self-review of the full diff was run in place of the missing clean passes. GitHub App reviewers gate this PR.

## Test plan

- [x] `CLAUDE.md` #3 states the canonical policy — heartbeat + decision points only, everything else suppressed unless explicitly requested (AC1).
- [x] `CLAUDE.md` #3's multi-line escalation list is narrowed to blockers/decisions/hard-stops; "state changes" and "final reports" are gone as blanket triggers (AC2).
- [x] `monitor-mode.md` reports failures and blockers only; successes fold into the heartbeat, and compaction/PM recovery no longer emit reports (AC3).
- [x] `phase-protocols.md` has no routine "Report to user" step in Phase A, B, or C; blocker (`blocked →`), silent-failure, and exhaustion reporting are retained (AC4).
- [x] `wrap/SKILL.md` default path emits nothing beyond decision-requiring items, and the `## Wrapped up` merged + follow-ups block renders only under `--verbose` or on request (AC5).
- [x] `/wrap` still creates follow-up issues and still records them (GitHub, `WRAP_FILED_ISSUES`, `session-state.json` `wrap_sweep.filed_issues`) on the silent path; only caveated or failed filings surface (AC6).
- [x] Opt-in detail still works: `--verbose`, "summarize", `/recap`, and `/standup` all render the full report from recorded state (AC7).
- [x] Rule corpus within budget — `.github/scripts/rule-lint.sh` exits 0 at 11,736 words against the 11,749 ratchet cap (AC8).
- [x] Cross-references stay consistent: Phase A's "do not execute steps 3, 5-7" matches the new step count, and `.claude/reference/issue-162-phase-protocol-verification.md` records the renumbering.
- [x] `pr-monitor-and-manage` prints the full table on first tick, resume, pause/stop, actionable verdicts, and explicit request — but not on a purely informational delta.
- [x] Full local suite green: all 5 repo lints, 52 bash test suites, 142 Python tests.

Runtime confirmation of the issue's behavioral checks (a full issue → PR → merge cycle showing heartbeats and zero routine reports, and a mid-run blocker surfacing tersely) is observable on this PR's own merge, which runs under the new policy.

Closes #851