### PR TITLE
fix(#876): redeem a stale bot approval by evidence, not by reviewer identity

### DIFF
--- a/.claude/reference/merge-gate-stale-approval-redemption.md
+++ b/.claude/reference/merge-gate-stale-approval-redemption.md
@@ -1,0 +1,154 @@
+# Stale-approval redemption — the CodeAnt in-place review edit (issue #876)
+
+Reference material for `merge-gate.sh`. Not auto-loaded; the enforced rule lives
+in the script and in `.claude/scripts/tests/merge-gate-codeant-inplace-review.test.sh`.
+
+## The quirk
+
+CodeAnt does not post a new review object on a re-review. It **PATCHes the
+existing one**. After a force-push its review keeps the same `id`, has
+`commit_id` correctly advanced to the new HEAD — and `submitted_at` **frozen at
+the original submission**, because GitHub's review API treats that field as
+immutable creation time rather than last-modified time.
+
+The #836 staleness guard compares `submitted_at` against the HEAD commit's
+committer date. So for CodeAnt specifically, a genuinely completed post-push
+re-review is stale **forever**, and no amount of re-triggering can clear it: each
+re-run edits the same object and leaves the same frozen timestamp.
+
+### Live trace — `auerbachb/skingod` PR #2596
+
+```text
+04:57:00Z  CodeAnt APPROVED, review id 4833716091, on pre-rebase SHA 3e9dfd0e
+04:59:42Z  force-push to f9b6041c                    <-- HEAD committer date
+05:02:01Z  @codeant-ai review posted
+05:02:06Z  "CodeAnt AI is running the review."
+05:02:34Z  sequence-diagram summary naming f9b6041c, accurately describing the
+           actual diff ("adds a SafeAreaProvider inside the native modal root…")
+05:03:35Z  "CodeAnt AI finished running the review."
+```
+
+`gh api .../pulls/2596/reviews` still returned review id **4833716091**, now
+`commit_id: f9b6041c…`, `submitted_at` still **04:57:00Z** — before the SHA it
+claimed to cover existed. `merge-gate.sh` reported
+`"CodeAnt approval on HEAD f9b6041 predates the HEAD commit (force-push
+retargeting)"` for 8 poll ticks over 15+ minutes, while a real verdict on the
+current SHA sat in the conversation the whole time.
+
+## The rule
+
+> A stale `submitted_at` may be **redeemed by external evidence on the current
+> SHA**. It is never **waived by reviewer identity**.
+
+`merge-gate.sh` computes `<P>_APPROVAL_STALE` exactly as #836 always did — the
+`norm_ts` ordering, unchanged, one meaning. Redemption is a separate, separately
+named term:
+
+```text
+<P>_STALE_REDEEMED         = <P>_APPROVAL_STALE AND external_evidence_ok(<login>)
+<P>_APPROVAL_STALE_BLOCKING = <P>_APPROVAL_STALE AND NOT <P>_STALE_REDEEMED
+```
+
+`<P>_APPROVAL_STALE_BLOCKING` is what the rest of the path consumes. Because
+redemption cannot fire unless the approval is already stale, the ordinary fresh
+path is byte-for-byte unaffected.
+
+The redemption term is `review-substance.sh`'s `external_evidence_on_head`:
+a substantive footprint anchored to HEAD and produced **outside the review object
+whose timestamp is in doubt** —
+
+- inline diff comments with `commit_id` **and** `original_commit_id` == HEAD, or
+- a `>= min_chars` conversation comment naming HEAD's SHA that is not a
+  capability-failure notice, or
+- a substantive non-`APPROVED` review on HEAD with `submitted_at >= push_ts`.
+
+Redemption is announced on stderr and is visible in the emitted
+`review_evidence`. Nothing about it is silent.
+
+## Three designs that were rejected
+
+**1. "CodeAnt's `submitted_at` is unreliable, so skip staleness for CodeAnt."**
+This is the shape the issue's own fix sketch offered as an option, and it is the
+one that must not ship. The same night #876 was filed, CodeAnt was observed
+across three repos emitting genuinely hollow approvals — `bodylen=0`, four in one
+second, one approving a commit that did not exist until 16 minutes later. An
+identity waiver re-opens exactly the hole issue #875 closed hours earlier. The
+correct shape is narrower by construction: evidence redeems, identity never does.
+CodeRabbit gets the identical redemption on identical evidence, and case (f) of
+the regression suite fails if that ever stops being true.
+
+**2. Corroborate with the "CodeAnt AI finished running the review" notice.**
+This was CodeRabbit's coding plan for the issue, and it is the intuitive reading
+of the AC. It is too weak: the notice is a fixed, content-free string, so
+accepting it lets a bot certify its own freshness with a constant. Case (c) pins
+the rejection. The live trace supplies a *better* signal at 05:02:34Z — the
+substantive summary naming the new SHA — and that is what the fix consumes.
+
+**3. Trust `commit_id == HEAD` outright for CodeAnt.**
+Rejected for the reason CodeRabbit itself gave: the retargeted `commit_id`
+*always* matches HEAD, so the AC's requirement that the uncorroborated shape stay
+blocked could not be satisfied.
+
+## Why this does not weaken #875
+
+`external_evidence_on_head` is strictly **stronger** than the `substantive`
+verdict it feeds — it is `substantive` minus the approval's own body. So the
+redemption channel is narrower than the coverage test, and the two are ANDed:
+a redeemed approval still has to clear `counts_as_coverage`.
+
+The practical consequence is case (e) of the regression suite. A reviewer with a
+summary naming HEAD *is* redeemable, but if its own newest SHA-naming comment
+names a different commit, `self_report_mismatch` still blocks it — and the
+`missing[]` entry is the #875 substance reason, not the #836 staleness one. The
+approval's own body never enters either verdict, so an approval can never vouch
+for its own frozen timestamp.
+
+## The parity pin was updated, not defeated
+
+`.claude/scripts/tests/ts-normalizer-parity.test.sh` pins that `merge-gate.sh` keeps the
+freshness verdict on the **outside** of the substance check, so the deliberately
+more permissive `canon_ts` in `review-substance.sh` (which drops fractional
+seconds) can never reorder something `norm_ts` ruled stale.
+
+That property is unchanged, because **redemption is not a timestamp comparison at
+all**. The pin's needle moved to `<P>_APPROVAL_STALE_BLOCKING`, and new
+structural assertions now keep the redemption channel exactly one term wide:
+
+- `<P>_APPROVAL_STALE_BLOCKING` may be derived only from `<P>_APPROVAL_STALE`
+  AND NOT `<P>_STALE_REDEEMED` — no disjunction, and exactly those two operands
+  (a third `&&` conjunct would narrow when staleness blocks while every
+  substring assertion still passed).
+- `<P>_STALE_REDEEMED` may be granted only by `external_evidence_ok`, only on an
+  already-stale approval, with no disjunction, and may not consult
+  `substance_ok`, `counts_as_coverage` (circular — includes the approval's own
+  body), or `norm_ts` (already decided).
+
+## Scope, and how this relates to issue #865
+
+Only the **CR path** is touched. `review_evidence` is `{}` on the BugBot and
+Greptile paths, so there is no evidence to redeem with there, and #876's trace is
+CodeAnt on the CR path. BugBot's own `submitted_at` staleness check (which has
+the same #836 shape) is deliberately left alone — BugBot has not been observed
+editing reviews in place, and widening the change without a trace would be
+speculative.
+
+Issue **#865** is the adjacent, still-open question: whether a fresh CR-path
+`APPROVED` (CodeRabbit or CodeAnt) should satisfy the gate while a PR is
+sticky-assigned to BugBot. The two do not collide and neither forecloses the
+other:
+
+- #876 changes **whether a CodeAnt approval is fresh**. It runs entirely inside
+  the `cr` path and never touches reviewer resolution or stickiness.
+- #865 would change **which path is consulted**. It is a routing decision.
+
+They compose in the obvious direction: if #865 is later decided in favour of
+letting a fresh CR-path approval satisfy a sticky-BugBot gate, #876 is what makes
+"fresh" mean the right thing for an in-place-edited CodeAnt review, so the two
+together remove the wait #865 describes. If #865 is decided the other way, #876
+still stands on its own. Notably, the workaround used in the #876 live run was
+precisely an #865-shaped escalation — switching PR #2596 to the BugBot path —
+which is why the two issues keep surfacing together.
+
+`review-substance.sh`'s `corroborating[]` field remains advisory for the same
+reason: letting BugBot silently stand in for the CR-path requirement is #865's
+decision to make, not this one's.

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -19,6 +19,21 @@
 #   check-run completed_at, BugBot reviews. Grace window: none (submitted_at must
 #   be >= committer date; equal timestamps are accepted). Guard is disabled when
 #   LAST_COMMIT_TS is empty (API failure) to avoid silently blocking clean reviews.
+#
+# Stale-approval redemption (issue #876): CodeAnt PATCHes its EXISTING review on
+#   a re-review — same review id, commit_id advanced to the new HEAD,
+#   submitted_at frozen — so a genuinely completed post-push re-review reads as
+#   #836-stale forever. A stale approval is therefore REDEEMED when that same
+#   reviewer left substantive evidence on the current SHA outside the review
+#   object (review-substance.sh `external_evidence_on_head`: HEAD-anchored inline
+#   comments, a status comment naming HEAD, or a substantive non-APPROVED review
+#   on HEAD). Redemption is by EVIDENCE, never by reviewer identity — CodeRabbit
+#   is treated identically, and an approval's own body can never redeem its own
+#   timestamp. `<P>_APPROVAL_STALE` keeps the unchanged norm_ts meaning;
+#   `<P>_APPROVAL_STALE_BLOCKING` (stale AND NOT redeemed) is what the path
+#   consumes. Redemption is announced on stderr and never bypasses the substance
+#   verdict, so a rubber stamp whose status comment names an older SHA still
+#   fails as `self_report_mismatch`.
 # Also enforces the pre-merge CI gate from .claude/rules/cr-merge-gate.md Step 1b
 # (incomplete runs OR blocking conclusions = not merge-ready), merge metadata
 # (mergeStateStatus including BEHIND, mergeable including CONFLICTING) per
@@ -793,8 +808,67 @@ case "$REVIEWER" in
         >/dev/null 2>&1 && echo true || echo false
     }
 
+    # Stale-approval redemption (issue #876). CodeAnt PATCHes its EXISTING review
+    # object on a re-review — same review id, commit_id correctly advanced to the
+    # new HEAD, submitted_at frozen at the original submission — and GitHub treats
+    # submitted_at as immutable creation time. So a genuinely completed post-push
+    # re-review reads as #836-stale and the gate wedges (auerbachb/skingod PR
+    # #2596: 8 poll ticks, 15+ minutes, on a review that had demonstrably run).
+    #
+    # The redemption term is external_evidence_on_head, NOT the reviewer's
+    # identity. "CodeAnt's submitted_at is unreliable, so skip staleness for
+    # CodeAnt" would re-open exactly the hole #875 closed the same night — that
+    # bot also emits genuinely hollow approvals (bodylen=0, four in one second,
+    # one approving a commit that did not exist for another 16 minutes). A stale
+    # timestamp may be redeemed by evidence on the current SHA; it is never
+    # waived by who submitted it. CodeRabbit gets the identical treatment.
+    #
+    # Nor is CodeAnt's own "finished running the review" notice the redeemer: it
+    # is a fixed, content-free string, so accepting it would let a bot certify
+    # its own freshness with a constant. external_evidence_on_head requires a
+    # SUBSTANTIVE footprint anchored to HEAD and produced OUTSIDE the review
+    # object whose timestamp is in doubt (review-substance.sh):
+    #   - inline diff comments with commit_id AND original_commit_id == HEAD, or
+    #   - a >= min_chars conversation comment naming HEAD's SHA that is not a
+    #     capability-failure notice, or
+    #   - a substantive non-APPROVED review on HEAD with submitted_at >= push.
+    # Each is anchored to the post-push commit, and the approval's own body is
+    # excluded by construction — an approval can never redeem its own timestamp.
+    #
+    # Fail-closed: any jq failure (missing/unparseable evidence) yields false, so
+    # a broken evaluator can only withhold redemption, never grant it.
+    external_evidence_ok() { # <login>
+      echo "$REVIEW_EVIDENCE" | jq -e --arg l "$1" \
+        '.reviewers[$l].external_evidence_on_head // false' >/dev/null 2>&1 && echo true || echo false
+    }
+
     CR_SUBSTANTIVE=$(substance_ok "coderabbitai[bot]")
     CA_SUBSTANTIVE=$(substance_ok "codeant-ai[bot]")
+
+    # <P>_APPROVAL_STALE above is the unchanged #836 norm_ts verdict and stays
+    # that way — redemption is a SEPARATE, separately-named term rather than a
+    # loosening of the ordering rule, so the timestamp comparison keeps exactly
+    # one meaning. <P>_APPROVAL_STALE_BLOCKING is what the rest of the path
+    # consumes. Redemption cannot fire unless the approval is stale in the first
+    # place, so the fresh path is byte-for-byte unaffected.
+    CR_STALE_REDEEMED=false
+    CA_STALE_REDEEMED=false
+    if [[ "$CR_APPROVAL_STALE" == true && "$(external_evidence_ok "coderabbitai[bot]")" == true ]]; then
+      CR_STALE_REDEEMED=true
+      echo "[merge-gate] CodeRabbit APPROVED on ${HEAD_SHA:0:7} has a stale submitted_at ($LATEST_CR_APPROVED_AT < $LAST_COMMIT_TS) but left substantive evidence on this SHA outside the review object — counting it as fresh (issue #876)." >&2
+    fi
+    if [[ "$CA_APPROVAL_STALE" == true && "$(external_evidence_ok "codeant-ai[bot]")" == true ]]; then
+      CA_STALE_REDEEMED=true
+      echo "[merge-gate] CodeAnt APPROVED on ${HEAD_SHA:0:7} has a stale submitted_at ($LATEST_CA_APPROVED_AT < $LAST_COMMIT_TS) but left substantive evidence on this SHA outside the review object — in-place re-review edit, counting it as fresh (issue #876)." >&2
+    fi
+    CR_APPROVAL_STALE_BLOCKING=false
+    CA_APPROVAL_STALE_BLOCKING=false
+    if [[ "$CR_APPROVAL_STALE" == true && "$CR_STALE_REDEEMED" == false ]]; then
+      CR_APPROVAL_STALE_BLOCKING=true
+    fi
+    if [[ "$CA_APPROVAL_STALE" == true && "$CA_STALE_REDEEMED" == false ]]; then
+      CA_APPROVAL_STALE_BLOCKING=true
+    fi
 
     # CR_HOLLOW / CA_HOLLOW: the approval cleared every pre-#875 check (present,
     # fresh, not retracted) but nothing evidences that a review happened. Kept
@@ -803,7 +877,7 @@ case "$REVIEWER" in
     CR_APPROVAL_VALID=false
     CR_HOLLOW=false
     if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false \
-          && "$CR_APPROVAL_STALE" == false && "$CR_APPROVAL_FRESHNESS_UNKNOWN" == false \
+          && "$CR_APPROVAL_STALE_BLOCKING" == false && "$CR_APPROVAL_FRESHNESS_UNKNOWN" == false \
           && "$CR_APPROVAL_SUBMITTED_AT_MISSING" == false ]]; then
       if [[ "$CR_SUBSTANTIVE" == true ]]; then
         CR_APPROVAL_VALID=true
@@ -817,7 +891,7 @@ case "$REVIEWER" in
     CA_APPROVAL_VALID=false
     CA_HOLLOW=false
     if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false \
-          && "$CA_APPROVAL_STALE" == false && "$CA_APPROVAL_FRESHNESS_UNKNOWN" == false \
+          && "$CA_APPROVAL_STALE_BLOCKING" == false && "$CA_APPROVAL_FRESHNESS_UNKNOWN" == false \
           && "$CA_APPROVAL_SUBMITTED_AT_MISSING" == false ]]; then
       if [[ "$CA_SUBSTANTIVE" == true ]]; then
         CA_APPROVAL_VALID=true
@@ -844,10 +918,10 @@ case "$REVIEWER" in
       if [[ "$CA_RETRACTED" == true && "$CR_APPROVAL_VALID" != true ]]; then
         MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} retracted by later CHANGES_REQUESTED — fix and re-trigger @codeant-ai review")
       fi
-      if [[ "$CR_APPROVAL_STALE" == true && "$CA_APPROVAL_VALID" != true ]]; then
+      if [[ "$CR_APPROVAL_STALE_BLOCKING" == true && "$CA_APPROVAL_VALID" != true ]]; then
         MISSING+=("CodeRabbit approval on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — re-review required; trigger @coderabbitai full review")
       fi
-      if [[ "$CA_APPROVAL_STALE" == true && "$CR_APPROVAL_VALID" != true ]]; then
+      if [[ "$CA_APPROVAL_STALE_BLOCKING" == true && "$CR_APPROVAL_VALID" != true ]]; then
         MISSING+=("CodeAnt approval on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — re-review required; trigger @codeant-ai review")
         CA_STALE_MISSING_EMITTED=true
       fi
@@ -872,7 +946,7 @@ case "$REVIEWER" in
         MISSING+=("CodeAnt APPROVED on HEAD ${HEAD_SHA:0:7} is not review coverage: $(substance_reasons "codeant-ai[bot]") — wait for a real review pass or comment @codeant-ai review (issue #875)")
       fi
       if [[ "$CR_RETRACTED" != true && "$CA_RETRACTED" != true \
-            && "$CR_APPROVAL_STALE" != true && "$CA_APPROVAL_STALE" != true \
+            && "$CR_APPROVAL_STALE_BLOCKING" != true && "$CA_APPROVAL_STALE_BLOCKING" != true \
             && "$CR_APPROVAL_FRESHNESS_UNKNOWN" != true && "$CA_APPROVAL_FRESHNESS_UNKNOWN" != true \
             && "$CR_APPROVAL_SUBMITTED_AT_MISSING" != true && "$CA_APPROVAL_SUBMITTED_AT_MISSING" != true \
             && "$CR_HOLLOW" != true && "$CA_HOLLOW" != true ]]; then
@@ -969,7 +1043,7 @@ case "$REVIEWER" in
       if [[ "$CA_CHANGES_BLOCKING" == true && ( -z "$LATEST_CA_CLEAN_AT" || "$(norm_ts "$LATEST_CA_CHANGES_REQUESTED_AT")" > "$(norm_ts "$LATEST_CA_CLEAN_AT")" ) ]]; then
         MISSING+=("CodeAnt CHANGES_REQUESTED on HEAD ${HEAD_SHA:0:7} is newer than the latest CodeAnt clean signal — address findings or wait for APPROVED / successful CodeAnt check-run")
       elif [[ "$CA_APPROVAL_VALID" != true && "$CODEANT_CHECK_OK" != true ]]; then
-        if [[ "$CA_APPROVAL_STALE" == true && "$CA_STALE_MISSING_EMITTED" != true ]]; then
+        if [[ "$CA_APPROVAL_STALE_BLOCKING" == true && "$CA_STALE_MISSING_EMITTED" != true ]]; then
           # Stale-approval guard (issue #836): CodeAnt's approval is retargeted;
           # emit a stale-specific message so callers know to re-trigger rather than
           # interpret this as a complete absence of CodeAnt review.
@@ -1001,9 +1075,9 @@ case "$REVIEWER" in
           # A successful CodeAnt check-run exists but it predates the HEAD commit —
           # report stale, not absent, so callers know to wait for a re-check.
           MISSING+=("CodeAnt check-run on HEAD ${HEAD_SHA:0:7} predates the HEAD commit (force-push retargeting) — wait for CodeAnt re-check or trigger @codeant-ai review")
-        elif [[ "$CA_APPROVAL_STALE" != true && "$CA_HOLLOW" != true ]]; then
+        elif [[ "$CA_APPROVAL_STALE_BLOCKING" != true && "$CA_HOLLOW" != true ]]; then
           # None of the freshness/stale conditions apply — emit the generic "no review"
-          # message. The CA_APPROVAL_STALE guard prevents emitting this alongside the
+          # message. The CA_APPROVAL_STALE_BLOCKING guard prevents emitting this alongside the
           # stale message when CA_STALE_MISSING_EMITTED was already set by the primary block.
           # CA_HOLLOW (issue #875) is excluded for the same reason: an approval DOES
           # exist, it just is not coverage, and the primary block already said so —

--- a/.claude/scripts/tests/merge-gate-codeant-inplace-review.test.sh
+++ b/.claude/scripts/tests/merge-gate-codeant-inplace-review.test.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+# merge-gate-codeant-inplace-review.test.sh — Regression tests for issue #876:
+# a CodeAnt IN-PLACE review edit must not read as a #836-stale approval.
+#
+# THE BUG
+#   CodeAnt PATCHes its EXISTING review object on a re-review rather than posting
+#   a new one. After a force-push its review keeps the same `id`, has `commit_id`
+#   correctly advanced to the new HEAD — and `submitted_at` frozen at the
+#   original submission, because GitHub treats that field as immutable creation
+#   time. The #836 staleness guard compares submitted_at against the HEAD
+#   commit's committer date, so a genuinely completed post-push re-review is
+#   permanently "stale" and the gate never opens.
+#
+#   Live trace (auerbachb/skingod PR #2596), reproduced by the fixtures below:
+#     04:57:00Z  CodeAnt APPROVED review id 4833716091 on the pre-rebase SHA
+#     04:59:42Z  force-push to the new HEAD  <-- committer date
+#     05:02:01Z  @codeant-ai review posted
+#     05:02:06Z  "CodeAnt AI is running the review."
+#     05:02:34Z  sequence-diagram summary, naming the new SHA, describing the
+#                actual diff
+#     05:03:35Z  "CodeAnt AI finished running the review."
+#     ...and the review object is STILL id 4833716091, commit_id now the new
+#     HEAD, submitted_at still 04:57:00Z. merge-gate.sh sat on
+#     "predates the HEAD commit" for 8 poll ticks / 15+ minutes.
+#
+# THE FIX BEING PINNED
+#   A stale submitted_at is REDEEMED by external evidence on the current SHA —
+#   review-substance.sh's `external_evidence_on_head`, i.e. substance produced
+#   OUTSIDE the review object whose timestamp is in doubt. Never waived by
+#   reviewer identity, because CodeAnt also emits genuinely hollow approvals
+#   (issue #875) and an identity waiver would re-open that hole.
+#
+#   Every case below is therefore a DISCRIMINATION test: (a) and (b) are the same
+#   review object and differ only in whether the reviewer left corroborating
+#   evidence on HEAD. If the fix is reverted, (a) fails. If the fix is widened
+#   into an identity waiver or a self-vouch, (b)/(c)/(d)/(g) fail.
+#
+# Only `gh` is stubbed; merge-gate.sh, review-substance.sh, ci-status.sh,
+# check-runs-dedup.sh and session-state.sh are the real scripts.
+#
+# Run from repo root: bash .claude/scripts/tests/merge-gate-codeant-inplace-review.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SUT="$REPO_ROOT/.claude/scripts/merge-gate.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+export HOME="$TMP/home"; mkdir -p "$HOME/.claude"
+
+PASS=0; FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+check_eq() { # expected actual label
+  if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected: '$1', got: '$2')"; fi
+}
+
+# --- The PR #2596 timeline ----------------------------------------------
+HEAD_SHA="f9b6041c7d3e2a5b8c9d0e1f2a3b4c5d6e7f8091"   # post-rebase HEAD
+OLD_SHA="3e9dfd0eb1c2d3e4f5061728394a5b6c7d8e9f01"    # pre-rebase SHA
+APPROVAL_TS="2026-08-01T04:57:00Z"   # frozen at the ORIGINAL submission
+COMMIT_TS="2026-08-01T04:59:42Z"     # force-push committer date
+MARKER_TS="2026-08-01T05:02:06Z"     # "is running the review"
+SUMMARY_TS="2026-08-01T05:02:34Z"    # substantive summary naming HEAD
+FINISH_TS="2026-08-01T05:03:35Z"     # "finished running the review"
+export HEAD_SHA
+
+# --- Fake gh stub -------------------------------------------------------
+BIN="$TMP/bin"; mkdir -p "$BIN"
+cat > "$BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  "repo view --json nameWithOwner --jq .nameWithOwner")
+    echo "solo/repo"; exit 0 ;;
+  "api user --jq .login")
+    echo "solouser"; exit 0 ;;
+  *"pr view "*headRefOid*)
+    jq -cn --arg sha "$HEAD_SHA" \
+      '{number:2596, state:"OPEN", headRefOid:$sha, baseRefName:"main",
+        mergeStateStatus:"CLEAN", mergeable:"MERGEABLE", reviewDecision:"APPROVED",
+        author:{login:"solouser", type:"User"}}'
+    exit 0 ;;
+  *"git/commits/"*)
+    jq -cn --arg d "$FAKE_COMMIT_TS" '{committer:{date:$d}}'; exit 0 ;;
+  *check-runs*)
+    jq -cn '{check_runs:[{id:1,name:"ci",status:"completed",conclusion:"success",
+               completed_at:"2026-08-01T05:01:00Z",
+               check_suite:{id:1},app:{slug:"gha",id:1}}]}'
+    exit 0 ;;
+  *pulls/*/reviews*)   printf '%s' "${FAKE_REVIEWS:-[]}"; exit 0 ;;
+  *pulls/*/comments*)  printf '%s' "${FAKE_PR_COMMENTS:-[]}"; exit 0 ;;
+  *issues/*/comments*) printf '%s' "${FAKE_ISSUE_COMMENTS:-[]}"; exit 0 ;;
+  *graphql*)
+    jq -cn '{data:{repository:{pullRequest:{reviewThreads:{nodes:[]}}}}}'; exit 0 ;;
+  *contents/*)
+    echo "Not Found" >&2; exit 1 ;;
+esac
+echo "unexpected gh call: $ARGS" >&2
+exit 1
+GHEOF
+chmod +x "$BIN/gh"
+
+# --- Fixture builders ---------------------------------------------------
+# The in-place-edited review object: SAME id throughout, commit_id advanced to
+# HEAD, submitted_at frozen. The body is deliberately substantive-looking — and
+# deliberately irrelevant, because review-substance.sh only pools review bodies
+# whose submitted_at postdates the push. If a future change let this body count,
+# the approval would be vouching for its own frozen timestamp, and case (b)
+# below (identical review, no external evidence) would start passing.
+ca_inplace_review() {
+  jq -cn --arg sha "$HEAD_SHA" --arg ts "$APPROVAL_TS" \
+    '[{id:4833716091, user:{login:"codeant-ai[bot]",type:"Bot"},
+       commit_id:$sha, state:"APPROVED", submitted_at:$ts,
+       body:"CodeAnt AI has reviewed this pull request and found no blocking issues."}]'
+}
+
+# Same object shape, empty body — the #875 rubber-stamp spelling.
+ca_empty_review() { # submitted_at
+  jq -cn --arg sha "$HEAD_SHA" --arg ts "$1" \
+    '[{id:4833716091, user:{login:"codeant-ai[bot]",type:"Bot"},
+       commit_id:$sha, state:"APPROVED", submitted_at:$ts, body:""}]'
+}
+
+cr_inplace_review() {
+  jq -cn --arg sha "$HEAD_SHA" --arg ts "$APPROVAL_TS" \
+    '[{id:4833716092, user:{login:"coderabbitai[bot]",type:"Bot"},
+       commit_id:$sha, state:"APPROVED", submitted_at:$ts, body:""}]'
+}
+
+# The genuine post-push conversation trail: run-start marker, then a substantive
+# summary NAMING HEAD, then the completion notice. The summary is the redeemer;
+# the completion notice deliberately is NOT (it is a fixed, content-free string,
+# so accepting it would let a bot certify its own freshness with a constant).
+ca_convo_genuine() { # login
+  jq -cn --arg login "${1:-codeant-ai[bot]}" \
+    --arg sha "$HEAD_SHA" --arg m "$MARKER_TS" --arg s "$SUMMARY_TS" --arg f "$FINISH_TS" \
+    '[{user:{login:$login,type:"Bot"}, created_at:$m, updated_at:$m,
+       body:"CodeAnt AI is running the review."},
+      {user:{login:$login,type:"Bot"}, created_at:$s, updated_at:$s,
+       body:("## Review summary for `" + $sha + "`\n\nThis change adds a SafeAreaProvider inside the native modal root so the sheet respects the notch inset. Two call sites were updated and the snapshot baseline regenerated. No blocking issues found.")},
+      {user:{login:$login,type:"Bot"}, created_at:$f, updated_at:$f,
+       body:"CodeAnt AI finished running the review."}]'
+}
+
+# The completion notice ALONE — no substantive summary. This is the shape the
+# corroboration-by-status-string design would have accepted.
+ca_convo_marker_only() {
+  jq -cn --arg m "$MARKER_TS" --arg f "$FINISH_TS" \
+    '[{user:{login:"codeant-ai[bot]",type:"Bot"}, created_at:$m, updated_at:$m,
+       body:"CodeAnt AI is running the review."},
+      {user:{login:"codeant-ai[bot]",type:"Bot"}, created_at:$f, updated_at:$f,
+       body:"CodeAnt AI finished running the review."}]'
+}
+
+# A substantive summary naming the PRE-REBASE SHA — the reviewer's own record
+# saying it read a different commit.
+ca_convo_old_sha() {
+  jq -cn --arg sha "$OLD_SHA" --arg s "$SUMMARY_TS" \
+    '[{user:{login:"codeant-ai[bot]",type:"Bot"}, created_at:$s, updated_at:$s,
+       body:("## Review summary for `" + $sha + "`\n\nReviewed the modal root change and the two updated call sites. No blocking issues found.")}]'
+}
+
+OUT=""; ERRTXT=""; RC=0
+run_gate() { # <reviews-json> <issue-comments-json> [reviewer]
+  local reviews="$1" convo="$2" reviewer="${3:-cr}"
+  OUT=$(PATH="$BIN:$PATH" \
+        FAKE_COMMIT_TS="$COMMIT_TS" \
+        FAKE_REVIEWS="$reviews" \
+        FAKE_PR_COMMENTS="[]" \
+        FAKE_ISSUE_COMMENTS="$convo" \
+        "$SUT" 2596 --reviewer "$reviewer" 2>"$TMP/err")
+  RC=$?
+  ERRTXT="$(cat "$TMP/err")"
+}
+
+met()           { echo "$OUT" | jq -r '.met'; }
+primary_met()   { echo "$OUT" | jq -r '.primary_review_met'; }
+missing_count() { echo "$OUT" | jq -r '.missing | length'; }
+missing_has()   { echo "$OUT" | jq -e --arg s "$1" \
+                    '[.missing[]? | select(contains($s))] | length > 0' \
+                  >/dev/null && echo yes || echo no; }
+ev()            { echo "$OUT" | jq -r --arg l "$1" --arg f "$2" '.review_evidence.reviewers[$l][$f]'; }
+
+STALE_MSG="predates the HEAD commit (force-push retargeting)"
+HOLLOW_MSG="is not review coverage"
+
+# -------------------------------------------------------------------------
+# (a) THE #876 CASE — in-place re-review edit with a corroborating trail.
+#     Frozen submitted_at, commit_id == HEAD, post-push summary naming HEAD.
+#     Must count as coverage.
+# -------------------------------------------------------------------------
+echo "--- (a) CodeAnt in-place re-review with corroborating post-push evidence ---"
+run_gate "$(ca_inplace_review)" "$(ca_convo_genuine)"
+check_eq "true"  "$(met)"                      "(a) in-place re-review: met == true"
+check_eq "true"  "$(primary_met)"              "(a) in-place re-review: primary_review_met == true"
+check_eq "0"     "$(missing_count)"            "(a) in-place re-review: no missing entries"
+check_eq "0"     "$RC"                         "(a) in-place re-review: exit 0"
+check_eq "no"    "$(missing_has "$STALE_MSG")" "(a) in-place re-review: no stale-retargeting blocker"
+# The redemption must be announced, never silent.
+if [[ "$ERRTXT" == *"issue #876"* ]]; then
+  ok "(a) in-place re-review: redemption announced on stderr"
+else
+  bad "(a) in-place re-review: redemption was silent (stderr: '$ERRTXT')"
+fi
+# And it must come from evidence OUTSIDE the review object.
+check_eq "true"  "$(ev "codeant-ai[bot]" external_evidence_on_head)" \
+                                               "(a) in-place re-review: external_evidence_on_head is what redeemed it"
+# The frozen approval body contributed nothing — proving the approval did not
+# vouch for its own timestamp.
+check_eq "0"     "$(ev "codeant-ai[bot]" body_len)" \
+                                               "(a) in-place re-review: the stale approval body counted for 0"
+# The approval predates the bot's own run marker, yet is NOT an inversion,
+# because external evidence on HEAD exists (issue #875's documented exemption).
+check_eq "false" "$(ev "codeant-ai[bot]" temporal_inversion)" \
+                                               "(a) in-place re-review: external evidence suppresses temporal_inversion"
+
+# -------------------------------------------------------------------------
+# (b) THE DISCRIMINATOR — byte-identical review object, NO corroborating
+#     evidence on HEAD. Must stay blocked with the unchanged #836 reason.
+#     (a) and (b) differ ONLY in the issue-comments payload.
+# -------------------------------------------------------------------------
+echo "--- (b) same in-place review shape, no corroborating evidence (genuinely stale) ---"
+run_gate "$(ca_inplace_review)" "[]"
+check_eq "false" "$(met)"                       "(b) uncorroborated stale: met == false"
+check_eq "false" "$(primary_met)"               "(b) uncorroborated stale: primary_review_met == false"
+check_eq "yes"   "$(missing_has "$STALE_MSG")"  "(b) uncorroborated stale: unchanged #836 reason"
+check_eq "1"     "$RC"                          "(b) uncorroborated stale: exit 1"
+check_eq "false" "$(ev "codeant-ai[bot]" external_evidence_on_head)" \
+                                                "(b) uncorroborated stale: no external evidence to redeem with"
+
+# -------------------------------------------------------------------------
+# (c) The completion notice ALONE does not redeem. A fixed, content-free
+#     status string must never let a bot certify its own freshness — that is
+#     the weaker design this fix deliberately did not take.
+# -------------------------------------------------------------------------
+echo "--- (c) 'finished running the review' marker alone does NOT redeem ---"
+run_gate "$(ca_inplace_review)" "$(ca_convo_marker_only)"
+check_eq "false" "$(met)"                       "(c) marker-only: met == false"
+check_eq "yes"   "$(missing_has "$STALE_MSG")"  "(c) marker-only: still the #836 reason"
+check_eq "1"     "$RC"                          "(c) marker-only: exit 1"
+
+# -------------------------------------------------------------------------
+# (d) RUBBER STAMP — empty body, status comment naming the PRE-REBASE SHA.
+#     The reviewer's own record says it read a different commit. Rejected.
+# -------------------------------------------------------------------------
+echo "--- (d) rubber stamp: bodylen=0, status comment names an OLDER SHA ---"
+run_gate "$(ca_empty_review "$APPROVAL_TS")" "$(ca_convo_old_sha)"
+check_eq "false" "$(met)"                       "(d) rubber stamp: met == false"
+check_eq "false" "$(primary_met)"               "(d) rubber stamp: primary_review_met == false"
+check_eq "1"     "$RC"                          "(d) rubber stamp: exit 1"
+check_eq "true"  "$(ev "codeant-ai[bot]" self_report_mismatch)" \
+                                                "(d) rubber stamp: self_report_mismatch recorded"
+check_eq "false" "$(ev "codeant-ai[bot]" external_evidence_on_head)" \
+                                                "(d) rubber stamp: nothing external to redeem with"
+
+# -------------------------------------------------------------------------
+# (e) THE STRONGEST DISCRIMINATOR — redemption must not bypass the substance
+#     verdict. Here the reviewer DOES have a summary naming HEAD (so it is
+#     redeemable), but a LATER status comment names the old SHA, so its own
+#     newest self-report contradicts the approval. Must stay blocked, and on
+#     the #875 hollow reason rather than the #836 stale one.
+# -------------------------------------------------------------------------
+echo "--- (e) redeemable but self-contradicting: substance still blocks ---"
+E_CONVO=$(jq -cn --arg head "$HEAD_SHA" --arg old "$OLD_SHA" \
+  --arg s "$SUMMARY_TS" --arg f "$FINISH_TS" \
+  '[{user:{login:"codeant-ai[bot]",type:"Bot"}, created_at:$s, updated_at:$s,
+     body:("## Review summary for `" + $head + "`\n\nReviewed the modal root change and the two updated call sites. No blocking issues found.")},
+    {user:{login:"codeant-ai[bot]",type:"Bot"}, created_at:$f, updated_at:$f,
+     body:("Re-analysis complete. The reviewed commit for this run was `" + $old + "` — a long enough notice to clear the substance threshold.")}]')
+run_gate "$(ca_empty_review "$APPROVAL_TS")" "$E_CONVO"
+check_eq "false" "$(met)"                        "(e) self-contradicting: met == false"
+check_eq "false" "$(primary_met)"                "(e) self-contradicting: primary_review_met == false"
+check_eq "yes"   "$(missing_has "$HOLLOW_MSG")"  "(e) self-contradicting: blocked on the #875 substance reason"
+check_eq "no"    "$(missing_has "$STALE_MSG")"   "(e) self-contradicting: staleness was redeemed, substance was not"
+check_eq "true"  "$(ev "codeant-ai[bot]" self_report_mismatch)" \
+                                                 "(e) self-contradicting: self_report_mismatch recorded"
+check_eq "1"     "$RC"                           "(e) self-contradicting: exit 1"
+
+# -------------------------------------------------------------------------
+# (f) IDENTITY IS NOT THE TEST — CodeRabbit gets the identical redemption on
+#     the identical evidence. If this ever fails while (a) passes, the fix has
+#     drifted into a per-bot waiver, which is the #875 hole.
+# -------------------------------------------------------------------------
+echo "--- (f) same redemption applies to CodeRabbit (evidence, not identity) ---"
+run_gate "$(cr_inplace_review)" "$(ca_convo_genuine "coderabbitai[bot]")"
+check_eq "true"  "$(met)"                       "(f) CodeRabbit redemption: met == true"
+check_eq "true"  "$(primary_met)"               "(f) CodeRabbit redemption: primary_review_met == true"
+check_eq "no"    "$(missing_has "$STALE_MSG")"  "(f) CodeRabbit redemption: no stale blocker"
+check_eq "0"     "$RC"                          "(f) CodeRabbit redemption: exit 0"
+# Same evidence assertions as (a). Equal outcomes could otherwise be reached by
+# unequal routes — the point of this case is that the SAME mechanism carries
+# both bots, so pin the mechanism, not just the verdict.
+check_eq "true"  "$(ev "coderabbitai[bot]" external_evidence_on_head)" \
+                                                "(f) CodeRabbit redemption: external_evidence_on_head is what redeemed it"
+check_eq "0"     "$(ev "coderabbitai[bot]" body_len)" \
+                                                "(f) CodeRabbit redemption: the stale approval body counted for 0"
+check_eq "false" "$(ev "coderabbitai[bot]" temporal_inversion)" \
+                                                "(f) CodeRabbit redemption: external evidence suppresses temporal_inversion"
+
+# -------------------------------------------------------------------------
+# (g) A genuinely FRESH CHANGES_REQUESTED still beats a redeemed approval —
+#     redemption restores freshness, never precedence.
+# -------------------------------------------------------------------------
+echo "--- (g) fresh CHANGES_REQUESTED still outranks a redeemed approval ---"
+G_REVIEWS=$(jq -cn --arg sha "$HEAD_SHA" --arg ap "$APPROVAL_TS" --arg cr "$FINISH_TS" \
+  '[{id:4833716091, user:{login:"codeant-ai[bot]",type:"Bot"},
+     commit_id:$sha, state:"APPROVED", submitted_at:$ap,
+     body:"CodeAnt AI has reviewed this pull request and found no blocking issues."},
+    {id:4833716093, user:{login:"codeant-ai[bot]",type:"Bot"},
+     commit_id:$sha, state:"CHANGES_REQUESTED", submitted_at:$cr,
+     body:"Blocking: the new provider is mounted outside the modal root."}]')
+run_gate "$G_REVIEWS" "$(ca_convo_genuine)"
+check_eq "false" "$(met)"             "(g) fresh CHANGES_REQUESTED: met == false"
+check_eq "false" "$(primary_met)"     "(g) fresh CHANGES_REQUESTED: primary_review_met == false"
+check_eq "1"     "$RC"                "(g) fresh CHANGES_REQUESTED: exit 1"
+# The point of this case is WHICH blocker fires. The corroborating evidence is
+# present, so the rejection must come from the fresh CHANGES_REQUESTED — not
+# from a leftover staleness verdict that would have blocked anyway. Without
+# these two, (g) would still pass on a build where redemption never worked.
+check_eq "true"  "$(ev "codeant-ai[bot]" external_evidence_on_head)" \
+                                      "(g) fresh CHANGES_REQUESTED: the corroborating evidence is present"
+check_eq "no"    "$(missing_has "$STALE_MSG")" \
+                                      "(g) fresh CHANGES_REQUESTED: rejected on the newer review, not on staleness"
+# Name the blocker positively, not just by the absence of the other one.
+check_eq "yes"   "$(missing_has "retracted by later CHANGES_REQUESTED")" \
+                                      "(g) fresh CHANGES_REQUESTED: blocker is the retraction, stated as such"
+
+# -------------------------------------------------------------------------
+# (h) A FRESH approval is unaffected: redemption is gated on the approval
+#     already being stale, so the normal path must not touch the redemption
+#     code at all (no stderr note).
+# -------------------------------------------------------------------------
+echo "--- (h) fresh approval path is unchanged (no redemption involved) ---"
+FRESH_REVIEW=$(jq -cn --arg sha "$HEAD_SHA" --arg ts "$SUMMARY_TS" \
+  '[{id:4833716094, user:{login:"codeant-ai[bot]",type:"Bot"},
+     commit_id:$sha, state:"APPROVED", submitted_at:$ts,
+     body:"CodeAnt AI reviewed the modal root change and the two updated call sites. No blocking issues found."}]')
+run_gate "$FRESH_REVIEW" "$(ca_convo_genuine)"
+check_eq "true"  "$(met)"          "(h) fresh approval: met == true"
+check_eq "0"     "$RC"             "(h) fresh approval: exit 0"
+if [[ "$ERRTXT" != *"issue #876"* ]]; then
+  ok "(h) fresh approval: redemption code never fired"
+else
+  bad "(h) fresh approval: redemption fired on a non-stale approval (stderr: '$ERRTXT')"
+fi
+
+# -------------------------------------------------------------------------
+echo "----------------------------------------"
+echo "merge-gate-codeant-inplace-review.test.sh: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/.claude/scripts/tests/ts-normalizer-parity.test.sh
+++ b/.claude/scripts/tests/ts-normalizer-parity.test.sh
@@ -281,8 +281,33 @@ check_eq "substance rule sees the same pair as EQUAL (more permissive)" "$SUB_AP
 
 # That extra permissiveness is safe ONLY because the two verdicts are ANDed with
 # freshness on the OUTSIDE: merge-gate.sh computes <PREFIX>_APPROVAL_STALE with
-# norm_ts and tests the substance verdict INSIDE that guard, so substance can
-# only ever subtract coverage — never restore an approval norm_ts ruled stale.
+# norm_ts and tests the substance verdict INSIDE that guard, so the substance
+# TIMESTAMP RULE can only ever subtract coverage — it can never reorder an
+# approval norm_ts ruled stale.
+#
+# ISSUE #876 UPDATED THIS PIN DELIBERATELY — read before "restoring" it.
+# The outer guard now reads <PREFIX>_APPROVAL_STALE_BLOCKING, which is
+# <PREFIX>_APPROVAL_STALE (the unchanged norm_ts verdict) AND NOT
+# <PREFIX>_STALE_REDEEMED. CodeAnt PATCHes its existing review object on a
+# re-review, advancing commit_id to the new HEAD while GitHub keeps submitted_at
+# frozen at creation time, so a genuinely completed post-push re-review is
+# permanently norm_ts-stale and wedges the gate.
+#
+# What makes that safe, and what the assertions below now have to protect:
+#   - The redemption is NOT a timestamp comparison. canon_ts's extra
+#     permissiveness still cannot leak into the freshness ordering, which is the
+#     exact hazard the original pin existed for. That property is unchanged.
+#   - The redemption term is external_evidence_on_head — substantive evidence on
+#     the current SHA produced OUTSIDE the review object under suspicion. It is
+#     strictly STRONGER than the substance verdict it feeds (it is `substantive`
+#     minus the approval's own body), so an approval can never redeem itself.
+#   - Reviewer identity is not consulted. "Skip staleness for CodeAnt" would
+#     re-open the #875 hollow-approval hole; evidence, not identity, decides.
+#   - The substance verdict is still tested INSIDE, so a redeemed approval whose
+#     status comment names an older SHA still fails as self_report_mismatch.
+# So two NEW structural assertions are added below: the derivation of
+# _STALE_BLOCKING, and the derivation of _STALE_REDEEMED. Together they keep the
+# redemption channel exactly one term wide.
 #
 # WHAT THIS HAS TO CATCH, and why presence-greps are not enough.
 # Asserting only that both tokens appear near each other catches a DELETED
@@ -319,7 +344,10 @@ check_guard_nesting() { # <prefix>
     || die "${p}_APPROVAL_VALID block in merge-gate.sh does not terminate in a matching 'fi' — extraction is unreliable and this guard cannot be trusted"
 
   # grep -F: these are literal shell fragments, not patterns.
-  stale_needle="\"\$${p}_APPROVAL_STALE\" == false"
+  # _STALE_BLOCKING, not _STALE, since #876 — the derivation of that variable is
+  # itself pinned by check_redemption_channel below, so widening the needle here
+  # does not widen what can reach the guard.
+  stale_needle="\"\$${p}_APPROVAL_STALE_BLOCKING\" == false"
   sub_needle="\"\$${p}_SUBSTANTIVE\" == true"
   stale_no="$(grep -nF "$stale_needle" <<<"$block" | head -1 | cut -d: -f1)"
   sub_no="$(grep -nF "$sub_needle" <<<"$block" | head -1 | cut -d: -f1)"
@@ -327,7 +355,7 @@ check_guard_nesting() { # <prefix>
   if [[ -n "$stale_no" ]]; then
     ok "merge-gate.sh gates ${p}_APPROVAL_VALID on the norm_ts staleness verdict"
   else
-    bad "merge-gate.sh no longer requires ${p}_APPROVAL_STALE == false before validating a ${p} approval — a substance-fresh but gate-stale approval could now satisfy the gate"
+    bad "merge-gate.sh no longer requires ${p}_APPROVAL_STALE_BLOCKING == false before validating a ${p} approval — a substance-fresh but gate-stale approval could now satisfy the gate"
     return
   fi
   if [[ -n "$sub_no" ]]; then
@@ -342,7 +370,7 @@ check_guard_nesting() { # <prefix>
   if [[ "$stale_no" -lt "$sub_no" ]]; then
     ok "${p} substance is tested INSIDE the freshness guard, so it can only subtract coverage"
   else
-    bad "${p}_SUBSTANTIVE is no longer nested inside the ${p}_APPROVAL_STALE guard in merge-gate.sh (staleness on block line $stale_no, substance on $sub_no) — substance may now be able to restore a gate-stale approval"
+    bad "${p}_SUBSTANTIVE is no longer nested inside the ${p}_APPROVAL_STALE_BLOCKING guard in merge-gate.sh (staleness on block line $stale_no, substance on $sub_no) — substance may now be able to restore a gate-stale approval"
   fi
 
   # Neither test may be an OR: a disjunction lets either side alone validate the
@@ -352,7 +380,7 @@ check_guard_nesting() { # <prefix>
   if [[ "$stale_line" != *"||"* ]]; then
     ok "${p} freshness test is a conjunction, not a disjunction"
   else
-    bad "the ${p}_APPROVAL_STALE test in merge-gate.sh is now part of a disjunction ('$stale_line') — staleness can be bypassed by the other operand"
+    bad "the ${p}_APPROVAL_STALE_BLOCKING test in merge-gate.sh is now part of a disjunction ('$stale_line') — staleness can be bypassed by the other operand"
   fi
   if [[ "$sub_line" != *"||"* ]]; then
     ok "${p} substance test is a conjunction, not a disjunction"
@@ -363,6 +391,160 @@ check_guard_nesting() { # <prefix>
 
 check_guard_nesting CR
 check_guard_nesting CA
+
+# --------------------------------------------------------------------------
+# Redemption channel (issue #876) — the widened needle above is only safe while
+# _STALE_BLOCKING and _STALE_REDEEMED are each derived from exactly one thing.
+#
+# Two independent breaks are in scope, and a presence-grep catches neither:
+#   1. _STALE_BLOCKING picking up a THIRD operand (say `|| $FORCE`), which would
+#      turn the outer guard back into a bypassable disjunction under a new name.
+#   2. _STALE_REDEEMED being set from something other than external_evidence_ok
+#      — counts_as_coverage (circular: the approval's own body would redeem its
+#      own timestamp), a reviewer-login test (identity waiver, the #875 hole), or
+#      a timestamp comparison (which is what norm_ts already decided).
+# So assert the assignment lines themselves, not merely that the names exist.
+# --------------------------------------------------------------------------
+# Extract the guarded condition of the `if` that assigns <VAR>=true, i.e. the
+# line above it. Both derivations are written as a two-line if/assign pair in
+# merge-gate.sh; a rewrite into any other shape fails loudly here rather than
+# silently escaping the check.
+#
+# Exactly ONE assignment site per variable is required. With two, `head -1`
+# would silently pin the first and leave the second — a laxer duplicate added
+# later — completely unguarded, which is the same silent-false-clean this suite
+# exists to prevent. Ambiguity returns empty so the caller reports it as a
+# missing derivation rather than passing on a partial view.
+# Emits "AMBIGUOUS" (never a real derivation line) when there is more than one
+# assignment site, so callers can distinguish "the variable vanished" from "a
+# second, possibly laxer, assignment appeared" — different breaks, different
+# fixes. Indentation-independent: a reindent must not read as a deletion.
+derivation_line() { # <assigned-var>
+  local pat n
+  pat="^[[:space:]]*$1=true[[:space:]]*$"
+  n="$(grep -cE "$pat" "$MERGE_GATE")"
+  if [[ "$n" == "0" ]]; then return 0; fi
+  if [[ "$n" != "1" ]]; then echo "AMBIGUOUS"; return 0; fi
+  grep -B1 -E "$pat" "$MERGE_GATE" | head -1
+}
+
+check_blocking_derivation() { # <prefix>
+  local p="$1" line
+  line="$(derivation_line "${p}_APPROVAL_STALE_BLOCKING")"
+  if [[ -z "$line" ]]; then
+    bad "could not find the ${p}_APPROVAL_STALE_BLOCKING derivation in merge-gate.sh — the outer freshness guard is now fed by something this suite cannot see"
+    return
+  fi
+  if [[ "$line" == "AMBIGUOUS" ]]; then
+    bad "merge-gate.sh has MORE THAN ONE ${p}_APPROVAL_STALE_BLOCKING=true assignment — a second, laxer path may set it and this suite can only see one"
+    return
+  fi
+  if [[ "$line" == *"${p}_APPROVAL_STALE\" == true"* && "$line" == *"${p}_STALE_REDEEMED\" == false"* ]]; then
+    ok "${p}_APPROVAL_STALE_BLOCKING is the norm_ts verdict minus redemption, and nothing else"
+  else
+    bad "${p}_APPROVAL_STALE_BLOCKING is no longer derived from ${p}_APPROVAL_STALE AND NOT ${p}_STALE_REDEEMED ('$line') — the outer freshness guard has gained an operand"
+  fi
+  if [[ "$line" != *"||"* ]]; then
+    ok "${p}_APPROVAL_STALE_BLOCKING derivation is a conjunction, not a disjunction"
+  else
+    bad "the ${p}_APPROVAL_STALE_BLOCKING derivation is a disjunction ('$line') — staleness can be bypassed by the other operand"
+  fi
+  # Exactly the two expected operands. The substring checks above prove both
+  # REQUIRED terms are present but say nothing about a THIRD one: a smuggled
+  # `&& "$SOME_OVERRIDE" == true` keeps every assertion above passing while
+  # narrowing when staleness blocks. Two conditions means exactly one `&&`.
+  local and_count
+  and_count="$(grep -o '&&' <<<"$line" | wc -l | tr -d ' ')"
+  if [[ "$and_count" == "1" ]]; then
+    ok "${p}_APPROVAL_STALE_BLOCKING derivation has exactly the two expected conditions"
+  else
+    bad "the ${p}_APPROVAL_STALE_BLOCKING derivation has $and_count '&&' operator(s) ('$line') — a third operand may have been smuggled in"
+  fi
+}
+
+check_redemption_channel() { # <prefix> <login>
+  local p="$1" login="$2" line
+  line="$(derivation_line "${p}_STALE_REDEEMED")"
+  if [[ -z "$line" ]]; then
+    bad "could not find the ${p}_STALE_REDEEMED derivation in merge-gate.sh — the #876 redemption channel is unpinned"
+    return
+  fi
+  if [[ "$line" == "AMBIGUOUS" ]]; then
+    bad "merge-gate.sh has MORE THAN ONE ${p}_STALE_REDEEMED=true assignment — redemption may now be granted on a second path this suite cannot see"
+    return
+  fi
+  if [[ "$line" == *"external_evidence_ok \"$login\""* ]]; then
+    ok "${p}_STALE_REDEEMED is granted only by external_evidence_ok (evidence outside the review object)"
+  else
+    bad "${p}_STALE_REDEEMED is no longer granted by external_evidence_ok ('$line') — an approval may now be able to redeem its own stale timestamp"
+  fi
+  # Redemption must not be reachable on a FRESH approval either: gating it on
+  # _APPROVAL_STALE keeps the non-stale path byte-for-byte unchanged.
+  if [[ "$line" == *"${p}_APPROVAL_STALE\" == true"* ]]; then
+    ok "${p}_STALE_REDEEMED can only fire on an approval norm_ts already ruled stale"
+  else
+    bad "${p}_STALE_REDEEMED is no longer gated on ${p}_APPROVAL_STALE ('$line') — redemption has escaped the stale-only path"
+  fi
+  # Same disjunction hazard as check_blocking_derivation: `external_evidence_ok
+  # … || <anything>` satisfies every substring assertion above while granting
+  # redemption on the other operand — an identity test, a status string, a
+  # per-PR flag. The redemption channel must stay exactly one term wide.
+  if [[ "$line" != *"||"* ]]; then
+    ok "${p}_STALE_REDEEMED derivation is a conjunction, not a disjunction"
+  else
+    bad "the ${p}_STALE_REDEEMED derivation in merge-gate.sh is a disjunction ('$line') — redemption could now be granted by something other than external_evidence_ok"
+  fi
+  # The three ways this could be laundered back into an identity waiver or a
+  # circular self-vouch. substance_ok is counts_as_coverage, which INCLUDES the
+  # approval's own body; counts_as_coverage is that same field by name.
+  #
+  # Bare tokens, deliberately NOT dot-prefixed (`.norm_ts`, `.substance_ok`).
+  # Two of the three are bash FUNCTION calls in merge-gate.sh, not JSON field
+  # accesses, so a dot-prefixed needle would never match the shape it is meant
+  # to reject and the guard would silently stop guarding. The false-positive it
+  # would buy does not exist either: every shell variable on this line is
+  # SCREAMING_CASE, so a lowercase token cannot appear except as a real call.
+  local needle
+  for needle in 'substance_ok' 'counts_as_coverage' 'norm_ts'; do
+    if [[ "$line" != *"$needle"* ]]; then
+      ok "${p}_STALE_REDEEMED does not consult $needle"
+    else
+      bad "${p}_STALE_REDEEMED now consults $needle ('$line') — redemption must be external evidence only, never the approval's own substance verdict or a timestamp"
+    fi
+  done
+}
+
+check_blocking_derivation CR
+check_blocking_derivation CA
+check_redemption_channel CR "coderabbitai[bot]"
+check_redemption_channel CA "codeant-ai[bot]"
+
+# The redemption helper itself must read external_evidence_on_head — the field
+# review-substance.sh defines as substance EXCLUDING the approval body. If it
+# ever reads a different field, every assertion above is checking a name rather
+# than a property.
+#
+# Scoped to the external_evidence_ok BODY, not the whole file: merge-gate.sh's
+# header prose names external_evidence_on_head several times, so a file-wide
+# grep would keep passing after the helper was repointed at counts_as_coverage
+# and only the comments still mentioned the right field.
+EXT_HELPER_BODY="$(awk '
+  /^[[:space:]]*external_evidence_ok\(\)[[:space:]]*\{/ { inblock = 1 }
+  inblock && !/^[[:space:]]*#/ { print }
+  inblock && /^[[:space:]]*\}[[:space:]]*$/ { exit }
+' "$MERGE_GATE")"
+if [[ -z "$EXT_HELPER_BODY" ]]; then
+  bad "could not locate the external_evidence_ok helper in merge-gate.sh — the #876 redemption source is unpinned"
+elif grep -q 'external_evidence_on_head' <<<"$EXT_HELPER_BODY"; then
+  ok "merge-gate.sh's external_evidence_ok helper reads external_evidence_on_head"
+else
+  bad "merge-gate.sh's external_evidence_ok helper no longer reads external_evidence_on_head — the #876 redemption is sourced from an unknown field"
+fi
+if grep -q 'external_evidence_on_head' "$SUBSTANCE"; then
+  ok "review-substance.sh still emits external_evidence_on_head"
+else
+  bad "review-substance.sh no longer emits external_evidence_on_head — merge-gate.sh's redemption will silently fail closed on every PR"
+fi
 
 ############################################################################
 echo "== structural guards: no re-inlined copy of the rule =="


### PR DESCRIPTION
## **User description**
## Problem

CodeAnt does not post a new review object on a re-review — it **PATCHes the
existing one**. After a force-push its review keeps the same `id`, has
`commit_id` correctly advanced to the new HEAD, and `submitted_at` **frozen at
the original submission**, because GitHub's review API treats that field as
immutable creation time.

The #836 staleness guard compares `submitted_at` against the HEAD commit's
committer date, so for CodeAnt a genuinely completed post-push re-review is
stale **forever** — re-triggering cannot clear it, because each re-run edits the
same object and leaves the same frozen timestamp. On `auerbachb/skingod` PR
#2596 the gate sat on `"predates the HEAD commit (force-push retargeting)"` for
8 poll ticks over 15+ minutes while CodeAnt's real verdict on the current SHA
(a sequence-diagram summary naming the new SHA and accurately describing the
diff) sat in the conversation the whole time.

## The rule

> A stale `submitted_at` may be **redeemed by external evidence on the current
> SHA**. It is never **waived by reviewer identity**.

The redemption term is `review-substance.sh`'s `external_evidence_on_head` (from
PR #883 / issue #875) — a substantive footprint anchored to HEAD and produced
**outside the review object whose timestamp is in doubt**: HEAD-anchored inline
diff comments, a `>= min_chars` status comment naming HEAD that is not a
capability-failure notice, or a substantive non-`APPROVED` review on HEAD.

`merge-gate.sh` keeps `<P>_APPROVAL_STALE` as the unchanged `norm_ts` verdict and
adds two separate terms, so the timestamp comparison keeps exactly one meaning:

```text
<P>_STALE_REDEEMED          = <P>_APPROVAL_STALE AND external_evidence_ok(<login>)
<P>_APPROVAL_STALE_BLOCKING = <P>_APPROVAL_STALE AND NOT <P>_STALE_REDEEMED
```

Redemption cannot fire unless the approval is already stale, so the ordinary
fresh path is byte-for-byte unaffected. It is announced on stderr and visible in
the emitted `review_evidence`.

## This deliberately does not weaken #875

Three designs were rejected, and the reasoning is in
`.claude/reference/merge-gate-stale-approval-redemption.md`:

1. **"Skip staleness for CodeAnt."** The issue's own fix sketch offered this, and
   it is the one that must not ship. The same night #876 was filed, CodeAnt was
   observed across three repos emitting genuinely hollow approvals — `bodylen=0`,
   four in one second, one approving a commit that did not exist for another 16
   minutes. An identity waiver re-opens exactly the hole #875 (PR #883) closed
   hours earlier. Case (f) below fails if the fix ever drifts that way.
2. **Corroborate with the "CodeAnt AI finished running the review" notice.**
   This was CodeRabbit's coding plan on the issue and the intuitive reading of
   the AC. It is too weak — a fixed, content-free string lets a bot certify its
   own freshness with a constant. Case (c) pins the rejection.
3. **Trust `commit_id == HEAD` outright for CodeAnt.** Rejected for the reason
   CodeRabbit itself gave: the retargeted `commit_id` *always* matches HEAD, so
   the uncorroborated shape could not stay blocked.

`external_evidence_on_head` is strictly **stronger** than the `substantive`
verdict it feeds (it is `substantive` minus the approval's own body), so the
redemption channel is narrower than the coverage test, and the two are ANDed. A
redeemed approval still has to clear `counts_as_coverage` — case (e) proves a
redeemable-but-self-contradicting approval still blocks, on the #875 substance
reason rather than the #836 staleness one.

## The parity pin was updated deliberately, not defeated

`ts-normalizer-parity.test.sh` pins that `merge-gate.sh` keeps the freshness
verdict on the **outside** of the substance check, so `review-substance.sh`'s
more permissive `canon_ts` can never reorder something `norm_ts` ruled stale.
**That property is unchanged, because redemption is not a timestamp comparison
at all.** The needle moved to `_STALE_BLOCKING`, and new structural assertions
keep the redemption channel exactly one term wide:

- `_APPROVAL_STALE_BLOCKING` may be derived only from `_APPROVAL_STALE` AND NOT
  `_STALE_REDEEMED` — no disjunction, and exactly those two operands (an `&&`
  count, so a third smuggled conjunct fails).
- `_STALE_REDEEMED` may be granted only by `external_evidence_ok`, only on an
  already-stale approval, with no disjunction, and may not consult
  `substance_ok`, `counts_as_coverage` (circular — includes the approval's own
  body) or `norm_ts` (already decided).
- Each derivation must have exactly one assignment site (`AMBIGUOUS` otherwise),
  and the `external_evidence_ok` helper body — not the file's prose — must be
  what reads `external_evidence_on_head`.

## Relationship to issue #865 (not foreclosed)

Issue **#865** — whether a fresh CR-path `APPROVED` should satisfy the gate while
a PR is sticky-assigned to BugBot — is untouched and stays open. The two concern
CodeAnt approvals on the CR path but are orthogonal:

- **#876 changes whether a CodeAnt approval is *fresh*.** It runs entirely inside
  the `cr` path and never touches reviewer resolution or stickiness.
- **#865 would change *which path is consulted*.** It is a routing decision.

They compose: if #865 is later decided in favour of letting a fresh CR-path
approval satisfy a sticky-BugBot gate, #876 is what makes "fresh" mean the right
thing for an in-place-edited CodeAnt review. If #865 is decided the other way,
#876 stands alone. Notably the workaround used in the #876 live run was itself an
#865-shaped escalation (switching PR #2596 to the BugBot path), which is why the
two keep surfacing together. `review-substance.sh`'s `corroborating[]` stays
advisory for the same reason. The interaction is written up in the reference doc.

## Scope

CR path only. `review_evidence` is `{}` on the BugBot and Greptile paths, so
there is no evidence to redeem with there. BugBot's own `submitted_at` staleness
check (same #836 shape) is deliberately left alone — BugBot has not been observed
editing reviews in place, and widening without a trace would be speculative.

## Files

| File | Change |
|---|---|
| `.claude/scripts/merge-gate.sh` | `external_evidence_ok` helper, `_STALE_REDEEMED` / `_APPROVAL_STALE_BLOCKING` terms, all consumers switched, header docs |
| `.claude/scripts/tests/merge-gate-codeant-inplace-review.test.sh` | **new** — 44 assertions across 8 discriminating cases reproducing the PR #2596 trace |
| `.claude/scripts/tests/ts-normalizer-parity.test.sh` | pin updated + redemption-channel assertions (81 assertions, was 61) |
| `.claude/reference/merge-gate-stale-approval-redemption.md` | **new** — quirk, rule, rejected designs, #865 interaction |

Rule corpus untouched: **11,730 / 11,749** words, unchanged. `.budget-soft-cap`
NOT raised (#879 is an open owner decision).

**Local review coverage:** none

CodeAnt CLI returned `403` on both attempts — the undocumented ~10/day agent-review
cap, not an auth problem (per repo memory, `codeant logout/login` is the wrong
response). CodeRabbit CLI ran **four** substantive rounds and produced 11 findings
(10 applied, 1 declined — its suggested `.norm_ts` / `.substance_ok` dot-prefixed
needles would have broken the guard, since both are bash function calls in
`merge-gate.sh` rather than JSON field accesses), then hit the Pro-tier rate limit
on the fifth and sixth attempts, so there is no confirming *clean* pass on either
CLI. A self-review of the full diff was run as the fallback. The GitHub-side
reviewers are unaffected.

## Test plan

- [x] A CodeAnt in-place re-review (frozen `submitted_at`, `commit_id` == HEAD, post-push status comment naming HEAD, real summary) counts as coverage — case (a): `met == true`, `primary_review_met == true`, no `missing` entries
- [x] Redemption comes from evidence outside the review object — case (a) asserts `external_evidence_on_head == true` and `body_len == 0`, so the frozen approval body contributed nothing
- [x] Redemption is announced on stderr, never silent — case (a)
- [x] The byte-identical review with **no** corroborating evidence stays blocked with the unchanged #836 reason — case (b); (a) and (b) differ only in the issue-comments payload
- [x] The content-free "finished running the review" marker alone does **not** redeem — case (c)
- [x] A rubber stamp (`bodylen=0`, status comment naming an older SHA) is still rejected, recording `self_report_mismatch` — case (d)
- [x] Redemption does not bypass substance: a redeemable but self-contradicting approval blocks on the #875 reason, not the #836 one — case (e)
- [x] Identity is not the test — CodeRabbit gets the identical redemption via the identical mechanism (`external_evidence_on_head`, `body_len == 0`, no `temporal_inversion`) — case (f)
- [x] A genuinely fresh `CHANGES_REQUESTED` still outranks a redeemed approval, and the blocker is stated as the retraction — case (g)
- [x] The fresh-approval path is unchanged: redemption code never fires on a non-stale approval — case (h)
- [x] Reverting the fix is caught loudly by both suites (re-measured in Phase C: collapsing `_STALE_BLOCKING` back to `_APPROVAL_STALE` fails **2 assertions** in `merge-gate-codeant-inplace-review.test.sh` — cases (b) and (c) lose the #836 reason — and **4 assertions** in `ts-normalizer-parity.test.sh`, which name the hazard directly: the CR/CA freshness guards are no longer fed by a `_STALE_BLOCKING` derivation the suite can see. An earlier "7 + 1" count in this box described a different revert shape and has been corrected.)
- [x] The #836 regression suite still passes unchanged (`merge-gate-stale-approval.test.sh`), including the genuinely-stale cases (b)/(c)/(d) and the fail-closed case (e)
- [x] Full repo suite green: `bash .github/scripts/run-hook-tests.sh` — 58 suites, 0 failed
- [x] `rule-lint.sh` passes and the rule corpus is unchanged at 11,730 words
- [x] `shellcheck` clean on every touched file (only pre-existing SC1091/SC2016 info notes remain)

Closes #876


___

## **CodeAnt-AI Description**
Allow evidence-backed bot re-reviews to pass stale approval checks

### What Changed
- CodeAnt and CodeRabbit approvals with outdated submission timestamps can pass when the reviewer left substantive evidence tied to the current commit outside the approval itself.
- Stale approvals without current-commit evidence remain blocked, and reviewer identity alone never bypasses the check.
- Hollow approvals, outdated status comments, and fresh blocking reviews continue to prevent merging.
- Added regression and structural tests covering in-place re-reviews, evidence requirements, identity bypasses, and unchanged fresh-approval behavior.

### Impact
`✅ Fewer merge-gate blocks after bot re-reviews`
`✅ No bypass for hollow or self-validating approvals`
`✅ Clearer stale-approval handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

