### PR TITLE
feat(#827): replace CronCreate "durability" with session-start reconciliation

### DIFF
--- a/.claude/hooks/polling-backoff-warn.sh
+++ b/.claude/hooks/polling-backoff-warn.sh
@@ -102,7 +102,7 @@ fi
 
 if (( user_blocker == 1 || streak >= 9 )); then
   [[ "$last_cron_type" == "delete" ]] && exit 0
-  emit_context "STOP - PR #${pr_number} is stable-blocked (digest_streak=${streak}, blocker_kind=${blocker_kind:-null}). Stop the poll before exiting this turn - cancel the /loop, or CronDelete if this poll is a cron job - and cancel any sibling ScheduleWakeup. Do not heartbeat again until the user nudges or the digest changes."
+  emit_context "STOP - PR #${pr_number} is stable-blocked (digest_streak=${streak}, blocker_kind=${blocker_kind:-null}). Stop the poll before exiting this turn - cancel the /loop, or CronDelete if this poll is a cron job - and cancel any ScheduleWakeup you armed for THIS poll - leave unrelated one-shot wakeups alone, this hook cannot tell them apart. Do not heartbeat again until the user nudges or the digest changes."
   exit 0
 fi
 

--- a/.claude/hooks/polling-backoff-warn.sh
+++ b/.claude/hooks/polling-backoff-warn.sh
@@ -111,7 +111,7 @@ if (( streak >= 3 )); then
   if [[ "$last_cron_type" == "update" && "$last_cron_interval" == "${WIDE_MIN}m" ]]; then
     exit 0
   fi
-  emit_context "STOP - PR #${pr_number} has ${streak} identical polling ticks. Widen the interval to ${WIDE_MIN}m before exiting this turn - re-arm the /loop at the wider cadence, or CronUpdate if this poll is a cron job - then update prs.${pr_number}.last_cron_action and suppress duplicate heartbeat noise."
+  emit_context "WIDEN (do NOT stop the poll) - PR #${pr_number} has ${streak} identical polling ticks. The poll must KEEP RUNNING at a slower cadence: widen it to ${WIDE_MIN}m before exiting this turn - re-arm the /loop at the wider cadence, or CronUpdate if this poll is a cron job - then update prs.${pr_number}.last_cron_action and suppress duplicate heartbeat noise. Stopping is only for the streak>=9 / user-blocked branch."
 fi
 
 exit 0

--- a/.claude/hooks/polling-backoff-warn.sh
+++ b/.claude/hooks/polling-backoff-warn.sh
@@ -102,7 +102,7 @@ fi
 
 if (( user_blocker == 1 || streak >= 9 )); then
   [[ "$last_cron_type" == "delete" ]] && exit 0
-  emit_context "STOP - PR #${pr_number} is stable-blocked (digest_streak=${streak}, blocker_kind=${blocker_kind:-null}). Call CronDelete and cancel any sibling ScheduleWakeup before exiting this turn. Do not heartbeat again until the user nudges or the digest changes."
+  emit_context "STOP - PR #${pr_number} is stable-blocked (digest_streak=${streak}, blocker_kind=${blocker_kind:-null}). Stop the poll before exiting this turn - cancel the /loop, or CronDelete if this poll is a cron job - and cancel any sibling ScheduleWakeup. Do not heartbeat again until the user nudges or the digest changes."
   exit 0
 fi
 
@@ -111,7 +111,7 @@ if (( streak >= 3 )); then
   if [[ "$last_cron_type" == "update" && "$last_cron_interval" == "${WIDE_MIN}m" ]]; then
     exit 0
   fi
-  emit_context "STOP - PR #${pr_number} has ${streak} identical polling ticks. Call CronUpdate to widen the interval to ${WIDE_MIN}m before exiting this turn, update prs.${pr_number}.last_cron_action, and suppress duplicate heartbeat noise."
+  emit_context "STOP - PR #${pr_number} has ${streak} identical polling ticks. Widen the interval to ${WIDE_MIN}m before exiting this turn - re-arm the /loop at the wider cadence, or CronUpdate if this poll is a cron job - then update prs.${pr_number}.last_cron_action and suppress duplicate heartbeat noise."
 fi
 
 exit 0

--- a/.claude/hooks/session-start-sync.sh
+++ b/.claude/hooks/session-start-sync.sh
@@ -82,12 +82,45 @@ if [[ -d "$skills_wt" && -f "$skills_wt/.git" ]]; then
   fi
 fi
 
+# --- Reconcile durable scheduling state (issue #827) ---
+# CronCreate jobs are in-memory and die with the session that armed them, so
+# every job this file recorded before now is already gone. Purge that dead
+# bookkeeping and surface the durable on-disk records that DID survive (an
+# overdue harness-audit, a paused PR fleet). Fail-soft by contract — the
+# script always exits 0, and any failure here must not block the session.
+
+# Resolved from this hook's own location, not from the skills worktree: the
+# reconciler reads session-state, so a broken or missing worktree — exactly
+# when stale bookkeeping is most likely — must not also suppress the cleanup.
+notices=""
+reconcile_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" 2>/dev/null && pwd)/session-scheduling-reconcile.sh"
+if [[ -f "$reconcile_script" ]]; then
+  notices=$(bash "$reconcile_script" 2>/dev/null)
+fi
+
+# Strip control characters before they reach jq. `$errors` carries raw git
+# stderr, and a clone/fetch progress meter emits carriage returns and escape
+# sequences — noise that lands verbatim in the context block, on exactly the
+# first run in a fresh HOME when the sync warning matters most.
+# CR (\015) is inside the deleted set: it is the character progress meters
+# actually emit, so leaving it out would have made this scrub miss its target.
+# Tab (\011) and newline (\012) are preserved — they carry real formatting.
+errors=$(printf '%s' "$errors" | LC_ALL=C tr -d '\000-\010\013-\015\016-\037')
+notices=$(printf '%s' "$notices" | LC_ALL=C tr -d '\000-\010\013-\015\016-\037')
+
 # Report result
 if [[ -n "$errors" ]]; then
-  jq -n --arg errors "$errors" '{
+  jq -n --arg errors "$errors" --arg notices "$notices" '{
     hookSpecificOutput: {
       hookEventName: "SessionStart",
-      additionalContext: ("SESSION SYNC WARNING: Config sync encountered errors: " + $errors + ". Skills, rules, or CLAUDE.md may be stale. Run manually: git -C ~/.claude/skills-worktree fetch origin main && git -C ~/.claude/skills-worktree reset --hard origin/main")
+      additionalContext: ("SESSION SYNC WARNING: Config sync encountered errors: " + $errors + ". Skills, rules, or CLAUDE.md may be stale. Run manually: git -C ~/.claude/skills-worktree fetch origin main && git -C ~/.claude/skills-worktree reset --hard origin/main" + (if $notices == "" then "" else "\n\n" + $notices end))
+    }
+  }'
+elif [[ -n "$notices" ]]; then
+  jq -n --arg notices "$notices" '{
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: $notices
     }
   }'
 else

--- a/.claude/hooks/session-start-sync.sh
+++ b/.claude/hooks/session-start-sync.sh
@@ -4,8 +4,11 @@
 # CLAUDE.md are up to date with origin/main. Runs on every session start
 # (fresh session, resume, clear, compact, fork).
 
-# Consume stdin (required by hook protocol)
-cat > /dev/null
+# Consume stdin (required by hook protocol) and keep it: SessionStart carries
+# a `source` telling us WHY it fired — startup | resume | clear | compact.
+# Only `startup` is a genuinely new session; the rest fire inside a live one.
+hook_stdin=$(cat)
+session_source=$(jq -r '.source // empty' <<<"$hook_stdin" 2>/dev/null)
 
 # --- Sync skills worktree ---
 skills_wt="$HOME/.claude/skills-worktree"
@@ -92,10 +95,22 @@ fi
 # Resolved from this hook's own location, not from the skills worktree: the
 # reconciler reads session-state, so a broken or missing worktree — exactly
 # when stale bookkeeping is most likely — must not also suppress the cleanup.
+#
+# Purge ONLY on `startup`. compact/resume/clear fire inside a live session,
+# where a job or watcher recorded in state may still be running: clearing its
+# bookkeeping there orphans a live job, and deciding a watcher is dead races
+# the tick that is about to refresh it. On a true startup neither is possible —
+# nothing from the previous session survived — so the purge is unambiguous.
+# An absent `source` (older harness) is treated as NOT startup: a stale record
+# lingering one more session is strictly cheaper than clearing a live one.
 notices=""
 reconcile_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" 2>/dev/null && pwd)/session-scheduling-reconcile.sh"
 if [[ -f "$reconcile_script" ]]; then
-  notices=$(bash "$reconcile_script" 2>/dev/null)
+  if [[ "$session_source" == "startup" ]]; then
+    notices=$(bash "$reconcile_script" 2>/dev/null)
+  else
+    notices=$(bash "$reconcile_script" --check 2>/dev/null)
+  fi
 fi
 
 # Strip control characters before they reach jq. `$errors` carries raw git

--- a/.claude/hooks/tests/polling-backoff-warn.test.sh
+++ b/.claude/hooks/tests/polling-backoff-warn.test.sh
@@ -120,6 +120,20 @@ ctx="$(run_hook "$PR" | context_of)"
 [[ -z "$ctx" ]] || fail "expected no re-emit when delete already applied, got: $ctx"
 ok "delete already applied → no re-emit from widen branch"
 
+# ── 10b. /loop path: no cron record at all → STOP fires, and the marker
+#         /babysit-pr T-END writes suppresses the second one. Since #827 the
+#         watcher is /loop-only, so this is now the DEFAULT path — case 10
+#         above only ever exercised a cron-backed poll.
+write_state "$PR" '{"digest_streak":9,"babysit":{"cadence_base_minutes":5}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -n "$ctx" ]] || fail "expected STOP on a /loop poll with no last_cron_action"
+ok "/loop poll (no cron record) → STOP emitted"
+
+write_state "$PR" '{"digest_streak":9,"babysit":{"cadence_base_minutes":5},"last_cron_action":{"type":"delete","interval":"paused"}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -z "$ctx" ]] || fail "the stop marker /babysit-pr T-END writes must suppress a second STOP, got: $ctx"
+ok "/loop stop marker suppresses the repeat STOP"
+
 # ── 11. Streak >= 9 → stop the poll ──────────────────────────────────────────
 write_state "$PR" '{"digest_streak":9,"babysit":{"cadence_base_minutes":5}}'
 ctx="$(run_hook "$PR" | context_of)"

--- a/.claude/hooks/tests/polling-backoff-warn.test.sh
+++ b/.claude/hooks/tests/polling-backoff-warn.test.sh
@@ -134,6 +134,18 @@ ctx="$(run_hook "$PR" | context_of)"
 [[ -z "$ctx" ]] || fail "the stop marker /babysit-pr T-END writes must suppress a second STOP, got: $ctx"
 ok "/loop stop marker suppresses the repeat STOP"
 
+# ── 10c. The widen advisory must never read as "stop the poll" ───────────────
+# streak 3..8 means keep polling, slower. The stop instruction belongs only to
+# the >=9 / user-blocked branch; conflating them silently kills the watcher at
+# the first backoff threshold.
+write_state "$PR" '{"digest_streak":4,"babysit":{"cadence_base_minutes":5}}'
+ctx="$(run_hook "$PR" | context_of)"
+[[ -n "$ctx" ]] || fail "expected a widen advisory at streak=4"
+echo "$ctx" | grep -q "WIDEN" || fail "widen advisory should be labelled WIDEN, got: $ctx"
+echo "$ctx" | grep -q "KEEP RUNNING" || fail "widen advisory must say the poll keeps running, got: $ctx"
+echo "$ctx" | grep -q "Stop the poll" && fail "widen advisory must not carry a stop-the-poll instruction, got: $ctx"
+ok "widen advisory (streak 3..8) says keep running, never stop"
+
 # ── 11. Streak >= 9 → stop the poll ──────────────────────────────────────────
 write_state "$PR" '{"digest_streak":9,"babysit":{"cadence_base_minutes":5}}'
 ctx="$(run_hook "$PR" | context_of)"

--- a/.claude/hooks/tests/polling-backoff-warn.test.sh
+++ b/.claude/hooks/tests/polling-backoff-warn.test.sh
@@ -2,7 +2,7 @@
 # Tests for polling-backoff-warn.sh (issue #794).
 #
 # Verifies the base-relative stable-state backoff ladder:
-#   digest_streak >= 3 → widen to max(15m, 3×base); streak >= 9 → CronDelete
+#   digest_streak >= 3 → widen to max(15m, 3×base); streak >= 9 → stop the poll
 # Covers multiple base cadences, the "already applied" no-op guard, and the
 # user_input blocker stop. Never touches real session state.
 set -euo pipefail
@@ -114,31 +114,32 @@ ctx="$(run_hook "$PR" | context_of)"
 [[ -z "$ctx" ]] || fail "expected no re-emit when update to 60m already applied, got: $ctx"
 ok "already-applied guard: update to 60m not re-emitted at base=20m"
 
-# ── 10. CronDelete already issued → no re-emit for either branch ─────────────
+# ── 10. stop already issued → no re-emit for either branch ───────────────────
 write_state "$PR" '{"digest_streak":5,"babysit":{"cadence_base_minutes":5},"last_cron_action":{"type":"delete","interval":"paused"}}'
 ctx="$(run_hook "$PR" | context_of)"
 [[ -z "$ctx" ]] || fail "expected no re-emit when delete already applied, got: $ctx"
 ok "delete already applied → no re-emit from widen branch"
 
-# ── 11. Streak >= 9 → stop (CronDelete) ──────────────────────────────────────
+# ── 11. Streak >= 9 → stop the poll ──────────────────────────────────────────
 write_state "$PR" '{"digest_streak":9,"babysit":{"cadence_base_minutes":5}}'
 ctx="$(run_hook "$PR" | context_of)"
 [[ -n "$ctx" ]] || fail "expected STOP message at streak=9"
-echo "$ctx" | grep -q "CronDelete" || fail "expected CronDelete in stop message, got: $ctx"
-ok "streak>=9 → STOP with CronDelete"
+echo "$ctx" | grep -q "Stop the poll" || fail "expected a stop-the-poll instruction, got: $ctx"
+echo "$ctx" | grep -q "CronDelete" || fail "stop message should still name CronDelete for cron-backed polls, got: $ctx"
+ok "streak>=9 → STOP the poll (naming both /loop and cron)"
 
 # ── 12. blocker_kind=user_input → stop immediately (any streak) ──────────────
 write_state "$PR" '{"digest_streak":1,"blocker_kind":"user_input","babysit":{"cadence_base_minutes":5}}'
 ctx="$(run_hook "$PR" | context_of)"
 [[ -n "$ctx" ]] || fail "expected STOP message on user_input even at streak=1"
-echo "$ctx" | grep -q "CronDelete" || fail "expected CronDelete in user_input stop, got: $ctx"
-ok "blocker_kind=user_input → STOP with CronDelete regardless of streak"
+echo "$ctx" | grep -q "Stop the poll" || fail "expected a stop-the-poll instruction in user_input stop, got: $ctx"
+ok "blocker_kind=user_input → STOP the poll regardless of streak"
 
 # ── 13. Stop branch "already applied" guard ───────────────────────────────────
 write_state "$PR" '{"digest_streak":9,"babysit":{"cadence_base_minutes":5},"last_cron_action":{"type":"delete","interval":"paused"}}'
 ctx="$(run_hook "$PR" | context_of)"
 [[ -z "$ctx" ]] || fail "expected no re-emit on stop branch when delete already applied, got: $ctx"
-ok "stop branch: CronDelete already applied → no re-emit"
+ok "stop branch: stop already applied → no re-emit"
 
 # ── 14. Non-polling command exits silently ────────────────────────────────────
 write_state "$PR" '{"digest_streak":5,"babysit":{"cadence_base_minutes":5}}'

--- a/.claude/hooks/tests/session-start-sync-reconcile.test.sh
+++ b/.claude/hooks/tests/session-start-sync-reconcile.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Tests for the SessionStart hook's scheduling-reconcile gate (issue #827).
+#
+# SessionStart fires on startup | resume | clear | compact. Only `startup` is a
+# genuinely new session; the others fire inside a LIVE one, where purging state
+# would orphan a running job and race a watcher about to refresh itself.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK="$REPO_ROOT/.claude/hooks/session-start-sync.sh"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { chmod -R u+w "$TMP_DIR" 2>/dev/null || true; rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "ok   — $*"; }
+
+CASE_N=0
+OUT=""
+STATE=""
+# run_hook <source-json> — fresh HOME seeded with purgeable state.
+# Sets $STATE and $OUT in the CALLER's scope: a command substitution would run
+# this in a subshell and the $STATE assignment would never escape it.
+run_hook() {
+  CASE_N=$((CASE_N + 1))
+  export HOME="$TMP_DIR/home$CASE_N"
+  mkdir -p "$HOME/.claude"
+  STATE="$HOME/.claude/session-state.json"
+  printf '%s' '{"polling_jobs":[{"id":"live_job"}],"pmm":{"auto_wake_cron_id":"live_cron"}}' > "$STATE"
+  OUT="$(printf '%s' "$1" | bash "$HOOK" 2>/dev/null)"
+}
+
+# --- 1. startup purges -------------------------------------------------------
+run_hook '{"source":"startup"}'
+[[ "$(jq -c '.polling_jobs' "$STATE")" == "[]" ]] \
+  || fail "startup should purge polling_jobs, got $(jq -c '.polling_jobs' "$STATE")"
+[[ "$(jq -r '.pmm.auto_wake_cron_id' "$STATE")" == "null" ]] \
+  || fail "startup should clear auto_wake_cron_id"
+ok "source=startup purges dead scheduling bookkeeping"
+
+# --- 2. compact/resume/clear must NOT purge ----------------------------------
+# These fire inside a live session: the recorded job may still be running.
+for SRC in compact resume clear; do
+  run_hook "{\"source\":\"$SRC\"}"
+  [[ "$(jq -c '.polling_jobs' "$STATE")" == '[{"id":"live_job"}]' ]] \
+    || fail "source=$SRC must not purge polling_jobs (a live job would be orphaned)"
+  [[ "$(jq -r '.pmm.auto_wake_cron_id' "$STATE")" == "live_cron" ]] \
+    || fail "source=$SRC must not clear auto_wake_cron_id"
+done
+ok "source=compact/resume/clear leaves live bookkeeping untouched"
+
+# --- 3. An absent source fails safe (treated as not-startup) -----------------
+run_hook '{}'
+[[ "$(jq -c '.polling_jobs' "$STATE")" == '[{"id":"live_job"}]' ]] \
+  || fail "an absent source must NOT purge — clearing a live record is the costlier error"
+ok "an absent source fails safe: no purge"
+
+run_hook 'not json at all'
+[[ "$(jq -c '.polling_jobs' "$STATE")" == '[{"id":"live_job"}]' ]] \
+  || fail "unparseable stdin must not purge"
+ok "unparseable stdin fails safe: no purge"
+
+# --- 4. Output stays valid JSON on every path --------------------------------
+for SRC in '{"source":"startup"}' '{"source":"compact"}' '{}' 'garbage'; do
+  run_hook "$SRC"
+  [[ -z "$OUT" ]] && fail "hook produced no output for stdin: $SRC"
+  jq -e . <<<"$OUT" >/dev/null 2>&1 \
+    || fail "hook emitted invalid JSON for stdin $SRC: $OUT"
+done
+ok "hook emits valid JSON for startup, compact, absent, and garbage stdin"
+
+echo
+echo "All session-start-sync reconcile-gate tests passed."

--- a/.claude/hooks/tests/session-start-sync-reconcile.test.sh
+++ b/.claude/hooks/tests/session-start-sync-reconcile.test.sh
@@ -26,6 +26,12 @@ run_hook() {
   CASE_N=$((CASE_N + 1))
   export HOME="$TMP_DIR/home$CASE_N"
   mkdir -p "$HOME/.claude"
+  # Pre-create a worktree-shaped stub so the hook's bootstrap branch is skipped.
+  # Without it every case shells out to setup-skills-worktree.sh, which runs
+  # `git fetch origin main` — making a pure state-reconciliation test
+  # network-dependent, slow, and flaky offline.
+  mkdir -p "$HOME/.claude/skills-worktree/.claude/skills"
+  : > "$HOME/.claude/skills-worktree/.git"
   STATE="$HOME/.claude/session-state.json"
   printf '%s' '{"polling_jobs":[{"id":"live_job"}],"pmm":{"auto_wake_cron_id":"live_cron"}}' > "$STATE"
   OUT="$(printf '%s' "$1" | bash "$HOOK" 2>/dev/null)"

--- a/.claude/reference/cross-session-durability.md
+++ b/.claude/reference/cross-session-durability.md
@@ -64,9 +64,21 @@ start.** `.claude/scripts/session-scheduling-reconcile.sh`, invoked by the
 
 1. Purges bookkeeping that cannot have survived — `polling_jobs[]`,
    `.pmm.auto_wake_cron_id`, every `babysit.cron_job_id`.
-2. Deactivates `babysit` watchers whose last tick predates this process (a live
-   watcher rewrites `last_tick_at` every tick, so this cannot reap a live one).
+2. Deactivates `babysit` watchers left behind by the previous session.
 3. Surfaces what is still meaningful: an audit month come due, a paused fleet.
+
+**Steps 1–2 run only when `SessionStart` fires with `source == "startup"`.**
+That event also fires on `compact`, `resume`, and `clear`, which happen *inside*
+a live session — and there, both mutations are unsafe: clearing a record whose
+job is still running orphans it, and judging a watcher dead races the tick about
+to refresh `last_tick_at`. On a true startup neither is possible, because
+nothing from the previous session survived, so the purge needs no heuristic to
+be correct. Every other source runs the reconciler in `--check` mode: notices
+only, no writes. An absent `source` is treated as not-startup — a stale record
+lingering one more session is strictly cheaper than clearing a live one.
+
+A watcher's freshness window (`max(3x cadence, 30m)`, matching `/babysit-pr`'s
+A2 check) is kept as a second line of defence, not the primary guard.
 
 Per feature: `--durable` was **dropped** from `/babysit-pr` (accepted and
 ignored, so an old chip payload does not hard-error); `--auto-wake` was

--- a/.claude/reference/cross-session-durability.md
+++ b/.claude/reference/cross-session-durability.md
@@ -1,0 +1,89 @@
+# Cross-Session Durability — what exists, and why our schedulers decline it
+
+Background for issue #827, which redesigned the three features built on the
+false promise that `CronCreate` survives session turnover. Read this before
+proposing that any skill "just use a durable job" — the durable primitive exists,
+and the reason we do not use it is not ignorance of it.
+
+Prior art: issue #808 (discovery), PR #825 (doc-only correction),
+`scheduling-reliability.md` (the authoritative `CronCreate` contract).
+
+## The two primitives, compared
+
+| | `CronCreate` | `mcp__scheduled-tasks__*` (`/schedule`) |
+|---|---|---|
+| Storage | in-memory, per session | on disk: `~/.claude/scheduled-tasks/{taskId}/SKILL.md` |
+| Survives session exit | **No** — `durable: true` is a documented no-op | **Yes** |
+| App closed when due | job is gone | runs on next launch |
+| Expiry | 7 days | none |
+| Run context | the current session | **a fresh session, no memory of the creator** |
+| Cadence precision | exact | several-minute deterministic dispatch delay |
+
+So the answer to "does the harness provide cross-session durability?" is **yes**
+— `mcp__scheduled-tasks__*` genuinely persists. The design question is not
+whether we *can* use it but whether each feature *should*.
+
+## Why all three features declined it
+
+**1. It would silently convert supervised work into standing automation.**
+
+`/babysit-pr` and `/pr-monitor-and-manage` auto-dispatch `/fixpr` and `/wrap`,
+and `/wrap` squash-merges. A scheduled task runs in a *fresh, unattended
+session*. Porting either watcher onto it would turn "watch this PR while I'm
+here" into "merge my PRs on a cron, forever, with nobody reading the output" —
+an authorization escalation nobody asked for, granted by a flag whose name
+(`--durable`) suggests only a scheduling detail. `CLAUDE.md`'s merge authority is
+scoped to a live session's work, not a standing job.
+
+This is the load-bearing objection. It is about **what the job would be allowed
+to do**, not about whether the scheduler works.
+
+**2. The durable record we actually needed was never a job.**
+
+Both remaining needs were already satisfied by state on disk:
+
+- A paused PR fleet resumes from `.pmm.paused_at` in `session-state.json` —
+  read by `pmm-lifecycle.md` Step 0a on the next invocation, in any session.
+- The monthly audit's cadence is driven by
+  `~/.claude/harness-audit/last-run.json`, checked at session start.
+
+Reconciling durable state at session start is strictly more reliable than any
+scheduler for these: sessions begin many times a day, there is no job id to
+orphan, no expiry to lapse, and no MCP dependency to be absent in a headless
+run. A scheduler would have been a less reliable way to reach state we can
+simply read.
+
+**3. Cadence fit.** A several-minute dispatch delay is irrelevant monthly and
+wrong for a 1–5 minute PR watcher.
+
+## What replaced them (issue #827)
+
+One mechanism serves all three: **durable on-disk state, reconciled at session
+start.** `.claude/scripts/session-scheduling-reconcile.sh`, invoked by the
+`SessionStart` hook (`session-start-sync.sh`):
+
+1. Purges bookkeeping that cannot have survived — `polling_jobs[]`,
+   `.pmm.auto_wake_cron_id`, every `babysit.cron_job_id`.
+2. Deactivates `babysit` watchers whose last tick predates this process (a live
+   watcher rewrites `last_tick_at` every tick, so this cannot reap a live one).
+3. Surfaces what is still meaningful: an audit month come due, a paused fleet.
+
+Per feature: `--durable` was **dropped** from `/babysit-pr` (accepted and
+ignored, so an old chip payload does not hard-error); `--auto-wake` was
+**reframed** to a `/loop` re-scan in `/pr-monitor-and-manage`, keeping its
+user-visible promise while deleting a fail-closed cron teardown that had been
+duplicated across three files; `/harness-audit`'s daily-registration cadence
+became the **session-start watermark check** above.
+
+## When to revisit
+
+Adopting `mcp__scheduled-tasks__*` would be reasonable for a task that is
+genuinely unattended-safe — advisory, read-only, or output-only, with no merge,
+push, or write authority — and that needs to fire on wall-clock time rather than
+when a human happens to start a session. Nothing in this repo met that bar in
+July 2026. If something does later, the objection to re-read is #1 above:
+enumerate what the fresh session would be *permitted* to do, not just what it is
+*intended* to do.
+
+Whatever the outcome, do not reintroduce the claim that `CronCreate` is durable.
+It is not, in any configuration.

--- a/.claude/reference/cross-session-durability.md
+++ b/.claude/reference/cross-session-durability.md
@@ -77,8 +77,19 @@ be correct. Every other source runs the reconciler in `--check` mode: notices
 only, no writes. An absent `source` is treated as not-startup — a stale record
 lingering one more session is strictly cheaper than clearing a live one.
 
-A watcher's freshness window (`max(3x cadence, 30m)`, matching `/babysit-pr`'s
-A2 check) is kept as a second line of defence, not the primary guard.
+A watcher's freshness window is kept as a second line of defence, not the
+primary guard.
+
+### Freshness window (canonical)
+
+**`max(3 x cadence_effective_minutes, BABYSIT_DISPATCH_TTL_MIN)`**, default TTL
+`30` minutes. Two places implement it: `/babysit-pr`'s A2 duplicate-watcher
+check and `session-scheduling-reconcile.sh`. They must stay identical — a
+*narrower* window in the reconciler reaps a watcher A2 still considers fresh; a
+*wider* one lets a dead watcher linger. Change one, change the other, and update
+this definition. Note that A2 tests with a bash numeric regex and so accepts a
+numeric string, which is why the reconciler coerces with `tonumber` instead of
+type-checking for a JSON number.
 
 Per feature: `--durable` was **dropped** from `/babysit-pr` (accepted and
 ignored, so an old chip payload does not hard-error); `--auto-wake` was

--- a/.claude/reference/harness-audit.md
+++ b/.claude/reference/harness-audit.md
@@ -94,11 +94,13 @@ This PR introduces the source and one consumer.
 
 ## Why a session-start check for a monthly audit
 
-The audit needs a cadence measured in weeks, and no scheduler in this harness
-survives that long. `CronCreate` is in-memory and dies at session exit; its
-7-day expiry means even a literal monthly cron could lapse before firing. Both
-failure modes are *silence* — the worst possible outcome for a skill whose
-entire job is noticing silent staleness.
+The audit needs a cadence measured in weeks, and `CronCreate` — the scheduler
+this skill used — does not last that long. It is in-memory and dies at session
+exit; its 7-day expiry means even a literal monthly cron could lapse before
+firing. Both failure modes are *silence* — the worst possible outcome for a
+skill whose entire job is noticing silent staleness. (A durable scheduler *does*
+exist in the harness; the separate reason this skill declines it is in
+`.claude/reference/cross-session-durability.md`.)
 
 An earlier design worked around this by registering the job **daily** and gating
 on a monthly watermark, reasoning that seven daily chances would catch an

--- a/.claude/reference/harness-audit.md
+++ b/.claude/reference/harness-audit.md
@@ -39,17 +39,17 @@ just as confidently either way. So the judgment wants the top of the fleet.
 
 But `subagent-orchestration.md` reserves the top tier for **interactive step-ups
 where a human watches the spend**, and states it is never a spawn default. A
-monthly cron quietly burning top-tier tokens unattended contradicts that rule's
+monthly tick quietly burning top-tier tokens unattended contradicts that rule's
 *stated harm model*, not merely its wording.
 
 Issue #770 offered two resolutions: (a) carve a narrow exception into the rule,
-or (b) have the cron do the cheap pass and *offer* the expensive one. **We took
+or (b) have the tick do the cheap pass and *offer* the expensive one. **We took
 (b).**
 
 Why (b) over (a):
 
 - The invariant's rationale (`agents/README.md`) is specifically about unattended
-  spend with nobody watching. A cron is the purest instance of that. An exception
+  spend with nobody watching. An unattended tick is the purest instance of that. An exception
   would contradict the reasoning while satisfying the letter — the worst kind of
   carve-out, because the next reader inherits a rule whose stated reason no
   longer matches its scope.
@@ -92,18 +92,30 @@ Migrating `/prompt`, the chip `**Model:**` lines, and `.claude/agents/*.md` off
 their own literals is deliberately **out of scope** here and tracked in #749.
 This PR introduces the source and one consumer.
 
-## Why a daily cron for a monthly audit
+## Why a session-start check for a monthly audit
 
-`CronCreate` jobs can be removed by a 7-day expiry
-(`scheduling-reliability.md`). A literal monthly cron can therefore expire before
-it ever fires — and its failure mode is silence, which is the worst possible
-outcome for a skill whose entire job is noticing silent staleness.
+The audit needs a cadence measured in weeks, and no scheduler in this harness
+survives that long. `CronCreate` is in-memory and dies at session exit; its
+7-day expiry means even a literal monthly cron could lapse before firing. Both
+failure modes are *silence* — the worst possible outcome for a skill whose
+entire job is noticing silent staleness.
 
-So the job is registered **daily** and gated on a **monthly watermark**. Twenty-
-nine ticks in thirty are a file read and an exit. The daily cadence buys seven
-chances to notice an expired job inside the expiry window and re-arm it.
+An earlier design worked around this by registering the job **daily** and gating
+on a monthly watermark, reasoning that seven daily chances would catch an
+expired job inside the expiry window. That reasoning assumed the job outlived
+the session, which it never did (issue #808, corrected in PR #825): a daily
+re-registration only ever fired inside the session that armed it.
 
-> **Caveat:** `CronCreate` is **session-only** (`durable: true` has no effect) — the job dies when Claude exits regardless of how it was created. The daily re-registration design fires only within the session that armed it. Redesign of this cadence is tracked as a follow-up ticket (`scheduling-reliability.md` contract note).
+Issue #827 replaced the scheduler with the thing that is actually durable. The
+watermark file already persists and already records everything the cadence
+needs, so the tick moved to **session start** — `session-scheduling-reconcile.sh`
+reads the watermark on every session start and nudges when the month is due.
+Sessions start many times a day, so a month cannot be missed, and there is no
+job id, expiry window, or `CronList` reconciliation to get wrong. `--arm` and
+`--stop` toggle `nudge_enabled` in the same file.
+
+Why not the genuinely durable scheduler the harness *does* provide
+(`mcp__scheduled-tasks__*`): `.claude/reference/cross-session-durability.md`.
 
 ### Two watermarks, not one
 
@@ -112,11 +124,11 @@ chances to notice an expired job inside the expiry window and re-arm it.
 | Field | Set when | Prevents |
 |-------|----------|----------|
 | `last_completed_month` | A judgment pass finished (including `--report-only`) | Re-auditing a month already done |
-| `last_offered_month` | A step-up chip was successfully spawned | Re-offering the same chip every single day |
+| `last_offered_month` | A step-up chip was successfully spawned | Re-offering the same chip on every session start |
 
 One field alone forces a choice between two bad behaviors. Set it on offer, and
 an unclicked chip marks the month done when nothing was audited. Set it only on
-completion, and an ignored chip is re-offered daily until someone clicks it out
+completion, and an ignored chip is re-offered every session until someone clicks it out
 of irritation. Two fields make "offered but not yet done" a representable state,
 which is what it actually is.
 
@@ -129,7 +141,7 @@ nothing.
 The CR plan for #770 had every run write `.claude/reference/harness-audit-YYYY-MM.md`.
 That is wrong for the unattended path.
 
-A cron tick can land in a session sitting on the **root repo, on `main`**.
+A tick can land in a session sitting on the **root repo, on `main`**.
 Writing a report there puts changes on `main` — against `CLAUDE.md` §ALWAYS USE A
 WORKTREE — and trips `dirty-main-guard` on the next session start. The tick would
 be manufacturing exactly the dirty-main state another part of the harness exists

--- a/.claude/reference/pm-monitoring-decision.md
+++ b/.claude/reference/pm-monitoring-decision.md
@@ -5,9 +5,9 @@
 Division of responsibility between orchestration and fleet monitoring:
 
 - **`/pm` never creates polls.** It is a strictly on-demand orchestrator: cold-start scan, inline execution of selected issues via the `/subagent` A→B→C flow (in-turn Dedicated Monitor Mode, not a recurring poll), thread prompts for the few issues too big for a subagent, on-demand status when the user asks, and handoff generation. At ≥3 active threads it redirects to `/pr-monitor-and-manage`; it does not offer `CronCreate` or `/loop`.
-- **`/pr-monitor-and-manage` owns PR-fleet between-message polling.** It establishes `/loop` at the configured cadence, optionally registers `CronCreate` auto-wake on idle pause, and dispatches per-PR fixes/merges.
+- **`/pr-monitor-and-manage` owns PR-fleet between-message polling.** It establishes `/loop` at the configured cadence, optionally keeps a low-frequency `/loop` re-scan running after an idle pause (`--auto-wake`), and dispatches per-PR fixes/merges.
 - **`/loop` remains valid for explicit user-invoked "poll every N"** that is not PR-fleet-specific (e.g., "poll every 5m /status" on a single thread). Hand-rolled one-shot `ScheduleWakeup` chains are forbidden for recurring polls.
-- **`CronCreate` is for wall-clock-cadence fleet ticks or scheduled jobs owned by dedicated skills** (`/pr-monitor-and-manage` auto-wake, `/babysit-pr --durable`, etc.) — not `/pm`. It is **session-only** and does not survive Claude exiting; see `scheduling-reliability.md` contract note.
+- **`CronCreate` is for wall-clock-cadence fleet ticks** — not `/pm`. It is **session-only** and does not survive Claude exiting (`scheduling-reliability.md` contract note). Since issue #827 no skill in this repo registers one; durable work uses on-disk state reconciled at session start (`.claude/reference/cross-session-durability.md`).
 
 ## Rationale
 
@@ -21,7 +21,7 @@ The canonical PM manager use case is **tracking worker output across GitHub-visi
 - easy cancellation,
 - already mandated for explicit "poll/check/watch every N" user requests per `scheduling-reliability.md`.
 
-`CronCreate` remains the right primitive for skill-owned wall-clock-cadence fleet ticks. It is **session-scoped** — jobs do not survive session turnover regardless of the `durable` flag. See `scheduling-reliability.md` for the authoritative contract.
+`CronCreate` remains the right primitive for a skill-owned wall-clock-cadence fleet tick, should one be needed. It is **session-scoped** — jobs do not survive session turnover regardless of the `durable` flag. See `scheduling-reliability.md` for the authoritative contract.
 
 ## State contract: `session-state.json`
 
@@ -34,7 +34,7 @@ PM orchestration reads and writes `~/.claude/session-state.json`. Unknown fields
 - `root_repo`: absolute path to the **git root** of the repo where PR helpers run (must match `git rev-parse --show-toplevel` for that checkout). This top-level field is a *default only*: the session file is shared across concurrent sessions, so whichever session wrote last owns it, and it must never gate polling (issue #647). Repo scoping is per PR — `.prs["N"].owner_repo` plus `.prs["N"].root_repo`, written by `polling-state-gate.sh --ensure-session` and validated by **repo identity** (normalized `origin` remote, falling back to the shared git common dir) rather than path equality, so sibling worktrees of one repo agree while a genuine cross-repo mismatch is still refused. "Genuine" means scoping recorded *inside the scope being read*: PR numbers are per-repo, so another repo also tracking an `N` is an expected collision, never a refusal (issue #854) — the gate reads only this repo's scope (or the legacy `_unknown` one), and a PR absent from it is simply unregistered here, which `--ensure-session` fixes.
 - `prs`: tracked PR map. Each entry may include `issue`, `phase`, `head_sha`, `reviewer`, `needs`, `status`, `worker`, and `updated_at`.
 - `active_agents`: subagent records. Each entry should include `id`, `task`, `issue`, `pr`, `phase`, `launched`, and optional `last_seen_at`.
-- `polling_jobs`: active scheduled jobs **owned by other skills** (`/pr-monitor-and-manage`, `/babysit-pr`, etc.). Each entry should include `primitive`, `id`, `cron`, `prompt`, `recurring`, `durable`, `created_at`, and `expires_at` when known. `/pm` does not create or clear this array.
+- `polling_jobs`: active scheduled jobs **owned by other skills**. Empty in normal operation since issue #827 — no skill registers a cron, and `session-scheduling-reconcile.sh` clears leftovers at session start. `/pm` does not create or clear this array.
 - `polling_failures`: prior dropped-loop recoveries.
 - `cr_quota` and `greptile_daily`: review-budget state used by Phase B decisions.
 - `pmm_*` fields: owned by `/pr-monitor-and-manage`.

--- a/.claude/reference/session-state-schema.json
+++ b/.claude/reference/session-state-schema.json
@@ -35,7 +35,6 @@
   "monitoring_mode": "cron",
   "monitoring_command": "/status",
   "monitoring_interval_minutes": 60,
-  "monitoring_durable": false,
   "monitoring_started_at": "2026-03-16T15:00:00Z",
   "last_poll_at": "2026-03-16T15:58:00Z",
   "next_expected_poll_at": "2026-03-16T16:58:00Z",
@@ -163,21 +162,8 @@
       "last_seen_at": "2026-03-16T15:58:00Z"
     }
   ],
-  "_polling_jobs_comment": "CronCreate jobs are SESSION-ONLY and in-memory — they die when Claude exits regardless of the durable field. durable:true is recorded for bookkeeping only and has no effect on persistence. expires_at reflects the 7-day auto-expiry within a session, not cross-session durability. On session resume, any prior polling_jobs entries are gone; owning skills must re-arm if needed.",
-  "polling_jobs": [
-    {
-      "primitive": "CronCreate",
-      "id": "cron_abc123",
-      "cron": "17 * * * *",
-      "prompt": "/pr-monitor-and-manage-wake --auto-check",
-      "recurring": true,
-      "durable": true,
-      "_durable_comment": "no-op — CronCreate is session-only regardless of this field",
-      "created_at": "2026-03-16T15:00:00Z",
-      "expires_at": "2026-03-23T15:00:00Z",
-      "_expires_at_comment": "7-day session-internal auto-expiry, not a cross-session durability guarantee"
-    }
-  ],
+  "_polling_jobs_comment": "CronCreate jobs are SESSION-ONLY and in-memory — they die when Claude exits regardless of the durable field, which is a no-op. Since issue #827 no skill in this repo registers one: /babysit-pr --durable was removed, /pr-monitor-and-manage --auto-wake uses /loop, and /harness-audit uses a session-start watermark check. This array therefore stays empty in normal operation, and session-scheduling-reconcile.sh clears any leftover entries at session start (they are already dead by then). Kept in the schema so a stale file from before #827 still validates. Why we do not use the durable scheduler that does exist: .claude/reference/cross-session-durability.md",
+  "polling_jobs": [],
   "polling_failures": [
     {
       "detected_at": "2026-03-16T15:58:00Z",
@@ -252,7 +238,7 @@
       "auto_wake": false,
       "auto_wake_cadence": "60m"
     },
-    "auto_wake_cron_id": null
+    "_auto_wake_comment": "auto_wake arms a /loop re-scan at pause time (issue #827) — session-scoped, with no job id to record. Cross-session continuity for a paused fleet comes from paused_at above, which is on disk and outlives the session."
   },
   "_token_exhaustion_example": {
     "phase": "B",

--- a/.claude/rules/scheduling-reliability.md
+++ b/.claude/rules/scheduling-reliability.md
@@ -11,7 +11,7 @@ The 5-minute heartbeat rule catches silence during turns; this file covers betwe
 | User request / context | Primitive | Why |
 |------------------------|-----------|-----|
 | Recurring: "poll/check/watch every N", "keep running /skill" | **`/loop`** | Runtime owns cadence |
-| ≥3 concurrent polls or wall-clock-cadence fleet ticks | **`CronCreate`** | Scheduled fleet job — **session-only** (see contract note below) |
+| Wall-clock cadence, ≥3 concurrent polls | **`CronCreate`** | **Session-only** (contract below); no skill here uses one |
 | One-shot "wake me in N minutes" | `ScheduleWakeup` | Single tick only |
 | Background work in flight (subagent, background process, watcher) | **ceiling watch** — `bgwork-ceiling.sh --arm-command` → `Monitor` | Backstop, not a poll — still `/loop` if status is due |
 
@@ -22,9 +22,9 @@ The 5-minute heartbeat rule catches silence during turns; this file covers betwe
 Division of responsibility (see `.claude/reference/pm-monitoring-decision.md`):
 
 - `/pm` never creates polls — on-demand orchestration only.
-- `/pr-monitor-and-manage` owns PR-fleet between-message polling (`/loop` + optional `CronCreate` auto-wake).
+- `/pr-monitor-and-manage` owns PR-fleet between-message polling (`/loop`, including `--auto-wake`).
 - `/loop` remains valid for explicit user-invoked "poll every N" that is not PR-fleet-specific.
-- `CronCreate` for wall-clock-cadence fleet ticks or scheduled jobs owned by dedicated skills — **not** for cross-session durability (see contract note below).
+- `CronCreate` — **never** for cross-session durability (contract below).
 
 Skill-owned polling turns update `session-state.json` per that skill's contract; stale orchestration state → `monitor-mode.md` PM Monitoring Recovery + this file's dropped-tick handling.
 
@@ -32,7 +32,7 @@ Skill-owned polling turns update `session-state.json` per that skill's contract;
 
 `CronCreate` is **session-only and in-memory**: the job lives in the harness process and is gone when Claude exits. The `durable` parameter has **no effect** — it is recorded in state for bookkeeping only. Recurring jobs auto-expire after **7 days** if not explicitly deleted first with `CronDelete`. Nothing about a `CronCreate` job persists across session boundaries. For the rejected alternatives see `.claude/reference/bgwork-ceiling.md`.
 
-> **Behavioral follow-up:** `--durable` in `/babysit-pr`, `--auto-wake` in `/pr-monitor-and-manage`, and `/harness-audit`'s daily registration cadence all relied on the false durability promise. Correcting those features' scheduling design is tracked as a separate ticket.
+**Durable work belongs in on-disk state, not a job** (#827): `session-scheduling-reconcile.sh` purges dead job records at session start and surfaces what survived. A genuinely durable scheduler exists (`mcp__scheduled-tasks__*`) — why no skill here uses it: `.claude/reference/cross-session-durability.md`.
 
 ## Mandatory Pre-Exit Checklist for Polling Turns
 
@@ -48,7 +48,7 @@ Before any polling turn ends (`/loop`, `CronCreate`, legacy one-shot, or a turn 
 
 ## Stable-State Backoff
 
-Each tick hash `(head_sha, cr_state, bugbot_state, greptile_state, ci_blocking_conclusions_sorted, blocker_kind)` into `prs.{N}.digest_streak` (free-text `blocker` excluded). Widen at streak ≥3 to `max(15m, 3×base)`; `CronDelete` at ≥9 or `blocker_kind == "user_input"`. Resume at base cadence after user message or changed digest. `polling-backoff-warn.sh` enforces this (reads `babysit.cadence_base_minutes`, defaults to 5). Backoff cannot reach the ceiling watch: it widens and deletes cron jobs; the watch is a `Monitor`.
+Each tick hash `(head_sha, cr_state, bugbot_state, greptile_state, ci_blocking_conclusions_sorted, blocker_kind)` into `prs.{N}.digest_streak` (free-text `blocker` excluded). Widen at streak ≥3 to `max(15m, 3×base)`; stop the poll at ≥9 or `blocker_kind == "user_input"`. Resume at base cadence after user message or changed digest. `polling-backoff-warn.sh` enforces this (reads `babysit.cadence_base_minutes`, defaults to 5). Backoff cannot reach the ceiling watch: it widens or stops the poll; the watch is a `Monitor`.
 
 ## Failure Recovery
 

--- a/.claude/scripts/off-peak-minute.sh
+++ b/.claude/scripts/off-peak-minute.sh
@@ -2,9 +2,12 @@
 # off-peak-minute.sh — Deterministic per-repo off-peak cron minute selector.
 #
 # PURPOSE
-#   Centralizes the minute-selection contract used by skills that schedule
-#   CronCreate jobs (e.g. `/pr-monitor-and-manage` auto-wake, `/babysit-pr
-#   --durable`). Each repo gets a stable minute in [0, 59] derived from its
+#   Centralizes the minute-selection contract for any skill that needs a
+#   wall-clock cron minute. No skill currently registers one — issue #827
+#   moved the last three (/babysit-pr --durable, /pr-monitor-and-manage
+#   auto-wake, /harness-audit) onto /loop and session-start reconciliation.
+#   Kept because the contract is the hard part, not the caller.
+#   Each repo gets a stable minute in [0, 59] derived from its
 #   `owner/name` string, then nudged off the fleet pile-up minutes (0, 5, 30,
 #   55) where every agent's schedule collides on the API. Deterministic so
 #   the same repo always lands on the same minute; spread so different repos

--- a/.claude/scripts/session-scheduling-reconcile.sh
+++ b/.claude/scripts/session-scheduling-reconcile.sh
@@ -41,11 +41,13 @@ WHAT IT PURGES (writes go through session-state.sh, the locked single writer)
   .pmm.auto_wake_cron_id               -> null
   .repos[*].prs[*].babysit.cron_job_id -> null
   .repos[*].prs[*].babysit.active      -> false, but ONLY past /babysit-pr's
-                                          own freshness window,
-                                          max(3 x cadence, 30m) — SessionStart
-                                          also fires on compact, when a live
-                                          watcher's last tick is legitimately
-                                          minutes old
+                                          own freshness window (its A2 check;
+                                          canonical definition and the reason
+                                          both copies must agree:
+                                          .claude/reference/cross-session-durability.md
+                                          "Freshness window"). SessionStart also
+                                          fires on compact, when a live watcher's
+                                          last tick is legitimately minutes old.
 
 WHAT IT SURFACES (durable, still meaningful)
   harness-audit due this month  (~/.claude/harness-audit/last-run.json)

--- a/.claude/scripts/session-scheduling-reconcile.sh
+++ b/.claude/scripts/session-scheduling-reconcile.sh
@@ -94,6 +94,18 @@ PURGED_JSON='{}'
 # through `.repos[]` (the scoped layout, issue #638) AND at the top level, so a
 # not-yet-migrated legacy file is reconciled too rather than silently skipped.
 
+SESSION_STATE_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/session-state.sh"
+
+# Migrate BEFORE planning. session-state.sh migrates a legacy top-level `.prs`
+# into `.repos[...]` as a side effect of any write, THEN applies our assignments
+# — so a plan built against the pre-migration layout would recreate a clean
+# top-level record while the migrated scoped record kept its stale cron_job_id
+# and active flag. Real consumers read the scoped path, so the purge would have
+# looked successful and changed nothing that matters.
+if [[ -f "$STATE_FILE" && -x "$SESSION_STATE_SH" && "$CHECK_ONLY" -eq 0 ]]; then
+  "$SESSION_STATE_SH" --migrate >/dev/null 2>&1 || true
+fi
+
 if [[ -f "$STATE_FILE" ]]; then
   NOW_EPOCH="$(date -u +%s)"
 
@@ -168,7 +180,6 @@ if [[ -f "$STATE_FILE" ]]; then
     [[ "$TOTAL" =~ ^[0-9]+$ ]] || TOTAL=0
 
     if (( CHECK_ONLY == 0 && TOTAL > 0 )); then
-      SESSION_STATE_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/session-state.sh"
       if [[ -x "$SESSION_STATE_SH" ]]; then
         # One atomic multi---set call under the helper's lock, not N writes.
         SET_ARGS=()

--- a/.claude/scripts/session-scheduling-reconcile.sh
+++ b/.claude/scripts/session-scheduling-reconcile.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# session-scheduling-reconcile.sh — reconcile durable scheduling state at
+# session start (issue #827).
+#
+# CronCreate jobs are in-memory and session-scoped: every job recorded by a
+# previous session is already gone by the time this runs. Rather than trying to
+# re-arm them (there is nothing left to re-arm), this purges the dead
+# bookkeeping and surfaces the durable on-disk records that DO survive — a
+# harness-audit month that came due, a paused PR fleet waiting to resume.
+#
+# Rationale and the per-feature decisions: .claude/reference/cross-session-durability.md
+#
+# Invoked by the SessionStart hook (.claude/hooks/session-start-sync.sh).
+# Fail-soft by contract: a missing, unreadable, or corrupt state file must
+# never block a session from starting, so every failure path still exits 0.
+
+set -uo pipefail
+
+STATE_FILE="${HOME}/.claude/session-state.json"
+AUDIT_WATERMARK="${HOME}/.claude/harness-audit/last-run.json"
+
+usage() {
+  cat <<'EOF'
+PURPOSE
+  Reconcile durable scheduling state at session start: purge scheduler
+  bookkeeping that cannot have survived the previous session, and report the
+  on-disk records that did.
+
+USAGE
+  session-scheduling-reconcile.sh [--check] [--format text|json]
+
+  --check          Report only; make no writes. Exit 0 always.
+  --format text    Human-readable lines (default).
+  --format json    {"purged":{...},"notices":[...]} for the hook to embed.
+
+WHAT IT PURGES (writes go through session-state.sh, the locked single writer)
+  .polling_jobs                        -> []
+  .pmm.auto_wake_cron_id               -> null
+  .repos[*].prs[*].babysit.cron_job_id -> null
+  .repos[*].prs[*].babysit.active      -> false, but ONLY past /babysit-pr's
+                                          own freshness window,
+                                          max(3 x cadence, 30m) — SessionStart
+                                          also fires on compact, when a live
+                                          watcher's last tick is legitimately
+                                          minutes old
+
+WHAT IT SURFACES (durable, still meaningful)
+  harness-audit due this month  (~/.claude/harness-audit/last-run.json)
+  a paused PR fleet             (.pmm.paused_at)
+
+EXIT STATUS
+  0  Always. This runs on the session-start path; it never blocks a session.
+EOF
+}
+
+CHECK_ONLY=0
+FORMAT=text
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) CHECK_ONLY=1; shift ;;
+    --format)
+      [[ $# -ge 2 ]] || { echo "session-scheduling-reconcile.sh: --format needs a value" >&2; exit 0; }
+      FORMAT="$2"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "session-scheduling-reconcile.sh: unknown flag '$1'" >&2; exit 0 ;;
+  esac
+done
+
+case "$FORMAT" in
+  text|json) ;;
+  *) echo "session-scheduling-reconcile.sh: --format must be text or json" >&2; exit 0 ;;
+esac
+
+command -v jq >/dev/null 2>&1 || {
+  # No jq: report nothing rather than guessing. Still a clean session start.
+  [[ "$FORMAT" == json ]] && echo '{"purged":{},"notices":[]}'
+  exit 0
+}
+
+NOTICES=()   # human-facing lines the hook forwards into session context
+PURGED_JSON='{}'
+
+# ---------------------------------------------------------------------------
+# 1. Purge dead scheduler bookkeeping
+# ---------------------------------------------------------------------------
+# Counting and rewriting happen in one jq pass over the whole document so the
+# counts always describe the write that actually landed. `.prs` is addressed
+# through `.repos[]` (the scoped layout, issue #638) AND at the top level, so a
+# not-yet-migrated legacy file is reconciled too rather than silently skipped.
+
+if [[ -f "$STATE_FILE" ]]; then
+  NOW_EPOCH="$(date -u +%s)"
+
+  # Deciding a watcher is dead uses /babysit-pr's OWN freshness rule (its A2
+  # duplicate-watcher check): a watcher is presumed alive within
+  # max(3 x cadence_effective_minutes, BABYSIT_DISPATCH_TTL_MIN). Two reasons it
+  # must match rather than approximate:
+  #
+  #   1. SessionStart fires on compact/resume/fork as well as a fresh start, so
+  #      this can run mid-session with a genuinely live watcher whose last tick
+  #      is legitimately minutes old. A naive "older than now" test reaps it,
+  #      and the next tick's T0 short-circuit then kills the watcher for good.
+  #   2. If the two rules disagreed, A2 and this script would each believe a
+  #      different thing about the same watcher.
+  #
+  # Read-only: this pass computes paths; every write goes through
+  # session-state.sh below (handoff-files.md — that helper is the only writer,
+  # and a raw jq+mv here would clobber a concurrent --set that held the lock).
+  PLAN="$(jq -c \
+      --argjson now "$NOW_EPOCH" \
+      --argjson ttl "${BABYSIT_DISPATCH_TTL_MIN:-30}" '
+    def prs_paths:
+      [paths(type == "object" and has("babysit"))]
+      | map(select(.[-2] == "prs"));
+
+    # Render a path array as a literal jq path for session-state.sh --raw-path.
+    # The leading "." is required: session-state.sh rejects a bare-key path, and
+    # the resulting no-op is swallowed rather than raised.
+    def as_path:
+      "." + (map(if type == "number" then "[\(.)]" else "[\"\(.)\"]" end) | join(""));
+
+    def watcher_dead($b):
+      # Accept "15" as well as 15: /babysit-pr A2 tests with a bash numeric
+      # regex, so a string-typed cadence is live there. Falling back to 5 would
+      # SHRINK the window below the one A2 uses and reap a backed-off watcher
+      # that A2 still considers fresh.
+      (($b.cadence_effective_minutes // 5) | try tonumber catch 5) as $cad
+      | ([$cad * 3, $ttl] | max) as $fresh_min
+      | ($b.last_tick_at // null) as $t
+      | if $t == null then true
+        else
+          # An unparseable stamp is deliberately NOT dead: this runs unattended
+          # on every compact, and wrongly clearing `active` makes the next tick
+          # T0-terminate a live watcher. A genuinely corrupt stamp is reclaimed
+          # by the bounded `last_tick_parse_failures` counter in A2 instead,
+          # which can afford to be aggressive because a human is watching it.
+          ($t | try (fromdateiso8601 < ($now - $fresh_min * 60)) catch false)
+        end;
+
+    . as $doc
+    | prs_paths as $pp
+    | [ $pp[] as $p | select(($doc | getpath($p)).babysit.cron_job_id != null)
+        | ($p + ["babysit","cron_job_id"] | as_path) ] as $cron_ids
+    | [ $pp[] as $p | ($doc | getpath($p)).babysit as $b
+        | select($b.active == true and watcher_dead($b))
+        | ($p + ["babysit","active"] | as_path) ] as $dead
+    | (if ((.polling_jobs? // []) | type == "array") then (.polling_jobs | length) else 0 end) as $pj
+    | (if (.pmm.auto_wake_cron_id? // null) != null then 1 else 0 end) as $aw
+    | {
+        counts: {polling_jobs: $pj, auto_wake_cron_id: $aw,
+                 babysit_cron_ids: ($cron_ids | length), babysit_watchers: ($dead | length)},
+        sets: (( if $pj > 0 then [".polling_jobs=[]"] else [] end)
+             + ( if $aw > 0 then [".pmm.auto_wake_cron_id=null"] else [] end)
+             + ( $cron_ids | map(. + "=null"))
+             + ( $dead     | map(. + "=false")))
+      }
+  ' "$STATE_FILE" 2>/dev/null)" || PLAN=""
+
+  if [[ -n "$PLAN" ]]; then
+    PURGED_JSON="$(jq -c '.counts' <<<"$PLAN" 2>/dev/null || echo '{}')"
+    TOTAL="$(jq -r '.sets | length' <<<"$PLAN" 2>/dev/null || echo 0)"
+    [[ "$TOTAL" =~ ^[0-9]+$ ]] || TOTAL=0
+
+    if (( CHECK_ONLY == 0 && TOTAL > 0 )); then
+      SESSION_STATE_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/session-state.sh"
+      if [[ -x "$SESSION_STATE_SH" ]]; then
+        # One atomic multi---set call under the helper's lock, not N writes.
+        SET_ARGS=()
+        while IFS= read -r assignment; do
+          [[ -n "$assignment" ]] && SET_ARGS+=(--set "$assignment")
+        done < <(jq -r '.sets[]' <<<"$PLAN" 2>/dev/null)
+        if (( ${#SET_ARGS[@]} > 0 )); then
+          if ! "$SESSION_STATE_SH" --raw-path "${SET_ARGS[@]}" >/dev/null 2>&1; then
+            # Exit 6 is a lock timeout; anything else is a helper/parse failure.
+            # Either way the file is untouched — say so instead of claiming a
+            # clean purge, and let the next session start retry.
+            NOTICES+=("scheduling-reconcile: could not clear $TOTAL dead scheduling record(s) — session-state.json left unmodified; will retry next session.")
+            TOTAL=0
+          fi
+        fi
+      else
+        NOTICES+=("scheduling-reconcile: session-state.sh not found — left $TOTAL dead scheduling record(s) in place.")
+        TOTAL=0
+      fi
+    fi
+
+    if (( TOTAL > 0 )); then
+      if (( CHECK_ONLY == 1 )); then
+        NOTICES+=("Would clear $TOTAL dead scheduling record(s) left by a previous session (--check: nothing written).")
+      else
+        NOTICES+=("Cleared $TOTAL dead scheduling record(s) left by a previous session (CronCreate jobs do not survive session exit).")
+      fi
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Surface the durable records that DID survive
+# ---------------------------------------------------------------------------
+
+# 2a. harness-audit — the watermark file is the durable record; a session start
+#     is the tick. Sessions start far more often than monthly, so this cannot
+#     miss a month the way an expiring in-memory cron could.
+if [[ -f "$AUDIT_WATERMARK" ]]; then
+  MONTH="$(TZ='America/New_York' date +%Y-%m)"
+  AUDIT_DUE="$(jq -r --arg m "$MONTH" '
+      if (.nudge_enabled // false) != true then "off"
+      elif (.last_completed_month // "") == $m then "done"
+      elif (.last_offered_month // "") == $m then "offered"
+      else "due" end
+    ' "$AUDIT_WATERMARK" 2>/dev/null || echo "off")"
+  case "$AUDIT_DUE" in
+    due)     NOTICES+=("harness-audit is due for $MONTH — run /harness-audit --tick to inventory and get the judgment-pass chip.") ;;
+    offered) NOTICES+=("harness-audit already offered its $MONTH step-up chip — click it, or run /harness-audit to audit now.") ;;
+  esac
+fi
+
+# 2b. A paused PR fleet resumes from the on-disk marker, in any later session —
+#     this is the cross-session continuity --auto-wake never actually provided.
+if [[ -f "$STATE_FILE" ]]; then
+  PAUSED_AT="$(jq -r '.pmm.paused_at // empty' "$STATE_FILE" 2>/dev/null || echo "")"
+  [[ -n "$PAUSED_AT" ]] && NOTICES+=("A paused PR fleet is recorded (paused at $PAUSED_AT) — resume with /pr-monitor-and-manage-wake, or /pmm-stop to discard it.")
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Report
+# ---------------------------------------------------------------------------
+if [[ "$FORMAT" == json ]]; then
+  printf '%s\n' "${NOTICES[@]:-}" \
+    | jq -R . | jq -sc --argjson purged "$PURGED_JSON" \
+        '{purged: $purged, notices: map(select(. != ""))}'
+else
+  for n in "${NOTICES[@]:-}"; do [[ -n "$n" ]] && echo "$n"; done
+fi
+
+exit 0

--- a/.claude/scripts/session-scheduling-reconcile.sh
+++ b/.claude/scripts/session-scheduling-reconcile.sh
@@ -193,11 +193,13 @@ if [[ -f "$STATE_FILE" ]]; then
             # clean purge, and let the next session start retry.
             NOTICES+=("scheduling-reconcile: could not clear $TOTAL dead scheduling record(s) — session-state.json left unmodified; will retry next session.")
             TOTAL=0
+            PURGED_JSON='{}'   # nothing landed; `purged` must not claim otherwise
           fi
         fi
       else
         NOTICES+=("scheduling-reconcile: session-state.sh not found — left $TOTAL dead scheduling record(s) in place.")
         TOTAL=0
+        PURGED_JSON='{}'
       fi
     fi
 

--- a/.claude/scripts/session-scheduling-reconcile.sh
+++ b/.claude/scripts/session-scheduling-reconcile.sh
@@ -10,7 +10,10 @@
 #
 # Rationale and the per-feature decisions: .claude/reference/cross-session-durability.md
 #
-# Invoked by the SessionStart hook (.claude/hooks/session-start-sync.sh).
+# Invoked by the SessionStart hook (.claude/hooks/session-start-sync.sh), which
+# passes --check on every source except `startup` — compact/resume/clear fire
+# inside a live session, where a recorded job may still be running and a watcher
+# may be about to refresh its own last_tick_at.
 # Fail-soft by contract: a missing, unreadable, or corrupt state file must
 # never block a session from starting, so every failure path still exits 0.
 

--- a/.claude/scripts/tests/session-scheduling-reconcile.test.sh
+++ b/.claude/scripts/tests/session-scheduling-reconcile.test.sh
@@ -273,5 +273,20 @@ jq -e '.notices == []' <<<"$("$SCRIPT" --format json)" >/dev/null \
   || fail "an empty state should yield an empty notices array, not [\"\"]"
 ok "--format json emits an empty notices array when there is nothing to say"
 
+# --- 11. A failed write must not report counts it did not land ---------------
+# `purged` is a claim about what changed. If the write fails, reporting the
+# planned counts tells a JSON consumer the cleanup succeeded when it did not.
+new_home "$FULL_STATE"
+chmod 500 "$HOME/.claude" 2>/dev/null || true
+J="$("$SCRIPT" --format json 2>/dev/null)"
+chmod 700 "$HOME/.claude" 2>/dev/null || true
+if jq -e '[.purged[]] | add > 0' <<<"$J" >/dev/null 2>&1; then
+  jq -e '.notices | length > 0' <<<"$J" >/dev/null     || fail "reported non-zero purged counts with no notice: $J"
+  # counts > 0 only legitimate if the write actually landed
+  [[ "$(jq -c '.polling_jobs' "$STATE")" == "[]" ]] \
+    || fail "purged counts reported but state file unchanged: $J"
+fi
+ok "purged counts never claim work the write did not land"
+
 echo
 echo "All session-scheduling-reconcile.sh tests passed."

--- a/.claude/scripts/tests/session-scheduling-reconcile.test.sh
+++ b/.claude/scripts/tests/session-scheduling-reconcile.test.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Tests for session-scheduling-reconcile.sh — session-start reconciliation of
+# durable scheduling state (issue #827).
+#
+# HOME is redirected into a temp dir for every case, so the suite never reads
+# or writes the real ~/.claude/session-state.json or audit watermark.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/.claude/scripts/session-scheduling-reconcile.sh"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { chmod -R u+w "$TMP_DIR" 2>/dev/null || true; rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "ok   — $*"; }
+
+CASE_N=0
+# new_home [state-json] [watermark-json] — fresh isolated HOME per case.
+new_home() {
+  CASE_N=$((CASE_N + 1))
+  export HOME="$TMP_DIR/home$CASE_N"
+  mkdir -p "$HOME/.claude/harness-audit"
+  [[ -n "${1:-}" ]] && printf '%s' "$1" > "$HOME/.claude/session-state.json"
+  [[ -n "${2:-}" ]] && printf '%s' "$2" > "$HOME/.claude/harness-audit/last-run.json"
+  STATE="$HOME/.claude/session-state.json"
+}
+
+# A watcher is judged by /babysit-pr's own freshness window,
+# max(3 x cadence, BABYSIT_DISPATCH_TTL_MIN=30m) — not by "older than now".
+PAST="2020-01-01T00:00:00Z"
+FUTURE="2099-01-01T00:00:00Z"
+
+# Relative stamps — never a hard-coded date, which flips past/future over time.
+stamp_minutes_ago() {
+  date -u -v-"$1"M +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -d "$1 minutes ago" +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+FULL_STATE=$(cat <<JSON
+{
+  "polling_jobs": [{"id":"cron_a","owner":"harness-audit"},{"id":"cron_b","owner":"pmm"}],
+  "pmm": {"auto_wake_cron_id": "cron_b"},
+  "repos": {"o/r": {"prs": {
+    "10": {"babysit": {"active": true, "cron_job_id": "cron_c", "last_tick_at": "$PAST"}},
+    "11": {"babysit": {"active": true, "cron_job_id": null, "last_tick_at": "$FUTURE"}}
+  }}},
+  "root_repo": "/keep/me"
+}
+JSON
+)
+
+# --- 0. The embedded jq program is quote-safe --------------------------------
+# The jq filter lives in a single-quoted heredoc-less block, so one apostrophe
+# in a comment (`A2's`) closes the quote and the rest parses as shell. The
+# script is fail-soft by design, so that breakage exits 0 and silently purges
+# nothing — caught here rather than in production.
+awk 'NR>1 && /^  . "\$STATE_FILE"/{inblock=0} inblock && /'"'"'/{print NR; found=1}
+     /--argjson ttl/{inblock=1} END{exit found?1:0}' "$SCRIPT" >/dev/null \
+  || fail "apostrophe inside the single-quoted jq program — it will break quoting"
+ok "the embedded jq program contains no quote-breaking apostrophes"
+
+# --- 1. Dead scheduler bookkeeping is purged ---------------------------------
+new_home "$FULL_STATE"
+"$SCRIPT" >/dev/null
+[[ "$(jq -c '.polling_jobs' "$STATE")" == "[]" ]] \
+  || fail "polling_jobs should be emptied, got $(jq -c '.polling_jobs' "$STATE")"
+[[ "$(jq -r '.pmm.auto_wake_cron_id' "$STATE")" == "null" ]] \
+  || fail "pmm.auto_wake_cron_id should be null"
+[[ "$(jq -r '.repos["o/r"].prs["10"].babysit.cron_job_id' "$STATE")" == "null" ]] \
+  || fail "babysit.cron_job_id should be null"
+ok "purges polling_jobs, auto_wake_cron_id, and babysit.cron_job_id"
+
+# --- 2. Only watchers that cannot be alive are deactivated -------------------
+# The freshness test is what keeps this from reaping a watcher armed seconds
+# ago in the current session — the exact failure that would make a re-arm
+# reconciler worse than no reconciler at all.
+[[ "$(jq -r '.repos["o/r"].prs["10"].babysit.active' "$STATE")" == "false" ]] \
+  || fail "stale watcher (last tick in the past) should be deactivated"
+[[ "$(jq -r '.repos["o/r"].prs["11"].babysit.active' "$STATE")" == "true" ]] \
+  || fail "watcher that ticked after process start must stay active"
+ok "deactivates a watcher whose last tick is far outside the freshness window"
+
+# --- 2b. A live watcher survives a mid-session run (compact/resume/fork) -----
+# SessionStart also fires on compact, so this script runs while a watcher is
+# genuinely alive with a last tick minutes old. Reaping it there would kill the
+# watcher for real: its next tick sees active=false and T0-terminates.
+for AGO in 1 4 9 29; do
+  new_home "$(cat <<JSON
+{"repos":{"o/r":{"prs":{"42":{"babysit":{"active":true,"cadence_effective_minutes":5,
+ "last_tick_at":"$(stamp_minutes_ago $AGO)"}}}}}}
+JSON
+)"
+  "$SCRIPT" >/dev/null
+  [[ "$(jq -r '.repos["o/r"].prs["42"].babysit.active' "$STATE")" == "true" ]] \
+    || fail "watcher that ticked ${AGO}m ago (5m cadence, 30m window) must stay active"
+done
+ok "a live watcher ticking 1–29m ago survives a compact-fired run"
+
+# Past the window it is reclaimable again — the guard must not be unbounded.
+new_home "$(cat <<JSON
+{"repos":{"o/r":{"prs":{"42":{"babysit":{"active":true,"cadence_effective_minutes":5,
+ "last_tick_at":"$(stamp_minutes_ago 45)"}}}}}}
+JSON
+)"
+"$SCRIPT" >/dev/null
+[[ "$(jq -r '.repos["o/r"].prs["42"].babysit.active' "$STATE")" == "false" ]] \
+  || fail "watcher 45m stale (past the 30m window) should be deactivated"
+ok "a watcher past the freshness window is still reclaimed"
+
+# A slow cadence widens the window: 20m cadence -> max(60, 30) = 60m.
+new_home "$(cat <<JSON
+{"repos":{"o/r":{"prs":{"42":{"babysit":{"active":true,"cadence_effective_minutes":20,
+ "last_tick_at":"$(stamp_minutes_ago 45)"}}}}}}
+JSON
+)"
+"$SCRIPT" >/dev/null
+[[ "$(jq -r '.repos["o/r"].prs["42"].babysit.active' "$STATE")" == "true" ]] \
+  || fail "45m-old tick on a 20m cadence is inside max(3x20,30)=60m — must stay active"
+ok "the window scales with the watcher's own cadence"
+
+# --- 2c. Writes go through session-state.sh, never a raw jq+mv ---------------
+# handoff-files.md: session-state.sh is the only writer. A raw rewrite here
+# would clobber a concurrent --set that legitimately held the lock.
+grep -q 'session-state.sh' "$SCRIPT" \
+  || fail "the reconciler must write via session-state.sh"
+grep -qE 'mv -f?[[:space:]]+"?\$\{?(TMP|STATE_FILE)' "$SCRIPT" \
+  && fail "the reconciler must not mv over session-state.json directly"
+ok "writes are delegated to session-state.sh, not a raw jq+mv"
+
+# A concurrent writer's field must survive the purge.
+new_home "$FULL_STATE"
+"$REPO_ROOT/.claude/scripts/session-state.sh" --raw-path --set '.concurrent_field="must_survive"' >/dev/null 2>&1
+"$SCRIPT" >/dev/null
+[[ "$(jq -r '.concurrent_field' "$STATE")" == "must_survive" ]] \
+  || fail "a field written by another writer must survive the purge"
+[[ "$(jq -c '.polling_jobs' "$STATE")" == "[]" ]] \
+  || fail "the purge itself must still have applied"
+ok "purge preserves another writer's fields"
+
+# --- 3. Unrelated siblings survive the rewrite -------------------------------
+# Value-not-location: writing through session-state.sh also performs its
+# documented legacy->scoped migration, so a top-level `root_repo` is relocated
+# under `.repos[...]`. Preserved, not lost — assert the value survives somewhere
+# rather than pinning the layout the canonical writer is entitled to change.
+jq -e --arg v "/keep/me" '[.. | strings] | index($v) != null' "$STATE" >/dev/null \
+  || fail "unrelated state values must survive the purge (got: $(jq -c . "$STATE"))"
+ok "preserves unrelated state values across the canonical writer's migration"
+
+# --- 4. Idempotent: a second run purges nothing and says nothing -------------
+OUT2="$("$SCRIPT")"
+grep -q "Cleared" <<<"$OUT2" && fail "second run should have nothing left to clear, got: $OUT2"
+ok "idempotent — a clean state produces no purge notice"
+
+# --- 5. --check makes no writes, and does not claim it did -------------------
+new_home "$FULL_STATE"
+BEFORE="$(cat "$STATE")"
+CHECK_OUT="$("$SCRIPT" --check)"
+[[ "$(cat "$STATE")" == "$BEFORE" ]] || fail "--check must not modify the state file"
+ok "--check reports without writing"
+
+grep -q "Cleared" <<<"$CHECK_OUT" \
+  && fail "--check must not report work as done; got: $CHECK_OUT"
+grep -q "Would clear" <<<"$CHECK_OUT" \
+  || fail "--check should say what it would clear; got: $CHECK_OUT"
+ok "--check says 'would clear', never 'cleared'"
+
+# --- 5b. A string-typed cadence gets the same window as a numeric one --------
+# /babysit-pr A2 tests cadence with a bash numeric regex, so "20" is live there.
+# Reading it as non-numeric here would fall back to 5 and SHRINK the window
+# below A2's — reaping a backed-off watcher A2 still considers fresh.
+for CAD in 20 '"20"'; do
+  new_home "$(cat <<JSON
+{"repos":{"o/r":{"prs":{"42":{"babysit":{"active":true,"cadence_effective_minutes":$CAD,
+ "last_tick_at":"$(stamp_minutes_ago 45)"}}}}}}
+JSON
+)"
+  "$SCRIPT" >/dev/null
+  [[ "$(jq -r '.repos["o/r"].prs["42"].babysit.active' "$STATE")" == "true" ]] \
+    || fail "cadence $CAD: 45m-old tick is inside max(3x20,30)=60m — must stay active"
+done
+ok "a string-typed cadence yields the same freshness window as a number"
+
+# --- 5c. An unparseable last_tick_at is NOT treated as dead ------------------
+# Deliberate: this runs unattended on every compact, and clearing `active` on a
+# stamp we merely failed to parse would T0-terminate a live watcher. A truly
+# corrupt stamp is reclaimed by A2's bounded parse-failure counter instead.
+new_home '{"repos":{"o/r":{"prs":{"42":{"babysit":{"active":true,"last_tick_at":"not-a-timestamp"}}}}}}'
+"$SCRIPT" >/dev/null
+[[ "$(jq -r '.repos["o/r"].prs["42"].babysit.active' "$STATE")" == "true" ]] \
+  || fail "an unparseable last_tick_at must not deactivate a watcher"
+ok "an unparseable last_tick_at leaves the watcher alone (A2 owns that reclaim)"
+
+# A genuinely absent stamp is still dead — the guard must not swallow that too.
+new_home '{"repos":{"o/r":{"prs":{"42":{"babysit":{"active":true}}}}}}'
+"$SCRIPT" >/dev/null
+[[ "$(jq -r '.repos["o/r"].prs["42"].babysit.active' "$STATE")" == "false" ]] \
+  || fail "a watcher with no last_tick_at at all should be deactivated"
+ok "a watcher with no last_tick_at is still reclaimed"
+
+# --- 6. A legacy (unmigrated, top-level .prs) file is reconciled too ---------
+new_home '{"prs":{"7":{"babysit":{"active":true,"cron_job_id":"cron_z","last_tick_at":"2020-01-01T00:00:00Z"}}}}'
+"$SCRIPT" >/dev/null
+[[ "$(jq -r '.prs["7"].babysit.cron_job_id' "$STATE")" == "null" ]] \
+  || fail "legacy top-level .prs layout should be reconciled, not skipped"
+ok "reconciles the legacy top-level .prs layout"
+
+# --- 7. harness-audit watermark drives the nudge -----------------------------
+MONTH="$(TZ='America/New_York' date +%Y-%m)"
+
+new_home '{}' "{\"nudge_enabled\":true,\"last_completed_month\":\"2000-01\"}"
+"$SCRIPT" | grep -q "harness-audit is due" || fail "a due month should nudge"
+ok "nudges when the audit month is due"
+
+new_home '{}' "{\"nudge_enabled\":true,\"last_completed_month\":\"$MONTH\"}"
+"$SCRIPT" | grep -q "harness-audit" && fail "an audited month must not nudge"
+ok "silent when this month is already audited"
+
+new_home '{}' "{\"nudge_enabled\":true,\"last_offered_month\":\"$MONTH\"}"
+"$SCRIPT" | grep -q "already offered" || fail "a pending chip should be named, not re-offered"
+ok "names the pending chip instead of re-offering"
+
+new_home '{}' "{\"nudge_enabled\":false,\"last_completed_month\":\"2000-01\"}"
+"$SCRIPT" | grep -q "harness-audit" && fail "--stop (nudge_enabled:false) must silence the nudge"
+ok "nudge_enabled:false silences the audit nudge"
+
+# --- 8. A paused fleet is surfaced (the real cross-session continuity) -------
+new_home '{"pmm":{"paused_at":"2026-07-30T10:00:00Z"}}'
+"$SCRIPT" | grep -q "paused PR fleet" || fail "a pause marker should be surfaced"
+ok "surfaces a paused PR fleet from the durable marker"
+
+# --- 9. Fail-soft: never block a session start -------------------------------
+# Each of these would be a plausible crash site; all must exit 0 and leave the
+# session startable, because this runs on the SessionStart path.
+new_home
+"$SCRIPT" >/dev/null 2>&1 || fail "missing state file must still exit 0"
+ok "exits 0 when the state file is absent"
+
+new_home '{ this is not json'
+"$SCRIPT" >/dev/null 2>&1 || fail "corrupt state file must still exit 0"
+[[ "$(cat "$STATE")" == '{ this is not json' ]] \
+  || fail "a corrupt state file must be left untouched, not truncated"
+ok "exits 0 and leaves a corrupt state file untouched"
+
+new_home '{"pmm":{"paused_at":"2026-07-30T10:00:00Z"}}' '{ bad json'
+"$SCRIPT" >/dev/null 2>&1 || fail "corrupt watermark must still exit 0"
+ok "exits 0 when the audit watermark is corrupt"
+
+new_home '{}'
+"$SCRIPT" --bogus-flag >/dev/null 2>&1 || fail "unknown flag must still exit 0"
+ok "exits 0 on an unknown flag rather than failing the hook"
+
+# --- 10. JSON output is well-formed for the hook to embed --------------------
+new_home "$FULL_STATE"
+J="$("$SCRIPT" --format json)"
+jq -e '.purged and (.notices | type == "array")' <<<"$J" >/dev/null \
+  || fail "--format json should emit {purged, notices}, got: $J"
+jq -e '.purged.polling_jobs == 2 and .purged.babysit_watchers == 1' <<<"$J" >/dev/null \
+  || fail "purge counts should describe the write that landed, got: $J"
+ok "--format json emits well-formed counts and notices"
+
+new_home '{}'
+jq -e '.notices == []' <<<"$("$SCRIPT" --format json)" >/dev/null \
+  || fail "an empty state should yield an empty notices array, not [\"\"]"
+ok "--format json emits an empty notices array when there is nothing to say"
+
+echo
+echo "All session-scheduling-reconcile.sh tests passed."

--- a/.claude/scripts/tests/session-scheduling-reconcile.test.sh
+++ b/.claude/scripts/tests/session-scheduling-reconcile.test.sh
@@ -202,9 +202,17 @@ ok "a watcher with no last_tick_at is still reclaimed"
 # --- 6. A legacy (unmigrated, top-level .prs) file is reconciled too ---------
 new_home '{"prs":{"7":{"babysit":{"active":true,"cron_job_id":"cron_z","last_tick_at":"2020-01-01T00:00:00Z"}}}}'
 "$SCRIPT" >/dev/null
-[[ "$(jq -r '.prs["7"].babysit.cron_job_id' "$STATE")" == "null" ]] \
-  || fail "legacy top-level .prs layout should be reconciled, not skipped"
-ok "reconciles the legacy top-level .prs layout"
+# Assert on EVERY babysit record in the document, not just the top-level one.
+# session-state.sh migrates legacy `.prs` into `.repos[...]` as a side effect of
+# writing, so checking only `.prs["7"]` would pass while a migrated scoped copy
+# kept the stale values that real consumers actually read.
+STALE=$(jq -c '[.. | objects | select(has("cron_job_id")) | select(.cron_job_id != null or .active == true)]' "$STATE")
+[[ "$STALE" == "[]" ]] \
+  || fail "every babysit record must be reconciled, incl. the migrated scoped copy; stale: $STALE"
+COUNT=$(jq '[.. | objects | select(has("cron_job_id"))] | length' "$STATE")
+[[ "$COUNT" == "1" ]] \
+  || fail "expected exactly one babysit record after migration, got $COUNT (a duplicate means the purge recreated a legacy record beside the migrated one)"
+ok "reconciles the legacy layout without leaving a stale migrated copy"
 
 # --- 7. harness-audit watermark drives the nudge -----------------------------
 MONTH="$(TZ='America/New_York' date +%Y-%m)"

--- a/.claude/skills/babysit-pr-stop/SKILL.md
+++ b/.claude/skills/babysit-pr-stop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: babysit-pr-stop
-description: Cleanly stop an active /babysit-pr watcher for a PR. Sets the watcher's stop flag in session-state so its next tick terminates, cancels the recurring poll (CronDelete in durable mode), and confirms. Invoke as `/babysit-pr-stop <PR>`.
+description: Cleanly stop an active /babysit-pr watcher for a PR. Sets the watcher's stop flag in session-state so its next tick terminates, cancels the recurring /loop, and confirms. Invoke as `/babysit-pr-stop <PR>`.
 triggers:
   - babysit-pr-stop
   - unwatch pr
@@ -11,9 +11,7 @@ argument-hint: "<PR>"
 
 Stop the `/babysit-pr` watcher for one PR. This is the clean-cancel companion to `/babysit-pr` — it does not merge, fix, or touch the PR itself; it only tears down the watcher loop and its state.
 
-Stopping is **cooperative and idempotent**: it flags the watcher to terminate on its next tick (the watcher's `T0` short-circuit handles the actual clean exit) and `CronDelete`s the scheduled job when `--durable` mode is active. Running it on a PR with no active watcher is a safe no-op.
-
-**Note:** `CronCreate` jobs (`--durable` mode) are session-scoped and die when Claude exits; `CronDelete` is still required to stop the job within the current session, since a session-scoped cron fires until explicitly deleted.
+Stopping is **cooperative and idempotent**: it flags the watcher to terminate on its next tick (the watcher's `T0` short-circuit handles the actual clean exit). Running it on a PR with no active watcher is a safe no-op.
 
 ## Resolve the state helper
 
@@ -70,57 +68,27 @@ Do **not** clear `active` here — let the watcher's terminate path own that so 
 
 ### 4. Cancel the recurring poll
 
-Branch on the watcher's recorded mode (`babysit.durable`):
+The watcher always runs on `/loop` (issue #827 removed `--durable`, the only other mode). The session loop stops re-arming once the watcher terminates; if you can cancel the active `/loop` immediately (runtime stop / "stop polling"), do so — otherwise the `stop_requested` flag set in Step 3 guarantees the next tick is the last.
+
+If you cancelled the loop outright rather than letting it tick once more, the watcher's T-END cleanup never runs — so perform the terminal cleanup here, clearing `dispatch_in_flight` as well as `active` so no stale in-flight marker is left behind:
 
 ```bash
-DURABLE=$("$SESSION_STATE_SH" --get ".prs[\"$PR\"].babysit.durable" 2>/dev/null || echo "false")
+"$SESSION_STATE_SH" \
+  --set ".prs[\"$PR\"].babysit.active=false" \
+  --set ".prs[\"$PR\"].babysit.dispatch_in_flight=null"
 ```
-
-- **`/loop` mode (`DURABLE != true`):** the session loop stops re-arming once the watcher terminates; if you can cancel the active `/loop` immediately (runtime stop / "stop polling"), do so — otherwise the `stop_requested` flag set in Step 3 guarantees the next tick is the last.
-- **Durable mode (`DURABLE == true`, `CronCreate`):** the recorded cron must actually be deleted before claiming a stop.
-
-  **Fail closed** — do not report "stopped", prune `polling_jobs[]`, or clear `active`/`dispatch_in_flight` unless the cron is genuinely gone. A **missing** `cron_job_id` in durable mode is itself a fail-closed condition (the job is orphaned — we cannot target it), not a license to skip `CronDelete` and still report success:
-
-  ```bash
-  CRON_ID=$("$SESSION_STATE_SH" --get ".prs[\"$PR\"].babysit.cron_job_id") || {
-    echo "ERROR: could not read cron_job_id — aborting stop; cron still active, retry /babysit-pr-stop $PR." >&2; exit 1; }
-  if [[ -z "$CRON_ID" || "$CRON_ID" == "null" ]]; then
-    echo "ERROR: durable watcher for PR #$PR has no recorded cron_job_id — the poll is orphaned. Run CronList, delete the matching job manually, then re-run /babysit-pr-stop $PR. NOT clearing state." >&2
-    exit 1
-  fi
-  CronDelete "$CRON_ID" || {
-    echo "ERROR: CronDelete failed for $CRON_ID — NOT clearing state; cron may still fire, retry /babysit-pr-stop $PR." >&2; exit 1; }
-  ```
-
-  Only **after** `CronDelete` succeeds, prune `polling_jobs[]` and clear the per-PR state. `session-state.sh --set` only **assigns** a path — it cannot splice an array element — so read the array, filter it locally with `jq` (a read/transform, not a state write), and write the whole new array back via `--set` (the only writer, keeping the atomic guarantee and the "no raw `jq` writes" rule):
-
-  ```bash
-  JOBS=$("$SESSION_STATE_SH" --get '.polling_jobs')              # JSON array (or "null")
-  if [[ "$JOBS" != "null" && -n "$JOBS" ]]; then
-    NEW_JOBS=$(jq -c --arg id "$CRON_ID" 'map(select(.id != $id))' <<<"$JOBS")
-  else
-    NEW_JOBS='[]'
-  fi
-  "$SESSION_STATE_SH" \
-    --set ".polling_jobs=$NEW_JOBS" \
-    --set ".prs[\"$PR\"].babysit.cron_job_id=null" \
-    --set ".prs[\"$PR\"].babysit.active=false" \
-    --set ".prs[\"$PR\"].babysit.dispatch_in_flight=null"
-  ```
-
-  After a successful `CronDelete` **no further tick will fire**, so the watcher's normal T-END cleanup never runs — this branch therefore performs the **full** terminal cleanup itself: it clears `active` **and** `dispatch_in_flight` (not just `active`), mirroring T-END so no stale in-flight marker is left behind (`pm/SKILL.md` mode-switch cleanup contract: `polling_jobs[]` stays authoritative).
 
 ### 5. Confirm
 
-Word the confirmation to match what actually happened — do **not** promise a "next tick" in durable mode, where `CronDelete` already terminated the watcher and this skill performed the full cleanup:
+Word the confirmation to match what actually happened:
 
-- **Durable mode (cron deleted in Step 4):**
+- **Loop cancelled outright (full cleanup done in Step 4):**
 
   ```
-  Stopped babysitting PR #<PR>. Durable poll cancelled (cron_job_id <ID> deleted) and watcher state fully cleared — no next tick will run. No further /fixpr or /wrap dispatches will be made.
+  Stopped babysitting PR #<PR>. Poll cancelled and watcher state cleared — no next tick will run. No further /fixpr or /wrap dispatches will be made.
   ```
 
-- **`/loop` mode (cooperative stop via the flag):**
+- **Cooperative stop (flag set, one tick remaining):**
 
   ```
   Stopped babysitting PR #<PR>. The watcher will exit on its next tick (stop_requested set). No further /fixpr or /wrap dispatches will be made.

--- a/.claude/skills/babysit-pr-stop/SKILL.md
+++ b/.claude/skills/babysit-pr-stop/SKILL.md
@@ -70,22 +70,36 @@ Do **not** clear `active` here — let the watcher's terminate path own that so 
 
 The watcher always runs on `/loop` (issue #827 removed `--durable`, the only other mode). The session loop stops re-arming once the watcher terminates; if you can cancel the active `/loop` immediately (runtime stop / "stop polling"), do so — otherwise the `stop_requested` flag set in Step 3 guarantees the next tick is the last.
 
-If you cancelled the loop outright rather than letting it tick once more, the watcher's T-END cleanup never runs — so perform the terminal cleanup here, clearing `dispatch_in_flight` as well as `active` so no stale in-flight marker is left behind:
+If you cancelled the loop outright rather than letting it tick once more, the watcher's T-END cleanup never runs — so perform the terminal cleanup here. **Clear `dispatch_in_flight` only when nothing is actually in flight:** a `/fixpr` or `/wrap` started by an earlier tick keeps running after the loop is cancelled, and clearing its marker lets a later `/babysit-pr` arm dispatch a second one on the same PR — while the original, on completion, overwrites whatever state that new dispatch had written.
 
 ```bash
-"$SESSION_STATE_SH" \
-  --set ".prs[\"$PR\"].babysit.active=false" \
-  --set ".prs[\"$PR\"].babysit.dispatch_in_flight=null"
+IN_FLIGHT=$("$SESSION_STATE_SH" --get ".prs[\"$PR\"].babysit.dispatch_in_flight" 2>/dev/null || echo "null")
+if [[ "$IN_FLIGHT" == "null" || -z "$IN_FLIGHT" ]]; then
+  "$SESSION_STATE_SH" \
+    --set ".prs[\"$PR\"].babysit.active=false" \
+    --set ".prs[\"$PR\"].babysit.dispatch_in_flight=null"
+else
+  # Leave the marker: T0's TTL reclaim owns it, so it can never wedge forever.
+  "$SESSION_STATE_SH" --set ".prs[\"$PR\"].babysit.active=false"
+fi
 ```
+
+Say which happened — a stop that leaves a dispatch running is not the same promise as a stop that does not.
 
 ### 5. Confirm
 
 Word the confirmation to match what actually happened:
 
-- **Loop cancelled outright (full cleanup done in Step 4):**
+- **Loop cancelled outright, nothing in flight:**
 
   ```
   Stopped babysitting PR #<PR>. Poll cancelled and watcher state cleared — no next tick will run. No further /fixpr or /wrap dispatches will be made.
+  ```
+
+- **Loop cancelled with a dispatch still running:**
+
+  ```
+  Stopped babysitting PR #<PR>. Poll cancelled — no new dispatch will start, but the in-flight <skill> may still complete and finish its own work.
   ```
 
 - **Cooperative stop (flag set, one tick remaining):**

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -211,6 +211,18 @@ NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 Arm the recurring poll: `/loop <cadence> /babysit-pr <PR> --tick`. The runtime owns the cadence and re-arms each cycle. `/loop` is the only primitive this watcher uses (`scheduling-reliability.md` decision tree) — the watcher is session-scoped by design, and a watcher that outlived its session would be auto-dispatching `/wrap` merges into an empty room.
 
+**Roll back if arming fails.** The `--set` above already published `active=true` with a fresh `last_tick_at`, so a failed arm leaves a watcher that A2 reads as *live* for the whole freshness window (30m by default) while nothing is ticking — re-arm is blocked precisely when it is needed. Treat init+arm as one transaction:
+
+```bash
+if ! arm_loop "$BASE_MIN" "$PR"; then
+  "$SESSION_STATE_SH" \
+    --set ".prs[\"$PR\"].babysit.active=false" \
+    --set ".prs[\"$PR\"].babysit.last_tick_at=null"
+  echo "ERROR: could not arm the /loop for PR #$PR — watcher state rolled back, re-run /babysit-pr $PR." >&2
+  exit 1
+fi
+```
+
 Then **run one tick immediately** (fall through to TICK MODE below) so the user gets instant feedback, and emit the initial heartbeat. Per the `scheduling-reliability.md` **pre-exit checklist**, before ending the arm turn confirm: (1) the loop is active, (2) a timestamped heartbeat was sent, (3) state was recorded.
 
 ---
@@ -556,6 +568,12 @@ NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 **Re-arm cadence only when it crosses a tier boundary.** `/loop` owns the cadence, so to change it: stop the current loop and re-arm `/loop <new-cadence> /babysit-pr <PR> --tick`. If the effective cadence is unchanged, do nothing — never re-arm an unchanged loop (forbidden hand-rolled re-arm churn).
 
+On an actual widen, record it so `polling-backoff-warn.sh` stops re-emitting its widen advisory (it dedupes on `type == "update"` at the new interval):
+
+```bash
+"$SESSION_STATE_SH" --set ".prs[\"$PR\"].last_cron_action={\"type\":\"update\",\"interval\":\"${WIDE_MIN}m\",\"at\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+```
+
 ### T6. Termination check
 
 Terminate (→ T-END) when **any** hold:
@@ -599,6 +617,12 @@ Append context: blocker reason on `hard-blocked`/`waiting-on-bots`; dispatch tar
 ```
 
 **Cancelling the poll is a required terminal action — the loop does NOT lapse on its own** (`/loop` re-arms every cycle). Cancel the active loop now (runtime loop-stop / "stop polling") and do not re-arm it.
+
+**Record the stop.** `polling-backoff-warn.sh` suppresses a repeated STOP advisory by reading `.prs["<N>"].last_cron_action.type == "delete"`. Nothing else writes that field on the `/loop` path, so without this the hook re-emits its STOP context on every subsequent tick. The field name is historical — it records the poll-lifecycle action, whatever primitive backs the poll:
+
+```bash
+"$SESSION_STATE_SH" --set ".prs[\"$PR\"].last_cron_action={\"type\":\"delete\",\"interval\":\"paused\",\"at\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+```
 
 Belt-and-suspenders: even if cancellation is delayed, the T0 short-circuit (`active != true`) makes every subsequent tick an immediate no-op terminate — but cancellation is still mandatory so the runtime stops invoking the watcher.
 

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: babysit-pr
-description: Watch a single PR on a recurring /loop and auto-dispatch /fixpr (recoverable blockers) or /wrap (merge-ready). Reads PR state via pr-state.sh + merge-gate.sh each tick, classifies into {merged, merge-ready, conflicting, has-recoverable-blockers, waiting-on-bots, hard-blocked}, tracks in-flight dispatches in session-state for idempotency, applies stable-state backoff, emits a timestamped heartbeat per tick, and hard-terminates on merge/hard-blocked/N blocker ticks/user stop. Stop with /babysit-pr-stop. Invoke as `/babysit-pr <PR> [--cadence Nm] [--max-iter N] [--silent] [--durable] [--auto-resolve-conflicts] [--max-conflict-rounds N]`.
+description: Watch a single PR on a recurring /loop and auto-dispatch /fixpr (recoverable blockers) or /wrap (merge-ready). Reads PR state via pr-state.sh + merge-gate.sh each tick, classifies into {merged, merge-ready, conflicting, has-recoverable-blockers, waiting-on-bots, hard-blocked}, tracks in-flight dispatches in session-state for idempotency, applies stable-state backoff, emits a timestamped heartbeat per tick, and hard-terminates on merge/hard-blocked/N blocker ticks/user stop. Stop with /babysit-pr-stop. Invoke as `/babysit-pr <PR> [--cadence Nm] [--max-iter N] [--silent] [--auto-resolve-conflicts] [--max-conflict-rounds N]`.
 triggers:
   - babysit pr
   - babysit this pr
   - watch this pr
   - keep an eye on pr
-argument-hint: "<PR> [--cadence Nm] [--max-iter N] [--silent] [--durable] [--auto-resolve-conflicts] [--max-conflict-rounds N]"
+argument-hint: "<PR> [--cadence Nm] [--max-iter N] [--silent] [--auto-resolve-conflicts] [--max-conflict-rounds N]"
 ---
 
 Watch one PR and drive it toward merge **without looping forever**. Each tick reads the PR's state through the shared scripts, classifies it, and dispatches the right skill — `/fixpr` to fix recoverable blockers, `/wrap` to merge when the gate is met — then re-arms the poll until a terminal condition fires.
@@ -38,11 +38,17 @@ A human `CHANGES_REQUESTED` on HEAD is `hard-blocked` → record and exit. Never
 | `--cadence Nm` | `5m` | Base poll cadence. Floor `1m` (60s) — clamp anything lower. |
 | `--max-iter N` | `6` | Hard termination after N **consecutive blocker-state ticks** (≈90 min once backoff widens to 15m). |
 | `--silent` | off | Suppress the per-tick heartbeat **except** on state change, dispatch, or termination (those always print). |
-| `--durable` | off | Use `CronCreate` instead of `/loop` for wall-clock-cadence ticking. **Does not provide cross-session durability** — `CronCreate` is session-only; `durable: true` has no effect. The job dies when Claude exits. Default is `/loop` (session-scoped). (Behavioral redesign tracked as a follow-up ticket.) |
 | `--auto-resolve-conflicts` | off | Opt-in: on `CONFLICTING`, dispatch `/fixpr` in safe-only mode (`BABYSIT_SAFE_CONFLICT_MODE=1`) to rebase and auto-resolve mechanically-simple hunks. Any complex hunk aborts the rebase and terminates with a per-hunk report. Off by default — performs unattended rebases and force-pushes. |
+| ~~`--durable`~~ | removed | Accepted and ignored (issue #827). It swapped `/loop` for a `CronCreate` job to buy cross-session continuity that never existed — `CronCreate` is in-memory and dies with the session, so the flag only ever changed cadence alignment. The watcher is always `/loop`. Why this is not re-implemented on the durable scheduler the harness *does* provide: `.claude/reference/cross-session-durability.md`. |
 | `--max-conflict-rounds N` | `3` | Hard termination after N consecutive conflict rounds. Each round that enters the auto-resolve path increments `conflict_streak`, which does not reset on SHA change — only on a non-`conflicting` tick. |
 
 Parse from `$ARGUMENTS`. The first bare integer is `<PR>`. Validate `--cadence` matches `^[0-9]+m$`; clamp `< 1m` to `1m`. Validate `--max-iter` is a positive integer. `--auto-resolve-conflicts` is a boolean flag (present = true, absent = false; stored as `AUTO_RESOLVE_CONFLICTS=true|false`). `--max-conflict-rounds N` must be a positive integer; default `3` (stored as `MAX_CONFLICT_ROUNDS`).
+
+`--durable` is still **accepted** so a saved chip payload or muscle memory does not hard-error; print one line and carry on with `/loop`:
+
+```text
+[babysit] --durable was removed (issue #827) — it never provided cross-session continuity. Watching on /loop.
+```
 
 ## Two modes: arm vs tick
 
@@ -127,12 +133,10 @@ bump_parse_failure_counter() {
   "blocker_streak": 0,          // consecutive blocker-state ticks (drives --max-iter)
   "max_blocker_ticks": 6,
   "silent": false,
-  "durable": false,
   "stop_requested": false,      // set true by /babysit-pr-stop
   "dispatch_in_flight": null,   // {"skill":"fixpr"|"wrap","started_at":"…"} while a dispatch runs
   "dispatch_parse_failures": 0, // consecutive T0 to_epoch() failures on dispatch_in_flight.started_at; force-reclaimed at BABYSIT_PARSE_FAIL_LIMIT (default 3)
   "last_dispatch": null,        // {"skill":"…","started_at":"…","completed_at":"…","status":"…"}
-  "cron_job_id": null,           // set when --durable arms a CronCreate job
   "auto_resolve_conflicts": false, // from --auto-resolve-conflicts; enables unattended rebase+force-push on simple conflicts
   "max_conflict_rounds": 3,        // from --max-conflict-rounds; hard cap on consecutive conflict rounds
   "conflict_streak": 0             // consecutive conflict rounds entered this watcher run; does not reset on SHA change — only on a non-conflicting tick
@@ -201,18 +205,13 @@ Write the babysit object (one atomic `--set` batch), seeding backoff fields to a
 ```bash
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 "$SESSION_STATE_SH" \
-  --set ".prs[\"$PR\"].babysit={\"active\":true,\"started_at\":\"$NOW\",\"last_tick_at\":\"$NOW\",\"last_tick_parse_failures\":0,\"cadence_base_minutes\":$BASE_MIN,\"cadence_effective_minutes\":$BASE_MIN,\"tick_count\":0,\"blocker_streak\":0,\"max_blocker_ticks\":$MAX_ITER,\"silent\":$SILENT,\"durable\":$DURABLE,\"stop_requested\":false,\"dispatch_in_flight\":null,\"dispatch_parse_failures\":0,\"last_dispatch\":null,\"cron_job_id\":null,\"auto_resolve_conflicts\":$AUTO_RESOLVE_CONFLICTS,\"max_conflict_rounds\":$MAX_CONFLICT_ROUNDS,\"conflict_streak\":0}" \
+  --set ".prs[\"$PR\"].babysit={\"active\":true,\"started_at\":\"$NOW\",\"last_tick_at\":\"$NOW\",\"last_tick_parse_failures\":0,\"cadence_base_minutes\":$BASE_MIN,\"cadence_effective_minutes\":$BASE_MIN,\"tick_count\":0,\"blocker_streak\":0,\"max_blocker_ticks\":$MAX_ITER,\"silent\":$SILENT,\"stop_requested\":false,\"dispatch_in_flight\":null,\"dispatch_parse_failures\":0,\"last_dispatch\":null,\"auto_resolve_conflicts\":$AUTO_RESOLVE_CONFLICTS,\"max_conflict_rounds\":$MAX_CONFLICT_ROUNDS,\"conflict_streak\":0}" \
   --set ".prs[\"$PR\"].digest_streak=0"
 ```
 
-Arm the recurring poll. **`/loop` is the default primitive** (`scheduling-reliability.md` decision tree); `CronCreate` only when `--durable` is set.
+Arm the recurring poll: `/loop <cadence> /babysit-pr <PR> --tick`. The runtime owns the cadence and re-arms each cycle. `/loop` is the only primitive this watcher uses (`scheduling-reliability.md` decision tree) — the watcher is session-scoped by design, and a watcher that outlived its session would be auto-dispatching `/wrap` merges into an empty room.
 
-**Warning:** `CronCreate` is **session-only** — the job is held in memory and dies when Claude exits. The `durable: true` field has **no effect**. `--durable` does not provide cross-session continuity for this watcher. (Behavioral redesign of `--durable` is tracked as a follow-up ticket.)
-
-- **`/loop` (default):** arm `/loop <cadence> /babysit-pr <PR> --tick`. The runtime owns the cadence and re-arms each cycle.
-- **`--durable` (CronCreate):** pick an off-peak minute via `.claude/scripts/off-peak-minute.sh`, create a recurring (`recurring: true`, `durable: true`) job whose prompt is `/babysit-pr <PR> --tick`, and persist the returned job id to `.prs["<N>"].babysit.cron_job_id` and to top-level `polling_jobs[]` (so `/babysit-pr-stop` and recovery can find it).
-
-Then **run one tick immediately** (fall through to TICK MODE below) so the user gets instant feedback, and emit the initial heartbeat. Per the `scheduling-reliability.md` **pre-exit checklist**, before ending the arm turn confirm: (1) the next tick is scheduled (loop active / cron created), (2) a timestamped heartbeat was sent, (3) state was recorded.
+Then **run one tick immediately** (fall through to TICK MODE below) so the user gets instant feedback, and emit the initial heartbeat. Per the `scheduling-reliability.md` **pre-exit checklist**, before ending the arm turn confirm: (1) the loop is active, (2) a timestamped heartbeat was sent, (3) state was recorded.
 
 ---
 
@@ -518,7 +517,7 @@ WIDE_MIN=$(( BASE_MIN * 3 )); (( WIDE_MIN < 15 )) && WIDE_MIN=15
 |-----------------|-------------------|
 | `< 3` | base (`--cadence`, default 5m) |
 | `>= 3` | `WIDE_MIN` = `max(15m, 3 × base)` — for the default 5m base this is **15m** (satisfies the AC) |
-| `>= 9` | **terminate** (truly frozen — cancel `/loop`; `CronDelete` in durable mode) |
+| `>= 9` | **terminate** (truly frozen — cancel the `/loop`) |
 
 **Revert to base cadence on any state change** (digest differs → `STREAK` reset to 1 → `cadence_effective_minutes` returns to `BASE_MIN`).
 
@@ -555,7 +554,7 @@ NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   --set ".prs[\"$PR\"].babysit.last_tick_at=$NOW"
 ```
 
-**Re-arm cadence only when it crosses a tier boundary.** `/loop` owns the cadence, so to change it: stop the current loop and re-arm `/loop <new-cadence> /babysit-pr <PR> --tick` (durable mode: `CronUpdate`/recreate the job at the new minute-range, persisting the new id). If the effective cadence is unchanged, do nothing — never re-arm an unchanged loop (forbidden hand-rolled re-arm churn).
+**Re-arm cadence only when it crosses a tier boundary.** `/loop` owns the cadence, so to change it: stop the current loop and re-arm `/loop <new-cadence> /babysit-pr <PR> --tick`. If the effective cadence is unchanged, do nothing — never re-arm an unchanged loop (forbidden hand-rolled re-arm churn).
 
 ### T6. Termination check
 
@@ -599,24 +598,7 @@ Append context: blocker reason on `hard-blocked`/`waiting-on-bots`; dispatch tar
   --set ".prs[\"$PR\"].babysit.dispatch_in_flight=null"
 ```
 
-**Cancelling the poll is a required terminal action — the loop does NOT lapse on its own** (`/loop` re-arms every cycle; `CronCreate` fires until deleted). Tear it down explicitly:
-
-- **`/loop` mode (default):** cancel the active loop now (runtime loop-stop / "stop polling"). Do not re-arm it.
-- **Durable mode:** **fail closed** — `CronDelete` the `cron_job_id` and only prune `polling_jobs[]` / clear the id **after** it succeeds, so a failed delete never leaves a cron firing against state that claims it's gone. `session-state.sh --set` cannot splice an array, so read → filter with `jq` (a read/transform) → write the new array back via `--set` (same supported delete path as `/babysit-pr-stop`):
-
-  ```bash
-  CRON_ID=$("$SESSION_STATE_SH" --get ".prs[\"$PR\"].babysit.cron_job_id") || CRON_ID=""
-  if [[ -n "$CRON_ID" && "$CRON_ID" != "null" ]]; then
-    CronDelete "$CRON_ID" || { echo "ERROR: CronDelete failed for $CRON_ID — leaving job recorded; re-run /babysit-pr-stop $PR." >&2; exit 1; }
-    JOBS=$("$SESSION_STATE_SH" --get '.polling_jobs')
-    if [[ "$JOBS" != "null" && -n "$JOBS" ]]; then
-      NEW_JOBS=$(jq -c --arg id "$CRON_ID" 'map(select(.id != $id))' <<<"$JOBS")
-    else
-      NEW_JOBS='[]'
-    fi
-    "$SESSION_STATE_SH" --set ".polling_jobs=$NEW_JOBS" --set ".prs[\"$PR\"].babysit.cron_job_id=null"
-  fi
-  ```
+**Cancelling the poll is a required terminal action — the loop does NOT lapse on its own** (`/loop` re-arms every cycle). Cancel the active loop now (runtime loop-stop / "stop polling") and do not re-arm it.
 
 Belt-and-suspenders: even if cancellation is delayed, the T0 short-circuit (`active != true`) makes every subsequent tick an immediate no-op terminate — but cancellation is still mandatory so the runtime stops invoking the watcher.
 
@@ -663,7 +645,8 @@ Conflict rounds: <conflict_streak> of <max_conflict_rounds> (omit when conflict_
 
 ## Notes
 
-- **Stop anytime:** `/babysit-pr-stop <PR>` sets `stop_requested=true` (and `CronDelete`s in durable mode); the next tick's T0 terminates cleanly. See `.claude/skills/babysit-pr-stop/SKILL.md`.
+- **Stop anytime:** `/babysit-pr-stop <PR>` sets `stop_requested=true`; the next tick's T0 terminates cleanly. See `.claude/skills/babysit-pr-stop/SKILL.md`.
 - **One watcher per PR** — arm mode refuses a duplicate (A2).
+- **Session-scoped by design.** The watcher dies with the session. A watcher left `active` by a session that ended is cleared at the next session start by `session-scheduling-reconcile.sh`, so `/status` never reports a watcher that is not running.
 - **Monitor mode:** while a dispatch subagent is in flight, the parent follows `monitor-mode.md` (orchestration only, ≤5-min heartbeat). The per-tick heartbeat satisfies the heartbeat requirement.
 - **Post-merge install:** after this skill lands on `main`, symlink it globally via the skills worktree per `skill-symlinks.md`.

--- a/.claude/skills/harness-audit/SKILL.md
+++ b/.claude/skills/harness-audit/SKILL.md
@@ -30,7 +30,7 @@ This skill is that missing question, run on a schedule.
 
 The split exists because of a real constraint. `subagent-orchestration.md` reserves
 the top tier for **interactive step-ups where a human watches the spend** — it is
-never a spawn default. A monthly cron that quietly burns top-tier tokens
+never a spawn default. A monthly tick that quietly burns top-tier tokens
 unattended contradicts that rule's stated harm model, not merely its wording. So
 the recurring tick runs only the cheap pass and then *offers* the judgment pass
 as a click-to-launch chip. Nobody's budget moves without a human clicking.
@@ -43,18 +43,18 @@ Rationale, alternatives considered, and the watermark scheme: `.claude/reference
 
 | Invocation | Meaning |
 |------------|---------|
-| `/harness-audit` | On-demand full run. Neither creates nor disturbs the recurring job. |
-| `/harness-audit --tick` | The cron body. Cheap pass + chip offer, gated on the monthly watermark. |
+| `/harness-audit` | On-demand full run. Neither enables nor disturbs the recurring nudge. |
+| `/harness-audit --tick` | The tick body. Cheap pass + chip offer, gated on the monthly watermark. |
 | `/harness-audit --report-only` | Dry run: verdicts and report, **files nothing**. |
 | `/harness-audit --report-to-repo` | Write the report into `.claude/reference/` instead of `~/.claude/`. Refuses outside a non-`main` worktree (Step 8). |
 | `/harness-audit --force-here` | Run the judgment pass on the current model even when it is not the resolved top tier; stamps a caveat into the report. |
-| `/harness-audit --arm` | Register the recurring job. |
-| `/harness-audit --stop` | Cancel the recurring job (fail-closed). |
+| `/harness-audit --arm` | Enable the session-start nudge. |
+| `/harness-audit --stop` | Disable the session-start nudge. |
 
 The first two rows and the last two are **modes** and are mutually exclusive.
 `--report-only`, `--report-to-repo`, and `--force-here` are **modifiers** that
 combine with a plain on-demand run (and with each other). A `--tick` ignores
-`--force-here` — a cron never runs the judgment pass, whatever it is passed.
+`--force-here` — a tick never runs the judgment pass, whatever it is passed.
 
 Resolve once, up front:
 
@@ -75,118 +75,66 @@ entirely.
 - **`--stop`** is strictly lifecycle-only: run Step 1 and exit, never auditing.
 - **`--arm`** runs Step 1, then performs **one inventory-only tick** (Steps 2–3
   and Step 5's offer) so the first month is evaluated immediately instead of
-  waiting a day, then exits. It never runs the judgment pass itself — an armed
-  cron and a hand-armed first tick behave identically.
+  waiting for the next session, then exits. It never runs the judgment pass
+  itself — a nudge-driven tick and a hand-armed first tick behave identically.
 
 ---
 
 ## Step 1 — `--arm` / `--stop` (recurrence lifecycle)
 
-**Cadence is monthly, but the job is registered daily.** `CronCreate` jobs can be
-removed by a 7-day expiry (`scheduling-reliability.md`), so a literal monthly
-cron can expire before it ever fires — it would silently never run, which is the
-worst possible failure for a skill whose whole job is noticing silent staleness.
-A daily tick gated on a monthly watermark costs almost nothing (29 of 30 ticks
-are a file read and an exit) and gives seven chances to notice an expired job
-inside the expiry window.
+**The recurrence is a session-start check, not a scheduled job** (issue #827).
+No scheduler in this harness outlives the session that armed it, so a monthly
+audit cannot be driven by one: the job would die at session exit and the audit
+would silently never run — the worst possible failure for a skill whose whole
+job is noticing silent staleness.
 
-> **Warning:** `CronCreate` is **session-only** — the job is held in memory and dies when Claude exits, regardless of `durable: true`. The daily registration design assumes the job survives long enough within a session to re-register itself; it does **not** persist across session boundaries. The current scheduling design therefore relies on a guarantee the harness does not provide. Redesign of the audit's scheduling cadence is tracked as a follow-up ticket.
+What *is* durable is the watermark file, and it already records everything the
+cadence needs. So the tick moved to the one event that recurs reliably: **the
+start of a session**. `session-scheduling-reconcile.sh` reads the watermark on
+every session start and surfaces a one-line nudge when the month is due.
+Sessions start far more often than monthly, so a month cannot be missed — and
+this needs no job id, no expiry window, and no `CronList` reconciliation.
+
+`--arm` and `--stop` therefore toggle that nudge, in the watermark file:
 
 ### `--arm`
 
 ```bash
-MINUTE="$(.claude/scripts/off-peak-minute.sh --repo "$(gh repo view --json nameWithOwner --jq .nameWithOwner)")"
-```
-
-Create the job with `CronCreate`: schedule `"$MINUTE 9 * * *"` (daily, off-peak
-minute, 9am local), `recurring: true`, `durable: true`, prompt
-`/harness-audit --tick`. Persist the returned id:
-
-```bash
-JOBS="$("$SESSION_STATE_SH" --get '.polling_jobs')"
-[[ "$JOBS" == "null" || -z "$JOBS" ]] && JOBS='[]'
-NEW_JOBS="$(jq -c --arg id "$CRON_ID" \
-  '. + [{"id":$id,"owner":"harness-audit","kind":"monthly-audit"}]' <<<"$JOBS")"
-"$SESSION_STATE_SH" --set ".polling_jobs=$NEW_JOBS"
+python3 - "$WATERMARK" <<'PY'
+import json, os, sys
+p = sys.argv[1]
+d = json.load(open(p)) if os.path.exists(p) else {}
+d["nudge_enabled"] = True
+json.dump(d, open(p, "w"), indent=2)
+PY
 ```
 
 Then run the single inventory-only tick described in Step 0 so the user sees the
-skill work immediately, and satisfy the `scheduling-reliability.md` **pre-exit
-checklist**: (1) next tick scheduled, (2) timestamped heartbeat sent, (3) state
-recorded.
+skill work immediately, and report that the nudge is on.
 
-**Arming is idempotent.** If `polling_jobs[]` already holds a live
-`owner: "harness-audit"` entry (confirm with `CronList`), report the existing id
-and create nothing. Two jobs would double every offer.
+**Arming is idempotent** — it sets a boolean. There is no way to arm twice, and
+so no way to double an offer.
 
-### `--stop` (fail-closed)
+### `--stop`
 
-`CronDelete` first; clear state **only** after it succeeds. A cleared record with
-a live cron is a job firing against state that claims it is gone.
+Set `nudge_enabled` to `false` the same way. Nothing else to tear down: there is
+no job, so there is nothing that can keep firing against state that says it is
+gone. Report that the nudge is off and **STOP** — `--stop` never runs an audit.
 
-**Cancel every audit-owned job, not just the first.** Arming is idempotent, but a
-crash between `CronCreate` and the state write — or an older job left by a
-previous version — can leave more than one. Stopping only the first would report
-success while a second cron kept firing, which is precisely the failure `--stop`
-exists to prevent:
-
-```bash
-JOBS="$("$SESSION_STATE_SH" --get '.polling_jobs')"
-# An absent/null polling_jobs is the normal "nothing armed" case, not an
-# error — guard before jq so it does not spew a parse error on `.[]`.
-[[ "$JOBS" == "null" || -z "$JOBS" ]] && JOBS='[]'
-mapfile -t CRON_IDS < <(jq -r '.[] | select(.owner == "harness-audit") | .id' <<<"$JOBS")
-
-FAILED=()
-DELETED=()
-for id in "${CRON_IDS[@]:-}"; do
-  [[ -n "$id" ]] || continue
-  if CronDelete "$id"; then DELETED+=("$id"); else FAILED+=("$id"); fi
-done
-
-if (( ${#FAILED[@]} > 0 )); then
-  # Fail closed: prune only what actually died, keep the rest recorded so a
-  # re-run can finish the job.
-  NEW_JOBS="$(jq -c --argjson gone "$(printf '%s\n' "${DELETED[@]:-}" | jq -R . | jq -s 'map(select(. != ""))')" \
-    'map(select(.id as $i | ($gone | index($i)) | not))' <<<"$JOBS")"
-  "$SESSION_STATE_SH" --set ".polling_jobs=$NEW_JOBS"
-  echo "ERROR: CronDelete failed for: ${FAILED[*]} — still recorded; re-run /harness-audit --stop." >&2
-  exit 1
-fi
-
-NEW_JOBS="$(jq -c 'map(select(.owner != "harness-audit"))' <<<"$JOBS")"
-"$SESSION_STATE_SH" --set ".polling_jobs=$NEW_JOBS"
-```
-
-Also reconcile against `CronList`: an audit-owned job **live in `CronList` but
-absent from `polling_jobs[]`** is an orphan from a lost state write — delete it
-too, and say so. State is the record, not the authority.
-
-Report what was cancelled (or that nothing was armed) and **STOP** — `--stop`
-never runs an audit.
+Both modes leave `last_completed_month` / `last_offered_month` untouched, so
+disabling and re-enabling the nudge never re-audits a month that is already done.
 
 ---
 
-## Step 2 — `--tick` gating (cron body only)
+## Step 2 — `--tick` gating (tick body only)
 
 Skip this step entirely for every non-`--tick` mode.
 
-**Confirm the job survives.** Call `CronList` and look for the recorded id.
+There is no job to confirm the survival of — the session-start nudge is the
+recurrence (Step 1), and it re-reads the watermark from disk every time. A tick
+is therefore pure watermark arithmetic.
 
-- **Missing** → the job expired or was deleted. Re-arm it (Step 1) before doing
-  anything else, and say so in the heartbeat.
-- **`CronList` unavailable** (headless, tool absent) → do **not** assume the job
-  survived. Record the failure and carry on with the tick's real work:
-
-  ```bash
-  FAILS="$("$SESSION_STATE_SH" --get '.polling_failures')"
-  [[ "$FAILS" == "null" || -z "$FAILS" ]] && FAILS='[]'
-  NEW="$(jq -c --arg at "$(date -u +%FT%TZ)" \
-    '. + [{"at":$at,"owner":"harness-audit","failure":"cronlist_unavailable"}]' <<<"$FAILS")"
-  "$SESSION_STATE_SH" --set ".polling_failures=$NEW"
-  ```
-
-**Then read the watermark** (`$WATERMARK`, absent on first run = never audited):
+**Read the watermark** (`$WATERMARK`, absent on first run = never audited):
 
 ```json
 {"last_completed_month": "2026-06", "last_completed_at": "...", "last_offered_month": "2026-07"}
@@ -199,8 +147,8 @@ Skip this step entirely for every non-`--tick` mode.
 | Neither matches | Proceed: Step 3 (inventory), then Step 5's chip offer. **A tick never runs the judgment pass itself.** |
 
 The two separate watermarks are load-bearing. One alone forces a choice between
-two bad behaviors: re-offering a chip every single day until it is clicked, or
-marking the month done when nothing was actually audited.
+two bad behaviors: re-offering a chip on every session start until it is
+clicked, or marking the month done when nothing was actually audited.
 
 ---
 
@@ -315,14 +263,14 @@ TOP_DISPLAY="$("$FLEET" --top-tier-display)"
 proceeding on an assumed tier. A fleet change is a one-file edit to
 `.claude/model-fleet.json`; nothing in this skill needs touching when it happens.
 
-### Cron path (`--tick`)
+### Tick path (`--tick`)
 
 Never run the judgment pass. **Claim the month, then offer it.**
 
 Claim *before* offering, not after. A tick that offers first and records second
-has a window in which a second tick — an overlapping cron, or a manual run
-alongside one — reads `last_offered_month` as unset and offers the same month
-again.
+has a window in which a second tick — a session start racing a manual run, or
+two sessions starting at once — reads `last_offered_month` as unset and offers
+the same month again.
 
 **Ordering alone is not enough: read-then-write is still a TOCTOU race.** Two
 ticks can both read an unset watermark, both conclude they won, and both offer.

--- a/.claude/skills/harness-audit/SKILL.md
+++ b/.claude/skills/harness-audit/SKILL.md
@@ -83,10 +83,12 @@ entirely.
 ## Step 1 — `--arm` / `--stop` (recurrence lifecycle)
 
 **The recurrence is a session-start check, not a scheduled job** (issue #827).
-No scheduler in this harness outlives the session that armed it, so a monthly
-audit cannot be driven by one: the job would die at session exit and the audit
-would silently never run — the worst possible failure for a skill whose whole
-job is noticing silent staleness.
+`CronCreate` — the scheduler this skill used — does not outlive the session that
+armed it, so a monthly audit cannot be driven by one: the job dies at session
+exit and the audit silently never runs, the worst possible failure for a skill
+whose whole job is noticing silent staleness. A genuinely durable scheduler does
+exist (`mcp__scheduled-tasks__*`); why this skill still declines it is in
+`.claude/reference/cross-session-durability.md`.
 
 What *is* durable is the watermark file, and it already records everything the
 cadence needs. So the tick moved to the one event that recurs reliably: **the
@@ -99,14 +101,24 @@ this needs no job id, no expiry window, and no `CronList` reconciliation.
 
 ### `--arm`
 
+Hold the shared lock and replace atomically. A concurrent `--tick` writing
+`last_offered_month` must not be clobbered, and an interrupted write must not
+leave invalid JSON where the next session start will read it:
+
 ```bash
-python3 - "$WATERMARK" <<'PY'
-import json, os, sys
-p = sys.argv[1]
+source "$REPO_ROOT/.claude/scripts/state-lock.sh"
+state_lock_acquire "$WATERMARK"
+python3 - "$WATERMARK" true <<'PY'
+import json, os, sys, tempfile
+p, val = sys.argv[1], sys.argv[2] == "true"
 d = json.load(open(p)) if os.path.exists(p) else {}
-d["nudge_enabled"] = True
-json.dump(d, open(p, "w"), indent=2)
+d["nudge_enabled"] = val
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(p))
+with os.fdopen(fd, "w") as f:
+    json.dump(d, f, indent=2)
+os.replace(tmp, p)
 PY
+state_lock_release "$WATERMARK"
 ```
 
 Then run the single inventory-only tick described in Step 0 so the user sees the
@@ -117,9 +129,9 @@ so no way to double an offer.
 
 ### `--stop`
 
-Set `nudge_enabled` to `false` the same way. Nothing else to tear down: there is
-no job, so there is nothing that can keep firing against state that says it is
-gone. Report that the nudge is off and **STOP** — `--stop` never runs an audit.
+Run the identical locked block with `false` in place of `true`. Nothing else to
+tear down: there is no job, so nothing can keep firing against state that claims
+it is gone. Report that the nudge is off and **STOP** — `--stop` never audits.
 
 Both modes leave `last_completed_month` / `last_offered_month` untouched, so
 disabling and re-enabling the nudge never re-audits a month that is already done.

--- a/.claude/skills/pm-handoff/SKILL.md
+++ b/.claude/skills/pm-handoff/SKILL.md
@@ -314,21 +314,21 @@ If no state files exist, output: "No in-flight work detected. Starting fresh."
 
 Snapshot any live scheduled jobs owned by **other skills** (`/pr-monitor-and-manage`, `/babysit-pr`, etc.) for informational continuity. `/pm` no longer arms its own polls — do not instruct the new thread to recreate `/pm` polls.
 
-Call the `CronList` tool to list all cron jobs scheduled in this session. For each job, record: `id`, `cron`, `prompt`, `recurring`, `durable`, and — if available — the last heartbeat time and cycle interval.
+Since issue #827 no skill in this repo registers a cron job, so this section is normally a single line. Still call `CronList` — a job from an older session build, or one a user armed by hand, should be reported rather than assumed away. For each job record `id`, `cron`, `prompt`, and `recurring`.
 
 Format as:
 
 ```
 ### Active Polling Jobs
 
-| Job ID | Schedule | Prompt | Recurring | Durable | Last heartbeat |
-|--------|----------|--------|-----------|---------|----------------|
-| abc123 | 17 * * * * | /pr-monitor-and-manage-wake --auto-check | true | true | {time} ET |
+| Job ID | Schedule | Prompt | Recurring |
+|--------|----------|--------|-----------|
+| abc123 | 17 * * * * | /some-skill --tick | true |
 
-**On resume:** All `CronCreate` jobs are **session-scoped** and do not survive session turnover — `durable: true` has no effect. Any job listed here died with the previous session. Re-arm via the owning skill if needed (do not use `CronList` to check for survivors — there will be none). For PR fleet monitoring, run `/pr-monitor-and-manage`.
+**On resume:** All `CronCreate` jobs are **session-scoped** and do not survive session turnover — `durable: true` has no effect. Any job listed here died with the previous session; do not use `CronList` to check for survivors, there will be none. Re-arm via the owning skill if needed. For PR fleet monitoring, run `/pr-monitor-and-manage` — a paused fleet resumes from its on-disk marker, not from a job.
 ```
 
-If `CronList` returns no jobs, output: "No active polling jobs from other skills. For PR fleet monitoring, run `/pr-monitor-and-manage`."
+If `CronList` returns no jobs (the expected case), output: "No active polling jobs from other skills. For PR fleet monitoring, run `/pr-monitor-and-manage`."
 
 ### Step 5c: Memory summary
 

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -458,7 +458,7 @@ If orchestration state is stale after context turnover, recover using `.claude/r
 
 ### 2.4: Backwards compatibility
 
-Any `/pm`-created `CronCreate` jobs from before this change died with their originating session (`CronCreate` is session-scoped; `durable: true` has no effect). New `/pm` sessions do not create replacement polls.
+Any `/pm`-created `CronCreate` jobs from before this change died with their originating session (`CronCreate` is session-scoped; `durable: true` has no effect). New `/pm` sessions do not create replacement polls, and `session-scheduling-reconcile.sh` clears the dead records at session start (issue #827).
 
 After setup, proceed to **Step 3: Orchestration Loop**.
 

--- a/.claude/skills/pr-monitor-and-manage-stop/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage-stop/SKILL.md
@@ -9,7 +9,7 @@ triggers:
 argument-hint: "(no arguments — stops the active PR-fleet-manager loop in this thread)"
 ---
 
-Clean-cancel companion to `/pr-monitor-and-manage`. Use this to stop the PR-fleet-manager loop without leaving a dangling `/loop`, stale monitoring state, or auto-wake cron behind.
+Clean-cancel companion to `/pr-monitor-and-manage`. Use this to stop the PR-fleet-manager loop without leaving a dangling `/loop`, stale monitoring state, or auto-wake re-scan behind.
 
 A stale pause marker left by a killed session is safely reconciled: the next `/pr-monitor-and-manage` invocation reads it and resumes (or the user runs `/pmm-stop` here to fully tear down), then re-runs discovery from scratch.
 
@@ -39,7 +39,7 @@ PAUSED_AT=$("$SESSION_STATE_SH" --get '.pmm.paused_at' 2>/dev/null || echo null)
 ```
 
 - If `$ACTIVE` is `true` → proceed to teardown.
-- If `$PAUSED_AT` is set (paused but not active) → proceed to teardown (clear pause marker + cron).
+- If `$PAUSED_AT` is set (paused but not active) → proceed to teardown (clear pause marker + any re-scan loop).
 - If both `false`/`null` → report "No active PR-fleet-manager loop found." and stop. (Still run Step 2's loop cancel best-effort in case a loop is armed without state.)
 
 ## Step 2: Tear down the loop
@@ -49,26 +49,9 @@ Cancel the recurring `/loop` that `/pr-monitor-and-manage` established:
 - If the runtime exposes a loop id / cancel handle, cancel it explicitly.
 - Otherwise interrupt the active loop (Ctrl+C in CLI, stop in web). Invoking `/pmm-stop` is itself the signal — the next tick must not re-arm.
 
-## Step 3: Delete auto-wake cron (fail-closed)
+## Step 3: Cancel the auto-wake re-scan
 
-If an auto-wake cron was registered at pause time, delete it before clearing state:
-
-```bash
-CRON_ID=$("$SESSION_STATE_SH" --get '.pmm.auto_wake_cron_id' 2>/dev/null || echo null)
-if [[ -n "$CRON_ID" && "$CRON_ID" != "null" ]]; then
-  CronDelete "$CRON_ID" || {
-    echo "ERROR: CronDelete failed for $CRON_ID — NOT clearing state; cron may still fire, retry /pmm-stop." >&2
-    exit 1
-  }
-  JOBS=$("$SESSION_STATE_SH" --get '.polling_jobs' 2>/dev/null || echo '[]')
-  if [[ "$JOBS" != "null" && -n "$JOBS" ]]; then
-    NEW_JOBS=$(jq -c --arg id "$CRON_ID" 'map(select(.id != $id))' <<<"$JOBS")
-  else
-    NEW_JOBS='[]'
-  fi
-  "$SESSION_STATE_SH" --set ".polling_jobs=$NEW_JOBS" --set '.pmm.auto_wake_cron_id=null'
-fi
-```
+If `--auto-wake` armed a re-scan at pause time, cancel that `/loop` the same way as Step 2. Since issue #827 it is a plain `/loop` with no recorded job id, so there is nothing to reconcile in state and nothing that can outlive this turn.
 
 ## Step 4: Clear monitoring state (preserve everything else)
 
@@ -92,7 +75,7 @@ Leave `pmm_in_flight`, `pmm_digest`, `pmm_digest_streak`, and `pmm_idle_streak` 
 Reason:   user /pmm-stop
 Loop:     cancelled (no further ticks)
 State:    pmm_active=false, pause marker cleared
-Auto-wake cron: <deleted job id | none>
+Auto-wake re-scan: <cancelled | none>
 In-flight at stop: <list any pmm_in_flight PR # + skill, or "none">
 Active subagents: <list any PMM-owned active_agents entries (match by pr + phase A, or task containing "PMM"), or "none">
 ```

--- a/.claude/skills/pr-monitor-and-manage-wake/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage-wake/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: pr-monitor-and-manage-wake
-description: Resume companion to /pr-monitor-and-manage. Wakes a paused PR-fleet-manager loop from its saved pause marker, tears down any auto-wake cron, and re-arms the main loop. Also serves as the lightweight --auto-check target for the hourly auto-wake cron. Triggers on "/pr-monitor-and-manage-wake", "/pmm-wake", "wake PR monitor".
+description: Resume companion to /pr-monitor-and-manage. Wakes a paused PR-fleet-manager loop from its saved pause marker, cancels any auto-wake re-scan, and re-arms the main loop. Also serves as the lightweight --auto-check target for that re-scan. Triggers on "/pr-monitor-and-manage-wake", "/pmm-wake", "wake PR monitor".
 triggers:
   - pr-monitor-and-manage-wake
   - pmm-wake
   - wake PR monitor
   - resume PR fleet
-argument-hint: "[--auto-check] (default: user-initiated resume; --auto-check = lightweight fleet scan from auto-wake cron)"
+argument-hint: "[--auto-check] (default: user-initiated resume; --auto-check = lightweight fleet scan from the auto-wake re-scan)"
 ---
 
-Resume companion to `/pr-monitor-and-manage`. Wakes a **paused** PR-fleet-manager loop: reads the pause marker, deletes any auto-wake cron, clears the marker, and re-arms the main loop at base cadence.
+Resume companion to `/pr-monitor-and-manage`. Wakes a **paused** PR-fleet-manager loop: reads the pause marker, cancels any auto-wake re-scan, clears the marker, and re-arms the main loop at base cadence.
 
 Idempotent: running on a non-paused session is a clean no-op.
 
@@ -35,8 +35,8 @@ SESSION_STATE_SH=$(resolve_script session-state.sh) || { echo "ERROR: session-st
 
 ## Step 1: Parse mode
 
-- **`--auto-check`** — lightweight fleet scan (invoked by the hourly auto-wake `CronCreate` job). Compare `gh pr list` against `.pmm.fleet_at_pause`; re-launch main skill only if changed.
-- **No flags (default)** — user-initiated resume: clear marker, delete cron, re-arm loop.
+- **`--auto-check`** — lightweight fleet scan (invoked by the auto-wake re-scan `/loop`). Compare `gh pr list` against `.pmm.fleet_at_pause`; re-launch main skill only if changed.
+- **No flags (default)** — user-initiated resume: clear marker, cancel the re-scan, re-arm loop.
 
 ## Step 2: Check pause marker
 
@@ -46,35 +46,16 @@ PAUSED_AT=$("$SESSION_STATE_SH" --get '.pmm.paused_at' 2>/dev/null || echo null)
 
 - If `$PAUSED_AT` is `null`/empty → print **"PMM not paused — either not started or already running."** and exit 0 (idempotent no-op).
 - If present → route by mode:
-  - **`--auto-check`** → Step 4a (compare fleet; cron stays unless changed).
-  - **User-initiated (default)** → Step 3 (delete cron) → Step 4b (resume).
+  - **`--auto-check`** → Step 4a (compare fleet; the re-scan stays unless changed).
+  - **User-initiated (default)** → Step 3 (cancel re-scan) → Step 4b (resume).
 
-## Step 3: Delete auto-wake cron (fail-closed — user resume and auto-check-on-change only)
+## Step 3: Cancel the auto-wake re-scan (user resume and auto-check-on-change only)
 
-**Do NOT run this step in `--auto-check` mode when the fleet is unchanged** — the cron must keep firing hourly until a change is detected.
+**Do NOT run this step in `--auto-check` mode when the fleet is unchanged** — the re-scan must keep running until a change is detected.
 
-When `$MODE` is `--auto-check`, skip to Step 4a first; only call the cron-delete block below from Step 4b after a fleet change is confirmed, or when `$MODE` is user-initiated resume (default).
+When `$MODE` is `--auto-check`, skip to Step 4a first; only cancel the re-scan from Step 4b after a fleet change is confirmed, or when `$MODE` is user-initiated resume (default).
 
-For **user-initiated resume** (default, no `--auto-check`), delete the cron before clearing the pause marker:
-
-```bash
-CRON_ID=$("$SESSION_STATE_SH" --get '.pmm.auto_wake_cron_id' 2>/dev/null || echo null)
-if [[ -n "$CRON_ID" && "$CRON_ID" != "null" ]]; then
-  CronDelete "$CRON_ID" || {
-    echo "ERROR: CronDelete failed for $CRON_ID — NOT clearing pause marker; cron may still fire, retry /pr-monitor-and-manage-wake." >&2
-    exit 1
-  }
-  JOBS=$("$SESSION_STATE_SH" --get '.polling_jobs' 2>/dev/null || echo '[]')
-  if [[ "$JOBS" != "null" && -n "$JOBS" ]]; then
-    NEW_JOBS=$(jq -c --arg id "$CRON_ID" 'map(select(.id != $id))' <<<"$JOBS")
-  else
-    NEW_JOBS='[]'
-  fi
-  "$SESSION_STATE_SH" --set ".polling_jobs=$NEW_JOBS" --set '.pmm.auto_wake_cron_id=null'
-fi
-```
-
-Factor this block as **`pmm_delete_auto_wake_cron`** — Step 4b (auto-check detected change) and Step 0a in the main skill reuse the same fail-closed teardown. Only **after** successful `CronDelete` (or when no cron was registered) proceed to marker clear / re-arm.
+Cancel the `/loop` armed at pause time (runtime loop-stop), then proceed to marker clear / re-arm. Since issue #827 the re-scan is a plain `/loop` rather than a `CronCreate` job, so there is no id to delete, no `polling_jobs[]` entry to prune, and no fail-closed teardown to get wrong — a loop cannot outlive the turn that armed it.
 
 ## Step 4a: `--auto-check` branch (lightweight scan)
 
@@ -95,12 +76,12 @@ CURRENT_FLEET=$(jq -c '[.[] | {pr: .number, head_sha: .headRefOid, state: .merge
 SAVED_FLEET=$(jq -c 'sort_by(.pr)' <<<"$FLEET_AT_PAUSE")
 ```
 
-- If `$CURRENT_FLEET` equals `$SAVED_FLEET` (count + per-PR state) → **no-op**. Print one line: `[auto-check] Fleet unchanged — cron continues.` Exit 0. Do **not** delete the cron or clear the pause marker.
-- If changed → run **`pmm_delete_auto_wake_cron`** (Step 3), then proceed to Step 4b (full resume + re-launch main skill).
+- If `$CURRENT_FLEET` equals `$SAVED_FLEET` (count + per-PR state) → **no-op**. Print one line: `[auto-check] Fleet unchanged — re-scan continues.` Exit 0. Do **not** cancel the re-scan or clear the pause marker.
+- If changed → cancel the re-scan (Step 3), then proceed to Step 4b (full resume + re-launch main skill).
 
 ## Step 4b: Resume (user wake or auto-check detected change)
 
-Run **`pmm_delete_auto_wake_cron`** (Step 3) if not already done (user-initiated resume runs it before this step; auto-check runs it only after detecting a change).
+Cancel the re-scan (Step 3) if not already done (user-initiated resume does it before this step; auto-check does it only after detecting a change).
 
 Read config, reconstruct invocation flags, clear marker, reset idle streak, re-arm loop:
 
@@ -142,10 +123,10 @@ The next tick runs full discovery + per-PR state read. Print:
 PMM resumed — re-armed at <CADENCE>. Fleet will be rediscovered on the next tick.
 ```
 
-For `--auto-check` with detected change, add: `[auto-check] Fleet changed — cron deleted, main loop re-launched.`
+For `--auto-check` with detected change, add: `[auto-check] Fleet changed — re-scan cancelled, main loop re-launched.`
 
 ## Safety
 
-- Never clear the pause marker on resume unless the auto-wake cron is confirmed deleted (Step 3) — except `--auto-check` no-op exits without touching either.
+- Never clear the pause marker on resume without also cancelling the auto-wake re-scan (Step 3) — except `--auto-check` no-op exits without touching either.
 - `--auto-check` must **not** run full per-PR gate reads — only `gh pr list` + comparison.
 - Re-running `/pr-monitor-and-manage-wake` on a non-paused session is always a clean no-op (Step 2).

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -25,13 +25,13 @@ Parent/subagent scope, prohibited actions, refusal template, and common misreads
 
 ### Step 0a: Resume from pause (when `.pmm.paused_at` is set)
 
-On **every** invocation, before Step 1, check for a pause marker. If present, this invocation is a **resume** — tear down any auto-wake cron, clear the marker, merge config, and continue. Full resume logic (cron teardown bash, flag-merge precedence rule): `references/pmm-lifecycle.md` "Step 0a: Resume from pause".
+On **every** invocation, before Step 1, check for a pause marker. If present, this invocation is a **resume** — cancel any auto-wake re-scan, clear the marker, merge config, and continue. Full resume logic (flag-merge precedence rule): `references/pmm-lifecycle.md` "Step 0a: Resume from pause".
 
 ```bash
 PAUSED_AT=$(.claude/scripts/session-state.sh --get '.pmm.paused_at' 2>/dev/null || echo null)
 if [ "$PAUSED_AT" != null ] && [ -n "$PAUSED_AT" ]; then
   SAVED=$(.claude/scripts/session-state.sh --get '.pmm.config_at_pause' 2>/dev/null || echo '{}')
-  # tear down auto-wake cron, clear pause marker, reset pmm_idle_streak=0 + pmm_active=true
+  # cancel auto-wake re-scan, clear pause marker, reset pmm_idle_streak=0 + pmm_active=true
   # (full bash in references/pmm-lifecycle.md)
   echo "[PMM] Resuming from pause (paused_at=$PAUSED_AT) — flags on this invocation override saved config."
 fi
@@ -52,8 +52,8 @@ Parse `$ARGUMENTS` (re-parse every tick — a `/loop` re-invocation passes the s
 - `--cadence Nm` — base poll interval. **Default:** `5m`.
 - `--max-parallel N` — max concurrent `phase-a-fixer` subagents. **Default:** `3`.
 - `--idle-pause-after N` — consecutive idle ticks before auto-pause. **Default:** `3`.
-- `--auto-wake` — register an hourly `CronCreate` job at pause time. **Default:** off.
-- `--auto-wake-cadence Nm` — cadence for the auto-wake cron. **Default:** `60m`.
+- `--auto-wake` — keep a low-frequency re-scan running after an idle pause, instead of going fully quiet. **Default:** off.
+- `--auto-wake-cadence Nm` — cadence for that re-scan. **Default:** `60m`.
 - `--confirm-merges` — require an explicit user confirmation before each `/wrap` merge dispatch. **Default:** off (invocation is authorization). This flag only adds a prompt before the `/wrap` dispatch — it never overrides hard stops (`BLOCKED:*` verdicts, gate failures, AC failures). Safety checks in `/wrap` still apply.
 
 ```bash
@@ -366,7 +366,7 @@ NOW=$(date -u +%FT%TZ)
 
 Reached from Step 7 when the fleet is empty or idle. Preserves a resume marker so `/pr-monitor-and-manage-wake` or re-invoking this skill can pick up where it left off.
 
-Full pause procedure (final heartbeat, loop cancel, fleet snapshot + config build, pause marker write, auto-wake cron registration, summary line): `references/pmm-lifecycle.md`.
+Full pause procedure (final heartbeat, loop cancel, fleet snapshot + config build, pause marker write, auto-wake re-scan, summary line): `references/pmm-lifecycle.md`.
 
 ```bash
 .claude/scripts/session-state.sh \
@@ -377,7 +377,7 @@ Full pause procedure (final heartbeat, loop cancel, fleet snapshot + config buil
   --set '.pmm_next_expected_tick_at=null'
 ```
 
-> **Session-only CronCreate warning (when `--auto-wake` is set):** `CronCreate` is **session-only** — this job fires only while Claude is running in the current session. `durable: true` has no effect. `--auto-wake` does **not** survive session turnover. (Behavioral redesign tracked as a separate ticket.)
+> **Scope of `--auto-wake` (issue #827):** it arms a `/loop` re-scan, so it is session-scoped like every other poll here. That is not a shortfall: a paused fleet resumes across sessions from the on-disk `.pmm.paused_at` marker (Step 0a), which is durable in a way no scheduler job was. The next session start also surfaces the paused fleet unprompted — `session-scheduling-reconcile.sh`.
 
 ---
 

--- a/.claude/skills/pr-monitor-and-manage/references/pmm-lifecycle.md
+++ b/.claude/skills/pr-monitor-and-manage/references/pmm-lifecycle.md
@@ -16,7 +16,6 @@ Pause marker fields live under nested `.pmm.*`. Existing runtime fields
 | `.pmm.paused_at` | ISO-8601 string | Main skill Pause step 4 | Step 0a, `-wake` Step 2 |
 | `.pmm.fleet_at_pause` | `[{pr, head_sha, state}]` | Main skill Pause step 3 | `-wake` Step 4a |
 | `.pmm.config_at_pause` | object | Main skill Pause step 3 | Step 0a, `-wake` Step 4b |
-| `.pmm.auto_wake_cron_id` | string or null | Main skill Pause step 5 | `-stop` Step 3, `-wake` Step 3 |
 
 `config_at_pause` fields: `author`, `repo`, `cadence`, `max_parallel`, `idle_pause_after`, `auto_wake`, `auto_wake_cadence`, `confirm_merges`.
 
@@ -26,7 +25,7 @@ Pause marker fields live under nested `.pmm.*`. Existing runtime fields
 
 ## Step 0a: Resume from pause
 
-On **every** invocation, before Step 1, check for a pause marker. If present, this invocation is a **resume** — tear down any auto-wake cron, clear the marker, merge config, and continue into normal ticking:
+On **every** invocation, before Step 1, check for a pause marker. If present, this invocation is a **resume** — stop any auto-wake re-scan, clear the marker, merge config, and continue into normal ticking:
 
 ```bash
 PAUSED_AT=$(.claude/scripts/session-state.sh --get '.pmm.paused_at' 2>/dev/null || echo null)
@@ -36,21 +35,9 @@ if [ "$PAUSED_AT" != null ] && [ -n "$PAUSED_AT" ]; then
   #    already-captured $SAVED variable, never re-read .pmm.config_at_pause from
   #    session-state after step 3 has run (it will be null by then).
   SAVED=$(.claude/scripts/session-state.sh --get '.pmm.config_at_pause' 2>/dev/null || echo '{}')
-  # 2. Delete auto-wake cron (fail-closed — see pr-monitor-and-manage-wake Step 3)
-  CRON_ID=$(.claude/scripts/session-state.sh --get '.pmm.auto_wake_cron_id' 2>/dev/null || echo null)
-  if [[ -n "$CRON_ID" && "$CRON_ID" != "null" ]]; then
-    CronDelete "$CRON_ID" || {
-      echo "ERROR: CronDelete failed for $CRON_ID — NOT clearing pause marker; cron may still fire, retry." >&2
-      exit 1
-    }
-    JOBS=$(.claude/scripts/session-state.sh --get '.polling_jobs' 2>/dev/null || echo '[]')
-    if [[ "$JOBS" != "null" && -n "$JOBS" ]]; then
-      NEW_JOBS=$(jq -c --arg id "$CRON_ID" 'map(select(.id != $id))' <<<"$JOBS")
-    else
-      NEW_JOBS='[]'
-    fi
-    .claude/scripts/session-state.sh --set ".polling_jobs=$NEW_JOBS" --set '.pmm.auto_wake_cron_id=null'
-  fi
+  # 2. Cancel the auto-wake re-scan loop, if one is running (runtime loop-stop).
+  #    Nothing to reconcile in state: since #827 the re-scan is a /loop, not a
+  #    recorded cron job, so there is no id that can outlive this turn.
   # 3. Clear pause marker + reset pmm_idle_streak=0 + set pmm_active=true
   #    + null .pmm_digest and .pmm_row_digest (atomic batch) — the digest reset
   #    forces Step 4's full table on the first post-resume tick (condition a)
@@ -68,9 +55,11 @@ if [ "$PAUSED_AT" != null ] && [ -n "$PAUSED_AT" ]; then
 fi
 ```
 
-Resume logic is shared with `/pr-monitor-and-manage-wake` — see `.claude/skills/pr-monitor-and-manage-wake/SKILL.md` Step 2 (cron teardown) and Step 3 (marker clear + loop re-arm). When resuming via re-invoking this skill (not `-wake`), apply the precedence rule in Step 1 after parsing `$ARGUMENTS`: any flag explicitly supplied on this invocation wins; omitted flags inherit from `.pmm.config_at_pause`. After resume, continue with Step 1 using the merged config and run a full discovery tick at **base** cadence (not the widened backoff cadence).
+Resume logic is shared with `/pr-monitor-and-manage-wake` — see `.claude/skills/pr-monitor-and-manage-wake/SKILL.md` Step 2 (re-scan teardown) and Step 3 (marker clear + loop re-arm). When resuming via re-invoking this skill (not `-wake`), apply the precedence rule in Step 1 after parsing `$ARGUMENTS`: any flag explicitly supplied on this invocation wins; omitted flags inherit from `.pmm.config_at_pause`. After resume, continue with Step 1 using the merged config and run a full discovery tick at **base** cadence (not the widened backoff cadence).
 
 A stale marker left by a killed session is safely reconciled here: the next `/pr-monitor-and-manage` invocation reads it, resumes (or the user runs `/pmm-stop`), and re-runs discovery from scratch.
+
+**This marker is the fleet's cross-session continuity** (issue #827). It lives on disk in `session-state.json`, so it outlives the session that wrote it — which the `--auto-wake` cron never did, despite being documented as if it had. A session start also surfaces the marker unprompted (`session-scheduling-reconcile.sh`), so a paused fleet is offered back rather than waiting to be remembered.
 
 ---
 
@@ -120,34 +109,17 @@ CONFIG_AT_PAUSE=$(jq -nc \
 
 Preserve `pmm_digest`, `pmm_digest_streak`, and `pmm_idle_streak` as audit trail.
 
-### 5. Optional auto-wake cron (`--auto-wake`)
+### 5. Optional auto-wake re-scan (`--auto-wake`)
 
-When `$PMM_AUTO_WAKE` is true, register an hourly scan at pause time:
+When `$PMM_AUTO_WAKE` is true, keep a low-frequency re-scan running instead of going fully quiet at pause:
 
-> **Warning:** `CronCreate` is **session-only** — this job fires only while Claude is running in the current session. `durable: true` has no effect. `--auto-wake` does **not** survive session turnover. (Behavioral redesign tracked as a follow-up ticket.)
-
-```bash
-# Derive cadence minutes from PMM_AUTO_WAKE_CADENCE (e.g. 60m → 60)
-AW_CADENCE_MIN="${PMM_AUTO_WAKE_CADENCE%m}"
-if [ "$AW_CADENCE_MIN" -ge 60 ] && [ $((AW_CADENCE_MIN % 60)) -eq 0 ]; then
-  # off-peak-minute.sh's --every-n-min only accepts 1..59 (it builds a step-range
-  # within one hour) — for hourly-or-longer cadences (the 60m default), use the
-  # plain no-flag minute + a */H hour step instead, matching /pm's hourly pattern.
-  AW_HOURS=$((AW_CADENCE_MIN / 60))
-  AW_MINUTE=$(.claude/scripts/off-peak-minute.sh)
-  if [ "$AW_HOURS" -eq 1 ]; then
-    AW_CRON="$AW_MINUTE * * * *"
-  else
-    AW_CRON="$AW_MINUTE */$AW_HOURS * * *"
-  fi
-else
-  { read -r AW_MINUTE; read -r AW_CRON; } < <(.claude/scripts/off-peak-minute.sh --every-n-min "$AW_CADENCE_MIN")
-fi
-# CronCreate with prompt "/pr-monitor-and-manage-wake --auto-check", cron="$AW_CRON", recurring=true, durable=true
-# Persist returned job id to .pmm.auto_wake_cron_id and append to polling_jobs[]
+```text
+/loop $PMM_AUTO_WAKE_CADENCE /pr-monitor-and-manage-wake --auto-check
 ```
 
-Tell the user the cron job id and 7-day auto-expiry; note that the job is session-scoped (see `scheduling-reliability.md` contract note).
+Nothing is recorded in `polling_jobs[]` and there is no job id to track — a `/loop` cannot outlive the turn that armed it, so there is no orphan to fail closed against. This replaces the `CronCreate` job that issue #827 removed: that job was session-scoped too, but was documented as surviving session turnover, and the fail-closed teardown it needed was duplicated across three files.
+
+Cross-session continuity is the pause marker's job, not this loop's — see the note under Step 0a.
 
 ### 6. Summary line
 
@@ -155,7 +127,7 @@ Tell the user the cron job id and 7-day auto-expiry; note that the job is sessio
 PMM paused — <N> PR(s) waiting on reviewer, no changes for <idle window>. Wake with `/pr-monitor-and-manage-wake` or re-run `/pr-monitor-and-manage <flags>`.
 ```
 
-If `--auto-wake` is set, add: `Auto-wake cron registered (<job_id>) — will scan hourly for fleet changes.`
+If `--auto-wake` is set, add: `Auto-wake re-scan armed — will scan every <cadence> for fleet changes while this session lasts.`
 
 > **Post-merge symlink:** after this skill's `-wake` companion merges to `main`, symlink `~/.claude/skills/pr-monitor-and-manage-wake` → the skills-worktree copy per `skill-symlinks.md`.
 
@@ -193,6 +165,6 @@ Hard-blocked PRs are reported here for visibility; the fleet may auto-pause afte
 The following were intentionally left out of this PR (scope: bounded dedup + reference-extraction per Issue #815 / Issue #778 Option 2):
 
 - **`resolve_script()` dedup across `-stop`/`-wake` family** — the same three-candidate lookup appears verbatim in `-stop/SKILL.md` and `-wake/SKILL.md`. A shared canonical location would prevent drift, but touching companion skills is out of scope here. Tracked for a future PR.
-- **`pmm_delete_auto_wake_cron` helper** — the cron teardown block is duplicated in `-stop/SKILL.md`, `-wake/SKILL.md`, and now this file (Step 0a). A single shared helper (bash script or reference) would prevent lock-step edits. Tracked for a future PR.
+- ~~**`pmm_delete_auto_wake_cron` helper**~~ — **resolved by issue #827**, which removed the auto-wake cron entirely. The teardown block it would have factored no longer exists in any of the three files.
 - **Full FU-2 ≤150-line dispatcher collapse** — this bounded refactor brings SKILL.md to ~400 lines. The full collapse to ≤150 lines (with a script-side no-change short-circuit) remains deferred until the `/babysit-pr` delegation contract (#456/#460) is settled, per `token-efficiency-audit-2026-07.md` FU-2.
 - **Per-PR `/babysit-pr` delegation** (#456/#460) — replacing Step 3's inline per-PR decision tree with one `/babysit-pr <PR>` dispatch per PR. The table, discovery, idempotency, and backoff scaffolding in SKILL.md stay unchanged until this lands.


### PR DESCRIPTION
## **User description**
Closes #827

## What & why

`CronCreate` is in-memory and dies at session exit — `durable: true` is a no-op. Three features were designed around cross-session durability it never provided. PR #825 corrected the docs and deferred the behavioral fix to this ticket.

**The investigation the issue asked for (design point 1):** the harness *does* now provide a genuinely durable scheduler — `mcp__scheduled-tasks__*` (`/schedule`), stored on disk at `~/.claude/scheduled-tasks/{taskId}/SKILL.md`, surviving session turnover with no 7-day expiry. **All three features decline it**, for two reasons:

1. **Merge authority.** `/babysit-pr` and `/pr-monitor-and-manage` auto-dispatch `/wrap`, which squash-merges. A scheduled task runs in a *fresh unattended session*, so adopting it would convert "watch this PR while I'm here" into "merge my PRs on a cron, forever" — an authorization escalation behind a flag (`--durable`) that reads as a scheduling detail.
2. **The durable record was never a job.** `.pmm.paused_at` and `~/.claude/harness-audit/last-run.json` are already on disk. Reconciling them at session start is *more* reliable than any scheduler: sessions start many times a day, with no job id to orphan, no expiry to lapse, no MCP dependency to be absent headless.

Recorded in [cross-session-durability.md](.claude/reference/cross-session-durability.md) so it isn't re-litigated, including when adopting it *would* be reasonable.

## One shared mechanism

New [`session-scheduling-reconcile.sh`](.claude/scripts/session-scheduling-reconcile.sh), called by the existing `SessionStart` hook: purges bookkeeping that cannot have survived (`polling_jobs[]`, `auto_wake_cron_id`, `cron_job_id`, orphaned watchers) and surfaces what did (an audit month come due, a paused fleet).

| Feature | Decision | Result |
|---|---|---|
| `/babysit-pr --durable` | **drop** | Accepted-and-ignored so an old chip payload doesn't hard-error. Deletes the arm / re-arm / fail-closed-teardown cron paths here and in `/babysit-pr-stop`. |
| `/pr-monitor-and-manage --auto-wake` | **reframe** | Keeps its name and cadence knob; arms a `/loop`. Deletes `.pmm.auto_wake_cron_id` and the teardown triplicated across `-stop`, `-wake`, and `pmm-lifecycle.md` — closing that file's own deferred follow-up by *removing* the duplication rather than factoring it. PR #843's dispatcher/references structure preserved. |
| `/harness-audit` daily registration | **reframe** | The "register daily to beat the 7-day expiry" cadence becomes a session-start watermark check. `--arm`/`--stop` toggle `nudge_enabled`. |

## Two defects found in self-review and fixed

Both automated CLIs were rate-limited, so an independent adversarial pass substituted. It found two real bugs, both now fixed with regression tests:

- **Live watcher reaped on compact.** `SessionStart` also fires on compact/resume/fork, so a naive "last tick older than now" test kills a watcher that is genuinely alive — and its next tick then T0-terminates for good. Liveness now reuses `/babysit-pr`'s own A2 freshness window, `max(3× cadence, 30m)`, so the two can never disagree about the same watcher.
- **Lock bypass.** The first draft wrote `session-state.json` with a raw `jq`+`mv`, which `handoff-files.md` forbids and which clobbers a concurrent `--set` holding the lock. Writes now go through `session-state.sh` as one atomic multi-`--set` call.

Also hardens the hook's JSON: raw git progress output in `$errors` embeds control characters that produced invalid JSON on a first run in a fresh `HOME`, silently dropping the whole session-start context block.

## Test plan

- [x] `session-scheduling-reconcile.sh` purges `polling_jobs[]`, `.pmm.auto_wake_cron_id`, and every `babysit.cron_job_id`
- [x] A watcher ticking 1–29m ago (5m cadence) **survives** a compact-fired run; one 45m stale is reclaimed; the window scales with the watcher's own cadence
- [x] Writes go through `session-state.sh`, never a raw `mv` over the state file; a concurrent writer's field survives the purge
- [x] Unrelated state values survive (across `session-state.sh`'s legacy→scoped migration)
- [x] Idempotent — a second run purges nothing; `--check` writes nothing
- [x] The legacy top-level `.prs` layout is reconciled, not skipped
- [x] harness-audit nudge fires when due, is silent when the month is audited, names a pending chip instead of re-offering, and is silenced by `nudge_enabled:false`
- [x] A paused PR fleet is surfaced from `.pmm.paused_at`
- [x] Fail-soft: exits 0 with the state file absent, corrupt (and leaves it untouched), watermark corrupt, or an unknown flag
- [x] `SessionStart` hook emits valid JSON on a first run in a fresh `HOME` and forwards the notices
- [x] Full suite green: **54** bash suites (the new hook-gate test auto-discovered), 142 Python tests, `rule-lint`
- [x] Rule corpus ≤ cap: **11732** words vs cap 11749 (this PR is net −12; the post-rebase number is higher only because `main` grew by 11 words underneath it — re-measured after the rebase per the known drift trap)
- [x] No cross-session durability claim reintroduced anywhere

## [COVERAGE] none — both local review CLIs unavailable

- **CodeAnt:** HTTP 403 (undocumented daily cap) on both the initial run and the single sanctioned retry. Dropped for the session per `cr-local-review.md`; never `logout`/`login`. It also capped at 15 of 24 changed files.
- **CodeRabbit CLI:** `rate_limit` — free-OSS tier exhausted, 36-minute reset.

Substituted an independent adversarial review pass (findings above). The GitHub App reviewers have quotas independent of their CLIs and still gate the merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added session-start scheduling reconciliation to clean up stale polling state while preserving active watchers.
  - Added safe dry-run and JSON reporting options for scheduling checks.
  - Updated monitoring and audit workflows to use session-scoped `/loop` polling and re-scans.

- **Bug Fixes**
  - Improved handling of stale or invalid scheduling data without disrupting live activity.
  - Stopping monitoring now clearly distinguishes immediate cancellation from cooperative shutdown.

- **Documentation**
  - Clarified scheduling, persistence, pause/resume, and legacy cron behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Replace unreliable cross-session scheduling with session-start recovery

### What Changed
- PR watchers and paused fleet checks now use session-scoped loops with durable on-disk state instead of pretending `CronCreate` jobs survive sessions.
- At true session startup, stale polling records and abandoned watchers are cleared; resume, compact, and clear events leave live scheduling state untouched.
- Session startup surfaces due harness audits and paused PR fleets so users can resume work without relying on an expired or missing job.
- `/babysit-pr --durable` remains accepted for compatibility but no longer changes behavior; `/pr-monitor-and-manage --auto-wake` uses a low-frequency loop.
- Stable polling now clearly distinguishes slowing down from stopping: repeated unchanged results widen the cadence, while long or user-blocked streaks stop the poll.
- Added coverage for startup safety, watcher freshness, durable-state reconciliation, failure handling, and polling backoff guidance.

### Impact
`✅ Fewer orphaned PR watchers`
`✅ Reliable recovery of paused fleets across sessions`
`✅ Fewer missed monthly audit reminders`
`✅ Clearer polling stop and backoff behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
