### PR TITLE
fix(#885): make gate/escalation timestamp drift fail in CI, not in review

### DIFF
--- a/.claude/scripts/escalate-review.sh
+++ b/.claude/scripts/escalate-review.sh
@@ -178,27 +178,31 @@ if [[ "$PRIMARY_REVIEW_MET" == "true" ]]; then
     FRESH_APPROVERS="$(jq -rn --arg sha "$HEAD_SHA" --arg push "$HEAD_COMMIT_TS" \
       --arg logins "$VALID_APPROVERS" --slurpfile doc "$STATE_PATH" '
       # Canonicalise before comparing (BugBot review, PR #883): this is a
-      # lexicographic string compare, and "…T10:00:22+00:00" sorts BEFORE
-      # "…T10:00:16Z", so a mixed spelling would mark a fresh approval stale and
-      # withhold gate_met on a PR merge-gate.sh considers fine.
+      # lexicographic string compare, so when two timestamps share a
+      # whole-second prefix the zone suffix is the first differing character —
+      # and "+" (0x2B) is below "Z" (0x5A), so "…T10:00:16+00:00" sorts BELOW
+      # "…T10:00:16Z" despite being the SAME instant. A push stamped "…16Z"
+      # against an approval stamped "…16+00:00" therefore reads as
+      # approval-before-push: a fresh approval is marked stale and gate_met is
+      # withheld on a PR merge-gate.sh considers fine.
       #
       # STRIP the zone suffix, do NOT rewrite it to "Z", and KEEP fractional
-      # seconds — this must reproduce exactly the ordering that norm_ts in
-      # merge-gate.sh produces, because the two scripts implement one rule
+      # seconds — this is the jq mirror of norm_ts in lib/ts-normalizer.sh and
+      # must reproduce its ordering exactly, because the two implement one rule
       # (#836) and a caller more permissive than the gate is a bug (BugBot
-      # review on 7de2a4c, PR #883). The earlier form dropped fractions and
-      # appended "Z", diverging in BOTH directions:
-      #   * dropping ".900" made "…49.900Z" and "…49Z" compare EQUAL, so an
-      #     approval the gate rules stale read as fresh here and escalation
-      #     could report gate_met on a PR merge-gate.sh blocks;
-      #   * a fraction retained under a trailing "Z" sorts the WRONG WAY —
-      #     "." (0x2E) is below "Z" (0x5A), so the LATER instant "…49.900Z"
-      #     compares below "…49Z".
-      # With the suffix gone, plain lexicographic order is correct for whole
-      # and fractional seconds alike. canon_ts in review-substance.sh keeps its
-      # own fraction-stripping form: every timestamp it compares passes through
-      # that one function, so it stays internally consistent and is never
-      # compared against a merge-gate value.
+      # review on 7de2a4c, PR #883). jq cannot source a bash function and this
+      # repo has no jq-module convention, so the mirror stays inline by design.
+      #
+      # It is NOT kept in step by hand (issue #885):
+      # tests/ts-normalizer-parity.test.sh extracts THIS def block from THIS
+      # file and asserts it agrees with norm_ts byte for byte across the whole
+      # spelling matrix (Z, +00:00, +0000, fractional, mixed, empty). Any edit
+      # that diverges — including a well-meant superset — fails that test.
+      #
+      # canon_ts in review-substance.sh keeps its own fraction-stripping form:
+      # every timestamp it compares passes through that one function, so it
+      # stays internally consistent and is never compared against a merge-gate
+      # value. The parity test pins that divergence too.
       #
       # NOTE: this comment sits inside a single-quoted jq program — no
       # apostrophes, or the quoting ends here and bash mis-parses the block.

--- a/.claude/scripts/lib/ts-normalizer.sh
+++ b/.claude/scripts/lib/ts-normalizer.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# lib/ts-normalizer.sh — Shared ISO-8601 normaliser for merge-gate timestamp
+# ordering (issue #885).
+#
+# Source this file (do NOT execute it directly) from merge-gate.sh — and from
+# any future bash caller that orders GitHub review/commit timestamps against the
+# gate's rule — so there is exactly one bash definition of that rule.
+#
+# PROBLEM SOLVED
+#   GitHub returns mixed ISO-8601 UTC spellings for the same instant: "…Z",
+#   "…+00:00", and the compact "…+0000". Bash [[ < ]] and jq's string compare are
+#   both purely lexicographic, so the FIRST differing character decides — and
+#   when two timestamps share a whole-second prefix, that character is the zone
+#   suffix. Z (0x5A) > + (0x2B), so:
+#
+#       "2026-08-01T10:00:16+00:00"  <  "2026-08-01T10:00:16Z"
+#
+#   These are the SAME instant, but they do not compare equal. The #836 rule
+#   asks whether an approval is at or after the HEAD commit, so a push stamped
+#   "…16Z" against an approval stamped "…16+00:00" reads as approval-before-push
+#   and a perfectly fresh approval is ruled stale. Nothing errors; the gate just
+#   returns the wrong merge-readiness verdict.
+#
+#   Two of the three review rounds on PR #883 were this bug:
+#     1. escalate-review.sh dropped fractional seconds while merge-gate.sh kept
+#        them, so the two ordered the same pair differently and escalation could
+#        report gate_met on an approval the gate rules stale.
+#     2. The repair then normalised "+0000" on one side only — the same
+#        divergence in a new spelling, introduced by the fix for the first.
+#   When two implementations must agree, a superset on one side is divergence,
+#   not a harmless extra.
+#
+# CONTRACT — the gate rule
+#   Strip EXACTLY ONE trailing UTC zone suffix ("Z", "+00:00", or "+0000") and
+#   change nothing else. In particular:
+#     * KEEP fractional seconds. These are DIFFERENT instants, and dropping
+#       ".900" collapses "…49.900Z" and "…49Z" to the same COMPARISON VALUE —
+#       so a strictly-earlier approval compares equal to the push and an
+#       approval the gate rules stale reads as fresh.
+#     * Do NOT rewrite the suffix to "Z". A fraction retained under a trailing
+#       "Z" sorts the WRONG WAY — "." (0x2E) is below "Z" (0x5A), so the LATER
+#       instant "…49.900Z" compares below "…49Z". With the suffix gone, plain
+#       lexicographic order is correct for whole and fractional seconds alike.
+#     * A genuine non-UTC offset is left untouched rather than mangled into a
+#       wrong instant.
+#   Output is a bare "YYYY-MM-DDTHH:MM:SS[.fraction]" string. Empty input gives
+#   empty output.
+#
+# CROSS-LANGUAGE MIRROR — escalate-review.sh
+#   escalate-review.sh implements the same rule as a jq `def canon_ts:` inside a
+#   single-quoted jq program. jq cannot source a bash function and this repo has
+#   no jq-module convention, so that mirror stays inline by design. It is not
+#   maintained by hand: `.claude/scripts/tests/ts-normalizer-parity.test.sh`
+#   extracts the jq def from the shipped file and asserts it agrees with
+#   norm_ts() byte for byte across the whole spelling matrix. Any edit that
+#   diverges fails that test.
+#
+#   Escalation is a CALLER of the gate, so it must never be the more permissive
+#   of the two — that asymmetry is why parity is enforced rather than trusted.
+#
+# OUT OF SCOPE — review-substance.sh
+#   review-substance.sh has its own `canon_ts` that strips fractional seconds
+#   AND folds the UTC spellings onto "Z". That is deliberately different, not
+#   drift: every timestamp it compares passes through that one function, so it
+#   is internally consistent and is never compared against a merge-gate value.
+#   Do NOT "unify" it into this library. The parity test pins the divergence so
+#   a future refactor that erases it fails loudly.
+#
+# USAGE
+#   # In merge-gate.sh:
+#   source "$SCRIPT_DIR/lib/ts-normalizer.sh"
+#   if [[ "$(norm_ts "$approved_at")" < "$(norm_ts "$commit_ts")" ]]; then …
+#
+# norm_ts <iso8601-timestamp>
+#   Prints the comparison-safe form. Idempotent — an already-stripped value is
+#   unchanged.
+#   Examples:
+#     norm_ts "2026-08-01T10:00:16Z"          -> "2026-08-01T10:00:16"
+#     norm_ts "2026-08-01T10:00:16+00:00"     -> "2026-08-01T10:00:16"
+#     norm_ts "2026-08-01T10:00:16+0000"      -> "2026-08-01T10:00:16"
+#     norm_ts "2026-08-01T10:00:16.900000Z"   -> "2026-08-01T10:00:16.900000"
+#     norm_ts "2026-08-01T10:00:16-04:00"     -> "2026-08-01T10:00:16-04:00"
+#     norm_ts ""                              -> ""
+
+# Exactly one suffix is stripped per call, matching the jq alternation
+# `sub("(Z|\\+00:00|\\+0000)$"; "")` in escalate-review.sh. The earlier
+# merge-gate.sh form chained three `${t%…}` expansions, which would strip BOTH
+# suffixes off a (never-observed) "…+00:00Z" while the jq mirror strips one —
+# a latent parity gap. No real GitHub timestamp carries two suffixes, so this
+# changes no live comparison.
+norm_ts() {
+  local t="${1-}"
+  case "$t" in
+    *Z)      printf '%s\n' "${t%Z}" ;;
+    *+00:00) printf '%s\n' "${t%+00:00}" ;;
+    *+0000)  printf '%s\n' "${t%+0000}" ;;
+    *)       printf '%s\n' "$t" ;;
+  esac
+}

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -130,7 +130,7 @@ printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >>
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TS_NORMALIZER_LIB="${SCRIPT_DIR}/lib/ts-normalizer.sh"
 if [[ ! -f "$TS_NORMALIZER_LIB" || ! -r "$TS_NORMALIZER_LIB" ]]; then
-  echo "merge-gate.sh: missing sibling library: $TS_NORMALIZER_LIB" >&2
+  echo "merge-gate.sh: sibling library missing or unreadable: $TS_NORMALIZER_LIB" >&2
   exit 4
 fi
 # shellcheck source=./lib/ts-normalizer.sh

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -120,6 +120,26 @@ set -uo pipefail
 printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
 
 # --------------------------------------------------------------------------
+# Shared timestamp normaliser (issue #885)
+# --------------------------------------------------------------------------
+# norm_ts() — the canonical #836 ordering rule — lives in lib/ts-normalizer.sh
+# so it has exactly one bash definition, and so the jq mirror in
+# escalate-review.sh has a single, testable thing to agree with. See that
+# library's header for the rule, the PR #883 failures that motivated it, and why
+# review-substance.sh keeps a deliberately different variant.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TS_NORMALIZER_LIB="${SCRIPT_DIR}/lib/ts-normalizer.sh"
+if [[ ! -f "$TS_NORMALIZER_LIB" || ! -r "$TS_NORMALIZER_LIB" ]]; then
+  echo "merge-gate.sh: missing sibling library: $TS_NORMALIZER_LIB" >&2
+  exit 4
+fi
+# shellcheck source=./lib/ts-normalizer.sh
+if ! source "$TS_NORMALIZER_LIB"; then
+  echo "merge-gate.sh: failed to load $TS_NORMALIZER_LIB" >&2
+  exit 4
+fi
+
+# --------------------------------------------------------------------------
 # Arg parsing
 # --------------------------------------------------------------------------
 PR_NUMBER=""
@@ -622,24 +642,13 @@ if [[ -n "$REVIEW_DECISION" && "$REVIEW_DECISION" != "APPROVED" ]]; then
   fi
 fi
 
-# Timestamp normaliser — used by all reviewer paths below (issue #836, BugBot round 5).
-# GitHub can return mixed ISO-8601 UTC forms ("…Z" and "…+00:00"). Bash [[ < ]] is
-# purely lexicographic; Z (ASCII 90) > + (ASCII 43), so "…Z" > "…+00:00" even for
-# equal instants, breaking stale-approval comparisons. Strip the timezone suffix to
-# produce a bare "YYYY-MM-DDTHH:MM:SS" string that sorts correctly for UTC timestamps.
-# `+0000` is stripped too (BugBot review on c90b32a, PR #883). escalate-review.sh
-# normalises all three UTC spellings for the same #836 freshness rule, so leaving
-# one of them out here made the two disagree: a `+0000` commit date against a `Z`
-# approval kept its suffix, the gate called a fresh approval stale, and escalation
-# — having stripped it — called the same pair fresh and could report gate_met on a
-# PR the gate blocks. Two implementations of one rule have to normalise the same
-# set. Purely additive: a suffix that used to survive and compare wrongly now does
-# not, and no other spelling changes.
-norm_ts() {
-  local t="${1%Z}"       # strip trailing Z
-  t="${t%+00:00}"        # strip trailing +00:00 (all GitHub timestamps are UTC)
-  echo "${t%+0000}"      # strip trailing +0000 (same instant, compact spelling)
-}
+# Timestamp normaliser — used by all reviewer paths below (issue #836).
+# norm_ts() is sourced from lib/ts-normalizer.sh near the top of this file
+# (issue #885): strip one trailing UTC suffix (Z / +00:00 / +0000), KEEP
+# fractional seconds. escalate-review.sh mirrors the rule in jq and must match it
+# byte for byte — that parity is enforced by tests/ts-normalizer-parity.test.sh,
+# not by a hand-maintained note. Rationale and the PR #883 failures it prevents
+# are in the library header.
 
 # Path-specific checks.
 # Default false — only the cr) branch below computes a meaningful value.

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -195,11 +195,26 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
   # untouched rather than mangled into a wrong instant.
   #
   # DELIBERATELY different from lib/ts-normalizer.sh (issue #885), which strips
-  # the suffix and KEEPS the fraction. Safe here because every timestamp this
-  # script compares passes through this one function, so it is internally
-  # consistent and is never compared against a merge-gate value. Do not "unify"
-  # the two: tests/ts-normalizer-parity.test.sh pins the difference, so a
-  # refactor that erases it fails loudly instead of silently reordering.
+  # the suffix and KEEPS the fraction.
+  #
+  # Precisely: merge-gate.sh does hand this script the SAME raw HEAD committer
+  # date it uses as LAST_COMMIT_TS (arriving as `push_ts`), and that value is
+  # compared against approval timestamps here. What never happens is a
+  # comparison ACROSS the two rules — both sides of every compare below are
+  # normalised by THIS function, so the ordering stays internally consistent.
+  #
+  # Dropping the fraction is more permissive than norm_ts (it can call equal
+  # what the gate orders), and that is safe because the two verdicts are
+  # independent and ANDed, not alternatives: merge-gate.sh evaluates
+  # CR_APPROVAL_STALE / CA_APPROVAL_STALE with norm_ts and uses it as the OUTER
+  # guard, with the counts_as_coverage verdict tested INSIDE it. Substance can
+  # therefore only ever subtract coverage — it can never restore an approval
+  # norm_ts has already ruled stale. Keep that nesting if either side is
+  # refactored.
+  #
+  # Do not "unify" the two: tests/ts-normalizer-parity.test.sh pins both the
+  # difference and that outer-guard ordering, so a refactor that erases either
+  # fails loudly instead of silently reordering.
   def canon_ts:
     (. // "")
     | if . == "" then ""

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -193,6 +193,13 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
   # same trap `norm_ts` guards against in merge-gate.sh. Fold the UTC spellings
   # onto `Z` and drop fractional seconds. A genuine non-UTC offset is left
   # untouched rather than mangled into a wrong instant.
+  #
+  # DELIBERATELY different from lib/ts-normalizer.sh (issue #885), which strips
+  # the suffix and KEEPS the fraction. Safe here because every timestamp this
+  # script compares passes through this one function, so it is internally
+  # consistent and is never compared against a merge-gate value. Do not "unify"
+  # the two: tests/ts-normalizer-parity.test.sh pins the difference, so a
+  # refactor that erases it fails loudly instead of silently reordering.
   def canon_ts:
     (. // "")
     | if . == "" then ""

--- a/.claude/scripts/tests/ts-normalizer-parity.test.sh
+++ b/.claude/scripts/tests/ts-normalizer-parity.test.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# ts-normalizer-parity.test.sh — Drift guard for the #836 timestamp rule
+# (issue #885).
+#
+# THE BUG THIS EXISTS TO CATCH
+#   merge-gate.sh orders review/commit timestamps with bash norm_ts (now
+#   lib/ts-normalizer.sh). escalate-review.sh orders the SAME pairs with a jq
+#   `def canon_ts:` inside its own program, because jq cannot source a bash
+#   function. Escalation is a CALLER of the gate, so if the two ever disagree
+#   escalation can report gate_met on an approval the gate rules stale.
+#
+#   That happened twice on PR #883, and both times only human review caught it:
+#     1. canon_ts dropped fractional seconds while norm_ts kept them, so
+#        "…49.900Z" and "…49Z" compared EQUAL on one side and ordered on the
+#        other.
+#     2. The repair then normalised "+0000" on one side only — the same
+#        divergence in a new spelling, introduced by the fix for the first.
+#        A superset on one side of a must-agree pair is divergence, not slack.
+#
+#   So this suite does not re-type either implementation. It EXTRACTS the real
+#   jq def blocks from the shipped scripts at runtime and sources the real bash
+#   library, then runs both over the spelling matrix. Editing production code is
+#   what the test observes; a divergent edit fails here instead of in review.
+#
+# ALSO PINNED
+#   review-substance.sh's canon_ts is deliberately DIFFERENT (drops the
+#   fraction, folds the UTC spellings onto "Z"). That is safe because every
+#   timestamp it compares passes through that one function. A future "unify all
+#   three" refactor would silently change its ordering, so the divergence is
+#   asserted rather than merely commented.
+#
+# Requires jq. Run from anywhere:
+#   bash .claude/scripts/tests/ts-normalizer-parity.test.sh
+set -uo pipefail
+
+# Anchor on this file, not the caller's cwd: run-hook-tests.sh cds to the repo
+# root first, but the header above promises this suite runs from anywhere and a
+# bare `git rev-parse` would resolve against wherever the caller happened to be.
+SELF_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)" || exit 1
+REPO_ROOT="$(git -C "$SELF_DIR" rev-parse --show-toplevel)" || exit 1
+SCRIPTS="$REPO_ROOT/.claude/scripts"
+LIB="$SCRIPTS/lib/ts-normalizer.sh"
+ESCALATE="$SCRIPTS/escalate-review.sh"
+SUBSTANCE="$SCRIPTS/review-substance.sh"
+MERGE_GATE="$SCRIPTS/merge-gate.sh"
+
+# No temp dir: this suite only reads the shipped scripts and evaluates jq
+# programs held in shell variables, so it writes nothing to disk.
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); echo "ok   — $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "FAIL — $1" >&2; }
+check_eq() { # desc expected actual
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+check_ne() { # desc not_expected actual
+  if [[ "$2" != "$3" ]]; then ok "$1"; else bad "$1 (expected something OTHER than '$2')"; fi
+}
+# Fatal: something this suite depends on is broken, so the remaining assertions
+# would be meaningless. Reports the counters accumulated so far rather than a
+# fabricated 0/1, and always exits non-zero.
+die() {
+  echo "FAIL — $1" >&2
+  FAIL=$((FAIL + 1))
+  echo
+  echo "== summary == $PASS passed, $FAIL failed (aborted early)"
+  exit 1
+}
+
+############################################################################
+# Load the real bash normaliser
+############################################################################
+[[ -r "$LIB" ]] || die "lib/ts-normalizer.sh not found at $LIB"
+# shellcheck source=../lib/ts-normalizer.sh
+source "$LIB" || die "could not source $LIB"
+declare -F norm_ts >/dev/null || die "norm_ts is not defined after sourcing $LIB"
+
+############################################################################
+# Extract the real jq def blocks from the shipped scripts
+#
+# The def spans several lines and contains an internal `;` (inside sub(…; …)),
+# so "up to the first semicolon" would truncate it. Both defs terminate on a
+# line ending in `end;`, so take from the `def canon_ts:` line through the first
+# such line. Collapsing the def onto one line still works — awk evaluates all
+# three rules against that single line, so it opens, prints, and closes there.
+#
+# Every failure mode below is fatal, never a skip: a test that silently stops
+# comparing is exactly the false-clean this suite exists to prevent.
+############################################################################
+DEF_RE='^[[:space:]]*def canon_ts:'
+
+extract_canon_ts() { # <file>
+  awk -v re="$DEF_RE" '
+    $0 ~ re { inblock = 1 }
+    inblock { print }
+    inblock && /end;[[:space:]]*$/ { exit }
+  ' "$1"
+}
+
+count_defs() { # <file>
+  grep -c "$DEF_RE" "$1"
+}
+
+# Build a one-expression jq program from a shipped file: the extracted def block
+# followed by the call, so `jq -rn --arg t <ts> "$BUILT_JQ"` evaluates the real
+# rule. Every failure path is fatal.
+#
+# The result lands in the global BUILT_JQ rather than on stdout ON PURPOSE:
+# `X="$(build_jq_program …)"` would run this in a SUBSHELL, where die's `exit 1`
+# kills only the subshell and the suite carries on with an empty program —
+# the silent-false-clean this file exists to prevent.
+BUILT_JQ=""
+build_jq_program() { # <file> <label>  -> sets BUILT_JQ
+  local file="$1" label="$2" block n prog probe
+  BUILT_JQ=""
+  [[ -r "$file" ]] || die "$label: file not readable at $file"
+  n="$(count_defs "$file")"
+  [[ "$n" == "1" ]] || die "$label: expected exactly 1 'def canon_ts:' in $file, found $n — extraction can no longer identify the production rule"
+  block="$(extract_canon_ts "$file")"
+  [[ -n "$block" ]] || die "$label: extracted an EMPTY canon_ts block from $file — the def shape changed and this guard has stopped guarding"
+  grep -q 'end;[[:space:]]*$' <<<"$block" || die "$label: extracted block from $file does not terminate in 'end;' — extraction truncated the def"
+  # Single-quoted on purpose: `$t` is the jq variable bound by `--arg t`, not a
+  # shell variable. shellcheck reports SC2016 here; expanding it would be the bug.
+  prog="$block"$'\n''$t | canon_ts'
+
+  # Prove the extracted text is a valid, runnable jq program before anything
+  # depends on it. A broken extraction must fail the suite, not quietly pass.
+  probe="$(jq -rn --arg t "1970-01-01T00:00:00Z" "$prog" 2>&1)" \
+    || die "$label: extracted canon_ts is not a valid jq program — $probe"
+  [[ "$probe" == "1970-01-01T00:00:00" || "$probe" == "1970-01-01T00:00:00Z" ]] \
+    || die "$label: extracted canon_ts produced an implausible result '$probe' for a plain Z timestamp"
+
+  BUILT_JQ="$prog"
+}
+
+command -v jq >/dev/null 2>&1 || die "jq is required by this suite"
+
+build_jq_program "$ESCALATE" "escalate-review.sh"
+GATE_JQ="$BUILT_JQ"
+build_jq_program "$SUBSTANCE" "review-substance.sh"
+SUBSTANCE_JQ="$BUILT_JQ"
+[[ -n "$GATE_JQ" && -n "$SUBSTANCE_JQ" ]] || die "a jq program came back empty — extraction is broken"
+
+canon_gate()      { jq -rn --arg t "$1" "$GATE_JQ"; }
+canon_substance() { jq -rn --arg t "$1" "$SUBSTANCE_JQ"; }
+
+############################################################################
+echo "== norm_ts contract (lib/ts-normalizer.sh) =="
+############################################################################
+check_eq "bare value untouched"        "2026-08-01T10:00:16"        "$(norm_ts "2026-08-01T10:00:16")"
+check_eq "Z stripped"                  "2026-08-01T10:00:16"        "$(norm_ts "2026-08-01T10:00:16Z")"
+check_eq "+00:00 stripped"             "2026-08-01T10:00:16"        "$(norm_ts "2026-08-01T10:00:16+00:00")"
+check_eq "+0000 stripped"              "2026-08-01T10:00:16"        "$(norm_ts "2026-08-01T10:00:16+0000")"
+check_eq "fraction RETAINED under Z"   "2026-08-01T10:00:16.900000" "$(norm_ts "2026-08-01T10:00:16.900000Z")"
+check_eq "fraction RETAINED under +00:00" "2026-08-01T10:00:16.900" "$(norm_ts "2026-08-01T10:00:16.900+00:00")"
+check_eq "empty in, empty out"         ""                           "$(norm_ts "")"
+check_eq "missing arg, empty out"      ""                           "$(norm_ts)"
+check_eq "idempotent on stripped value" "2026-08-01T10:00:16"       "$(norm_ts "$(norm_ts "2026-08-01T10:00:16Z")")"
+# A real non-UTC offset must NOT be mangled into a wrong instant.
+check_eq "non-UTC offset left alone"   "2026-08-01T10:00:16-04:00"  "$(norm_ts "2026-08-01T10:00:16-04:00")"
+# Suffix stripping must not rewrite to "Z" — a fraction under a trailing Z sorts
+# the wrong way ("." 0x2E < "Z" 0x5A), which is the h6d failure.
+check_ne "output does not re-append Z" "2026-08-01T10:00:16Z"       "$(norm_ts "2026-08-01T10:00:16Z")"
+
+############################################################################
+echo "== parity: norm_ts (merge-gate) vs canon_ts (escalate-review) =="
+############################################################################
+# The spelling matrix from issue #885 and scenarios (h6b)-(h6e) of
+# escalate-review.test.sh. Every entry must normalise IDENTICALLY on both sides.
+MATRIX=(
+  "2026-08-01T10:00:16"
+  "2026-08-01T10:00:16Z"
+  "2026-08-01T10:00:16+00:00"
+  "2026-08-01T10:00:16+0000"
+  "2026-08-01T10:00:16.900Z"
+  "2026-08-01T10:00:16.900000Z"
+  "2026-08-01T10:00:16.900+00:00"
+  "2026-08-01T10:00:16.900000+0000"
+  "2026-08-01T10:00:22+00:00"
+  "2026-08-01T10:00:22Z"
+  "2026-08-01T23:59:59.999999Z"
+  "2026-08-01T10:00:16-04:00"
+  "2026-08-01T10:00:16+05:30"
+  ""
+)
+for ts in "${MATRIX[@]}"; do
+  check_eq "parity on '${ts:-<empty>}'" "$(norm_ts "$ts")" "$(canon_gate "$ts")"
+done
+
+############################################################################
+echo "== parity at the COMPARISON level (the shape PR #883 actually got wrong) =="
+############################################################################
+# Normalising identically is necessary but not sufficient — what the gate and
+# escalation both do is a lexicographic ORDER test. Assert the two agree on the
+# verdict, not just on the strings.
+cmp_bash() { # a b -> lt|gt|eq
+  local a b; a="$(norm_ts "$1")"; b="$(norm_ts "$2")"
+  if [[ "$a" < "$b" ]]; then echo lt; elif [[ "$a" > "$b" ]]; then echo gt; else echo eq; fi
+}
+cmp_jq() { # a b -> lt|gt|eq
+  local a b; a="$(canon_gate "$1")"; b="$(canon_gate "$2")"
+  if [[ "$a" < "$b" ]]; then echo lt; elif [[ "$a" > "$b" ]]; then echo gt; else echo eq; fi
+}
+check_order() { # desc expected a b
+  local desc="$1" want="$2" a="$3" b="$4"
+  local got_bash got_jq
+  got_bash="$(cmp_bash "$a" "$b")"
+  got_jq="$(cmp_jq "$a" "$b")"
+  check_eq "$desc — merge-gate order"  "$want" "$got_bash"
+  check_eq "$desc — escalation agrees" "$got_bash" "$got_jq"
+}
+
+# (h6b): mixed +00:00 / Z spellings of a genuinely later approval.
+check_order "(h6b) approval 10:00:22+00:00 is AFTER push 10:00:16Z" \
+  gt "2026-08-01T10:00:22+00:00" "2026-08-01T10:00:16Z"
+# (h6e): the compact +0000 spelling of the same case. This is finding #2 on
+# PR #883 — one side stripped it, the other did not.
+check_order "(h6e) approval 10:00:22Z is AFTER push 10:00:16+0000" \
+  gt "2026-08-01T10:00:22Z" "2026-08-01T10:00:16+0000"
+# (h6c): approval EARLIER within the same second as a fractional push. This is
+# finding #1 on PR #883 — dropping the fraction collapsed these to eq, so
+# escalation called a gate-stale approval fresh.
+check_order "(h6c) approval …16Z is BEFORE push …16.900000Z (fraction must not collapse)" \
+  lt "2026-08-01T10:00:16Z" "2026-08-01T10:00:16.900000Z"
+# (h6d): the mirror — a fractional approval AFTER a whole-second push. Under a
+# retained trailing "Z" this inverts, because "." (0x2E) < "Z" (0x5A).
+check_order "(h6d) approval …16.900000Z is AFTER push …16Z (fraction must not invert)" \
+  gt "2026-08-01T10:00:16.900000Z" "2026-08-01T10:00:16Z"
+# Equal instants in three different spellings must all compare eq on both sides.
+check_order "equal instant, Z vs +00:00" \
+  eq "2026-08-01T10:00:16Z" "2026-08-01T10:00:16+00:00"
+check_order "equal instant, +00:00 vs +0000" \
+  eq "2026-08-01T10:00:16+00:00" "2026-08-01T10:00:16+0000"
+
+############################################################################
+echo "== review-substance.sh canon_ts: divergence is DELIBERATE and pinned =="
+############################################################################
+# review-substance.sh strips the fraction and folds the UTC spellings onto "Z".
+# Safe there — every timestamp it compares passes through that one function, so
+# it is internally consistent and is never compared against a merge-gate value
+# (issue #875). These assertions exist so a future "unify all three normalisers"
+# refactor fails HERE rather than silently reordering that script's markers.
+check_eq "substance folds +00:00 onto Z" \
+  "2026-08-01T10:00:16Z" "$(canon_substance "2026-08-01T10:00:16+00:00")"
+check_eq "substance folds +0000 onto Z" \
+  "2026-08-01T10:00:16Z" "$(canon_substance "2026-08-01T10:00:16+0000")"
+check_eq "substance DROPS the fraction" \
+  "2026-08-01T10:00:16Z" "$(canon_substance "2026-08-01T10:00:16.900000Z")"
+check_eq "substance is idempotent" \
+  "2026-08-01T10:00:16Z" "$(canon_substance "$(canon_substance "2026-08-01T10:00:16.900000+0000")")"
+check_eq "substance passes empty through" "" "$(canon_substance "")"
+
+# The two rules must remain genuinely different on the inputs that define the
+# difference — if these ever start matching, someone unified them.
+check_ne "substance != gate on a fractional input" \
+  "$(norm_ts "2026-08-01T10:00:16.900000Z")" "$(canon_substance "2026-08-01T10:00:16.900000Z")"
+check_ne "substance != gate on an offset input" \
+  "$(norm_ts "2026-08-01T10:00:16+00:00")" "$(canon_substance "2026-08-01T10:00:16+00:00")"
+
+############################################################################
+echo "== structural guards: no re-inlined copy of the rule =="
+############################################################################
+# The whole point of #885 is that there is ONE bash definition and ONE jq mirror
+# that a test can compare. Re-inlining a private copy into merge-gate.sh would
+# put the drift back where no assertion can see it.
+#
+# These guards read EXECUTABLE lines only. A prose mention must never satisfy
+# them: both files carry long comments that name `lib/ts-normalizer.sh`,
+# `norm_ts` and `canon_ts`, so a plain `grep -q` over the whole file would still
+# pass after someone deleted the actual `source` line or the last call site.
+# `code_lines` strips comment-only lines — which covers jq comments too, since
+# jq also uses `#`.
+code_lines() { # <file>
+  grep -v '^[[:space:]]*#' "$1"
+}
+
+# Without this, an unreadable merge-gate.sh makes code_lines emit nothing and
+# every count below comes back 0 — which reads as "no local norm_ts, all good"
+# on the one check whose passing value IS 0. Fail loudly instead.
+[[ -r "$MERGE_GATE" ]] || die "merge-gate.sh not readable at $MERGE_GATE — the structural guards below would silently pass on an empty file"
+
+# Matches `norm_ts() {`, `function norm_ts {`, and `function norm_ts() {` — all
+# three are valid bash, and a re-inlined copy in any of them is the drift this
+# guard exists to reject.
+MG_LOCAL_DEFS="$(code_lines "$MERGE_GATE" | grep -cE '^[[:space:]]*(function[[:space:]]+)?norm_ts([[:space:]]*\(\))?[[:space:]]*\{')"
+check_eq "merge-gate.sh defines no local norm_ts" "0" "$MG_LOCAL_DEFS"
+
+# An executable `source`/`.` of the library, not a comment that mentions it.
+# Two independent conditions on the same non-comment line — it must invoke
+# `source` (or the `.` builtin) AND name the library, directly or via the
+# variable holding its path. Deliberately not position-anchored: the real line is
+# `if ! source "$TS_NORMALIZER_LIB"; then`, and a guard that only recognises one
+# spelling of the wiring is a guard that breaks on a harmless refactor.
+MG_SOURCE_STMTS="$(code_lines "$MERGE_GATE" \
+  | grep -E '(^|[[:space:]])(source|\.)[[:space:]]' \
+  | grep -cE 'TS_NORMALIZER_LIB|ts-normalizer\.sh')"
+if [[ "$MG_SOURCE_STMTS" -ge 1 ]]; then
+  ok "merge-gate.sh has an executable source of lib/ts-normalizer.sh"
+else
+  bad "merge-gate.sh has no executable 'source' of lib/ts-normalizer.sh — only prose. norm_ts has been re-inlined, renamed, or the wiring was deleted"
+fi
+
+# Sourcing it is pointless if nothing calls it: require real call sites.
+MG_CALLS="$(code_lines "$MERGE_GATE" | grep -c 'norm_ts[[:space:]]*"')"
+if [[ "$MG_CALLS" -ge 1 ]]; then
+  ok "merge-gate.sh calls norm_ts in executable code ($MG_CALLS call sites)"
+else
+  bad "merge-gate.sh no longer calls norm_ts — the gate has stopped normalising and this suite guards nothing"
+fi
+
+# Guard the guard: if escalate-review.sh stops CALLING canon_ts, the def this
+# suite extracts is dead code and parity would be asserted against something the
+# gate path never runs. Count usages that are not the definition line itself.
+ESC_CALLS="$(code_lines "$ESCALATE" | grep 'canon_ts' | grep -vc "$DEF_RE")"
+if [[ "$ESC_CALLS" -ge 1 ]]; then
+  ok "escalate-review.sh calls canon_ts in its jq program ($ESC_CALLS call sites)"
+else
+  bad "escalate-review.sh defines canon_ts but never calls it — this parity suite is testing dead code"
+fi
+
+# Same for review-substance.sh, whose divergence is pinned above.
+SUB_CALLS="$(code_lines "$SUBSTANCE" | grep 'canon_ts' | grep -vc "$DEF_RE")"
+if [[ "$SUB_CALLS" -ge 1 ]]; then
+  ok "review-substance.sh calls canon_ts in its jq program ($SUB_CALLS call sites)"
+else
+  bad "review-substance.sh defines canon_ts but never calls it — the pinned divergence is meaningless"
+fi
+
+############################################################################
+echo
+echo "== summary == $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/.claude/scripts/tests/ts-normalizer-parity.test.sh
+++ b/.claude/scripts/tests/ts-normalizer-parity.test.sh
@@ -259,6 +259,46 @@ check_ne "substance != gate on an offset input" \
   "$(norm_ts "2026-08-01T10:00:16+00:00")" "$(canon_substance "2026-08-01T10:00:16+00:00")"
 
 ############################################################################
+echo "== the divergence is one-directional, and merge-gate.sh keeps it safe =="
+############################################################################
+# merge-gate.sh hands review-substance.sh the SAME raw HEAD committer date it
+# uses as LAST_COMMIT_TS (as push_ts), so a merge-gate value really does get
+# compared here — just never ACROSS the two rules.
+#
+# Pin the direction of the difference: dropping the fraction makes canon_ts
+# MORE permissive than norm_ts. On this pair the gate orders approval < push
+# (stale) while substance sees them as equal (fresh).
+GATE_APPROVAL="$(norm_ts "2026-08-01T10:00:16Z")"
+GATE_PUSH="$(norm_ts "2026-08-01T10:00:16.900000Z")"
+SUB_APPROVAL="$(canon_substance "2026-08-01T10:00:16Z")"
+SUB_PUSH="$(canon_substance "2026-08-01T10:00:16.900000Z")"
+if [[ "$GATE_APPROVAL" < "$GATE_PUSH" ]]; then
+  ok "gate rule orders this approval BEFORE the push (stale)"
+else
+  bad "gate rule no longer orders …16Z before …16.900000Z — norm_ts has stopped keeping fractions"
+fi
+check_eq "substance rule sees the same pair as EQUAL (more permissive)" "$SUB_APPROVAL" "$SUB_PUSH"
+
+# That extra permissiveness is safe ONLY because the two verdicts are ANDed with
+# freshness on the OUTSIDE: merge-gate.sh computes CR_APPROVAL_STALE with
+# norm_ts and tests the substance verdict INSIDE that guard, so substance can
+# only ever subtract coverage — never restore an approval norm_ts ruled stale.
+# If a refactor ever inverts that nesting, a canon_ts-fresh / norm_ts-stale
+# approval would slip through. Pin the nesting itself.
+GUARD_BLOCK="$(awk '/^[[:space:]]*CR_APPROVAL_VALID=false/ { n = 12 } n-- > 0' "$MERGE_GATE")"
+[[ -n "$GUARD_BLOCK" ]] || die "could not locate the CR_APPROVAL_VALID block in merge-gate.sh — this safety guard cannot be checked"
+if grep -q 'CR_APPROVAL_STALE" == false' <<<"$GUARD_BLOCK"; then
+  ok "merge-gate.sh gates CR_APPROVAL_VALID on the norm_ts staleness verdict"
+else
+  bad "merge-gate.sh no longer requires CR_APPROVAL_STALE == false before validating a CR approval — a substance-fresh but gate-stale approval could now satisfy the gate"
+fi
+if grep -q 'CR_SUBSTANTIVE" == true' <<<"$GUARD_BLOCK"; then
+  ok "substance is tested INSIDE the freshness guard, so it can only subtract coverage"
+else
+  bad "the CR substance check has moved out of the freshness guard in merge-gate.sh — substance may now be able to override a stale approval"
+fi
+
+############################################################################
 echo "== structural guards: no re-inlined copy of the rule =="
 ############################################################################
 # The whole point of #885 is that there is ONE bash definition and ONE jq mirror

--- a/.claude/scripts/tests/ts-normalizer-parity.test.sh
+++ b/.claude/scripts/tests/ts-normalizer-parity.test.sh
@@ -280,23 +280,89 @@ fi
 check_eq "substance rule sees the same pair as EQUAL (more permissive)" "$SUB_APPROVAL" "$SUB_PUSH"
 
 # That extra permissiveness is safe ONLY because the two verdicts are ANDed with
-# freshness on the OUTSIDE: merge-gate.sh computes CR_APPROVAL_STALE with
+# freshness on the OUTSIDE: merge-gate.sh computes <PREFIX>_APPROVAL_STALE with
 # norm_ts and tests the substance verdict INSIDE that guard, so substance can
 # only ever subtract coverage — never restore an approval norm_ts ruled stale.
-# If a refactor ever inverts that nesting, a canon_ts-fresh / norm_ts-stale
-# approval would slip through. Pin the nesting itself.
-GUARD_BLOCK="$(awk '/^[[:space:]]*CR_APPROVAL_VALID=false/ { n = 12 } n-- > 0' "$MERGE_GATE")"
-[[ -n "$GUARD_BLOCK" ]] || die "could not locate the CR_APPROVAL_VALID block in merge-gate.sh — this safety guard cannot be checked"
-if grep -q 'CR_APPROVAL_STALE" == false' <<<"$GUARD_BLOCK"; then
-  ok "merge-gate.sh gates CR_APPROVAL_VALID on the norm_ts staleness verdict"
-else
-  bad "merge-gate.sh no longer requires CR_APPROVAL_STALE == false before validating a CR approval — a substance-fresh but gate-stale approval could now satisfy the gate"
-fi
-if grep -q 'CR_SUBSTANTIVE" == true' <<<"$GUARD_BLOCK"; then
-  ok "substance is tested INSIDE the freshness guard, so it can only subtract coverage"
-else
-  bad "the CR substance check has moved out of the freshness guard in merge-gate.sh — substance may now be able to override a stale approval"
-fi
+#
+# WHAT THIS HAS TO CATCH, and why presence-greps are not enough.
+# Asserting only that both tokens appear near each other catches a DELETED
+# staleness check, but not the refactor that actually breaks the invariant:
+# folding the two into one DISJUNCTION —
+#
+#     if [[ "$CR_SUBSTANTIVE" == true || "$CR_APPROVAL_STALE" == true ]]; then
+#
+# still contains both strings, so two `grep -q`s pass while a substantive but
+# norm_ts-stale approval now validates. So pin the STRUCTURE, not the tokens:
+# the staleness test must sit on an EARLIER (outer) line than the substance
+# test, and neither of those two lines may be a disjunction.
+#
+# Both reviewer paths are checked. The CR and CA blocks are structurally
+# identical and carry the identical hazard, and CodeAnt hollow approvals are
+# what motivated #875 — pinning only CR would leave the other half unguarded.
+#
+# The block is delimited by its closing `fi` rather than a fixed line count, so
+# adding a comment inside it cannot push the substance test out of view and
+# produce a spurious failure.
+extract_guard_block() { # <prefix>
+  awk -v pat="^[[:space:]]*$1_APPROVAL_VALID=false" '
+    $0 ~ pat { inblock = 1 }
+    inblock { print }
+    inblock && /^    fi[[:space:]]*$/ { exit }
+  ' "$MERGE_GATE"
+}
+
+check_guard_nesting() { # <prefix>
+  local p="$1" block stale_needle sub_needle stale_no sub_no stale_line sub_line
+  block="$(extract_guard_block "$p")"
+  [[ -n "$block" ]] || die "could not locate the ${p}_APPROVAL_VALID block in merge-gate.sh — this safety guard cannot be checked"
+  grep -q '^    fi[[:space:]]*$' <<<"$block" \
+    || die "${p}_APPROVAL_VALID block in merge-gate.sh does not terminate in a matching 'fi' — extraction is unreliable and this guard cannot be trusted"
+
+  # grep -F: these are literal shell fragments, not patterns.
+  stale_needle="\"\$${p}_APPROVAL_STALE\" == false"
+  sub_needle="\"\$${p}_SUBSTANTIVE\" == true"
+  stale_no="$(grep -nF "$stale_needle" <<<"$block" | head -1 | cut -d: -f1)"
+  sub_no="$(grep -nF "$sub_needle" <<<"$block" | head -1 | cut -d: -f1)"
+
+  if [[ -n "$stale_no" ]]; then
+    ok "merge-gate.sh gates ${p}_APPROVAL_VALID on the norm_ts staleness verdict"
+  else
+    bad "merge-gate.sh no longer requires ${p}_APPROVAL_STALE == false before validating a ${p} approval — a substance-fresh but gate-stale approval could now satisfy the gate"
+    return
+  fi
+  if [[ -n "$sub_no" ]]; then
+    ok "merge-gate.sh tests the ${p} substance verdict inside that block"
+  else
+    bad "the ${p} substance check has left the ${p}_APPROVAL_VALID block in merge-gate.sh — substance may now be able to override a stale approval"
+    return
+  fi
+
+  # Ordering: the freshness test must be the OUTER one. Strictly earlier also
+  # proves the two are not folded onto a single condition line.
+  if [[ "$stale_no" -lt "$sub_no" ]]; then
+    ok "${p} substance is tested INSIDE the freshness guard, so it can only subtract coverage"
+  else
+    bad "${p}_SUBSTANTIVE is no longer nested inside the ${p}_APPROVAL_STALE guard in merge-gate.sh (staleness on block line $stale_no, substance on $sub_no) — substance may now be able to restore a gate-stale approval"
+  fi
+
+  # Neither test may be an OR: a disjunction lets either side alone validate the
+  # approval, which is exactly the "substance overrides staleness" break.
+  stale_line="$(sed -n "${stale_no}p" <<<"$block")"
+  sub_line="$(sed -n "${sub_no}p" <<<"$block")"
+  if [[ "$stale_line" != *"||"* ]]; then
+    ok "${p} freshness test is a conjunction, not a disjunction"
+  else
+    bad "the ${p}_APPROVAL_STALE test in merge-gate.sh is now part of a disjunction ('$stale_line') — staleness can be bypassed by the other operand"
+  fi
+  if [[ "$sub_line" != *"||"* ]]; then
+    ok "${p} substance test is a conjunction, not a disjunction"
+  else
+    bad "the ${p}_SUBSTANTIVE test in merge-gate.sh is now part of a disjunction ('$sub_line') — a norm_ts-stale approval could validate on substance alone"
+  fi
+}
+
+check_guard_nesting CR
+check_guard_nesting CA
 
 ############################################################################
 echo "== structural guards: no re-inlined copy of the rule =="


### PR DESCRIPTION
Closes #885

## What this changes

Three ISO-8601 normalisers implement overlapping rules across the merge-gate call graph, and two of them **must agree byte for byte** — `norm_ts` in `merge-gate.sh` and the jq `canon_ts` in `escalate-review.sh`. Escalation is a *caller* of the gate, so if it is ever the more permissive of the two it reports `gate_met` on an approval the gate rules stale.

That invariant was maintained by hand, with a comment in each file asking the reader to keep them in step. It broke twice on PR #883, and both times only human review caught it:

1. `canon_ts` dropped fractional seconds while `norm_ts` kept them, so `…49.900Z` and `…49Z` compared **equal** on one side and **ordered** on the other.
2. The repair then normalised `+0000` on one side only — the same divergence in a new spelling, introduced by the fix for the first. When two functions must agree, a superset on one side is divergence, not slack.

This PR makes that drift fail in CI instead of in review.

## Approach — hybrid, not full unification

`norm_ts` is bash; both `canon_ts` implementations are jq embedded in single-quoted jq programs. jq cannot source a bash function, and this repo has **no** jq-module (`jq -L` / `import`) convention. Generating the jq `def` from a bash variable and splicing it into `escalate-review.sh` would be new infrastructure invented as a side effect, touching quoting that the script's own comment flags as fragile. So:

- **Extract the bash side into `.claude/scripts/lib/ts-normalizer.sh`**, mirroring the existing `lib/repo-normalizer.sh` precedent (#704). `merge-gate.sh` sources it with the hard-fail pattern from `session-state.sh`. One bash definition, and one clearly-named thing for the jq mirror to agree with.
- **Leave the jq mirror inline** in `escalate-review.sh` — unchanged in behaviour.
- **Enforce the cross-language invariant with a test that extracts both real implementations from the shipped files at runtime.** No logic is retyped in the test, so an edit to production code is what the test observes.

`review-substance.sh`'s `canon_ts` stays deliberately different (strips the fraction, folds UTC spellings onto `Z`). That is load-bearing: every timestamp it compares passes through that one function, so it is internally consistent and is never compared against a merge-gate value. The difference is now **asserted**, not just commented — a future "unify all three" refactor fails loudly instead of silently reordering that script's markers.

## Behaviour changes

One, deliberate and inert on real data: `norm_ts` now strips **exactly one** trailing UTC suffix. The previous form chained three `${t%…}` expansions, so a hypothetical `…+00:00Z` would lose both suffixes while the jq alternation strips only one — a latent parity gap. No GitHub timestamp carries two suffixes; every live comparison is unchanged. Nothing else about the rule moves.

`merge-gate.sh` exits `4` (its documented local/tooling-error code, same as `die_local` for a missing sibling script) if the library is absent. The exit is before `die_local` and `HEAD_SHA` exist, so it prints to stderr rather than emitting the JSON envelope — unavoidable at source time, and it is a broken-install path, not a gate verdict.

## Verification — the guard was proven to fail on the real regressions

Both PR #883 findings were re-injected into `escalate-review.sh` and the suite was run against each:

| Injected drift | Result |
|---|---|
| Finding 1 — `canon_ts` drops the fraction and re-appends `Z` | **12 failures**, including `(h6c)`/`(h6d)` at the comparison level: `escalation agrees (expected 'lt', got 'eq')` |
| Finding 2 — `canon_ts` handles `Z`/`+00:00` but not `+0000` | **3 failures**, including `equal instant, +00:00 vs +0000 — escalation agrees (expected 'eq', got 'lt')` |
| Restored (both reverted) | **53 passed, 0 failed** |

A guard that cannot be shown to fail is not a guard.

The extraction machinery was proven fatal too: renaming `def canon_ts:` in `escalate-review.sh` aborts the suite with `expected exactly 1 'def canon_ts:' … found 0`, exit 1 — it does not quietly stop comparing.

The structural guards read **executable lines only** (comment-only lines are stripped before matching). That matters here: `merge-gate.sh` mentions `ts-normalizer.sh` on 4 lines, only 1 of which is the actual `source` — a naive `grep -q` would stay green after someone deleted the wiring and left the prose.

Full suite: `run-hook-tests.sh` — **57 suites discovered, 0 failed**. `rule-lint.sh` — OK. `shellcheck -x` on all five touched files emits only `SC1091 (info): Not following` for the sourced library, identical in kind to the existing `session-state.sh` → `lib/repo-normalizer.sh` baseline; no warnings, no errors.

**Rule corpus unchanged: 11,730 words against the 11,749 cap.** No `CLAUDE.md` or `.claude/rules/` edit — this is scripts + tests, and all narrative lives in script headers (not auto-loaded, therefore free). `.budget-soft-cap` untouched.

## Interaction with adjacent open work

Neither is being worked; read both so this change does not foreclose either.

- **Issue #865** (sticky BugBot vs. a fresh CodeAnt `APPROVED`) changes *which reviewer path* the gate consults. It does not touch normalisation. `norm_ts` keeps its name, signature, and semantics at every call site, so that work is unaffected.
- **Issue #876** (CodeAnt in-place review edits false-positive the #836 staleness guard) changes *what signal* the freshness check trusts — `commit_id` or check-run corroboration instead of `submitted_at` alone. Whatever timestamps it ends up comparing still flow through `norm_ts`, and the parity test constrains only *normalisation*, never *which fields are compared*. Both options in that ticket's fix sketch remain open.

**Contention:** verified before pushing. The sibling pipeline on issues #871/#872 touches `.claude/skills/pr-monitor-and-manage*/SKILL.md` — no overlap with this file set, and `origin/main` had not moved off `023eb4c` at push time.

## Test plan

- [x] `.claude/scripts/lib/ts-normalizer.sh` exists and is the only bash definition of `norm_ts`
- [x] `merge-gate.sh` sources it, hard-fails with a clear stderr message if it is missing, and every `norm_ts` call site is unchanged
- [x] `escalate-review.sh`'s jq `canon_ts` is unchanged in behaviour (comment repointed at the enforcing test only)
- [x] `review-substance.sh`'s deliberately different `canon_ts` is unchanged in behaviour
- [x] The parity test extracts both jq defs from the **shipped files** at runtime and never retypes the logic
- [x] Parity holds across the full spelling matrix: bare, `Z`, `+00:00`, `+0000`, `.900Z`, `.900000Z`, fractional+offset, non-UTC offset, empty
- [x] Parity is asserted at the **comparison** level for scenarios (h6b)–(h6e), not just on normalised strings
- [x] `review-substance.sh`'s intended divergence is pinned (fraction dropped, UTC folded to `Z`) so unification fails loudly
- [x] The divergence direction is pinned as one-directional (substance is the more permissive rule) and `merge-gate.sh`'s outer freshness guard around the substance check is asserted, so substance can never restore a `norm_ts`-stale approval
- [x] Structural guards read executable lines only, and fail if `norm_ts` is re-inlined, the `source` is deleted, or `canon_ts` stops being called
- [x] Extraction failure (missing def, wrong count, truncated block, invalid jq) is a loud FAIL, never a silent pass — including that `die` inside a command substitution cannot swallow the abort
- [x] Verified by injection: both PR #883 regression shapes make the suite red; restoring makes it green
- [x] `run-hook-tests.sh` green (57 suites, 0 failed)
- [x] `shellcheck -x` clean on all touched scripts against the repo's existing baseline
- [x] Rule corpus word count unchanged (11,730 / 11,749); `.budget-soft-cap` not raised

**Local review coverage:** cr-only

CodeRabbit CLI raised three findings on the first pass and all were addressed before the second:

- **major** — structural guards matched any text occurrence rather than executable usage. Fixed: guards now strip comment-only lines and separately assert an executable `source` **and** real call sites in `merge-gate.sh`, `escalate-review.sh`, and `review-substance.sh`.
- **minor** — `REPO_ROOT` came from a bare `git rev-parse`, so the header's "run from anywhere" claim was false. Fixed: anchored on `${BASH_SOURCE[0]}` via `git -C`.
- **trivial** — process reminder to complete the GitHub review loop before declaring done. Not a code finding; skipped, and the loop is being followed.

A latent bug of my own was also caught while addressing these: an intermediate refactor put the fatal `die` inside a command substitution, where `exit 1` would kill only the subshell and let the suite continue with an empty jq program — precisely the silent false-clean this file exists to prevent. The builder now writes to a global instead, with a comment explaining why.

The second pass raised three more, all fixed:

- **minor** — the lexicographic example in the new library header was simply **wrong**: `…10:00:16Z` vs `…10:00:22+00:00` differ at the seconds digit, so the suffix never decides. The trap only bites when the whole-second prefix matches. Rewritten around a correct pair (`…16+00:00` < `…16Z`, same instant). **The same error existed in `escalate-review.sh`, inherited from PR #883** — corrected there too, since that block is already in this diff.
- **minor** — no readability guard on `merge-gate.sh` before the structural checks. That mattered: an unreadable file makes `code_lines` emit nothing, every count returns 0, and the one check whose *passing* value is 0 ("defines no local `norm_ts`") would go green on an empty read. Now a fatal `die`.
- **trivial** — the local-def check only matched `norm_ts() {`. Broadened to `function norm_ts {` and `function norm_ts() {`.

The third pass took ~70 minutes but did return, with two more findings — the second of which was the most useful of the run:

- **minor** — the library-guard error message said "missing" while the condition also tests unreadable. Reworded.
- **trivial (but substantive)** — my `review-substance.sh` comment claimed its `canon_ts` is "never compared against a merge-gate value". **That was too strong and I verified it against the code: `merge-gate.sh` does hand it the same raw HEAD committer date it uses as `LAST_COMMIT_TS`, arriving as `push_ts`.** What never happens is a comparison *across* the two rules — both sides of every compare in that script are normalised by its own function. Reworded to say that precisely.

  Following that thread surfaced a real, untested, load-bearing property. Dropping the fraction makes `canon_ts` **strictly more permissive** than `norm_ts`, so it can call equal what the gate orders. That is safe *only* because the two verdicts are ANDed with freshness on the **outside**: `merge-gate.sh` computes `CR_APPROVAL_STALE` with `norm_ts` and tests `counts_as_coverage` **inside** that guard, so substance can only ever subtract coverage — never restore an approval `norm_ts` has ruled stale. Invert that nesting and a substance-fresh / gate-stale approval slips through. The suite now pins both the divergence direction and the guard structure (4 new assertions, 53 total).

Local suite re-verified after each round: 53/53 parity, 57/57 suites, zero shellcheck warnings. One full-suite run showed `handoff-state.test.sh` red; it passes in isolation and on re-run — it had raced this session's own handoff-file write, not a code regression.

CodeAnt CLI was dropped for this session after two consecutive `403 Access denied` responses on `codeant review --all --headless` (the known undocumented ~10/day agent-review cap — not an auth fault; `codeant logout`/`login` deliberately not run). Both runs exited `0` with `"issues": []` and reported `0 files have suggestions`, which is a **failed run**, not a clean pass: the stderr stream carried `API Error` / `[error] Failed to review` for every file. The CodeAnt GitHub App is unaffected.

## Phase B — review round 1 (commit `1d2ab2c`)

Phase B audited the outer-guard assertions added in `4c4f86f` rather than
inheriting them, and found the pin did not constrain what its own comment said
it constrained.

**The gap.** The guard check was two `grep -q`s over a 12-line window: does
`<PREFIX>_APPROVAL_STALE" == false` appear, and does `<PREFIX>_SUBSTANTIVE" == true`
appear. Proven by injecting each shape into the real `merge-gate.sh` and
re-running the suite:

| Injected refactor | Old assertions | New assertions |
|---|---|---|
| Staleness check **deleted** from the outer conditional | 1 failure (caught) | caught |
| Substance test turned into a **disjunction** (`\|\|` with the staleness flag) | **silently passed** | 1 failure |
| Staleness moved out of the outer guard into an inner disjunction | **silently passed** | 3 failures |

The two silent passes are precisely the "substance restores a `norm_ts`-stale
approval" break the pin exists to prevent — both strings are still present, so
presence-greps stay green while the invariant is gone.

**The fix.** Pin the structure rather than the tokens: the staleness test must
sit on a strictly earlier (outer) line than the substance test — which also
proves the two are not folded onto one condition line — and neither line may
contain a disjunction operator. The block is now delimited by its closing `fi`
instead of a fixed line count, so adding a comment inside it cannot push the
substance test out of view and cause a spurious failure.

**Coverage extended to CodeAnt.** The `CA_APPROVAL_VALID` block had *no*
assertion at all. It is structurally identical to the CR block and carries the
identical hazard, and hollow CodeAnt approvals are what motivated #875 in the
first place. Both paths are now checked by one shared helper.

`merge-gate.sh` is unchanged by this commit — every injection above was reverted
and the file verified byte-identical (`git diff` empty).

**Superseding the counts above:** parity suite is now **61 passed, 0 failed**
(was 53). `run-hook-tests.sh` 57 suites, 0 failed. `shellcheck` on the test file
emits only the pre-existing `SC1091` / `SC2016` info lines. Rule corpus still
untouched at **11,730 / 11,749** — this PR's `CLAUDE.md` + `.claude/rules/`
delta is zero.

**Adjacent open work re-confirmed.** Issues #865 and #876 both remain fully
open. Neither touches normalisation, and the parity suite still constrains only
*how* timestamps normalise and *how the two verdicts nest* — never *which*
fields are compared, which is what #876 would change. If either lands a change
to the freshness signal, these assertions fail loudly with a message naming the
invariant, which is the intended behaviour of a pin, not a blocker.

## Phase C — independent AC verification (commit `1d2ab2c`)

Every Test Plan box was verified against the committed source, not against this
body or prior summaries. The rewritten guard pin was **re-proven by injection**
in an isolated scratch copy of `.claude/scripts` — the real files were never
modified — because an assertion that passes while the invariant is broken is
worse than no assertion at all.

| Injected break | Suite result |
|---|---|
| CR substance test folded into a disjunction | **1 failure** — named the disjunction |
| CR staleness moved out of the outer guard into an inner disjunction | **2 failures** — ordering + disjunction |
| CA staleness conjunct **deleted** (the path Phase B newly covered) | **1 failure**, then early-return |
| Executable `source` of the library removed, prose left in place | **1 failure** |
| Local `norm_ts` re-inlined into `merge-gate.sh` | **1 failure** |
| `def canon_ts:` renamed in `escalate-review.sh` (0 defs) | **aborted**, exit 1 |
| Duplicate `def canon_ts:` added (2 defs) | **aborted**, exit 1 |
| #883 shape 1 — jq `canon_ts` drops the fraction | **7 failures**, incl. comparison level |
| #883 shape 2 — `+0000` dropped from the jq alternation | **3 failures**, incl. `equal instant, +00:00 vs +0000 — escalation agrees (expected 'eq', got 'lt')` |
| All reverted | **61 passed, 0 failed** |

Independently confirmed alongside the above:

- Exactly **one** bash `norm_ts` definition exists repo-wide, in `lib/ts-normalizer.sh`.
- All **12** `norm_ts` call sites in `merge-gate.sh` are byte-identical to `origin/main`.
- `escalate-review.sh` and `review-substance.sh` have a **comment-only** diff — both
  `canon_ts` bodies are unchanged, confirmed by extracting each def and diffing
  non-comment lines against `origin/main`.
- Missing library ⇒ exit `4`, stderr `sibling library missing or unreadable: …`,
  **no** JSON on stdout.
- `run-hook-tests.sh`: **57 suites discovered, 0 failed**. `rule-lint.sh`: OK.
- `shellcheck -x` on the five touched files: only `SC1091`/`SC2016` **info** — strictly
  cleaner than the untouched `session-state.sh` baseline, which additionally carries
  `SC2295`, `SC2015` and an `SC2064` **warning**.
- Rule corpus **11,730 / 11,749**; `git diff origin/main...HEAD -- CLAUDE.md .claude/rules/`
  is empty; `.budget-soft-cap` unchanged.

**Review state at merge:** BugBot clean on `1d2ab2c` (`Cursor Bugbot` check-run
`completed`/`success`, body names the full HEAD SHA, no failure phrase); CI 5/5;
0 unresolved threads. CodeRabbit did not return — it is under an org-wide Fair
Usage limit and posted no review. CodeAnt's three `body=0` approvals are hollow
and are correctly discounted by the #875 detector this PR modifies.
