### PR TITLE
feat(#873): claim an issue at pick time so two threads can't work it at once

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -25,6 +25,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `wrap-fixpr-delegation.md` — `/wrap` Step 2.1 → full `/fixpr` recovery handoff contract
 - `state-file-contracts.md` — expanded scoping, write-lock, migration, and field-type mechanics for `session-state.json` + handoffs (`handoff-files.md`; #625, #638, #639, #651, #655, #682, #687, #704)
 - `authorship-guard.md` — `pr-authorship.sh` exit-code semantics, the three shared-script fail-safes, and `--allow-nonauthor` override plumbing (`safety.md` §Authorship; #733)
+- `issue-claim.md` — `issue-claim.sh` mechanism: the three GitHub claim artifacts, why the holder token is finer-grained than the login, block-at-holder / release-at-account, staleness, the `--allow-claimed` override, and every call site (`issue-planning.md` step 0; #873)
 - `autofile-dedup.md` — duplicate-check thresholds for autonomous issue filing (`/wrap` Phase 3, `/harness-audit` Step 7); strong/weak/none classification, exact-artifact dedup, and the comment-vs-file rule
 - `harness-audit.md` — `/harness-audit` design record: two-pass split, the step-up chip that preserves the top-tier spawn invariant, the model-fleet resolver, dual watermarks, and the out-of-repo report default (#770)
 - `graphql-thread-resolution.md` — full GraphQL queries/mutations for resolving PR review threads

--- a/.claude/reference/chip-launching.md
+++ b/.claude/reference/chip-launching.md
@@ -117,6 +117,26 @@ A chip launches an independent thread that cannot see any sibling, so the launch
 
 **Click time, never offer time.** Offering a chip is not launching one (`/start-issue` "Execution boundary"), and a chip may sit unclicked for days — claiming at offer time would park the issue for a thread that never starts. This claims at exactly the moment work begins. It also means two chips for the same issue are harmless: whichever is clicked first holds the claim, and the second stops.
 
+### Claim line (shared contract — reproduce verbatim)
+
+Emitters spell out their own payload templates and copy only the **named** sections of this file, so a rule that lives only in the prose above never reaches a generated chip. The claim therefore ships as a `### Constraints` bullet, exactly like the merge-authority line. **Every issue-bearing block, every emitter, both delivery modes.**
+
+Two forms — pick by whether the emitter already holds the claim:
+
+**Form A — emitter holds no claim** (`/pm`, `/prompt`, `/wave`, `/issue-maker`): the launched thread takes it.
+
+```text
+- Claim the issue before anything else: run `.claude/scripts/issue-claim.sh <N> --check`, and if it clears, `.claude/scripts/issue-claim.sh <N> --claim`. Do this after the model-guard check and before any repo read, edit, or planning. Exit 1 (`claimed`) or 4 (`unknown`) → stop and report the claim rather than proceeding; `stale` → say so and continue. If `--claim` itself fails, stop — a passing check is not a held claim.
+```
+
+**Form B — emitter already holds the claim** (`/start-issue`, which claims at its Step 2b): the launched thread **inherits** that holder instead of competing with it.
+
+```text
+- This issue is already claimed for you (holder `{CLAIM_HOLDER}`). Re-affirm it before anything else — `.claude/scripts/issue-claim.sh <N> --claim --holder "{CLAIM_HOLDER}"` — after the model-guard check and before any repo read, edit, or planning. It is a no-op that confirms the claim is still yours; a non-zero exit means you do NOT hold it, so stop and report rather than proceeding.
+```
+
+**Why Form B exists.** A `/start-issue` run and the thread it hands off to are **one pickup of the issue, handed over** — not two independent threads racing. Without the inherited holder the launched thread would read its own predecessor's claim as a foreign one, exit 1, and refuse to start the work the chip exists to do. Passing the holder makes the re-claim a no-op (`mine`) while a genuinely different thread still sees `claimed`. `{CLAIM_HOLDER}` is the value the emitter passed to its own `--claim`.
+
 This does not touch the placement rule above — the claim instruction is *content following* the preamble, so the `**Model:**`-first / `**Effort:**`-next / no-blank-line ordering that `chip-model-guard-lint.sh` enforces is unchanged. Contract: `.claude/reference/issue-claim.md` (issue #873).
 
 ### Literal vs resolved model names (emitter classes)

--- a/.claude/reference/chip-launching.md
+++ b/.claude/reference/chip-launching.md
@@ -102,6 +102,23 @@ active model, so the check relies on the model naming itself accurately.
 
 **Placement rule:** for every emitter, the `**Model:**` line is the first line of the `prompt` payload, the `**Effort:**` line is next, and this preamble is the content that immediately follows them — see each skill's Step for how its own template maps onto this shape.
 
+## Claim the issue on click (not on offer)
+
+A chip launches an independent thread that cannot see any sibling, so the launched thread claims the issue itself. Every issue-bearing `prompt` payload instructs the thread to run, as its **first actions after the MODEL GUARD preamble and before any repo read, file edit, or planning**:
+
+```bash
+.claude/scripts/issue-claim.sh <N> --check      # then, if it clears:
+.claude/scripts/issue-claim.sh <N> --claim
+```
+
+- `claimed` (exit 1) or `unknown` (exit 4) → the thread **stops** and reports the claim instead of proceeding. `unknown` never reads as permission.
+- `stale` (exit 0) → surface the warning and proceed; `--claim` takes the claim over.
+- `mine` (exit 0) → no-op; a resumed or post-compaction thread re-runs this safely.
+
+**Click time, never offer time.** Offering a chip is not launching one (`/start-issue` "Execution boundary"), and a chip may sit unclicked for days — claiming at offer time would park the issue for a thread that never starts. This claims at exactly the moment work begins. It also means two chips for the same issue are harmless: whichever is clicked first holds the claim, and the second stops.
+
+This does not touch the placement rule above — the claim instruction is *content following* the preamble, so the `**Model:**`-first / `**Effort:**`-next / no-blank-line ordering that `chip-model-guard-lint.sh` enforces is unchanged. Contract: `.claude/reference/issue-claim.md` (issue #873).
+
 ### Literal vs resolved model names (emitter classes)
 
 Most emitters write the recommended model straight into the `**Model:**` line, because the recommendation is a judgment about *that issue* — a small mechanical fix and a subtle concurrency bug want different tiers, and neither answer comes from a lookup table.
@@ -197,6 +214,8 @@ Withdraw a tracked chip via `mcp__ccd_session__dismiss_task` (pass the recorded 
 2. **Superseded** — a later batch replaced the suggestion.
 3. **Re-planned** — the issue's plan or scope changed, so the chip's prompt is stale. Spawn the replacement chip *first*, then dismiss the old one.
 4. **Issue closed** — the underlying issue is closed (merged, resolved, declined, or duplicate). The chip's work no longer exists to launch; dismiss with no replacement. Distinct from trigger 1: a closed issue may never have had an *open* PR (e.g. "won't fix" or duplicate closures), so trigger 1 alone doesn't reliably catch it. Added by the [#838](https://github.com/auerbachb/claude-code-config/issues/838) sweep, where it was 28/28 of the stale chips found.
+
+   **Also release the claim here** — `.claude/scripts/issue-claim.sh <N> --release` alongside the `dismiss_task`. A close *without* a merged PR is precisely the terminal state `/wrap` never sees, so nothing else would drop the claim and it would sit until it aged out (issue #873). Harmless when no claim is held: `--release` is idempotent, and it never touches a collaborator's claim.
 
 **Fail-closed:** only clear tracked chip state once the dismiss outcome is known. Distinguish the two non-error outcomes from a real failure:
 

--- a/.claude/reference/issue-claim.md
+++ b/.claude/reference/issue-claim.md
@@ -1,0 +1,100 @@
+# Issue Claims — Mechanism and Rationale (issue #873)
+
+Detail for the claim rule in `.claude/rules/issue-planning.md`. Not auto-loaded; the rule file carries the binding behavior, this file carries the mechanism.
+
+## The problem
+
+Work gets picked up from several independent places — a `/pm` thread running issues inline, a click-to-launch chip, `/start-issue` in a fresh tab, or a plain "go work on #167". None of those threads can see each other; the only thing they share is GitHub.
+
+Every entry path *did* guard itself, but on the wrong question: **"does an open PR exist for this issue?"** A PR is the *last* artifact a thread produces. Between picking an issue and opening its PR there is a plan-and-code window that routinely runs half an hour or more, and for that entire window every other thread's check comes back clean. Two threads then work the same issue in good faith, and the collision only surfaces when the second PR appears. The cost is not a merge conflict — it is two full pipelines (planning, coding, CI, reviewer quota) buying one issue's worth of progress, plus a PR to throw away.
+
+`.claude/scripts/issue-claim.sh` stakes the claim at **pick** time instead.
+
+## Artifacts
+
+GitHub is the only store. There is no local claim state — a local file by definition cannot see a sibling thread, let alone another machine.
+
+| Artifact | Carries | Read by |
+|---|---|---|
+| `in-progress` label | the coarse "someone is working this" bit | any issue list, `/wave`'s batch pre-filter, a human skimming the backlog |
+| `@me` assignee | ownership at **account** level (#732) | `--release`'s ownership test |
+| claim comment `<!-- claude-claim: {"holder":…,"login":…} -->` | **holder** identity + the claimed-at timestamp (`created_at`) | `--check`'s `mine` vs `claimed` decision |
+
+The label is created idempotently on first use (`gh label list` existence check, then `gh label create … || true`) — the repo had no such label before this feature.
+
+## Why a holder token, not just the login
+
+This is the one place the implementation deliberately departs from the CodeRabbit plan, which defined `mine` as "label present **and** viewer in assignees".
+
+The failure this feature exists to prevent is **two Claude threads belonging to the same human**. Both authenticate as the same GitHub login, so an assignee-only test answers "yes, mine" in the second tab and blocks nothing — the feature would be inert in exactly its motivating case. The claim comment therefore records a holder token, and `mine` means *this thread*, not *this account*.
+
+`.claude/scripts/tests/issue-claim.test.sh` pins this: substituting the login-level comparison makes scenario (2) fail.
+
+**Holder resolution:** `--holder ID` → `$CLAUDE_CLAIM_HOLDER` → `$CLAUDE_SESSION_ID` → `<hostname>:<git toplevel>`.
+
+The default is honest about its granularity rather than hiding it: two threads sharing one checkout resolve to one holder. That is acceptable because `CLAUDE.md` mandates a worktree per thread, so the mandated workflow always yields distinct holders. A caller holding a real session id should still pass `--holder`.
+
+## Block at holder level, release at account level
+
+A deliberate asymmetry:
+
+- **`--check` / `--claim` compare holders**, so a sibling thread of yours is blocked. That is the whole point.
+- **`--release` compares logins**, so a terminal state reached by a *different* thread of yours — a Phase C merger, a `/wrap` run from another worktree — still clears the claim instead of leaking it.
+
+Releasing your own account's claim is always safe. #732 protects a *collaborator's* claim, and no action here ever touches one: `--release` removes only the viewer's own assignment and only the viewer's own claim comments, and leaves a collaborator's label in place.
+
+## Verdicts and exit codes
+
+| Verdict | Meaning | Exit | Caller does |
+|---|---|---|---|
+| `unclaimed` | no label, no claim comment | 0 | proceed |
+| `mine` | claim comment holder == this holder | 0 | proceed (re-claim is a no-op) |
+| `stale` | foreign holder, older than `CLAIM_STALE_HOURS` | 0 | **warn** and proceed; `--claim` takes it over |
+| `claimed` | foreign holder, fresh | 1 | skip, naming the claim |
+| `unknown` | any indeterminate `gh` result | 4 | skip — treat exactly as `claimed` |
+
+Exit codes mirror `pr-authorship.sh` (`2` usage, `3` not found) so the two guards read the same way at a call site.
+
+**Fail-closed** is the rule that matters most: a `gh` failure, an unparseable issue, or a claim with no readable timestamp all resolve to a live claim, never to "startable". An `unknown` verdict never reads as permission.
+
+## Staleness
+
+A thread that dies mid-task must not poison the issue forever, so a claim ages out — `CLAIM_STALE_HOURS`, default **4**. Long enough to survive a slow CR plan plus a long coding phase; short enough that a dead thread does not park an issue for a day.
+
+Stale is **surfaced as a warning, never a block**: `--check` returns `stale` with exit **0**. The timestamp comes from the claim comment's `created_at`, falling back to the most recent `labeled` event for `in-progress` on the issue timeline — which is what makes a label applied by hand, with no claim comment, still expirable rather than permanent.
+
+Timestamp parsing is done arithmetically in `awk` rather than by shelling out to `date -d` / `date -j`, because GNU and BSD `date` disagree on both spellings.
+
+## Override
+
+`--allow-claimed` proceeds past a fresh foreign claim **and says so** on stderr.
+
+It is only ever an explicit per-issue, per-session instruction from the user in chat ("start it anyway") — never a config default, never inferred from context, never carried forward to the next issue. The same shape as the authorship override in `.claude/rules/safety.md`. The flag is rejected with a usage error on `--check` and `--release`, where it would otherwise sit silently inert; a silently-inert override flag is how an override becomes a default.
+
+## Call sites
+
+| Path | Where |
+|---|---|
+| `/start-issue` | Step 2b — after reading the issue, **before** CR-plan polling and worktree creation |
+| `/subagent` | Step 6.0, alongside the existing open-PR check; `--claim` before spawning Phase A |
+| chip-launched thread | first action in the `prompt`, after the MODEL GUARD preamble, before any repo read |
+| ad-hoc "work on #N" | `.claude/rules/issue-planning.md` step 0 |
+| `/wave` | Step 2 candidate filter (see batching below) |
+| `/wrap` | after Step 2.4's squash merge succeeds — `--release` |
+| `admin-merge.sh` | after each `FINAL_MERGED == true` — `--release` |
+| chip stale-hygiene trigger 4 | issue closed without a merged PR — `--release` |
+
+### `/wave` batching
+
+Running `--check` per candidate over a 30-issue backlog would be ~90 API calls. `/wave` instead makes **one** `gh issue list --label in-progress --json number` call and runs the helper only for candidates in that (usually tiny) intersection. Candidates outside it cannot hold a claim, because the label is written before the claim comment.
+
+### Release is best-effort at merge time
+
+`/wrap` and `admin-merge.sh` release **after** the merge has already succeeded. A failed release is a warning there, never a non-zero exit — an unreleased claim ages out on its own within `CLAIM_STALE_HOURS`, whereas failing an already-completed merge would be a much worse outcome.
+
+## Relationship to neighbouring issues
+
+- **#756** serializes *different* issues that share a file. This covers the *same* issue picked twice; no overlap filter addresses that.
+- **#636** — `/wave`'s launch-time filtering, whose dedup this strengthens.
+- **#732** — authorship scope. A collaborator's claim is context, never something to overwrite.
+- The same-machine `git worktree list` guard in `/start-issue` stays as a backstop. It only covers one entry path, on one machine, and only after the worktree stage — it is not a substitute for a claim other threads can see.

--- a/.claude/rules/issue-planning.md
+++ b/.claude/rules/issue-planning.md
@@ -1,33 +1,22 @@
 # Issue Flow
 
-> **Always:** Create a GitHub issue before any code work. Merge CR's plan into the issue body before coding. A skill may open issues autonomously — reported in-thread only when filing is the ask (`/issue-maker`: number, title, rationale, link); incidental filings are recorded, not narrated.
-> **Ask first:** Never — issue creation and planning are autonomous. Filing is reversible; closing an unwanted issue is the escape hatch, not a confirmation prompt.
-> **Never:** Skip the issue. Start coding without a plan. Post the plan as scattered comments instead of editing the issue body. Open an issue without recording it.
+> **Always:** Create a GitHub issue before any code work. Merge CR's plan into the issue body before coding. A skill may open issues autonomously — reported in-thread only when filing is the ask; incidental filings are recorded, not narrated.
+> **Ask first:** Never — issue creation and planning are autonomous. Filing is reversible — closing an unwanted issue is the escape hatch.
+> **Never:** Skip the issue. Start coding without a plan. Post the plan as scattered comments instead of editing the issue body. Open an issue without recording it. Start a claimed issue absent an explicit chat override.
 
 ## Issue Planning Flow — Procedural Checklist
 
 > **Username note:** `coderabbitai` (no suffix) for issue comments; `coderabbitai[bot]` for PR reviews.
 
+0. **GATE: Claim the issue** — `.claude/scripts/issue-claim.sh N --check`, then `--claim`, at **pick** time: before planning, before the worktree, every entry path, freeform "work on #N" included. `claimed`/`unknown` → **STOP** and name the claim (`unknown` is never permission); `stale` → warn and proceed; `mine` → no-op. Release on merge, close, or abandonment. Override only on the user naming the issue in chat → `--allow-claimed`, stated as an override. Detail: `.claude/reference/issue-claim.md`.
 1. **Draft the issue locally** — title, body, acceptance criteria, context. Do NOT post yet.
-2. **Create the issue** via `gh issue create`. The `.github/workflows/cr-plan-on-issue.yml` workflow auto-comments `@coderabbitai plan` (skips bot-created issues). Only post manually if the workflow visibly failed.
-3. **Check for an existing CR plan** — `.claude/scripts/cr-plan.sh N`; exit 0 = substantive plan found (filters out ack-only replies and the issue-enrichment / Issue-Planner-checkbox boilerplate — real plans need actual sections/steps).
-4. **If no CR plan, request/poll:**
-   - If `@coderabbitai plan` was already requested: `.claude/scripts/cr-plan.sh N --poll 5`.
-   - Else: post `@coderabbitai plan`, then `.claude/scripts/cr-plan.sh N --poll 5`.
-   - 5-min timeout: log "CR plan unavailable" and continue. Claude's plan + issue-body merge are still required.
+2. **Create the issue** via `gh issue create`. CI auto-comments `@coderabbitai plan` (`cr-plan-on-issue.yml`; skips bot-created issues). Only post manually if that workflow visibly failed.
+3. **Check for an existing CR plan** — `.claude/scripts/cr-plan.sh N`; exit 0 = substantive plan found (ack-only replies and enrichment boilerplate are filtered out; real plans need actual sections/steps — `cr-plan.sh --help`).
+4. **If no CR plan:** post `@coderabbitai plan` unless already requested, then `.claude/scripts/cr-plan.sh N --poll 5`. On 5-min timeout log "CR plan unavailable" and continue — Claude's plan + issue-body merge are still required.
 5. **Build Claude's plan** — explore codebase, design approach. Always required, regardless of CR.
 6. **Merge into the issue body** — one canonical document for the coding agent:
-   - If CR plan exists: incorporate anything Claude missed (files, edge cases, risks). Best of both.
-   - Else: Claude's plan as-is.
-   - `gh issue edit --body` replaces the entire body — fetch-concatenate-edit:
-
-   ```bash
-   current_body="$(gh issue view N --json body --jq .body)"
-   gh issue edit N --body "${current_body}
-
-   ## Implementation Plan
-   <merged plan here>"
-   ```
+   - CR plan exists: incorporate anything Claude missed (files, edge cases, risks). Else: Claude's plan as-is.
+   - `gh issue edit --body` replaces the entire body — fetch, concatenate, then edit. Snippet (with the re-run duplicate strip): `/start-issue` Step 5.
 7. **GATE: Verify the implementation plan is in the issue body.**
 
    ```bash
@@ -35,11 +24,9 @@
    ```
 
    If it fails: **STOP** — go back and merge before coding.
-8. **Comment confirming the merge** with source attribution — `gh issue comment N --body "Implementation plan merged into issue body (<source>). Ready for implementation."` where `<source>` is "Claude's analysis + CodeRabbit's recommendations" or "Claude's analysis only — CodeRabbit plan was not available".
+8. **Comment confirming the merge**, attributing the source — `Implementation plan merged into issue body (<source>). Ready for implementation.`, where `<source>` names Claude's analysis and whether CodeRabbit's plan was available.
 9. **Start coding only after the gate passes** — create branch `issue-N-short-description`, read the issue body (not scattered comments) as canonical spec, implement, then run Local CodeRabbit Review Loop (`cr-local-review.md`) + Post-Clean checklist.
-
-> Do NOT jump to step 9 without passing step 7. The `## Implementation Plan` section in the issue body is the canonical spec for the coding work.
 
 ## Capture-only issue threads
 
-For capture-only threads (just opening issues), use `/issue-maker`. The plan-merge gate (steps 5–7) runs later at `/start-issue` time.
+Capture-only threads (just opening issues) use `/issue-maker`; steps 0 and 5–7 run later at `/start-issue` time.

--- a/.claude/scripts/admin-merge.sh
+++ b/.claude/scripts/admin-merge.sh
@@ -104,6 +104,25 @@ printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >>
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# release_issue_claim — drop the pick-time claim on the PR's linked issue once
+# the merge is confirmed (issue #873). A merged PR is a terminal state, so the
+# issue becomes startable again.
+#
+# BEST-EFFORT BY DESIGN: this only ever runs AFTER a merge has already landed,
+# so it must never change the exit status. An unreleased claim ages out on its
+# own within CLAIM_STALE_HOURS; failing an already-completed merge would be the
+# far worse outcome. Every failure path here is a warning.
+release_issue_claim() {
+  local issue
+  [[ -x "$SCRIPT_DIR/pr-issue-ref.sh" && -x "$SCRIPT_DIR/issue-claim.sh" ]] || return 0
+  issue="$("$SCRIPT_DIR/pr-issue-ref.sh" "$PR_NUMBER" 2>/dev/null || true)"
+  [[ -n "$issue" ]] || return 0
+  if ! "$SCRIPT_DIR/issue-claim.sh" "$issue" --release >/dev/null 2>&1; then
+    echo "WARNING: could not release the claim on issue #$issue — it will expire on its own. Clear it early with: $SCRIPT_DIR/issue-claim.sh $issue --release" >&2
+  fi
+  return 0
+}
+
 print_usage() {
   awk 'NR == 1 { next } /^$/ { exit } { print }' "$0" | sed 's/^# \{0,1\}//'
 }
@@ -665,6 +684,7 @@ if [[ "$MODE" == "auto-plain" ]]; then
     echo "WARNING: PR does not report state=MERGED after retrying — the merge may not have completed (e.g. a queued/deferred merge). Verify manually: gh pr view $PR_NUMBER --json state,mergedAt" >&2
     exit 7
   fi
+  release_issue_claim
 
   # After-the-fact report (issue #754): which PR, which shape, and the
   # clean-BEHIND evidence that authorized the bypass. Relay this to the user.
@@ -726,6 +746,7 @@ if [[ "$MODE" == "execute" ]]; then
       echo "WARNING: PR does not report state=MERGED after retrying — verify manually: gh pr view $PR_NUMBER --json state,mergedAt" >&2
       exit 7
     fi
+    release_issue_claim
     exit 0
   fi
 
@@ -792,6 +813,7 @@ if [[ "$MODE" == "execute" ]]; then
     echo "WARNING: enforce_admins did not report enabled=true — verify manually." >&2
     exit 7
   fi
+  release_issue_claim
   exit 0
 fi
 

--- a/.claude/scripts/issue-claim.sh
+++ b/.claude/scripts/issue-claim.sh
@@ -427,21 +427,35 @@ if [[ "$ACTION" == "release" ]]; then
   fi
 
   RELEASE_ERRORS=0
-  EDIT_ARGS=()
-  [[ "$HAS_LABEL" == "true" ]] && EDIT_ARGS+=(--remove-label "$CLAIM_LABEL")
-  [[ " $ASSIGNEES " == *" $VIEWER "* ]] && EDIT_ARGS+=(--remove-assignee "$VIEWER")
-  if (( ${#EDIT_ARGS[@]} > 0 )); then
-    gh issue edit "$ISSUE_NUMBER" "${EDIT_ARGS[@]}" >/dev/null 2>"$ERR_FILE" || RELEASE_ERRORS=1
-  fi
 
-  # Delete every claim comment written by this account — not just the newest —
-  # so a re-stamped claim never leaves an older marker behind to be read as a
-  # live claim by the next thread.
+  # ORDER MATTERS: comments first, label last.
+  #
+  # A release can fail part-way, and the two possible half-states are not
+  # equally safe. The `in-progress` label is the cheap index every batch reader
+  # uses to narrow a backlog before calling --check at all (`/wave` Step 2), so
+  # a claim comment left WITHOUT the label is invisible to those readers and
+  # reads as unclaimed. The reverse — label without comment — still shows up in
+  # every batch scan and still blocks. Removing the label last makes the label a
+  # superset of the claim at every intermediate point, so a partial failure
+  # degrades toward over-blocking (which expires on its own) rather than toward
+  # a missed claim (which does not).
   while IFS= read -r cid; do
     [[ -z "$cid" ]] && continue
     gh api -X DELETE "$REPO_PREFIX/issues/comments/$cid" >/dev/null 2>"$ERR_FILE" || RELEASE_ERRORS=1
   done < <(printf '%s' "$CLAIM_COMMENTS" | jq -r --arg v "$VIEWER" \
     '.[] | select((.user.login // "") == $v) | .id' 2>/dev/null || true)
+
+  # Ordering alone is not enough — the label must also be WITHHELD when a comment
+  # delete failed. Dropping it anyway would produce exactly the comment-without-
+  # label state the ordering exists to prevent, just one step later.
+  if (( ! RELEASE_ERRORS )); then
+    EDIT_ARGS=()
+    [[ "$HAS_LABEL" == "true" ]] && EDIT_ARGS+=(--remove-label "$CLAIM_LABEL")
+    [[ " $ASSIGNEES " == *" $VIEWER "* ]] && EDIT_ARGS+=(--remove-assignee "$VIEWER")
+    if (( ${#EDIT_ARGS[@]} > 0 )); then
+      gh issue edit "$ISSUE_NUMBER" "${EDIT_ARGS[@]}" >/dev/null 2>"$ERR_FILE" || RELEASE_ERRORS=1
+    fi
+  fi
 
   if (( RELEASE_ERRORS )); then
     fail_closed "release of issue #$ISSUE_NUMBER partially failed ($(tr '\n' ' ' < "$ERR_FILE"))"
@@ -507,7 +521,22 @@ CLAIM_BODY="$(printf '%s\n\n%s\n' \
   "<!-- $CLAIM_MARKER: $(jq -cn --arg h "$HOLDER" --arg l "$VIEWER" '{holder: $h, login: $l}') -->")"
 
 if ! gh issue comment "$ISSUE_NUMBER" --body "$CLAIM_BODY" >/dev/null 2>"$ERR_FILE"; then
-  fail_closed "claim markers were written on issue #$ISSUE_NUMBER but the claim comment failed ($(tr '\n' ' ' < "$ERR_FILE")); the claim carries no holder or timestamp"
+  # ROLL BACK the label + assignee this run added. A half-written claim (marker
+  # present, holder absent) is worse than no claim: `mine` requires a parsed
+  # claim comment, so the very thread that wrote the label reads its own claim
+  # back as a foreign `claimed` and cannot re-claim without --allow-claimed —
+  # while every other thread stays blocked too. Leave the issue as we found it.
+  COMMENT_ERR="$(tr '\n' ' ' < "$ERR_FILE")"
+  ROLLBACK_ARGS=()
+  [[ "$HAS_LABEL" != "true" ]] && ROLLBACK_ARGS+=(--remove-label "$CLAIM_LABEL")
+  [[ " $ASSIGNEES " != *" $VIEWER "* ]] && ROLLBACK_ARGS+=(--remove-assignee "$VIEWER")
+  if (( ${#ROLLBACK_ARGS[@]} == 0 )); then
+    fail_closed "could not post the claim comment on issue #$ISSUE_NUMBER ($COMMENT_ERR); this run added no marker of its own, so nothing was left behind"
+  fi
+  if gh issue edit "$ISSUE_NUMBER" "${ROLLBACK_ARGS[@]}" >/dev/null 2>&1; then
+    fail_closed "could not post the claim comment on issue #$ISSUE_NUMBER ($COMMENT_ERR); the label/assignee this run added were rolled back, so the issue is unclaimed — retry"
+  fi
+  fail_closed "could not post the claim comment on issue #$ISSUE_NUMBER ($COMMENT_ERR) AND could not roll the label/assignee back; the issue carries a holderless marker that expires in ${STALE_HOURS}h — clear it with: issue-claim.sh $ISSUE_NUMBER --release"
 fi
 
 CLAIMANT="$VIEWER"

--- a/.claude/scripts/issue-claim.sh
+++ b/.claude/scripts/issue-claim.sh
@@ -1,0 +1,523 @@
+#!/usr/bin/env bash
+# issue-claim.sh — Claim an issue at PICK time so two threads can't work it at once (issue #873).
+#
+# PURPOSE
+#   Every entry path that starts work on an issue (/start-issue, /subagent Step
+#   6.0, a chip-launched coding thread, an ad-hoc "work on #N") used to guard
+#   itself by asking "is there an open PR for this issue?" — but a PR is the LAST
+#   artifact a thread produces. For the whole plan-and-code window (routinely
+#   30+ minutes) that check comes back clean, so a second thread picks the same
+#   issue in good faith. This script stakes the claim when work STARTS.
+#
+#   GitHub is the only source of truth. There is no local claim state — a
+#   local file by definition cannot see a sibling thread, let alone another
+#   machine. The claim is written as three GitHub artifacts:
+#
+#     1. the `in-progress` label   — the coarse "someone is working this" bit,
+#                                    visible in every issue list at a glance
+#     2. the `@me` assignee        — ownership at ACCOUNT level (issue #732)
+#     3. a claim comment carrying  — HOLDER identity + the "claimed at" timestamp
+#        <!-- claude-claim: {...} -->
+#
+# WHY A HOLDER, NOT JUST A LOGIN
+#   The failure this script exists to prevent is two Claude threads belonging to
+#   the SAME human. Both authenticate as the same GitHub login, so "is the
+#   assignee me?" answers "yes" in both tabs and blocks nothing. The claim
+#   comment therefore records a holder token, and `mine` means *this thread*,
+#   not *this account*.
+#
+#   Holder resolution order:
+#     --holder ID  ->  $CLAUDE_CLAIM_HOLDER  ->  $CLAUDE_SESSION_ID
+#                  ->  <hostname>:<git toplevel>     (default)
+#   The default is honest about its granularity: two threads sharing one
+#   checkout resolve to one holder. That is acceptable because CLAUDE.md
+#   mandates a worktree per thread, so the mandated workflow always yields
+#   distinct holders — but a caller that has a real session id should pass it.
+#
+# BLOCK AT HOLDER LEVEL, RELEASE AT ACCOUNT LEVEL (deliberate asymmetry)
+#   --check/--claim compare HOLDERS, so a sibling thread of yours is blocked.
+#   --release compares LOGINS, so a terminal state reached by a different thread
+#   of yours (a Phase C merger, a /wrap in another worktree) still clears the
+#   claim instead of leaking it. Releasing your own account's claim is always
+#   safe; #732 only protects a *collaborator's* claim, and that is still never
+#   touched by any action here.
+#
+# STALE IS A WARNING, NEVER A PERMANENT BLOCK
+#   A thread that dies mid-task must not poison the issue forever. A claim older
+#   than CLAIM_STALE_HOURS (default 4) reports `stale` and exits 0 — startable.
+#   The caller surfaces the warning and proceeds; --claim takes it over.
+#
+# FAIL-CLOSED
+#   Any indeterminate `gh` result (viewer lookup, issue fetch, comment fetch,
+#   timeline fetch) resolves to verdict `unknown`, exit 4. Callers MUST treat
+#   `unknown` exactly like `claimed`: skip with a visible note. An `unknown`
+#   verdict NEVER reads as permission.
+#
+# OVERRIDE
+#   --allow-claimed proceeds past a fresh foreign claim and SAYS SO in its
+#   output. It is only ever an explicit per-issue, per-session chat override
+#   from the user ("start it anyway") — never a config default, never inferred
+#   from context, never carried forward to the next issue.
+#
+# USAGE
+#   issue-claim.sh <issue_number> --check   [--repo owner/repo] [--holder ID] [--json]
+#   issue-claim.sh <issue_number> --claim   [--repo owner/repo] [--holder ID] [--json] [--allow-claimed]
+#   issue-claim.sh <issue_number> --release [--repo owner/repo] [--holder ID] [--json]
+#   issue-claim.sh --help | -h
+#
+#   --check          Report the verdict without writing anything.
+#   --claim          Take the claim (no-op when already yours).
+#   --release        Drop your own claim (idempotent; never a collaborator's).
+#   --repo           Act on a named repo instead of the current checkout's.
+#   --holder ID      Override the holder token (see above).
+#   --json           Machine-readable object on stdout instead of the verdict word.
+#   --allow-claimed  Explicit user override; only valid with --claim.
+#
+# ENVIRONMENT
+#   CLAIM_STALE_HOURS     Stale window in hours (default 4).
+#   CLAUDE_CLAIM_HOLDER   Holder token, when no --holder is passed.
+#   CLAUDE_SESSION_ID     Fallback holder token.
+#
+# OUTPUT
+#   Default: one word on stdout — unclaimed | mine | claimed | stale | unknown.
+#            Human-readable refusal / warning / override lines go to stderr, so a
+#            caller reading only the exit code still surfaces a clear message.
+#   --json:  {"issue":N,"repo":...,"viewer":...,"holder":...,"verdict":...,
+#             "claimant":...,"claimant_holder":...,"claimed_at":...,
+#             "stale":true|false,"overridden":true|false,"reason":"..."}
+#
+# EXIT STATUS
+#   0  startable / authorized — unclaimed, mine, stale, or an --allow-claimed
+#      override; also every successful --claim / --release.
+#   1  blocked   — a fresh claim held by another thread or person.
+#   2  usage     — bad/missing issue number, unknown or conflicting flags.
+#   3  not_found — no such issue.
+#   4  unknown   — claim state undetermined. FAIL-CLOSED: treat as claimed.
+#
+# DEPENDENCIES
+#   - gh (authenticated)
+#   - jq
+#
+# EXAMPLES
+#   issue-claim.sh 873 --check                 # -> unclaimed (exit 0)
+#   issue-claim.sh 873 --claim                 # -> mine      (exit 0)
+#   issue-claim.sh 873 --check                 # -> claimed   (exit 1, in another thread)
+#   issue-claim.sh 873 --claim --allow-claimed # -> mine      (exit 0, override stated)
+#   issue-claim.sh 873 --release               # -> unclaimed (exit 0)
+
+set -uo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
+
+CLAIM_LABEL="in-progress"
+CLAIM_MARKER="claude-claim"
+GUARD_REF="the issue-claim guard (.claude/rules/issue-planning.md)"
+
+print_help() {
+  # Print the leading comment header (everything after the shebang up to the
+  # first blank line), stripping the leading "# ".
+  awk 'NR == 1 { next } /^$/ { exit } { print }' "$0" | sed 's/^# \{0,1\}//'
+}
+
+die_usage() {
+  echo "issue-claim.sh: $1" >&2
+  echo "Run with --help for usage." >&2
+  exit 2
+}
+
+# --- arg parsing ---------------------------------------------------------------
+ISSUE_NUMBER=""
+REPO=""
+ACTION=""
+HOLDER_ARG=""
+JSON=0
+ALLOW_CLAIMED=0
+
+set_action() {
+  [[ -n "$ACTION" ]] && die_usage "only one of --check / --claim / --release may be given (got --$ACTION and $1)"
+  ACTION="${1#--}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)      print_help; exit 0 ;;
+    --check|--claim|--release) set_action "$1"; shift ;;
+    --json)         JSON=1; shift ;;
+    --allow-claimed) ALLOW_CLAIMED=1; shift ;;
+    --repo)
+      [[ $# -lt 2 || -z "${2-}" ]] && die_usage "--repo requires a value (owner/repo)"
+      REPO="$2"; shift 2 ;;
+    --repo=*)
+      REPO="${1#--repo=}"
+      [[ -z "$REPO" ]] && die_usage "--repo requires a value (owner/repo)"
+      shift ;;
+    --holder)
+      [[ $# -lt 2 || -z "${2-}" ]] && die_usage "--holder requires a value"
+      HOLDER_ARG="$2"; shift 2 ;;
+    --holder=*)
+      HOLDER_ARG="${1#--holder=}"
+      [[ -z "$HOLDER_ARG" ]] && die_usage "--holder requires a value"
+      shift ;;
+    --) shift; break ;;
+    -*) die_usage "unknown flag: $1" ;;
+    *)
+      [[ -n "$ISSUE_NUMBER" ]] && die_usage "unexpected positional argument: $1"
+      ISSUE_NUMBER="$1"; shift ;;
+  esac
+done
+
+[[ -z "$ISSUE_NUMBER" ]] && die_usage "<issue_number> is required"
+[[ "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]] || die_usage "<issue_number> must be a positive integer, got: $ISSUE_NUMBER"
+[[ -z "$ACTION" ]] && die_usage "one of --check / --claim / --release is required"
+if [[ -n "$REPO" ]] && ! [[ "$REPO" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+  die_usage "--repo must be owner/repo, got: $REPO"
+fi
+# --allow-claimed is a write-time override; on --check or --release it would be
+# silently inert, and a silently-inert override flag is how an override leaks
+# into a config default. Reject it outright instead.
+if (( ALLOW_CLAIMED )) && [[ "$ACTION" != "claim" ]]; then
+  die_usage "--allow-claimed is only valid with --claim"
+fi
+
+for dep in gh jq; do
+  command -v "$dep" >/dev/null 2>&1 || { echo "issue-claim.sh: '$dep' not found on PATH" >&2; exit 2; }
+done
+
+STALE_HOURS="${CLAIM_STALE_HOURS:-4}"
+if ! [[ "$STALE_HOURS" =~ ^[0-9]+$ ]]; then
+  die_usage "CLAIM_STALE_HOURS must be a non-negative integer, got: $STALE_HOURS"
+fi
+
+# --- holder resolution ---------------------------------------------------------
+resolve_holder() {
+  [[ -n "$HOLDER_ARG" ]] && { printf '%s' "$HOLDER_ARG"; return; }
+  [[ -n "${CLAUDE_CLAIM_HOLDER:-}" ]] && { printf '%s' "$CLAUDE_CLAIM_HOLDER"; return; }
+  [[ -n "${CLAUDE_SESSION_ID:-}" ]] && { printf '%s' "$CLAUDE_SESSION_ID"; return; }
+  local host top
+  host="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo unknown-host)"
+  top="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  printf '%s:%s' "$host" "$top"
+}
+HOLDER="$(resolve_holder)"
+
+# --- API path helpers ----------------------------------------------------------
+# {owner}/{repo} resolves from the current checkout unless --repo names one.
+REPO_PREFIX="repos/{owner}/{repo}"
+[[ -n "$REPO" ]] && REPO_PREFIX="repos/$REPO"
+
+# Select the repo via GH_REPO rather than a `--repo` argument array: an empty
+# array expanded under `set -u` is an unbound-variable error in bash 3.2, which
+# is the shell macOS ships. GH_REPO is read natively by every `gh` subcommand
+# and by the {owner}/{repo} placeholder, so one export covers all of them.
+[[ -n "$REPO" ]] && export GH_REPO="$REPO"
+
+# --- emit helper ---------------------------------------------------------------
+# Populated as the state is read; emit() serializes whatever is known.
+VIEWER=""
+VERDICT=""
+CLAIMANT=""
+CLAIMANT_HOLDER=""
+CLAIMED_AT=""
+IS_STALE="false"
+OVERRIDDEN="false"
+
+# emit <verdict> <exit_code> <reason>
+emit() {
+  local verdict="$1" code="$2" reason="$3"
+  if [[ "$JSON" -eq 1 ]]; then
+    jq -cn \
+      --argjson issue "$ISSUE_NUMBER" \
+      --arg repo "$REPO" \
+      --arg viewer "$VIEWER" \
+      --arg holder "$HOLDER" \
+      --arg verdict "$verdict" \
+      --arg claimant "$CLAIMANT" \
+      --arg claimant_holder "$CLAIMANT_HOLDER" \
+      --arg claimed_at "$CLAIMED_AT" \
+      --argjson stale "$IS_STALE" \
+      --argjson overridden "$OVERRIDDEN" \
+      --arg reason "$reason" \
+      '{issue: $issue,
+        repo: (if $repo == "" then null else $repo end),
+        viewer: (if $viewer == "" then null else $viewer end),
+        holder: $holder,
+        verdict: $verdict,
+        claimant: (if $claimant == "" then null else $claimant end),
+        claimant_holder: (if $claimant_holder == "" then null else $claimant_holder end),
+        claimed_at: (if $claimed_at == "" then null else $claimed_at end),
+        stale: $stale,
+        overridden: $overridden,
+        reason: $reason}'
+  else
+    printf '%s\n' "$verdict"
+  fi
+  # Non-startable verdicts, the stale warning, and the override statement all go
+  # to stderr so a caller reading only the exit code still surfaces a message.
+  case "$verdict" in
+    claimed|unknown) echo "issue-claim.sh: $reason" >&2 ;;
+    stale)           echo "issue-claim.sh: $reason" >&2 ;;
+  esac
+  [[ "$OVERRIDDEN" == "true" ]] && echo "issue-claim.sh: OVERRIDE — proceeding past a live claim on issue #$ISSUE_NUMBER because --allow-claimed was passed. This is only valid as an explicit per-issue instruction from the user; it is never a default." >&2
+  exit "$code"
+}
+
+fail_closed() {
+  emit unknown 4 "$1 — claim state undetermined; treat issue #$ISSUE_NUMBER as claimed (fail-closed per $GUARD_REF)"
+}
+
+# --- resolve the authenticated viewer ------------------------------------------
+VIEWER="$(gh api user --jq '.login' 2>/dev/null || true)"
+if [[ -z "$VIEWER" || "$VIEWER" == "null" ]]; then
+  fail_closed "could not resolve the authenticated user (gh api user failed)"
+fi
+
+# --- read the issue ------------------------------------------------------------
+ERR_FILE="$(mktemp)"
+trap 'rm -f "$ERR_FILE" 2>/dev/null' EXIT
+
+if ! ISSUE_JSON="$(gh api "$REPO_PREFIX/issues/$ISSUE_NUMBER" 2>"$ERR_FILE")"; then
+  # ERE for BSD/macOS grep portability (pr-authorship.sh lesson).
+  if grep -qiE "http 404|not found|could not resolve|no such" "$ERR_FILE"; then
+    emit unknown 3 "issue #$ISSUE_NUMBER not found${REPO:+ in $REPO} — cannot act"
+  fi
+  fail_closed "gh api failed reading issue #$ISSUE_NUMBER ($(tr '\n' ' ' < "$ERR_FILE"))"
+fi
+
+HAS_LABEL="$(printf '%s' "$ISSUE_JSON" | jq -r --arg l "$CLAIM_LABEL" '[.labels[]?.name] | index($l) != null' 2>/dev/null || echo "ERR")"
+[[ "$HAS_LABEL" == "ERR" ]] && fail_closed "could not parse issue #$ISSUE_NUMBER labels"
+ASSIGNEES="$(printf '%s' "$ISSUE_JSON" | jq -r '[.assignees[]?.login] | join(" ")' 2>/dev/null || echo "ERR")"
+[[ "$ASSIGNEES" == "ERR" ]] && fail_closed "could not parse issue #$ISSUE_NUMBER assignees"
+
+# --- read the claim comment ----------------------------------------------------
+# The marker is an HTML comment so it renders invisibly, and carries the holder
+# token + claimant login as JSON. Newest matching comment wins.
+if ! COMMENTS_JSON="$(gh api --paginate "$REPO_PREFIX/issues/$ISSUE_NUMBER/comments?per_page=100" 2>"$ERR_FILE")"; then
+  fail_closed "gh api failed reading issue #$ISSUE_NUMBER comments ($(tr '\n' ' ' < "$ERR_FILE"))"
+fi
+
+# --paginate concatenates one JSON array per page; -s flattens them into one.
+CLAIM_COMMENTS="$(printf '%s' "$COMMENTS_JSON" | jq -s --arg m "$CLAIM_MARKER" \
+  '[ .[] | .[]? | select(.body != null and (.body | contains("<!-- " + $m + ":"))) ]' 2>/dev/null || echo "ERR")"
+[[ "$CLAIM_COMMENTS" == "ERR" ]] && fail_closed "could not parse issue #$ISSUE_NUMBER comments"
+
+# Extract the newest claim comment's payload. The payload is the JSON object
+# between the marker prefix and the closing " -->".
+read_claim_field() {
+  printf '%s' "$CLAIM_COMMENTS" | jq -r --arg m "$CLAIM_MARKER" --arg f "$1" '
+    if length == 0 then ""
+    else
+      (sort_by(.created_at) | last) as $c
+      | ($c.body | capture("<!-- " + $m + ": *(?<p>.*?) *-->") | .p) as $raw
+      | ($raw | fromjson) as $payload
+      | if $f == "created_at" then $c.created_at
+        elif $f == "id" then ($c.id | tostring)
+        else ($payload[$f] // "") end
+    end' 2>/dev/null || printf ''
+}
+
+CLAIMANT_HOLDER="$(read_claim_field holder)"
+CLAIMANT="$(read_claim_field login)"
+CLAIMED_AT="$(read_claim_field created_at)"
+
+HAS_CLAIM_COMMENT=0
+[[ -n "$CLAIMANT_HOLDER" ]] && HAS_CLAIM_COMMENT=1
+
+# --- fallback timestamp: the label's most recent `labeled` timeline event ------
+# Only needed when the label was applied without a claim comment (a human
+# labelling the issue by hand). Skipped otherwise so the common path stays at
+# three API reads.
+if [[ "$HAS_LABEL" == "true" && "$HAS_CLAIM_COMMENT" -eq 0 ]]; then
+  if ! TIMELINE_JSON="$(gh api --paginate "$REPO_PREFIX/issues/$ISSUE_NUMBER/timeline?per_page=100" 2>"$ERR_FILE")"; then
+    fail_closed "gh api failed reading issue #$ISSUE_NUMBER timeline ($(tr '\n' ' ' < "$ERR_FILE"))"
+  fi
+  CLAIMED_AT="$(printf '%s' "$TIMELINE_JSON" | jq -rs --arg l "$CLAIM_LABEL" '
+    [ .[] | .[]? | select(.event == "labeled" and .label.name == $l) ]
+    | if length == 0 then "" else (sort_by(.created_at) | last | .created_at) end' 2>/dev/null || printf '')"
+fi
+
+# --- staleness -----------------------------------------------------------------
+# Portable epoch conversion: GNU date and BSD date disagree on -d/-j, so parse
+# the ISO-8601 timestamp arithmetically instead of shelling out to either.
+iso_to_epoch() {
+  local ts="$1"
+  [[ -z "$ts" ]] && { printf ''; return; }
+  printf '%s' "$ts" | awk '
+    match($0, /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})/) {
+      y = substr($0,1,4)+0; mo = substr($0,6,2)+0; d = substr($0,9,2)+0
+      h = substr($0,12,2)+0; mi = substr($0,15,2)+0; s = substr($0,18,2)+0
+      # Days since the Unix epoch via the civil-from-days algorithm.
+      yy = y - (mo <= 2 ? 1 : 0)
+      era = int((yy >= 0 ? yy : yy - 399) / 400)
+      yoe = yy - era * 400
+      doy = int((153 * (mo + (mo > 2 ? -3 : 9)) + 2) / 5) + d - 1
+      doe = yoe * 365 + int(yoe/4) - int(yoe/100) + doy
+      days = era * 146097 + doe - 719468
+      print days * 86400 + h * 3600 + mi * 60 + s
+    }'
+}
+
+NOW_EPOCH="$(date -u +%s)"
+CLAIMED_EPOCH="$(iso_to_epoch "$CLAIMED_AT")"
+AGE_SECONDS=""
+if [[ -n "$CLAIMED_EPOCH" ]]; then
+  AGE_SECONDS=$(( NOW_EPOCH - CLAIMED_EPOCH ))
+fi
+
+is_stale() {
+  # A claim with no readable timestamp cannot be aged out. Fail closed: it stays
+  # a live claim rather than expiring instantly into "startable".
+  [[ -z "$AGE_SECONDS" ]] && return 1
+  (( AGE_SECONDS > STALE_HOURS * 3600 ))
+}
+
+# --- verdict -------------------------------------------------------------------
+# A claim exists when EITHER artifact is present: the comment (written by this
+# script) or the label (which a human may apply by hand). Requiring both would
+# let a half-written claim read as unclaimed.
+CLAIM_EXISTS=0
+[[ "$HAS_LABEL" == "true" || "$HAS_CLAIM_COMMENT" -eq 1 ]] && CLAIM_EXISTS=1
+
+if (( ! CLAIM_EXISTS )); then
+  VERDICT="unclaimed"
+elif [[ "$HAS_CLAIM_COMMENT" -eq 1 && "$CLAIMANT_HOLDER" == "$HOLDER" ]]; then
+  VERDICT="mine"
+elif is_stale; then
+  VERDICT="stale"
+  IS_STALE="true"
+else
+  VERDICT="claimed"
+fi
+
+viewer_owns_claim() {
+  # Account-level ownership, for --release only (see the header's asymmetry
+  # note). True when the claim comment is the viewer's, or when there is no
+  # claim comment but the viewer is assigned alongside the label.
+  if [[ "$HAS_CLAIM_COMMENT" -eq 1 ]]; then
+    [[ "$CLAIMANT" == "$VIEWER" ]]
+  else
+    [[ " $ASSIGNEES " == *" $VIEWER "* ]]
+  fi
+}
+
+describe_claim() {
+  local who="${CLAIMANT:-an unknown account}"
+  local when="${CLAIMED_AT:-an unrecorded time}"
+  printf 'issue #%s is already being worked — claimed by %s (holder %s) at %s' \
+    "$ISSUE_NUMBER" "$who" "${CLAIMANT_HOLDER:-unknown}" "$when"
+}
+
+# --- action: --check -----------------------------------------------------------
+if [[ "$ACTION" == "check" ]]; then
+  case "$VERDICT" in
+    unclaimed) emit unclaimed 0 "issue #$ISSUE_NUMBER is unclaimed — startable" ;;
+    mine)      emit mine 0 "issue #$ISSUE_NUMBER is already claimed by this thread (holder $HOLDER) — startable" ;;
+    stale)     emit stale 0 "$(describe_claim), which is older than the ${STALE_HOURS}h stale window — proceeding is allowed; surface this as a warning, not a block" ;;
+    claimed)   emit claimed 1 "$(describe_claim). Skipping. Only an explicit per-issue instruction from the user (\"start it anyway\") authorizes starting it, per $GUARD_REF." ;;
+  esac
+fi
+
+# --- action: --release ---------------------------------------------------------
+if [[ "$ACTION" == "release" ]]; then
+  if (( ! CLAIM_EXISTS )); then
+    emit unclaimed 0 "issue #$ISSUE_NUMBER holds no claim — nothing to release"
+  fi
+  if ! viewer_owns_claim; then
+    # Never touch a collaborator's claim (issue #732). Not an error: releasing
+    # what isn't yours was never the job.
+    emit "$VERDICT" 0 "issue #$ISSUE_NUMBER is claimed by ${CLAIMANT:-another account}, not you ($VIEWER) — left untouched"
+  fi
+
+  RELEASE_ERRORS=0
+  EDIT_ARGS=()
+  [[ "$HAS_LABEL" == "true" ]] && EDIT_ARGS+=(--remove-label "$CLAIM_LABEL")
+  [[ " $ASSIGNEES " == *" $VIEWER "* ]] && EDIT_ARGS+=(--remove-assignee "$VIEWER")
+  if (( ${#EDIT_ARGS[@]} > 0 )); then
+    gh issue edit "$ISSUE_NUMBER" "${EDIT_ARGS[@]}" >/dev/null 2>"$ERR_FILE" || RELEASE_ERRORS=1
+  fi
+
+  # Delete every claim comment written by this account — not just the newest —
+  # so a re-stamped claim never leaves an older marker behind to be read as a
+  # live claim by the next thread.
+  while IFS= read -r cid; do
+    [[ -z "$cid" ]] && continue
+    gh api -X DELETE "$REPO_PREFIX/issues/comments/$cid" >/dev/null 2>"$ERR_FILE" || RELEASE_ERRORS=1
+  done < <(printf '%s' "$CLAIM_COMMENTS" | jq -r --arg v "$VIEWER" \
+    '.[] | select((.user.login // "") == $v) | .id' 2>/dev/null || true)
+
+  if (( RELEASE_ERRORS )); then
+    fail_closed "release of issue #$ISSUE_NUMBER partially failed ($(tr '\n' ' ' < "$ERR_FILE"))"
+  fi
+  CLAIMANT=""; CLAIMANT_HOLDER=""; CLAIMED_AT=""; IS_STALE="false"
+  emit unclaimed 0 "released the claim on issue #$ISSUE_NUMBER"
+fi
+
+# --- action: --claim -----------------------------------------------------------
+# Already ours: a genuine no-op. A resumed thread or a post-compaction recovery
+# re-claims constantly; writing a second marker each time would turn recovery
+# into comment spam and break the "one live claim" read.
+if [[ "$VERDICT" == "mine" ]]; then
+  emit mine 0 "issue #$ISSUE_NUMBER is already claimed by this thread (holder $HOLDER) — no-op"
+fi
+
+if [[ "$VERDICT" == "claimed" ]]; then
+  if (( ! ALLOW_CLAIMED )); then
+    emit claimed 1 "$(describe_claim). Refusing to claim it. Only an explicit per-issue instruction from the user (\"start it anyway\") authorizes taking it, per $GUARD_REF."
+  fi
+  OVERRIDDEN="true"
+fi
+
+PRIOR_HOLDER="$CLAIMANT_HOLDER"
+PRIOR_CLAIMANT="$CLAIMANT"
+
+# Create the label idempotently. An existing label is reused, never recreated —
+# `gh label create` on an existing name is an error, not a no-op.
+# `gh --jq` takes a bare expression — it has no `--arg` passthrough — so the
+# label name is matched by jq reading it from the environment instead.
+LABEL_EXISTS="$(CLAIM_LABEL="$CLAIM_LABEL" gh label list --limit 200 --json name \
+  --jq '[.[].name] | index(env.CLAIM_LABEL) != null' 2>/dev/null || echo "")"
+if [[ "$LABEL_EXISTS" != "true" ]]; then
+  gh label create "$CLAIM_LABEL" \
+    --color FBCA04 \
+    --description "A thread is actively working this issue (issue-claim.sh)" \
+    >/dev/null 2>&1 || true
+fi
+
+if ! gh issue edit "$ISSUE_NUMBER" \
+     --add-label "$CLAIM_LABEL" --add-assignee "@me" >/dev/null 2>"$ERR_FILE"; then
+  fail_closed "could not write the claim on issue #$ISSUE_NUMBER ($(tr '\n' ' ' < "$ERR_FILE"))"
+fi
+
+# Stale takeover / override: drop our OWN stale markers so exactly one live
+# claim comment of ours remains and staleness is measured from the new claim.
+#
+# A collaborator's claim comment is deliberately left in place even here (#732):
+# deleting another person's comment is a write to their content, and an
+# --allow-claimed override authorizes starting the work, not editing someone
+# else's writing. Leaving it is safe — every read takes the newest claim
+# comment, which is the one written just below.
+if (( HAS_CLAIM_COMMENT )); then
+  while IFS= read -r cid; do
+    [[ -z "$cid" ]] && continue
+    gh api -X DELETE "$REPO_PREFIX/issues/comments/$cid" >/dev/null 2>&1 || true
+  done < <(printf '%s' "$CLAIM_COMMENTS" | jq -r --arg v "$VIEWER" \
+    '.[] | select((.user.login // "") == $v) | .id' 2>/dev/null || true)
+fi
+
+CLAIM_BODY="$(printf '%s\n\n%s\n' \
+  "🔒 Claimed by \`$VIEWER\` for active work. It will be released when this issue's PR merges, when the issue closes, or automatically after ${STALE_HOURS}h of no activity." \
+  "<!-- $CLAIM_MARKER: $(jq -cn --arg h "$HOLDER" --arg l "$VIEWER" '{holder: $h, login: $l}') -->")"
+
+if ! gh issue comment "$ISSUE_NUMBER" --body "$CLAIM_BODY" >/dev/null 2>"$ERR_FILE"; then
+  fail_closed "claim markers were written on issue #$ISSUE_NUMBER but the claim comment failed ($(tr '\n' ' ' < "$ERR_FILE")); the claim carries no holder or timestamp"
+fi
+
+CLAIMANT="$VIEWER"
+CLAIMANT_HOLDER="$HOLDER"
+CLAIMED_AT="$(date -u +%FT%TZ)"
+IS_STALE="false"
+
+if [[ "$OVERRIDDEN" == "true" ]]; then
+  emit mine 0 "claimed issue #$ISSUE_NUMBER for holder $HOLDER, overriding a live claim held by ${PRIOR_CLAIMANT:-another account} (holder ${PRIOR_HOLDER:-unknown})"
+elif [[ "$VERDICT" == "stale" ]]; then
+  emit mine 0 "took over the stale claim on issue #$ISSUE_NUMBER (previously ${PRIOR_CLAIMANT:-an unknown account}, holder ${PRIOR_HOLDER:-unknown}) for holder $HOLDER"
+fi
+emit mine 0 "claimed issue #$ISSUE_NUMBER for holder $HOLDER"

--- a/.claude/scripts/tests/issue-claim.test.sh
+++ b/.claude/scripts/tests/issue-claim.test.sh
@@ -67,6 +67,7 @@ reset_issue() {
   export FAKE_ISSUE_MODE="json"
   export FAKE_COMMENTS_MODE="json"
   unset CLAIM_STALE_HOURS
+  unset FAKE_COMMENT_POST_MODE FAKE_COMMENT_DELETE_MODE
 }
 
 # ---- stub gh on PATH ----------------------------------------------------------
@@ -102,6 +103,9 @@ case "${1:-}" in
         ;;
       */issues/comments/*)
         [[ "$METHOD" == "DELETE" ]] || { echo "unexpected method $METHOD on $ENDPOINT" >&2; exit 99; }
+        if [[ "${FAKE_COMMENT_DELETE_MODE:-ok}" == "error" ]]; then
+          echo "gh: HTTP 500: could not delete comment" >&2; exit 1
+        fi
         CID="${ENDPOINT##*/}"
         jq --argjson id "$CID" '[ .[] | select(.id != $id) ]' "$S/comments.json" > "$S/c.tmp" \
           && mv "$S/c.tmp" "$S/comments.json"
@@ -163,6 +167,9 @@ case "${1:-}" in
             *) shift ;;
           esac
         done
+        if [[ "${FAKE_COMMENT_POST_MODE:-ok}" == "error" ]]; then
+          echo "gh: HTTP 422: could not create comment" >&2; exit 1
+        fi
         ID=$(( $(cat "$S/next_id") + 1 )); echo "$ID" > "$S/next_id"
         CREATED="${FAKE_COMMENT_CREATED_AT:-$(date -u +%FT%TZ)}"
         jq --argjson id "$ID" --arg body "$BODY" --arg login "${FAKE_VIEWER:-}" --arg at "$CREATED" \
@@ -370,6 +377,53 @@ check_eq "ages out via the labeled timeline event" "stale" "$OUT"
 check_eq "exit 0" 0 "$RC"
 
 ############################################################################
+echo "== (12) a failed claim comment ROLLS BACK the label + assignee =="
+# A half-written claim is worse than none: `mine` needs a parsed claim comment,
+# so the thread that wrote the label would read its own claim back as foreign.
+reset_issue
+FAKE_COMMENT_POST_MODE=error run 873 --claim --holder threadA
+check_eq "verdict unknown (fail-closed)" "unknown" "$OUT"
+check_eq "exit 4" 4 "$RC"
+check_eq "label rolled back" "" "$(cat "$STATE/labels")"
+check_eq "assignee rolled back" "" "$(cat "$STATE/assignees")"
+check_contains "says it rolled back" "rolled back" "$ERR"
+run 873 --check --holder threadA
+check_eq "issue is startable again" "unclaimed" "$OUT"
+check_eq "exit 0" 0 "$RC"
+# ...and the SAME holder can now claim for real (the orphan-label trap is gone).
+run 873 --claim --holder threadA
+check_eq "same holder can claim after rollback" "mine" "$OUT"
+check_eq "exit 0" 0 "$RC"
+
+echo "== (12b) rollback preserves a label this run did NOT add =="
+# Stale takeover on a hand-labelled issue: rollback must not strip a pre-existing marker.
+reset_issue
+echo "in-progress" > "$STATE/labels"
+jq -n --arg at "$(iso_ago 6)" '[{event:"labeled",label:{name:"in-progress"},created_at:$at}]' > "$STATE/timeline.json"
+FAKE_COMMENT_POST_MODE=error run 873 --claim --holder threadA
+check_eq "exit 4" 4 "$RC"
+check_eq "pre-existing label left intact" "in-progress" "$(cat "$STATE/labels")"
+
+echo "== (13) release removes the comment BEFORE the label =="
+# Ordering matters: /wave pre-filters a backlog on the label, so a partial release
+# must never leave a claim comment with no label (invisible => reads as unclaimed).
+# It may leave a label with no comment (still blocks, and expires on its own).
+reset_issue
+run 873 --claim --holder threadA
+check_eq "claim held" 0 "$RC"
+FAKE_COMMENT_DELETE_MODE=error run 873 --release --holder threadA
+check_eq "partial release fails closed" 4 "$RC"
+check_eq "label still present (comment delete failed first)" "in-progress" "$(cat "$STATE/labels")"
+check_eq "claim comment still present" 1 "$(claim_comment_count)"
+run 873 --check --holder threadB
+check_eq "still blocks another thread" "claimed" "$OUT"
+check_eq "exit 1" 1 "$RC"
+# A retry with the delete working completes the release.
+run 873 --release --holder threadA
+check_eq "retry succeeds" 0 "$RC"
+check_eq "label gone" "" "$(cat "$STATE/labels")"
+check_eq "comment gone" 0 "$(claim_comment_count)"
+
 echo "== (11) usage errors =="
 reset_issue
 run 873 --check --allow-claimed --holder threadA

--- a/.claude/scripts/tests/issue-claim.test.sh
+++ b/.claude/scripts/tests/issue-claim.test.sh
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+# Offline unit tests for issue-claim.sh (issue #873 — claim an issue at pick time).
+#
+# Stubs `gh` on PATH with a STATEFUL fake issue (labels, assignees, comments,
+# timeline) so a claim written by one run is read back by the next — that
+# round trip is the whole point of the feature, and a stateless stub would
+# assert nothing about it. No network or auth is needed. Requires jq.
+#
+# Run from repo root:
+#   bash .claude/scripts/tests/issue-claim.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/.claude/scripts/issue-claim.sh"
+
+TMP="$(mktemp -d)"
+TMP_HOME="$(mktemp -d)"
+cleanup() { rm -rf "$TMP" "$TMP_HOME"; }
+trap cleanup EXIT
+export HOME="$TMP_HOME"
+mkdir -p "$HOME/.claude"
+
+PASS=0
+FAIL=0
+check_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    PASS=$((PASS + 1)); echo "ok   — $desc"
+  else
+    FAIL=$((FAIL + 1)); echo "FAIL — $desc (expected '$expected', got '$actual')"
+  fi
+}
+check_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1)); echo "ok   — $desc"
+  else
+    FAIL=$((FAIL + 1)); echo "FAIL — $desc (expected to contain '$needle', got '$haystack')"
+  fi
+}
+
+# ---- portable ISO-8601 timestamp N hours in the past --------------------------
+# GNU and BSD date disagree on both the offset and the epoch-to-string flags, so
+# try each spelling rather than assuming a platform.
+iso_ago() {
+  local hours="$1" epoch
+  epoch=$(( $(date -u +%s) - hours * 3600 ))
+  date -u -r "$epoch" +%FT%TZ 2>/dev/null && return 0
+  date -u -d "@$epoch" +%FT%TZ 2>/dev/null && return 0
+  echo "iso_ago: no usable date(1) spelling" >&2
+  return 1
+}
+
+# ---- stateful fake-issue store ------------------------------------------------
+STATE="$TMP/state"
+mkdir -p "$STATE"
+export FAKE_STATE="$STATE"
+
+reset_issue() {
+  : > "$STATE/labels"
+  : > "$STATE/assignees"
+  echo '[]' > "$STATE/comments.json"
+  echo '[]' > "$STATE/timeline.json"
+  printf 'bug\nenhancement\n' > "$STATE/repo_labels"
+  echo 0 > "$STATE/next_id"
+  export FAKE_VIEWER="alice"
+  export FAKE_ISSUE_MODE="json"
+  export FAKE_COMMENTS_MODE="json"
+  unset CLAIM_STALE_HOURS
+}
+
+# ---- stub gh on PATH ----------------------------------------------------------
+STUB_BIN="$TMP/bin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+S="$FAKE_STATE"
+
+json_array_of_lines() { # file -> ["a","b"]
+  jq -Rn --rawfile f "$1" '($f | split("\n") | map(select(length > 0)))'
+}
+
+case "${1:-}" in
+  api)
+    shift
+    METHOD="GET"; ENDPOINT=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -X) METHOD="$2"; shift 2 ;;
+        --paginate|--slurp) shift ;;
+        --jq) shift 2 ;;
+        *) [[ -z "$ENDPOINT" ]] && ENDPOINT="$1"; shift ;;
+      esac
+    done
+    case "$ENDPOINT" in
+      user)
+        if [[ "${FAKE_VIEWER:-}" == "__FAIL__" ]]; then
+          echo "gh: could not authenticate to github.com" >&2; exit 1
+        fi
+        printf '%s\n' "${FAKE_VIEWER:-}"
+        ;;
+      */issues/comments/*)
+        [[ "$METHOD" == "DELETE" ]] || { echo "unexpected method $METHOD on $ENDPOINT" >&2; exit 99; }
+        CID="${ENDPOINT##*/}"
+        jq --argjson id "$CID" '[ .[] | select(.id != $id) ]' "$S/comments.json" > "$S/c.tmp" \
+          && mv "$S/c.tmp" "$S/comments.json"
+        echo '{}'
+        ;;
+      */comments*)
+        case "${FAKE_COMMENTS_MODE:-json}" in
+          error) echo "gh: HTTP 500: internal server error" >&2; exit 1 ;;
+          *) cat "$S/comments.json" ;;
+        esac
+        ;;
+      */timeline*)
+        cat "$S/timeline.json"
+        ;;
+      */issues/*)
+        case "${FAKE_ISSUE_MODE:-json}" in
+          404)   echo "gh: HTTP 404: Not Found (https://api.github.com/$ENDPOINT)" >&2; exit 1 ;;
+          error) echo "gh: HTTP 500: internal server error" >&2; exit 1 ;;
+          *)
+            jq -n \
+              --argjson labels "$(json_array_of_lines "$S/labels")" \
+              --argjson assignees "$(json_array_of_lines "$S/assignees")" \
+              '{number: 873, state: "open",
+                labels: ($labels | map({name: .})),
+                assignees: ($assignees | map({login: .}))}'
+            ;;
+        esac
+        ;;
+      *) echo "unexpected endpoint: $ENDPOINT" >&2; exit 99 ;;
+    esac
+    ;;
+  issue)
+    sub="${2:-}"; shift 2
+    # drop the issue number positional
+    [[ "${1:-}" =~ ^[0-9]+$ ]] && shift
+    case "$sub" in
+      edit)
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            --repo) shift 2 ;;
+            --add-label)    grep -qxF "$2" "$S/labels"    || echo "$2" >> "$S/labels"; shift 2 ;;
+            --remove-label) grep -vxF "$2" "$S/labels" > "$S/l.tmp" || true; mv "$S/l.tmp" "$S/labels"; shift 2 ;;
+            --add-assignee)
+              who="$2"; [[ "$who" == "@me" ]] && who="${FAKE_VIEWER:-}"
+              grep -qxF "$who" "$S/assignees" || echo "$who" >> "$S/assignees"; shift 2 ;;
+            --remove-assignee)
+              grep -vxF "$2" "$S/assignees" > "$S/a.tmp" || true; mv "$S/a.tmp" "$S/assignees"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        echo "edited"
+        ;;
+      comment)
+        BODY=""
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            --repo) shift 2 ;;
+            --body) BODY="$2"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        ID=$(( $(cat "$S/next_id") + 1 )); echo "$ID" > "$S/next_id"
+        CREATED="${FAKE_COMMENT_CREATED_AT:-$(date -u +%FT%TZ)}"
+        jq --argjson id "$ID" --arg body "$BODY" --arg login "${FAKE_VIEWER:-}" --arg at "$CREATED" \
+          '. + [{id: $id, body: $body, created_at: $at, user: {login: $login}}]' \
+          "$S/comments.json" > "$S/c.tmp" && mv "$S/c.tmp" "$S/comments.json"
+        echo "commented"
+        ;;
+      *) echo "unexpected issue subcommand: $sub" >&2; exit 99 ;;
+    esac
+    ;;
+  label)
+    sub="${2:-}"; shift 2
+    case "$sub" in
+      list) json_array_of_lines "$S/repo_labels" | jq '[ .[] | {name: .} ]' ;;
+      create)
+        NAME="$1"
+        if grep -qxF "$NAME" "$S/repo_labels"; then
+          echo "gh: label already exists" >&2; exit 1
+        fi
+        echo "$NAME" >> "$S/repo_labels"; echo "created"
+        ;;
+      *) echo "unexpected label subcommand: $sub" >&2; exit 99 ;;
+    esac
+    ;;
+  *) echo "unexpected gh call: $*" >&2; exit 99 ;;
+esac
+STUB
+chmod +x "$STUB_BIN/gh"
+export PATH="$STUB_BIN:$PATH"
+
+# The stub's `gh label list --json name --jq EXPR` path ignores --jq, so the
+# script's own jq expression never runs against it. Give the real flag shape a
+# home by post-filtering here instead: the stub prints the raw JSON and the
+# script's --jq is a no-op, which is exactly how a caller-side jq failure would
+# look. Verified separately in test (10).
+
+run() {
+  # run <args...> ; sets OUT (stdout), ERR (stderr), RC (exit code)
+  local errfile="$TMP/err"
+  OUT="$(bash "$SCRIPT" "$@" 2>"$errfile")"; RC=$?
+  ERR="$(cat "$errfile")"
+}
+
+claim_comment_count() {
+  jq '[ .[] | select(.body | contains("<!-- claude-claim:")) ] | length' "$STATE/comments.json"
+}
+
+############################################################################
+echo "== (1) claim on an unclaimed issue: writes label + assignee + claim comment =="
+reset_issue
+run 873 --check --holder threadA
+check_eq "unclaimed before" "unclaimed" "$OUT"
+check_eq "exit 0 (startable)" 0 "$RC"
+run 873 --claim --holder threadA
+check_eq "verdict mine" "mine" "$OUT"
+check_eq "exit 0" 0 "$RC"
+check_eq "in-progress label written" "in-progress" "$(cat "$STATE/labels")"
+check_eq "assignee written" "alice" "$(cat "$STATE/assignees")"
+check_eq "one claim comment" 1 "$(claim_comment_count)"
+check_eq "label created in repo" "true" "$(grep -qxF in-progress "$STATE/repo_labels" && echo true)"
+
+############################################################################
+echo "== (2) a SECOND thread of the same account is blocked — with no PR anywhere =="
+# This is the failure the feature exists for: both threads authenticate as the
+# same login, so an assignee-only check would answer 'mine' and start anyway.
+run 873 --check --holder threadB
+check_eq "verdict claimed" "claimed" "$OUT"
+check_eq "exit 1 (blocked)" 1 "$RC"
+check_contains "names the claim" "already being worked" "$ERR"
+run 873 --claim --holder threadB
+check_eq "claim refused" "claimed" "$OUT"
+check_eq "exit 1 (blocked)" 1 "$RC"
+check_eq "still one claim comment" 1 "$(claim_comment_count)"
+
+############################################################################
+echo "== (3) re-claim by the SAME holder is a no-op (resume / post-compaction) =="
+run 873 --check --holder threadA
+check_eq "verdict mine" "mine" "$OUT"
+check_eq "exit 0" 0 "$RC"
+run 873 --claim --holder threadA
+check_eq "verdict mine" "mine" "$OUT"
+check_eq "exit 0 (no error)" 0 "$RC"
+check_eq "no duplicate marker" 1 "$(claim_comment_count)"
+check_eq "assignee not duplicated" "alice" "$(cat "$STATE/assignees")"
+
+############################################################################
+echo "== (4) release returns the issue to unclaimed =="
+run 873 --release --holder threadA
+check_eq "verdict unclaimed" "unclaimed" "$OUT"
+check_eq "exit 0" 0 "$RC"
+check_eq "label removed" "" "$(cat "$STATE/labels")"
+check_eq "assignee removed" "" "$(cat "$STATE/assignees")"
+check_eq "claim comment deleted" 0 "$(claim_comment_count)"
+run 873 --check --holder threadB
+check_eq "startable again for another thread" "unclaimed" "$OUT"
+check_eq "exit 0" 0 "$RC"
+run 873 --release --holder threadA
+check_eq "release is idempotent" 0 "$RC"
+
+############################################################################
+echo "== (5) a claim older than CLAIM_STALE_HOURS is stale and STARTABLE =="
+reset_issue
+FAKE_COMMENT_CREATED_AT="$(iso_ago 5)" run 873 --claim --holder threadA
+check_eq "claim written" 0 "$RC"
+run 873 --check --holder threadB
+check_eq "verdict stale" "stale" "$OUT"
+check_eq "exit 0 (warning, NOT a block)" 0 "$RC"
+check_contains "stale surfaced on stderr" "stale window" "$ERR"
+run 873 --check --holder threadB --json
+check_eq "json stale flag" "true" "$(jq -r '.stale' <<<"$OUT")"
+# A fresher window keeps the very same claim live — proves the boundary is the
+# timestamp, not an incidental property of the fixture.
+CLAIM_STALE_HOURS=9 run 873 --check --holder threadB
+check_eq "not stale under a 9h window" "claimed" "$OUT"
+check_eq "exit 1 (blocked)" 1 "$RC"
+
+echo "== (5b) --claim takes over a stale claim and re-stamps it =="
+run 873 --claim --holder threadB
+check_eq "verdict mine" "mine" "$OUT"
+check_eq "exit 0" 0 "$RC"
+check_eq "exactly one claim comment after takeover" 1 "$(claim_comment_count)"
+run 873 --check --holder threadA
+check_eq "original thread is now the blocked one" "claimed" "$OUT"
+check_eq "exit 1" 1 "$RC"
+
+############################################################################
+echo "== (6) --allow-claimed overrides a fresh foreign claim and SAYS SO =="
+reset_issue
+run 873 --claim --holder threadA
+check_eq "claim held by threadA" 0 "$RC"
+run 873 --claim --holder threadB
+check_eq "blocked without the override" 1 "$RC"
+run 873 --claim --holder threadB --allow-claimed
+check_eq "verdict mine" "mine" "$OUT"
+check_eq "exit 0 (override authorized)" 0 "$RC"
+check_contains "states that it is overriding" "OVERRIDE" "$ERR"
+run 873 --check --holder threadB --json
+check_eq "override transferred the claim" "mine" "$(jq -r '.verdict' <<<"$OUT")"
+
+############################################################################
+echo "== (7) issue not found -> exit 3 =="
+reset_issue
+FAKE_ISSUE_MODE=404 run 873 --check --holder threadA
+check_eq "exit 3 (not found)" 3 "$RC"
+
+############################################################################
+echo "== (8) fail-closed: gh errors NEVER read as unclaimed =="
+reset_issue
+FAKE_ISSUE_MODE=error run 873 --check --holder threadA
+check_eq "verdict unknown" "unknown" "$OUT"
+check_eq "exit 4 (fail-closed)" 4 "$RC"
+FAKE_VIEWER=__FAIL__ run 873 --check --holder threadA
+check_eq "unknown on viewer failure" "unknown" "$OUT"
+check_eq "exit 4" 4 "$RC"
+FAKE_COMMENTS_MODE=error run 873 --check --holder threadA
+check_eq "unknown on comment-read failure" "unknown" "$OUT"
+check_eq "exit 4" 4 "$RC"
+# A failed claim write must not report success.
+FAKE_ISSUE_MODE=error run 873 --claim --holder threadA
+check_eq "claim fails closed too" 4 "$RC"
+
+############################################################################
+echo "== (9) a collaborator's claim is never released or overwritten (#732) =="
+reset_issue
+export FAKE_VIEWER="bob"
+run 873 --claim --holder threadBob
+check_eq "bob holds the claim" 0 "$RC"
+export FAKE_VIEWER="alice"
+run 873 --release --holder threadA
+check_eq "release exits 0 (nothing of alice's to drop)" 0 "$RC"
+check_eq "collaborator label untouched" "in-progress" "$(cat "$STATE/labels")"
+check_eq "collaborator assignee untouched" "bob" "$(cat "$STATE/assignees")"
+check_eq "collaborator claim comment untouched" 1 "$(claim_comment_count)"
+run 873 --check --holder threadA
+check_eq "still blocked for alice" "claimed" "$OUT"
+check_eq "exit 1" 1 "$RC"
+
+echo "== (9b) overriding a collaborator's claim never deletes their comment (#732) =="
+# The override authorizes starting the work, not editing someone else's writing.
+run 873 --claim --holder threadA --allow-claimed
+check_eq "override succeeds" 0 "$RC"
+check_eq "bob's comment survives alongside alice's" 2 "$(claim_comment_count)"
+check_eq "bob's comment specifically is intact" 1 \
+  "$(jq '[ .[] | select(.user.login == "bob" and (.body | contains("<!-- claude-claim:"))) ] | length' "$STATE/comments.json")"
+# The newest claim comment decides the verdict, so the stale one is inert.
+run 873 --check --holder threadA
+check_eq "alice now holds it" "mine" "$OUT"
+run 873 --check --holder threadB
+check_eq "threadB still blocked" "claimed" "$OUT"
+
+############################################################################
+echo "== (10) a hand-applied label with no claim comment still blocks =="
+reset_issue
+echo "in-progress" > "$STATE/labels"
+jq -n --arg at "$(iso_ago 1)" '[{event: "labeled", label: {name: "in-progress"}, created_at: $at}]' \
+  > "$STATE/timeline.json"
+run 873 --check --holder threadA
+check_eq "verdict claimed" "claimed" "$OUT"
+check_eq "exit 1 (blocked)" 1 "$RC"
+# ...and the timeline supplies the timestamp, so it can still age out.
+jq -n --arg at "$(iso_ago 6)" '[{event: "labeled", label: {name: "in-progress"}, created_at: $at}]' \
+  > "$STATE/timeline.json"
+run 873 --check --holder threadA
+check_eq "ages out via the labeled timeline event" "stale" "$OUT"
+check_eq "exit 0" 0 "$RC"
+
+############################################################################
+echo "== (11) usage errors =="
+reset_issue
+run 873 --check --allow-claimed --holder threadA
+check_eq "--allow-claimed rejected outside --claim" 2 "$RC"
+run abc --check
+check_eq "non-numeric issue" 2 "$RC"
+run 873
+check_eq "no action flag" 2 "$RC"
+run 873 --check --claim
+check_eq "two action flags" 2 "$RC"
+run 873 --check --repo not-a-repo
+check_eq "malformed --repo" 2 "$RC"
+
+echo
+echo "== summary: $PASS passed, $FAIL failed =="
+[[ "$FAIL" -eq 0 ]] || exit 1
+echo "OK: issue-claim.sh tests passed"

--- a/.claude/skills/issue-maker/SKILL.md
+++ b/.claude/skills/issue-maker/SKILL.md
@@ -329,6 +329,7 @@ Start coding issue #{ISSUE_NUMBER}: {TITLE}
 Run `/start-issue {ISSUE_NUMBER}`. It polls for CodeRabbit's implementation plan, merges it into the issue body, creates a worktree and branch, and hands you a ready-to-code summary — continue from there.
 
 ## Constraints
+- Claim the issue before anything else: run `.claude/scripts/issue-claim.sh <N> --check`, and if it clears, `.claude/scripts/issue-claim.sh <N> --claim`. Do this after the model-guard check and before any repo read, edit, or planning. Exit 1 (`claimed`) or 4 (`unknown`) → stop and report the claim rather than proceeding; `stale` → say so and continue. If `--claim` itself fails, stop — a passing check is not a held claim.
 - Do NOT work on main — use the worktree /start-issue creates
 - Do NOT modify .env files
 - Merging is automatic and yours to do: once the merge gate passes and every Test Plan / AC checkbox verifies, run the full `/wrap` yourself to squash-merge — no approval pause, no pre-merge message (`CLAUDE.md` "PR MERGE AUTHORIZATION")

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -524,6 +524,7 @@ Fix/implement issue #{N}: {title}
 9. Enter the review polling loop and fix any findings
 
 ## Constraints
+- Claim the issue before anything else: run `.claude/scripts/issue-claim.sh <N> --check`, and if it clears, `.claude/scripts/issue-claim.sh <N> --claim`. Do this after the model-guard check and before any repo read, edit, or planning. Exit 1 (`claimed`) or 4 (`unknown`) → stop and report the claim rather than proceeding; `stale` → say so and continue. If `--claim` itself fails, stop — a passing check is not a held claim.
 - Do NOT work on main — use a worktree or feature branch
 - Do NOT modify .env files
 - Merging is automatic and yours to do: once the merge gate passes and every Test Plan / AC checkbox verifies, run the full `/wrap` yourself to squash-merge — no approval pause, no pre-merge message (`CLAUDE.md` "PR MERGE AUTHORIZATION")

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -352,6 +352,7 @@ These are mandatory verification points. The executing agent MUST follow these:
 
 {ALWAYS include this section, at every tier:}
 ## Constraints
+- Claim the issue before anything else: run `.claude/scripts/issue-claim.sh <N> --check`, and if it clears, `.claude/scripts/issue-claim.sh <N> --claim`. Do this after the model-guard check and before any repo read, edit, or planning. Exit 1 (`claimed`) or 4 (`unknown`) → stop and report the claim rather than proceeding; `stale` → say so and continue. If `--claim` itself fails, stop — a passing check is not a held claim.
 - Do NOT work on main — use a worktree or feature branch
 - Do NOT modify .env files
 - Merging is automatic and yours to do: once the merge gate passes and every Test Plan / AC checkbox verifies, run the full `/wrap` yourself to squash-merge — no approval pause, no pre-merge message (`CLAUDE.md` "PR MERGE AUTHORIZATION")

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -56,6 +56,33 @@ gh issue view "$ISSUE_NUMBER" --json number,title,body,state,createdAt --comment
 - Capture `TITLE`, `BODY`, and `CREATED_AT` (from the `createdAt` JSON field) for downstream steps.
 - Compute issue age in seconds from `CREATED_AT`. Use a portable approach (Python or `gdate` on macOS if available; otherwise derive from the recorded `ISSUE_CREATED_AT` when the issue was just created by this skill).
 
+## Step 2b: Claim the issue (GATE — before planning, before the worktree)
+
+An open-PR check cannot see a thread that picked this issue twenty minutes ago and has not pushed yet. Stake the claim here, at pick time — **before** CR-plan polling (Step 3) and **before** the worktree (Step 6) — so a sibling thread checking a minute from now sees it (issue #873).
+
+```bash
+CLAIM=$(.claude/scripts/issue-claim.sh "$ISSUE_NUMBER" --check); CLAIM_RC=$?
+```
+
+| Verdict | Exit | Do |
+|---|---|---|
+| `unclaimed` / `mine` | 0 | proceed to `--claim` below |
+| `stale` | 0 | surface the stale warning to the user, then proceed — a dead thread must not park the issue forever |
+| `claimed` | 1 | **STOP.** Report it in the same shape as the existing worktree skip: "Issue #N is already being worked — claimed by `{claimant}` at {time} — skipping." Do not plan, do not create a worktree. |
+| `unknown` | 4 | **STOP**, same as `claimed`. An `unknown` verdict never reads as permission. |
+
+When the check clears, take the claim before doing anything else:
+
+```bash
+.claude/scripts/issue-claim.sh "$ISSUE_NUMBER" --claim
+```
+
+**Override.** If the user explicitly says to start it anyway — naming this issue, in chat — re-run with `--allow-claimed` and state in the reply that you are overriding a live claim. The override is per-issue and per-session: never inferred from context, never a default, never carried to the next issue.
+
+**Release.** The claim is dropped by `/wrap` when the PR merges, by `admin-merge.sh`, on issue close, or by running `--release` yourself if the user abandons the work.
+
+The Step 6 `git worktree list` guard stays as a same-machine backstop — it covers only this one entry path, on one machine, and only after the worktree stage. Contract and rationale: `.claude/reference/issue-claim.md`.
+
 ## Step 3: Handle CR implementation plan
 
 CR's plan is identified by a comment from `coderabbitai` (no `[bot]` suffix — issue comments use the bare name). Use `.claude/scripts/cr-plan.sh` for detection — it encapsulates the canonical substantive-plan filter (`cr-plan-filter.py`: reject the issue-enrichment/Issue-Planner boilerplate and "actions performed" ack lines, then require >200 chars of stripped content plus a heading or numbered step — issue #541) and the 60s polling loop.

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -71,11 +71,19 @@ CLAIM=$(.claude/scripts/issue-claim.sh "$ISSUE_NUMBER" --check); CLAIM_RC=$?
 | `claimed` | 1 | **STOP.** Report it in the same shape as the existing worktree skip: "Issue #N is already being worked — claimed by `{claimant}` at {time} — skipping." Do not plan, do not create a worktree. |
 | `unknown` | 4 | **STOP**, same as `claimed`. An `unknown` verdict never reads as permission. |
 
-When the check clears, take the claim before doing anything else:
+When the check clears, take the claim before doing anything else — and **gate on the result**. `--check` passing is not the same as `--claim` succeeding: another thread can win the race between the two calls, and a write can fail outright. Proceeding on an unheld claim is exactly the duplicate-work window this step exists to close:
 
 ```bash
-.claude/scripts/issue-claim.sh "$ISSUE_NUMBER" --claim
+CLAIM_HOLDER="${CLAUDE_CLAIM_HOLDER:-issue-$ISSUE_NUMBER-$(hostname -s)-$$}"
+if ! .claude/scripts/issue-claim.sh "$ISSUE_NUMBER" --claim --holder "$CLAIM_HOLDER"; then
+  # exit 1 = another thread claimed it in the race; exit 4 = write failed / undetermined.
+  # Either way the claim is NOT held — STOP, same as a `claimed` verdict above.
+  echo "Issue #$ISSUE_NUMBER — could not take the claim; not starting." >&2
+  exit 1
+fi
 ```
+
+`CLAIM_HOLDER` is captured explicitly because it must be **handed to the thread that continues this work** — see Step 7.
 
 **Override.** If the user explicitly says to start it anyway — naming this issue, in chat — re-run with `--allow-claimed` and state in the reply that you are overriding a live claim. The override is per-issue and per-session: never inferred from context, never a default, never carried to the next issue.
 
@@ -258,6 +266,7 @@ Print a compact summary to the user. Per `chip-launching.md`, the content **insi
 {unchecked checkbox items from the issue body}
 
 ### Constraints
+- This issue is already claimed for you (holder `{CLAIM_HOLDER}`). Re-affirm it before anything else — `.claude/scripts/issue-claim.sh <N> --claim --holder "{CLAIM_HOLDER}"` — after the model-guard check and before any repo read, edit, or planning. It is a no-op that confirms the claim is still yours; a non-zero exit means you do NOT hold it, so stop and report rather than proceeding.
 - Do NOT work on main — use the worktree above
 - Do NOT modify .env files
 - Merging is automatic and yours to do: once the merge gate passes and every Test Plan / AC checkbox verifies, run the full `/wrap` yourself to squash-merge — no approval pause, no pre-merge message (`CLAUDE.md` "PR MERGE AUTHORIZATION")
@@ -282,6 +291,12 @@ Ready to code. Start with step 1 of the plan above. Run the dual-CLI local revie
 **The `**Model:**` line, the `**Effort:**` line, and the guard live in the base block, not as a chip-only addition** — chips preset neither picker control, so both a fallback-mode reader and a chip-mode spawned session need the recommendations and the guard in the text itself. The visible short summary in chip mode still repeats both lines (not the guard) so the user can set the picker before clicking. When the parent thread is on Fable and the chip recommends a different model, add the pre-click warning from `chip-launching.md` "Upstream requirement."
 
 **Record the returned `task_id` immediately,** before any dependent step — an unrecorded chip cannot be withdrawn. `/start-issue` has no Active Work table, so track it **session-locally**, keyed by issue number, and say so in the summary; the chip stays dismissable for this session only. If the issue already has a live chip recorded in this session, skip the spawn rather than offering it twice. `dismiss_task` hygiene and print-on-demand replay ("print the full prompt for #N" re-emits that chip's `prompt` verbatim — Model line, guard preamble, and block — in the fenced form fallback would have printed; the chip stays offered) follow the reference — do not restate its rules here.
+
+### Claim inheritance in the Constraints block
+
+`/start-issue` is the one emitter that **already holds the claim** by the time it offers a chip (Step 2b), so its Constraints block carries **Form B** of `chip-launching.md`'s "Claim line" — the inheriting form. Substitute `{CLAIM_HOLDER}` with the exact value passed to `--claim` in Step 2b, in both the chip `prompt` and the fallback block.
+
+Getting this wrong is not cosmetic: with Form A (or an unsubstituted placeholder) the launched thread would take the claim it is meant to inherit as a *foreign* one, exit 1, and refuse to start the very work the chip exists to do. A `/start-issue` run and the thread it hands off to are one pickup of the issue, handed over — not two threads racing.
 
 ### Merge authority in the Constraints block
 

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -130,15 +130,28 @@ Apply Step 4's verdict per issue. **Being too big is not a failure — it routes
 
 For each qualifying issue:
 
-### 6.0: Check for existing open PRs
+### 6.0: Check for existing open PRs *and* for a live claim
 
-For each qualifying issue, verify no PR is already open:
+For each qualifying issue, verify no PR is already open **and** that no other thread has claimed it. A PR is the *last* artifact a thread produces, so the PR check alone comes back clean for the entire plan-and-code window (issue #873) — both checks run, every time:
 
 ```bash
 gh pr list --search "head:issue-{NUMBER}" --json number,title,state
+.claude/scripts/issue-claim.sh {NUMBER} --check
 ```
 
-If a PR already exists for the issue, skip it: "Issue #N already has PR #{M} — skipping."
+Either signal skips the issue, and the skip line names **which** one fired:
+
+- PR exists → "Issue #N already has PR #{M} — skipping."
+- claim check exits `1` (`claimed`) or `4` (`unknown`) → "Issue #N is already being worked — claimed by `{claimant}` at {time} — skipping." `unknown` is treated exactly as `claimed`; it never reads as permission.
+- `stale` (exit 0) → not a skip. Surface the stale warning and continue.
+
+When both checks pass, **take the claim before spawning Phase A** so it is held for the whole pipeline, not just this step:
+
+```bash
+.claude/scripts/issue-claim.sh {NUMBER} --claim
+```
+
+`/wrap` releases it at merge. If the user explicitly says to start a claimed issue anyway — naming that issue, in chat — pass `--allow-claimed` and say in the report that you are overriding a live claim; it is per-issue and per-session, never inferred and never a default. Contract: `.claude/reference/issue-claim.md`.
 
 ### 6.0b: Serialize overlapping issues (launch-side overlap filter — issue #756)
 

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -145,11 +145,14 @@ Either signal skips the issue, and the skip line names **which** one fired:
 - claim check exits `1` (`claimed`) or `4` (`unknown`) → "Issue #N is already being worked — claimed by `{claimant}` at {time} — skipping." `unknown` is treated exactly as `claimed`; it never reads as permission.
 - `stale` (exit 0) → not a skip. Surface the stale warning and continue.
 
-When both checks pass, **take the claim before spawning Phase A** so it is held for the whole pipeline, not just this step:
+When both checks pass, **take the claim before spawning Phase A** so it is held for the whole pipeline, not just this step — and **gate the spawn on it succeeding**. A passing `--check` is not a held claim: another thread can win the race between the two calls, and the write itself can fail. Spawning on an unheld claim reopens the exact window this guards:
 
 ```bash
-.claude/scripts/issue-claim.sh {NUMBER} --claim
+.claude/scripts/issue-claim.sh {NUMBER} --claim || {
+  echo "Issue #{NUMBER} — could not take the claim; skipping (not spawning Phase A)."; }
 ```
+
+Skip the issue on any non-zero exit (`1` = lost the race, `4` = write failed/undetermined), reporting it the same way as a `claimed` verdict. Do not spawn.
 
 `/wrap` releases it at merge. If the user explicitly says to start a claimed issue anyway — naming that issue, in chat — pass `--allow-claimed` and say in the report that you are overriding a live claim; it is per-issue and per-session, never inferred and never a default. Contract: `.claude/reference/issue-claim.md`.
 

--- a/.claude/skills/wave/SKILL.md
+++ b/.claude/skills/wave/SKILL.md
@@ -58,7 +58,18 @@ Start from the ranked order and remove, in this sequence:
 
    Leave jq's stderr unredirected — a malformed log file should surface as a visible error, not look identical to "no live chip found" (`chip-launching.md` "Cross-skill chip visibility"). Drop any candidate whose number appears in the command's output, silently — same treatment as (1). An issue-maker thread already offering a chip for #N is the same "already offered" state as a `Chip offered` row, just recorded in a different store.
 3. **Already in flight on GitHub (dedup — any author).** Drop any issue referenced by a closing keyword (`close`/`closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`, case-insensitive) in an open PR body — local (`#N`) and cross-repo (`owner/repo#N`) forms both, **regardless of who authored the PR**: you don't want to start work a collaborator is already doing. Reuse the open-PR data `/pm` already fetched (it carries the `author` field); do not re-query. As you drop each one, note whether the covering PR is **yours** (`author.login` equals your authenticated login — `$GH_USER`, else `gh api user --jq .login`) or a **collaborator's** — only your own feed the ceiling count below.
-4. **Explicitly blocked labels.** Drop `blocked`, `on-hold`, `wontfix`, `duplicate` (`/pm` 1B.4 already excludes these — this is a cheap re-check, not a re-ranking).
+4. **Already claimed by another thread (no PR yet).** Item 3 only sees issues that have reached a PR; a thread that picked an issue twenty minutes ago and is still planning is invisible to it. Consult the claim instead (issue #873). **Batch the lookup** — one call for the whole backlog, then the helper only for the intersection, because a candidate without the label cannot hold a claim:
+
+   ```bash
+   CLAIMED=$(gh issue list --label in-progress --state open --limit 100 --json number --jq '.[].number')
+   # then, only for candidates whose number appears in $CLAIMED:
+   .claude/scripts/issue-claim.sh <N> --check
+   ```
+
+   Drop a candidate whose verdict is `claimed` (exit 1) or `unknown` (exit 4), naming the claim as the reason. `unknown` is treated exactly as `claimed` — it never reads as permission. `stale` is **not** an exclusion: keep the candidate and surface the stale warning alongside it.
+
+   Respect issue #732 the same way item 3 does: a **collaborator's** fresh claim drops the issue as context, but it never counts toward *your* `IN_FLIGHT` ceiling and is never overwritten.
+5. **Explicitly blocked labels.** Drop `blocked`, `on-hold`, `wontfix`, `duplicate` (`/pm` 1B.4 already excludes these — this is a cheap re-check, not a re-ranking).
 
 Every issue removed here is **silent** — it is not a wave exclusion and does not appear in the excluded list (Step 9). The excluded list is for issues that were genuine candidates and lost on independence or cap.
 

--- a/.claude/skills/wave/SKILL.md
+++ b/.claude/skills/wave/SKILL.md
@@ -66,6 +66,8 @@ Start from the ranked order and remove, in this sequence:
    .claude/scripts/issue-claim.sh <N> --check
    ```
 
+   The label is a safe pre-filter because `issue-claim.sh` maintains it as a **superset** of the claim: `--claim` writes the label before the claim comment and rolls the label back if the comment fails, and `--release` deletes the comment before removing the label. So a claim that exists at all carries the label at every intermediate point — there is no "comment but no label" state for this filter to miss.
+
    Drop a candidate whose verdict is `claimed` (exit 1) or `unknown` (exit 4), naming the claim as the reason. `unknown` is treated exactly as `claimed` — it never reads as permission. `stale` is **not** an exclusion: keep the candidate and surface the stale warning alongside it.
 
    Respect issue #732 the same way item 3 does: a **collaborator's** fresh claim drops the issue as context, but it never counts toward *your* `IN_FLIGHT` ceiling and is never overwritten.

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -248,6 +248,15 @@ After blockers clear (Phase 1 + Step 2.1 recovery + Step 2.2), run `gh pr merge 
 gh pr merge "$PR_NUM" --squash
 ```
 
+**Release the issue claim** once the merge succeeds — a merged PR is the terminal state that makes the issue startable again (issue #873). Step 3.1 resolves the linked issue for follow-ups, but that runs later, so resolve it here too:
+
+```bash
+MERGED_ISSUE=$(.claude/scripts/pr-issue-ref.sh "$PR_NUM" 2>/dev/null || true)
+[ -n "$MERGED_ISSUE" ] && .claude/scripts/issue-claim.sh "$MERGED_ISSUE" --release || true
+```
+
+Best-effort by design: the merge has already landed, so a failed release is a warning, never a non-zero exit from `/wrap`. An unreleased claim ages out on its own within `CLAIM_STALE_HOURS`; failing an already-completed merge would be far worse. This is the only release call on the merge path — Phase C (`phase-c-merger.md`) runs `/wrap` and inherits it, so do not add a second one there.
+
 Do NOT use `--delete-branch`. The current worktree is still checked out on the feature branch — git refuses to delete a branch held by a worktree. The branch is cleaned up out-of-band by `/pm-update` via `.claude/scripts/stale-cleanup.sh`.
 
 ### Step 2.5: Sync root repo main (aggressive reset)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Detail: `.claude/reference/continuous-work-posture.md`.
 
 ## PR & ISSUE WORKFLOW
 
-**The flow is always:** GitHub issue → CR plan (when available) → implementation plan → feature branch → code → local review → push → PR → GitHub review → merge. Never jump straight to coding (full flow: `issue-planning.md`).
+**The flow is always:** GitHub issue → claim → CR plan (when available) → implementation plan → feature branch → code → local review → push → PR → GitHub review → merge. Never jump straight to coding (full flow: `issue-planning.md`).
 
 **Key rules:**
 - **Every PR must link to a GitHub issue.** No exceptions — create one via `gh issue create` first. Use `Closes #N` in the PR body.


### PR DESCRIPTION
Closes #873

## What changed

Work was guarded by the wrong question: **"does an open PR exist for this issue?"** A PR is the *last* artifact a thread produces, so for the entire plan-and-code window — routinely 30+ minutes — every other thread's check comes back clean, and a second thread picks the same issue in good faith.

This stakes the claim at **pick** time instead.

`.claude/scripts/issue-claim.sh <N> --check|--claim|--release` writes the claim to GitHub as three artifacts (`in-progress` label + `@me` assignee + a claim comment carrying the holder token and timestamp). No local claim state — a local file by definition cannot see a sibling thread.

| Path | Wiring |
|---|---|
| `/start-issue` | new **Step 2b** — before CR-plan polling, before the worktree |
| `/subagent` | Step 6.0, alongside the existing open-PR check; `--claim` before spawning Phase A |
| chip-launched thread | first action after the MODEL GUARD preamble (`chip-launching.md`) |
| ad-hoc "work on #N" | `issue-planning.md` **step 0** |
| `/wave` | Step 2 item 4, batched to one `gh issue list` for the whole backlog |
| `/wrap`, `admin-merge.sh`, chip trigger 4 | `--release` on the terminal states |

## Three design calls worth reviewing

**1. The claim records a holder token, not just the login.** This is a deliberate departure from the CodeRabbit plan, which defined `mine` as "label present **and** viewer in assignees". The failure this feature exists to prevent is *two Claude tabs belonging to the same human* — both authenticate as the same login, so an assignee-only test answers "yes, mine" in the second tab and blocks nothing. The feature would have been inert in exactly its motivating case. `issue-claim.test.sh` scenario (2) pins this: substituting the login-level comparison makes it fail (verified by mutation, below).

**2. Block at holder level, release at account level.** `--check`/`--claim` compare holders, so a sibling thread is blocked. `--release` compares logins, so a terminal state reached by a *different* thread of yours — a Phase C merger, a `/wrap` from another worktree — still clears the claim instead of leaking it. A collaborator's claim is never touched by either (#732), including under `--allow-claimed`: the override authorizes starting the work, not deleting someone else's comment.

**3. Rule-corpus cost paid in place, no ratchet-cap raise.** The corpus was at 11,744 against a cap of 11,749 — five words of headroom. Rather than write into four rule files (CR's plan) or reset the ratchet with `--allow-raise` (which would jump the cap by 776, not by the ~30 actually needed), the rule text lands in one place and is paid for by moving mechanism out: the fetch-concatenate-edit snippet → `/start-issue` Step 5 (which carries a fuller version including the duplicate-section strip), the CR-plan filter detail → `cr-plan.sh --help`, and everything else → the new non-loaded `.claude/reference/issue-claim.md`. **Final: 11,749 / 11,749.**

## Local review coverage: `none` (self-review)

Both local CLIs were unavailable, so this was pushed on a self-review per `cr-local-review.md`:

- **CodeAnt** — `Access denied (403)` on both the full run and the scoped retry (the known undocumented daily cap; no `logout`/`login` attempted, per the rule). `meta.capped: true`, zero review records.
- **CodeRabbit CLI** — hung 10 minutes in `setting_up` after `Free OSS limits apply`, well past the 2-minute drop threshold. No findings emitted.

The GitHub App reviewers are unaffected and still gate the merge.

The self-review did find one real defect, now fixed with a regression test: the takeover path deleted the previous claim comment unconditionally, which would have deleted a **collaborator's** comment under `--allow-claimed` — a #732 violation. It now deletes only the viewer's own markers; reads take the newest claim comment, so a leftover foreign marker is inert.

## Verification performed

- `issue-claim.test.sh` — **75 assertions, 0 failures**, offline stubbed `gh` with a *stateful* fake issue so a claim written by one run is read back by the next.
- **Mutation-tested**, because a test that passes both ways proves nothing:
  - login-level `mine` (CR's design) → scenario (2) fails ✔
  - staleness disabled → scenario (5) fails ✔
- `run-hook-tests.sh` — **53 suites, 0 failed**; the new test is auto-discovered (no workflow edit).
- `admin-merge.test.sh` — 81 passed, 0 failed, after adding the release helper to all three merge shapes.
- All five lints green: `rule-lint`, `chip-model-guard-lint`, `merge-authority-lint`, `skill-catalog-lint`, `verbatim-block-lint`.
- The `awk` epoch converter (used instead of `date -d`/`date -j`, which disagree across GNU/BSD) checked against Python at the epoch boundary, a leap day, and a year end — exact on all four.

## Test plan

- [x] Thread A claims #N; thread B's pre-start check reports #N as claimed and does not start — with no PR existing anywhere
- [x] Thread A claims and then merges; the claim is released and #N is startable again
- [x] Claim older than the stale window → surfaced as stale, work is allowed to proceed
- [x] Same thread re-claims #N after a compaction-recovery restart → no-op, no error, no duplicate marker
- [x] Explicit chat override starts work on a claimed issue and states that it is overriding
- [x] `/wave` and `/subagent` both exclude a claimed-but-PR-less issue from their candidate sets, naming the claim as the reason
- [x] Stubbed-`gh` offline test passes in CI
- [x] Claim is taken at pick time — before CR-plan polling and before worktree creation
- [x] An indeterminate `gh` result (`unknown`) is treated as claimed and never reads as permission
- [x] A collaborator's claim is never released or overwritten, including under `--allow-claimed` (#732)
- [x] Rule corpus stays within its ratchet cap with no `--allow-raise`

