### PR TITLE
fix(skills): make pmm-wake resume fail-closed and reset table digests

### DIFF
--- a/.claude/skills/pr-monitor-and-manage-wake/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage-wake/SKILL.md
@@ -62,22 +62,66 @@ Cancel the `/loop` armed at pause time (runtime loop-stop), then proceed to mark
 Read saved config and fleet snapshot:
 
 ```bash
-CONFIG=$("$SESSION_STATE_SH" --get '.pmm.config_at_pause' 2>/dev/null || echo '{}')
-FLEET_AT_PAUSE=$("$SESSION_STATE_SH" --get '.pmm.fleet_at_pause' 2>/dev/null || echo '[]')
-AUTHOR=$(jq -r '.author // empty' <<<"$CONFIG")
-REPO=$(jq -r '.repo // empty' <<<"$CONFIG")
+CONFIG=$("$SESSION_STATE_SH" --get '.pmm.config_at_pause' 2>/dev/null || echo 'null')
+# Fall back to `null`, NOT `[]`: an empty array is a *valid* snapshot (a fleet
+# that drained to zero), so defaulting to it would turn a failed state read into
+# a silent "fleet changed" and resume. `null` fails the guard below instead.
+FLEET_AT_PAUSE=$("$SESSION_STATE_SH" --get '.pmm.fleet_at_pause' 2>/dev/null || echo 'null')
+AUTHOR=$(jq -r '.author // empty' <<<"$CONFIG" 2>/dev/null || echo '')
+REPO=$(jq -r '.repo // empty' <<<"$CONFIG" 2>/dev/null || echo '')
 REPO_FLAG=()
 [[ -n "$REPO" ]] && REPO_FLAG=(--repo "$REPO")
 
-# Lightweight scan — gh pr list only, no full per-PR gate reads
+# Fail closed: a scan that cannot *prove* the fleet changed must keep the pause.
+# An unchecked failure here reads as a fleet change and starts a full monitor
+# run the user never asked for (issue #871).
+scan_failed() {
+  echo "ERROR: [auto-check] fleet scan failed — $1. Pause marker and re-scan kept; retrying on the next re-scan tick." >&2
+  exit 1
+}
+
+# An empty $AUTHOR would silently rescope the scan (or error), so the result
+# could never be compared against a snapshot taken for a specific author.
+[[ -n "$AUTHOR" ]] || scan_failed "no author in .pmm.config_at_pause — cannot scope the scan"
+
+# Lightweight scan — gh pr list only, no full per-PR gate reads.
+# Capture the exit status rather than trusting it (the run_gh() idiom in
+# .claude/scripts/pr-state.sh): `|| RC=$?` keeps set -e from swallowing it.
+# Keep stderr OUT of $CURRENT — gh writes upgrade notices there even on success,
+# and folding them in would corrupt otherwise-valid JSON.
+SCAN_RC=0
 CURRENT=$(gh pr list --state open --author "$AUTHOR" "${REPO_FLAG[@]}" \
-  --json number,headRefOid,mergeStateStatus --limit 500)
-CURRENT_FLEET=$(jq -c '[.[] | {pr: .number, head_sha: .headRefOid, state: .mergeStateStatus}] | sort_by(.pr)' <<<"$CURRENT")
-SAVED_FLEET=$(jq -c 'sort_by(.pr)' <<<"$FLEET_AT_PAUSE")
+  --json number,headRefOid,mergeStateStatus --limit 500 2>/dev/null) || SCAN_RC=$?
+
+[[ $SCAN_RC -eq 0 ]] || scan_failed "gh pr list exited $SCAN_RC"
+[[ -n "$CURRENT" ]]  || scan_failed "gh pr list returned empty output"
+# `[]` is a VALID empty fleet (every PR landed) — a real change, never a failure.
+jq -e 'type == "array"' <<<"$CURRENT" >/dev/null 2>&1 \
+  || scan_failed "gh pr list output is not a JSON array"
+
+# The saved snapshot is the other half of the comparison: a null or malformed
+# .pmm.fleet_at_pause makes SAVED_FLEET empty, so a perfectly good CURRENT_FLEET
+# compares as "changed" and resumes just as wrongly.
+jq -e 'type == "array"' <<<"$FLEET_AT_PAUSE" >/dev/null 2>&1 \
+  || scan_failed "saved snapshot .pmm.fleet_at_pause is missing or not a JSON array"
+
+CURRENT_FLEET=$(jq -c '[.[] | {pr: .number, head_sha: .headRefOid, state: .mergeStateStatus}] | sort_by(.pr)' <<<"$CURRENT") \
+  || scan_failed "could not normalise the scan result"
+SAVED_FLEET=$(jq -c 'sort_by(.pr)' <<<"$FLEET_AT_PAUSE") \
+  || scan_failed "could not normalise the saved snapshot"
 ```
 
-- If `$CURRENT_FLEET` equals `$SAVED_FLEET` (count + per-PR state) → **no-op**. Print one line: `[auto-check] Fleet unchanged — re-scan continues.` Exit 0. Do **not** cancel the re-scan or clear the pause marker.
-- If changed → cancel the re-scan (Step 3), then proceed to Step 4b (full resume + re-launch main skill).
+Only once every guard above has passed may the two snapshots be compared:
+
+```bash
+if [[ "$CURRENT_FLEET" == "$SAVED_FLEET" ]]; then
+  # No-op: do NOT cancel the re-scan, do NOT clear the pause marker.
+  echo "[auto-check] Fleet unchanged — re-scan continues."
+  exit 0
+fi
+# Changed (count or per-PR state): cancel the re-scan (Step 3), then Step 4b
+# (full resume + re-launch main skill).
+```
 
 ## Step 4b: Resume (user wake or auto-check detected change)
 
@@ -102,12 +146,20 @@ jq -e '.auto_wake == true' <<<"$CONFIG" >/dev/null 2>&1 && PMM_FLAGS="$PMM_FLAGS
 PMM_FLAGS="$PMM_FLAGS --auto-wake-cadence $(jq -r '.auto_wake_cadence // "60m"' <<<"$CONFIG")"
 jq -e '.confirm_merges == true' <<<"$CONFIG" >/dev/null 2>&1 && PMM_FLAGS="$PMM_FLAGS --confirm-merges"
 
+# One atomic, locked read-modify-write. The two digest nulls MUST ride in this
+# same call: this step clears .pmm.paused_at before the main skill runs, so its
+# Step 0a reset branch (guarded on a non-null marker) never fires on this path —
+# without them the stale digests survive and the first post-resume tick can
+# render as a quiet heartbeat instead of the full table (issue #872).
+# Mirror Step 0a exactly: .pmm_digest_streak is deliberately preserved.
 "$SESSION_STATE_SH" \
   --set '.pmm.paused_at=null' \
   --set '.pmm.fleet_at_pause=null' \
   --set '.pmm.config_at_pause=null' \
   --set '.pmm_idle_streak=0' \
   --set '.pmm_active=true' \
+  --set '.pmm_digest=null' \
+  --set '.pmm_row_digest=null' \
   --set '.pmm_next_expected_tick_at=null'
 ```
 
@@ -128,5 +180,7 @@ For `--auto-check` with detected change, add: `[auto-check] Fleet changed — re
 ## Safety
 
 - Never clear the pause marker on resume without also cancelling the auto-wake re-scan (Step 3) — except `--auto-check` no-op exits without touching either.
+- **A failed or unverifiable scan is never a fleet change.** If `gh pr list` errors, returns empty, or either snapshot fails to parse as a JSON array, Step 4a keeps the pause marker and the re-scan and exits non-zero — it never falls through to the comparison. Only a scan that *proves* a difference may resume.
+- **Step 4b must null `.pmm_digest` and `.pmm_row_digest` in the same `--set` batch that clears the marker.** It clears `.pmm.paused_at` before the main skill runs, so the main skill's Step 0a reset cannot fire on this path; the digests are what make its Step 4 print the full table on the first post-resume tick.
 - `--auto-check` must **not** run full per-PR gate reads — only `gh pr list` + comparison.
 - Re-running `/pr-monitor-and-manage-wake` on a non-paused session is always a clean no-op (Step 2).

--- a/.claude/skills/pr-monitor-and-manage/SKILL.md
+++ b/.claude/skills/pr-monitor-and-manage/SKILL.md
@@ -39,6 +39,8 @@ fi
 
 After any resume (and on the **first** invocation in a thread), null the table digests — `session-state.sh --set '.pmm_digest=null' --set '.pmm_row_digest=null'` — so Step 4's first tick always prints the full table.
 
+> **Both resume paths own this reset.** The branch above covers **direct re-invocation** (this skill run while `.pmm.paused_at` is still set). On the **`-wake`** path it cannot fire: `/pr-monitor-and-manage-wake` Step 4b clears the marker *before* re-arming the loop, so by this tick `paused_at` is already null. That step therefore nulls both digests in its own atomic `--set` batch (issue #872). Changing either side alone re-opens the gap.
+
 > **PR-fleet-manager mode active.** My only job in **this parent thread** is to watch and manage your open PRs as a fleet — rediscover them each tick, print a status table, and dispatch rebase / parallel `phase-a-fixer` subagents (fix work, including merge conflicts) / sequential `/wrap` (merge-ready) per the decision tree. Merge-ready PRs are landed autonomously via inline `/wrap` dispatch (unless `--confirm-merges` is set). I will not edit feature code **directly in this thread**, start issues, or do unrelated work here — but I **will** dispatch subagents that edit code, resolve conflicts, fix findings, push, and reply/resolve threads.
 
 ---

--- a/.claude/skills/pr-monitor-and-manage/references/pmm-lifecycle.md
+++ b/.claude/skills/pr-monitor-and-manage/references/pmm-lifecycle.md
@@ -55,6 +55,8 @@ if [ "$PAUSED_AT" != null ] && [ -n "$PAUSED_AT" ]; then
 fi
 ```
 
+> **The digest reset has two owners, one per resume path.** The branch above is guarded on a non-null `.pmm.paused_at`, so it covers only **direct re-invocation** of this skill. On the **`-wake`** path, Step 4b clears the marker before re-arming the loop — this branch is already skipped by the time the loop's first tick runs — so `-wake` Step 4b nulls `.pmm_digest` and `.pmm_row_digest` in its own atomic `--set` batch (issue #872). The guarantee "both digests are null after **any** resume" holds only while both sides do it; neither is redundant.
+
 Resume logic is shared with `/pr-monitor-and-manage-wake` — see `.claude/skills/pr-monitor-and-manage-wake/SKILL.md` Step 2 (re-scan teardown) and Step 3 (marker clear + loop re-arm). When resuming via re-invoking this skill (not `-wake`), apply the precedence rule in Step 1 after parsing `$ARGUMENTS`: any flag explicitly supplied on this invocation wins; omitted flags inherit from `.pmm.config_at_pause`. After resume, continue with Step 1 using the merged config and run a full discovery tick at **base** cadence (not the widened backoff cadence).
 
 A stale marker left by a killed session is safely reconciled here: the next `/pr-monitor-and-manage` invocation reads it, resumes (or the user runs `/pmm-stop`), and re-runs discovery from scratch.


### PR DESCRIPTION
## **User description**
Two resume-path defects in `/pr-monitor-and-manage-wake`, both surfaced by CodeRabbit on PR #867 in code that PR didn't touch, and both landing in the **same Step 4 region of the same file**. Shipped together because separate PRs would conflict with each other for no benefit.

Closes #871
Closes #872

## #871 — a failed fleet scan could resume the monitor

Step 4a compared `CURRENT_FLEET` against `SAVED_FLEET` without ever checking that `gh pr list` and `jq` had succeeded. On failure the empty/invalid result read as a **fleet change**, so Step 4b cancelled the re-scan, cleared `.pmm.paused_at`, and started a full monitor run the user never asked for.

Step 4a is now **fail-closed** — a scan that cannot *prove* the fleet changed keeps the pause:

- Captures the `gh pr list` exit status (`|| SCAN_RC=$?`, the `run_gh()` idiom from `.claude/scripts/pr-state.sh`) instead of trusting it.
- Rejects empty output and non-JSON-array output **on both sides** of the comparison. CodeRabbit's plan only guarded the `gh` side; a null/malformed `.pmm.fleet_at_pause` is the identical defect — it makes `SAVED_FLEET` empty so a perfectly good `CURRENT_FLEET` compares as "changed" and resumes just as wrongly.
- Keeps stderr **out** of `$CURRENT` — `gh` writes upgrade notices there even on success, which would corrupt otherwise-valid JSON.
- Every failure path keeps `.pmm.paused_at`, keeps the re-scan, reports a retry, and exits non-zero. Since #827 the re-scan is a plain `/loop`, so the retry is free on the next tick.
- The prose-only comparison is now **explicit bash**, so the no-op and changed branches cannot misfire.
- `[]` remains a **valid** snapshot — a fleet that drained to zero is a real change, not a scan failure.

**Two fail-open holes found during self-review** (neither in the issue nor CR's plan), closed here because each one bypassed the new guard entirely:

1. `.pmm.fleet_at_pause` was read with a `|| echo '[]'` fallback. An empty array is a *legitimate* drained fleet, so a failed state read sailed straight past the array check and compared as "changed". Now falls back to `null`, which the guard rejects.
2. An empty `$AUTHOR` (missing/failed `config_at_pause`) would silently rescope the scan, making the result incomparable to a snapshot taken for a specific author. Now fails closed.

## #872 — first post-resume tick could render as a quiet heartbeat

This is a **cross-file ordering contract**, not a two-field edit:

- `pr-monitor-and-manage` Step 4 prints the full table when the digests are null (condition **a**).
- Step 0a nulls them — but only **inside** `if .pmm.paused_at != null`.
- `-wake` Step 4b clears `.pmm.paused_at` *before* re-arming the loop. By the time that loop's first tick reaches Step 0a, the marker is already null, so the reset branch never fires, the stale digests survive, and the first post-resume tick can match the previous digest and print a quiet heartbeat instead of the table.

Step 4b now nulls `.pmm_digest` and `.pmm_row_digest` in the **same** `session-state.sh` call that clears the marker — one atomic locked read-modify-write, so there is no window where the marker is cleared but the digests are not. `.pmm_digest_streak` is deliberately preserved, mirroring Step 0a.

Verified as a trace rather than as "two fields were added": Step 4b → digests null on disk → `/loop` fires the main skill → Step 0a skips (marker already null) → Step 4 reads `PREV`/`ROW_PREV` as null → condition (a) fires → full table.

Step 0a's own reset stays in place: it still owns the **direct re-invocation** path. Both skills and `pmm-lifecycle.md` now record that the reset has one owner per resume path, so neither side gets "cleaned up" as redundant later.

## Verification

These are procedural markdown skills — **they have no automated test coverage in this repo, and this PR does not add any.** The `.claude/scripts/tests/*.test.sh` suite covers shell scripts, not `SKILL.md` prose. Rather than assert correctness by inspection, I extracted the *actual* fenced bash from Step 4a (via `awk`, so it exercises the committed file, not a copy) and ran it against stubbed `gh` / `session-state.sh` fixtures:

| Case | Expected | Result |
|---|---|---|
| `gh` non-zero exit | keep pause, rc=1 | PASS |
| `gh` empty output | keep pause, rc=1 | PASS |
| `gh` non-JSON output | keep pause, rc=1 | PASS |
| `gh` JSON object (not array) | keep pause, rc=1 | PASS |
| saved snapshot `null` | keep pause, rc=1 | PASS |
| saved snapshot garbage | keep pause, rc=1 | PASS |
| `session-state.sh` read failure | keep pause, rc=1 | PASS |
| config present but no author | keep pause, rc=1 | PASS |
| unchanged fleet | no-op, rc=0 | PASS |
| empty fleet `[]` | valid change, rc=0 | PASS |
| changed `head_sha` | resume, rc=0 | PASS |
| `[]` vs `[]` | unchanged, rc=0 | PASS |

**12/12 pass.** Run against the pre-fix file from `main`, **8 of the first 10 fail** — so the harness discriminates rather than rubber-stamping. The harness is a scratch verification tool and is not committed.

Also run: `bash .github/scripts/run-hook-tests.sh` → **56 suites discovered, 0 failed**; `rule-lint: OK`; `skill-conventions-audit.sh` → 0 errors (44 pre-existing warnings, none from these files).

**Corpus budget:** unchanged at **11,730 / 11,749**. All three files are under `.claude/skills/`, which is not part of the auto-loaded rule corpus — no `CLAUDE.md`, no `.claude/rules/*.md`, and `.budget-soft-cap` untouched (#879 stays the owner's call).

**Local review coverage:** none

> Both CLIs were down. CodeAnt returned `403 Access denied` on two consecutive runs — the known undocumented daily cap; no re-auth attempted, per `cr-local-review.md`. CodeRabbit CLI connected and then hung at the `analyzing/summarizing` phase with a clean stream, no error record, and no new stdout for 3 minutes; killed per the 2-minute rule. Both exit `0` on total failure, so both were checked for the documented false-clean signatures (CodeAnt stderr, CodeRabbit stdout NDJSON `type: "error"`) rather than trusted. Self-review substituted — and it caught the two fail-open holes listed above, so it was not a formality.

## Test plan

**#871**
- [x] Step 4a captures the `gh pr list` exit status and does not compare on a non-zero exit
- [x] Step 4a rejects empty and non-JSON-array scan output before computing `CURRENT_FLEET`
- [x] Step 4a validates `.pmm.fleet_at_pause` is a JSON array before computing `SAVED_FLEET`
- [x] An empty fleet (`[]`) is still treated as a valid scan, not a failure
- [x] Every failure path keeps `.pmm.paused_at`, keeps the re-scan, reports a retry, and exits non-zero
- [x] The unchanged/changed comparison is explicit bash, not prose bullets
- [x] The Safety section states that a failed scan is not a fleet change
- [x] `.pmm.fleet_at_pause` read falls back to `null`, not `[]`, so a failed state read cannot pass the guard
- [x] An empty `$AUTHOR` fails closed rather than silently rescoping the scan

**#872**
- [x] `-wake` Step 4b nulls both `.pmm_digest` and `.pmm_row_digest`
- [x] Both live in the same single `session-state.sh` call as the existing flags (atomic)
- [x] `.pmm_digest_streak` is left untouched, matching Step 0a
- [x] Step 0a's own reset branch remains for the direct re-invocation path
- [x] Main-skill and `pmm-lifecycle.md` prose name `-wake` Step 4b as a resume-path digest reset
- [x] Traced end to end: after a `-wake` resume, Step 4 condition (a) holds on the first tick

**Repo-wide**
- [x] Corpus word count unchanged (11,730) and `.budget-soft-cap` not raised
- [x] `run-hook-tests.sh`, `rule-lint.sh`, and `skill-conventions-audit.sh` all pass


___

## **CodeAnt-AI Description**
Prevent unsafe monitor resumes and refresh status after waking

### What Changed
- Failed, empty, malformed, or improperly scoped fleet scans now keep the monitor paused and retry later instead of treating the failure as a fleet change.
- An empty open-PR fleet remains a valid detected change, while missing or invalid saved snapshots are rejected.
- Resuming through the wake flow now clears stale table digests so the first monitoring tick shows the full current status.
- Monitoring documentation now explains the separate digest reset behavior for direct and wake-based resumes.

### Impact
`✅ Fewer unintended monitor resumes`
`✅ Safer retries after fleet-scan failures`
`✅ Accurate status tables after waking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
