### PR TITLE
fix(#894): believe an all-decimal short SHA, without believing every number

### DIFF
--- a/.claude/reference/review-substance-evidence.md
+++ b/.claude/reference/review-substance-evidence.md
@@ -141,9 +141,11 @@ intermittent. Timing still keys off the latest approval; only substance pools
 
 ### Two deliberate anti-false-positive choices
 
-- **SHA-like tokens must contain at least one `a-f` letter.** `\b[0-9a-f]{7,40}\b`
-  alone would read `20260731` or a line count as a commit id and manufacture a
-  mismatch out of an ordinary sentence.
+- **SHA-like tokens are not decided by form alone.** `\b[0-9a-f]{7,40}\b` with no
+  further test would read `20260731` or a line count as a commit id and
+  manufacture a mismatch out of an ordinary sentence. Requiring an `a-f` letter
+  fixed that, but then discarded a *genuine* short SHA that happens to be all
+  decimal — 3.5% of commits. See "Three admission rules" below.
 - **A comment naming HEAD needs no freshness filter.** Naming HEAD's SHA is
   itself proof the comment postdates HEAD, so the substance signal survives a
   missing push timestamp.
@@ -160,6 +162,91 @@ intermittent. Timing still keys off the latest approval; only substance pools
   clears the innocent shape. Keeping sub-second precision was not the
   alternative — under mixed precision `"10:00:22.5Z"` sorts *before*
   `"10:00:22Z"` (`.` < `Z`), which would corrupt ordering outright.
+
+## Three admission rules for SHA-like tokens (issue #894)
+
+A 7-character short SHA is all decimal with probability (10/16)^7 ≈ 3.7%; measured
+against this repo's real history, **15 of the last 431 commits on `main` (3.5%)**.
+For every one of those commits the `a-f` requirement made `sha_tokens` return an
+empty list for any comment naming HEAD's short form, so `status_comment_names_head`
+was *structurally* false, `external_evidence_on_head` with it, and the #876
+stale-approval redemption could not fire. A reviewer that did the work, said so,
+and named the commit was still not believed — the exact wedge PR #893 removed,
+back for one commit in thirty.
+
+The fix stops deciding token-hood purely by form. `sha_tokens` now admits a token
+under any of three rules, and **each addition can move the verdict in exactly one
+direction**:
+
+| # | Rule | Admits | Can grant coverage? | Can withhold coverage? |
+|---|---|---|---|---|
+| 1 | **FORM** (unchanged, #875) | `\b[0-9a-f]{7,40}\b` with at least one `a-f` | yes | yes |
+| 2 | **IDENTITY** (#894) | all-decimal `\b[0-9]{7,40}\b` that prefix-matches the known HEAD SHA | yes | yes |
+| 3 | **CODE SPAN** (#894) | all-decimal run that is a complete inline code span (`` `1234567` ``) | **no — structurally impossible** | yes |
+
+**Rule 2 corroborates against HEAD's identity, not against token form** — precisely
+the comparison `tokens_name_head` was about to make anyway, so nothing is guessed.
+A decimal run that is a genuine prefix of the actual HEAD SHA is not a coincidence
+worth guarding against (~1e-7), and it is the same exposure rule 1 has always
+carried for hex tokens.
+
+**Rule 3 exists only for the `self_report_mismatch` diagnostic.** Without it, a
+rubber stamp whose status comment names an *older* all-decimal SHA yields no
+tokens at all, is therefore not a self-report candidate, and a long-bodied
+approval naming a different commit counts as full coverage.
+
+**Rule 3 alone reads fence-stripped text.** A CodeRabbit walkthrough quotes diff
+hunks inside ``` fences, and quoted code carries backticks of its own — a JS
+template literal in a fenced hunk is a numeric literal being *discussed*, not a
+commit the reviewer claims to have read (raised by the CodeRabbit CLI on the #894
+PR). Rules 1-2 keep scanning the whole body on purpose: rule 1 must stay
+byte-identical to its pre-#894 behaviour, and rule 2 is anchored on HEAD's
+identity, so a run that matches HEAD is HEAD wherever it appears. Only rule 3
+infers commit-hood from surrounding punctuation, so only rule 3 needs that
+punctuation to be trustworthy.
+
+> The fence strip is `gsub("```.*?```"; " "; "m")`. The flag is **`m`, not `s`** —
+> jq inverts the PCRE convention: jq's `m` is what makes `.` match a newline, and
+> its `s` only rebinds `^` and `$`. Written with `s` the gsub matches nothing at
+> all and every fenced block is silently scanned as prose.
+
+### Why rule 3 cannot weaken the gate
+
+Any token admitted by rule 3 and **not** by rules 1-2 is, by construction, an
+all-decimal run that does *not* prefix-match HEAD — otherwise rule 2 would already
+have admitted it. So a rule-3-only token can never satisfy `tokens_name_head`:
+
+- `status_comment_names_head` is byte-identical with and without rule 3;
+- `external_evidence_on_head`, and so the #876 redemption, is byte-identical too;
+- `$selfrep` is the newest token-bearing comment, so adding a candidate that fails
+  to name HEAD can only move `self_report_mismatch` **false → true**, never back.
+
+Rule 3's only reachable effect is to *withhold* coverage. A false positive there
+blocks a merge, which is recoverable by a re-review and a push; the direction it
+structurally cannot take is the one that grants a merge. `merge-gate-review-substance.test.sh`
+case `(ee)` asserts this invariant directly rather than leaving it as an argument.
+
+### What was rejected
+
+- **Dropping the `a-f` filter outright.** Any 7-digit issue number, date or epoch
+  becomes a commit id, able both to falsely redeem a stale approval and to falsely
+  clear a mismatch — the failure the filter exists to prevent, in the direction
+  that grants merges.
+- **Rule 2 alone.** Fixes the redemption wedge but silently drops the mismatch
+  diagnostic for all-decimal SHAs, which is a real hole and not merely a lost
+  message (see rule 3 above).
+- **Matching against a `known_shas` set (the PR's commit list).** The SHA a rubber
+  stamp names is typically a *pre-rebase* commit that no longer appears in
+  `gh pr view --json commits` — the exact #876 trace — so it would miss the case it
+  was added for, at the cost of a new input contract.
+- **Cue words (`commit`/`sha`/`for`/`at`).** The cues these bots actually use include
+  `for`, `at`, `and` and `between` — broad enough to be meaningless. The inline
+  code-span shape is what both bots genuinely emit (`` ## Review summary for `<sha>` ``)
+  and it excludes prose numbers, `#1234` refs, and fenced-block contents.
+
+This change is **upstream** of the redemption channel, not part of it: it alters what
+`external_evidence_on_head` can *see*, never what redeems. The #876 channel stays
+exactly one term wide, and `tests/ts-normalizer-parity.test.sh` passes unmodified.
 
 ## The evidence payload must be complete
 

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -76,15 +76,20 @@
 #                             original_commit_id == HEAD, so comments GitHub
 #                             "moved" forward on force-push do not count)
 #   status_comment_names_head a conversation comment by that bot containing the
-#                             HEAD SHA (full, or a >=7-char hex token that
-#                             prefix-matches HEAD) and >= min_chars long. No
+#                             HEAD SHA (full, or a >=7-char token that
+#                             prefix-matches HEAD — hex OR all-decimal, issue
+#                             #894) and >= min_chars long. No
 #                             freshness filter is applied or needed: naming
 #                             HEAD's SHA is itself proof the comment postdates it.
 #   self_report_mismatch      among that bot's conversation comments containing any
 #                             SHA-like token, the MOST RECENT one names no SHA
-#                             matching HEAD. SHA-like = \b[0-9a-f]{7,40}\b that
-#                             contains at least one a-f letter, so bare digit runs
-#                             (dates, counts, IDs) cannot manufacture a mismatch.
+#                             matching HEAD. SHA-like = \b[0-9a-f]{7,40}\b with at
+#                             least one a-f letter, PLUS two all-decimal admissions
+#                             (issue #894): a run that prefix-matches HEAD, and a
+#                             run that is a complete inline code span. Bare digit
+#                             runs in prose (dates, counts, IDs) still cannot
+#                             manufacture a mismatch. See sha_tokens for why the
+#                             code-span rule can only ever withhold coverage.
 #   temporal_inversion        approval submitted_at < the EARLIEST post-push
 #                             run-start marker from that reviewer. The earliest
 #                             marker (not the latest) is deliberate: a re-review
@@ -229,12 +234,75 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
   | ($reviewers | split(",") | map(select(length > 0)))     as $approvers
   | ($corroborators | split(",") | map(select(length > 0))) as $others
 
-  # SHA-like token: 7-40 hex chars on a word boundary containing at least one a-f
-  # letter. The letter requirement stops "20260731" or a line count from being
-  # read as a commit id and manufacturing a false mismatch.
+  # SHA-like tokens. THREE admission rules, deliberately asymmetric: each of the
+  # two additions can move the verdict in exactly ONE direction, and which
+  # direction is a structural property of the rule, not of the fixture that
+  # happens to exercise it.
+  #
+  #  1. FORM (unchanged, issue #875). \b[0-9a-f]{7,40}\b containing at least one
+  #     a-f letter. Form alone is enough here: prose does not emit hex-letter
+  #     runs by accident, so no corroboration is required.
+  #
+  #  2. IDENTITY (issue #894). An ALL-DECIMAL \b[0-9]{7,40}\b run that
+  #     prefix-matches the known HEAD SHA (or is prefixed by it) — precisely the
+  #     comparison tokens_name_head is about to make anyway. Rule 1 alone
+  #     discards a GENUINE short SHA that happens to be all decimal: 15 of the
+  #     last 431 commits on this repo"s main (3.5%; (10/16)^7 in general). When
+  #     HEAD is one of those, NO comment can name it, status_comment_names_head
+  #     is structurally false, and the #876 stale-approval redemption can never
+  #     fire — reinstating the exact wedge PR #893 was written to remove.
+  #     Corroborating against HEAD"s IDENTITY rather than against token FORM is
+  #     what makes this safe: a decimal run that is a genuine prefix of the
+  #     actual HEAD SHA is not a coincidence worth guarding against (~1e-7), and
+  #     it is the same exposure rule 1 has always carried for hex tokens.
+  #
+  #  3. CODE SPAN (issue #894). An ALL-DECIMAL run that is a COMPLETE inline
+  #     code span (`1234567`) — the shape both bots use when naming the commit
+  #     they reviewed ("## Review summary for `<sha>`"). This exists ONLY for
+  #     the self_report_mismatch diagnostic: without it, a rubber stamp whose
+  #     status comment names an OLDER all-decimal SHA yields no tokens at all,
+  #     is therefore not a self-report candidate, and a long-bodied approval
+  #     sails through with the contradiction unrecorded.
+  #
+  #     Rule 3 alone reads FENCE-STRIPPED text. A CodeRabbit walkthrough quotes
+  #     diff hunks in ``` fences, and quoted code contains backticks of its own —
+  #     a JS template literal `1234567` inside a fenced hunk is a numeric literal
+  #     being DISCUSSED, not a commit the bot claims to have read (CodeRabbit CLI
+  #     review of this PR). Rules 1-2 deliberately keep scanning the whole body:
+  #     rule 1 must stay byte-identical to its pre-#894 behaviour, and rule 2 is
+  #     anchored on HEAD"s identity, so a run that matches HEAD is HEAD wherever
+  #     it appears. Only rule 3 infers commit-hood from surrounding punctuation,
+  #     so only rule 3 needs the surrounding punctuation to be trustworthy.
+  #
+  # WHY RULE 3 CANNOT WEAKEN THE GATE (the load-bearing argument). Any token
+  # admitted by rule 3 and not by rules 1-2 is, by construction, an all-decimal
+  # run that does NOT prefix-match HEAD — otherwise rule 2 would already have
+  # admitted it. So a rule-3-only token can never satisfy tokens_name_head:
+  # names_head is byte-identical with and without rule 3. Its only reachable
+  # effect is to ADD a self-report candidate that fails to name HEAD, i.e. to
+  # move self_report_mismatch false -> true. It can never redeem a stale
+  # approval, never clear a mismatch, never grant coverage. A false positive
+  # here withholds a merge (recoverable — re-review and push); the direction it
+  # structurally cannot take is the one that grants one.
+  #
+  # Bare decimal runs in prose ("reviewed 20260731 files across 1234567 lines")
+  # remain unadmitted under all three rules — pinned by case (k).
   | def sha_tokens:
-      [ (. // "") | ascii_downcase | scan("\\b[0-9a-f]{7,40}\\b")
-        | select(test("[a-f]")) ];
+      ((. // "") | ascii_downcase) as $btxt
+      # Fenced blocks blanked for rule 3 only. The flag is "m", NOT "s": jq
+      # inverts the PCRE convention — jq"s "m" is what makes . match a newline,
+      # and its "s" only rebinds ^ and $. With "s" this gsub silently matches
+      # nothing and every fenced block is scanned as prose. The lazy quantifier
+      # stops at the FIRST closing fence, so consecutive blocks are not swallowed
+      # whole along with the prose between them. An unclosed fence matches
+      # nothing and is simply scanned as prose.
+      | ($btxt | gsub("```.*?```"; " "; "m")) as $unfenced
+      | [ ( $btxt | scan("\\b[0-9a-f]{7,40}\\b") | select(test("[a-f]")) ),
+          ( $btxt | scan("\\b[0-9]{7,40}\\b") | . as $t
+                  | select(($sha | length) > 0
+                           and (($sha | startswith($t)) or ($t | startswith($sha)))) ),
+          ( $unfenced | scan("`([0-9]{7,40})`") | .[0] ) ]
+        | unique;
 
     # Does this token list identify $sha? A token matches when it prefixes the
     # full HEAD SHA (short form) or the full HEAD SHA prefixes it.

--- a/.claude/scripts/tests/merge-gate-codeant-inplace-review.test.sh
+++ b/.claude/scripts/tests/merge-gate-codeant-inplace-review.test.sh
@@ -347,6 +347,131 @@ else
   bad "(h) fresh approval: redemption fired on a non-stale approval (stderr: '$ERRTXT')"
 fi
 
+# =========================================================================
+# ISSUE #894 — the SAME redemption, on a HEAD whose 7-char short form is
+# ALL DECIMAL. Every case above uses a hex-containing SHA, so all of them
+# passed while 3.5% of real commits (15 of the last 431 on main;
+# (10/16)^7 in general) could not be redeemed at all: sha_tokens discarded
+# any token with no a-f letter, so a status comment naming the short SHA
+# produced no tokens, status_comment_names_head was structurally false, and
+# external_evidence_on_head could never become true. The #876 wedge, back
+# for one commit in thirty.
+#
+# Cases (i)-(n) are the discrimination set. (i) is the fix; (j)-(n) are the
+# reasons the fix is not "delete the [a-f] filter".
+# =========================================================================
+HEAD_SHA="1234567abcdef0123456789abcdef0123456789a"   # short form: 1234567
+DEC_SHORT="${HEAD_SHA:0:7}"
+OLD_DEC_SHA="9998887fedcba9876543210fedcba9876543210f"  # short form: 9998887
+
+# The genuine post-push trail, naming HEAD by its ALL-DECIMAL short form —
+# which is how these bots actually quote a short SHA.
+dec_convo_genuine() { # login
+  jq -cn --arg login "${1:-codeant-ai[bot]}" --arg short "$DEC_SHORT" \
+    --arg m "$MARKER_TS" --arg s "$SUMMARY_TS" --arg f "$FINISH_TS" \
+    '[{user:{login:$login,type:"Bot"}, created_at:$m, updated_at:$m,
+       body:"CodeAnt AI is running the review."},
+      {user:{login:$login,type:"Bot"}, created_at:$s, updated_at:$s,
+       body:("## Review summary for `" + $short + "`\n\nThis change adds a SafeAreaProvider inside the native modal root so the sheet respects the notch inset. Two call sites were updated and the snapshot baseline regenerated. No blocking issues found.")},
+      {user:{login:$login,type:"Bot"}, created_at:$f, updated_at:$f,
+       body:"CodeAnt AI finished running the review."}]'
+}
+
+echo "--- (i) #894: an ALL-DECIMAL short SHA redeems exactly as a hex one does ---"
+run_gate "$(ca_inplace_review)" "$(dec_convo_genuine)"
+check_eq "true"  "$(met)"                       "(i) decimal short SHA: met == true"
+check_eq "true"  "$(primary_met)"               "(i) decimal short SHA: primary_review_met == true"
+check_eq "0"     "$RC"                          "(i) decimal short SHA: exit 0"
+check_eq "no"    "$(missing_has "$STALE_MSG")"  "(i) decimal short SHA: no stale-retargeting blocker"
+check_eq "true"  "$(ev "codeant-ai[bot]" status_comment_names_head)" \
+                                                "(i) decimal short SHA: the status comment is seen to name HEAD"
+check_eq "true"  "$(ev "codeant-ai[bot]" external_evidence_on_head)" \
+                                                "(i) decimal short SHA: external_evidence_on_head is what redeemed it"
+check_eq "0"     "$(ev "codeant-ai[bot]" body_len)" \
+                                                "(i) decimal short SHA: the stale approval body still counted for 0"
+# Revert guard, stated positively: on the pre-#894 evaluator this token list is
+# EMPTY, so this assertion is what fails loudly if sha_tokens is narrowed back.
+check_eq "1234567" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].status_comment_shas[0] // "NONE"')" \
+                                                "(i) decimal short SHA: the decimal token was admitted (empty before the fix)"
+
+echo "--- (j) #894 discriminator: bare decimal runs in prose are NOT SHAs ---"
+# Same HEAD, same stale review. The comment is long and post-push, but names
+# only an issue number, a date and a line count. Nothing here identifies the
+# commit, so nothing may redeem — this is the case the [a-f] filter existed for,
+# and it must survive the widening intact.
+J_CONVO=$(jq -cn --arg s "$SUMMARY_TS" \
+  '[{user:{login:"codeant-ai[bot]",type:"Bot"}, created_at:$s, updated_at:$s,
+     body:"CodeAnt AI reviewed 20260801 files across 1234567890 lines of diff for issue 4128773 and found nothing at all worth reporting in this revision."}]')
+run_gate "$(ca_inplace_review)" "$J_CONVO"
+check_eq "false" "$(met)"                       "(j) prose decimals: met == false"
+check_eq "yes"   "$(missing_has "$STALE_MSG")"  "(j) prose decimals: unchanged #836 reason"
+check_eq "1"     "$RC"                          "(j) prose decimals: exit 1"
+check_eq "false" "$(ev "codeant-ai[bot]" status_comment_names_head)" \
+                                                "(j) prose decimals: no decimal run was read as HEAD"
+check_eq "false" "$(ev "codeant-ai[bot]" external_evidence_on_head)" \
+                                                "(j) prose decimals: nothing to redeem with"
+check_eq "false" "$(ev "codeant-ai[bot]" self_report_mismatch)" \
+                                                "(j) prose decimals: and no mismatch was manufactured either"
+
+echo "--- (k) #894: a code-span decimal that is NOT HEAD records a mismatch, never a redemption ---"
+# The asymmetry that makes the code-span rule safe. `9998887` is admitted as a
+# SHA-shaped self-report, so the contradiction is RECORDED — but it cannot
+# prefix-match HEAD, so it can never satisfy tokens_name_head. The only
+# direction this rule can move the verdict is toward withholding coverage.
+K_CONVO=$(jq -cn --arg old "${OLD_DEC_SHA:0:7}" --arg s "$SUMMARY_TS" \
+  '[{user:{login:"codeant-ai[bot]",type:"Bot"}, created_at:$s, updated_at:$s,
+     body:("## Review summary for `" + $old + "`\n\nReviewed the modal root change and the two updated call sites. No blocking issues found.")}]')
+run_gate "$(ca_empty_review "$APPROVAL_TS")" "$K_CONVO"
+check_eq "false" "$(met)"                       "(k) old decimal SHA: met == false"
+check_eq "1"     "$RC"                          "(k) old decimal SHA: exit 1"
+check_eq "true"  "$(ev "codeant-ai[bot]" self_report_mismatch)" \
+                                                "(k) old decimal SHA: self_report_mismatch IS recorded (issue #894 AC3)"
+check_eq "false" "$(ev "codeant-ai[bot]" status_comment_names_head)" \
+                                                "(k) old decimal SHA: it did not name HEAD"
+check_eq "false" "$(ev "codeant-ai[bot]" external_evidence_on_head)" \
+                                                "(k) old decimal SHA: and so could not redeem the stale timestamp"
+
+echo "--- (l) #894 launder guard: a long comment naming an OLDER hex SHA still mismatches ---"
+L_CONVO=$(jq -cn --arg old "$OLD_SHA" --arg s "$SUMMARY_TS" \
+  '[{user:{login:"codeant-ai[bot]",type:"Bot"}, created_at:$s, updated_at:$s,
+     body:("Re-analysis complete for this pull request. The reviewed commit for this run was `" + $old + "`, covering the modal root change and the two updated call sites.")}]')
+run_gate "$(ca_empty_review "$APPROVAL_TS")" "$L_CONVO"
+check_eq "false" "$(met)"                       "(l) launder attempt: met == false"
+check_eq "1"     "$RC"                          "(l) launder attempt: exit 1"
+check_eq "true"  "$(ev "codeant-ai[bot]" self_report_mismatch)" \
+                                                "(l) launder attempt: self_report_mismatch still recorded on a decimal HEAD"
+check_eq "false" "$(ev "codeant-ai[bot]" external_evidence_on_head)" \
+                                                "(l) launder attempt: nothing external to redeem with"
+
+echo "--- (m) #894: a hollow approval on a decimal HEAD still blocks on the #875 reason ---"
+# FRESH (post-push) empty approval, no footprint anywhere. Staleness is not in
+# play, so the blocker must be the #875 substance reason and nothing else. The
+# widening must not have made "no evidence" look like evidence.
+run_gate "$(ca_empty_review "$SUMMARY_TS")" "[]"
+check_eq "false" "$(met)"                        "(m) hollow on decimal HEAD: met == false"
+check_eq "false" "$(primary_met)"                "(m) hollow on decimal HEAD: primary_review_met == false"
+check_eq "yes"   "$(missing_has "$HOLLOW_MSG")"  "(m) hollow on decimal HEAD: blocked on the #875 substance reason"
+check_eq "1"     "$RC"                           "(m) hollow on decimal HEAD: exit 1"
+check_eq "false" "$(ev "codeant-ai[bot]" substantive)" \
+                                                 "(m) hollow on decimal HEAD: nothing reads as substance"
+
+echo "--- (n) #894: the full 40-char form still redeems on a decimal-short HEAD ---"
+# Rule 1 (hex-letter form) is untouched: a decimal-PREFIXED but hex-containing
+# full SHA worked before the fix and must still work after it. If (n) ever fails
+# while (i) passes, the widening replaced the old rule instead of adding to it.
+run_gate "$(ca_inplace_review)" "$(ca_convo_genuine)"
+check_eq "true"  "$(met)"                       "(n) full 40-char SHA: met == true"
+check_eq "0"     "$RC"                          "(n) full 40-char SHA: exit 0"
+check_eq "true"  "$(ev "codeant-ai[bot]" external_evidence_on_head)" \
+                                                "(n) full 40-char SHA: redeemed by the unchanged form rule"
+
+echo "--- (o) #894: identity is still not the test — CodeRabbit gets the same decimal redemption ---"
+run_gate "$(cr_inplace_review)" "$(dec_convo_genuine "coderabbitai[bot]")"
+check_eq "true"  "$(met)"                       "(o) CodeRabbit decimal redemption: met == true"
+check_eq "0"     "$RC"                          "(o) CodeRabbit decimal redemption: exit 0"
+check_eq "true"  "$(ev "coderabbitai[bot]" external_evidence_on_head)" \
+                                                "(o) CodeRabbit decimal redemption: same mechanism, not a per-bot waiver"
+
 # -------------------------------------------------------------------------
 echo "----------------------------------------"
 echo "merge-gate-codeant-inplace-review.test.sh: $PASS passed, $FAIL failed"

--- a/.claude/scripts/tests/merge-gate-review-substance.test.sh
+++ b/.claude/scripts/tests/merge-gate-review-substance.test.sh
@@ -25,6 +25,9 @@
 #   (j) rate-limit notice followed by a real review   -> met  (false-negative guard)
 #   (k) digit-only hex-shaped tokens                  -> no manufactured mismatch
 #   (l) review_evidence present on non-cr paths       -> emitted, does not gate
+#   (ee) sha_tokens admission rules on a decimal HEAD -> issue #894, both
+#        directions plus the invariant that the code-span rule can only ever
+#        withhold coverage, never grant it
 #
 # Only `gh` is stubbed; merge-gate.sh, review-substance.sh, ci-status.sh,
 # check-runs-dedup.sh and session-state.sh are the real scripts.
@@ -475,6 +478,88 @@ FAKE_ISSUE_COMMENTS="$(convo "coderabbitai[bot]" "We could not run the review du
 OUT="$(run_gate)"
 check_eq "true" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["coderabbitai[bot]"].capability_failure')" "(dd) same-second failure notice is still post-push"
 check_eq "false" "$(echo "$OUT" | jq -r '.met')" "(dd) and the gate does not pass on it"
+
+echo "=== (ee) sha_tokens admission rules, at the evaluator (issue #894) ==="
+# Case (k) above pins that BARE digit runs are not commit ids. This case pins the
+# two all-decimal admissions added for #894 and, more importantly, the ASYMMETRY
+# that makes the second one safe. Driven through review-substance.sh directly so
+# the token rules are pinned independently of merge-gate.sh's plumbing.
+#
+# HEAD here has an ALL-DECIMAL 7-char short form — 3.5% of real commits (15 of
+# the last 431 on main). Under the pre-#894 rule NO token could be extracted from
+# a comment naming it, so status_comment_names_head was structurally false and
+# the #876 redemption could never fire on those commits.
+DEC_HEAD="1234567abcdef0123456789abcdef0123456789a"
+ee_eval() { # <comment-body>  -> the codeant reviewer object
+  jq -cn --arg sha "$DEC_HEAD" --arg b "$1" \
+    '{head_sha:$sha, push_ts:"2026-07-31T10:00:00Z",
+      reviews:[{user:{login:"codeant-ai[bot]"},commit_id:$sha,state:"APPROVED",
+                submitted_at:"2026-07-31T10:04:00Z",body:""}],
+      pr_comments:[],
+      issue_comments:[{user:{login:"codeant-ai[bot]"},
+                       created_at:"2026-07-31T10:05:00Z",
+                       updated_at:"2026-07-31T10:05:00Z", body:$b}]}' \
+  | "$EVAL_SUT" 2>/dev/null | jq -c '.reviewers["codeant-ai[bot]"]'
+}
+SUMMARY_TAIL=$'\n\nReviewed the modal root change and the two updated call sites. No blocking issues found.'
+
+# Rule 2 — IDENTITY. An all-decimal run that prefix-matches HEAD is a commit id.
+R2="$(ee_eval "## Review summary for \`1234567\`${SUMMARY_TAIL}")"
+check_eq "true"  "$(echo "$R2" | jq -r '.status_comment_names_head')"  "(ee) rule 2: a decimal run prefix-matching HEAD names HEAD"
+check_eq "true"  "$(echo "$R2" | jq -r '.external_evidence_on_head')"  "(ee) rule 2: and so supplies evidence outside the approval"
+check_eq "false" "$(echo "$R2" | jq -r '.self_report_mismatch')"       "(ee) rule 2: with no mismatch, because it names this commit"
+
+# Rule 3 — CODE SPAN. An all-decimal run in a complete inline code span is a
+# self-report candidate even when it is NOT HEAD. This is what keeps the #875
+# mismatch diagnostic alive when the SHA a rubber stamp names is all decimal.
+R3="$(ee_eval "## Review summary for \`9998887\`${SUMMARY_TAIL}")"
+check_eq "true"  "$(echo "$R3" | jq -r '.self_report_mismatch')"       "(ee) rule 3: an older all-decimal SHA is still recorded as a mismatch"
+check_eq "9998887" "$(echo "$R3" | jq -r '.status_comment_shas[0] // "NONE"')" "(ee) rule 3: and is reported, so the blocker names the SHA it read"
+
+# THE INVARIANT that makes rule 3 safe, asserted rather than argued. A token
+# admitted by rule 3 and not by rule 2 is by construction an all-decimal run that
+# does NOT prefix-match HEAD, so it can never satisfy tokens_name_head. Rule 3
+# therefore cannot move names_head or external_evidence_on_head at all — its ONLY
+# reachable effect is self_report_mismatch false -> true, i.e. WITHHOLDING
+# coverage. If a future change ever lets a code-span token redeem an approval,
+# these two flip to true and this case fails.
+check_eq "false" "$(echo "$R3" | jq -r '.status_comment_names_head')"  "(ee) invariant: a rule-3-only token can never name HEAD"
+check_eq "false" "$(echo "$R3" | jq -r '.external_evidence_on_head')"  "(ee) invariant: and can never redeem a stale approval"
+
+# Neither rule admits bare prose decimals — the (k) guarantee, restated against a
+# decimal HEAD so the widening cannot have quietly relaxed it.
+R0="$(ee_eval "CodeAnt AI reviewed 20260801 files across 1234567890 lines of diff for issue 4128773 and found nothing worth reporting.")"
+check_eq "false" "$(echo "$R0" | jq -r '.status_comment_names_head')"  "(ee) prose decimals still name nothing"
+check_eq "false" "$(echo "$R0" | jq -r '.self_report_mismatch')"       "(ee) prose decimals still manufacture no mismatch"
+check_eq "[]"    "$(echo "$R0" | jq -c '.status_comment_shas')"        "(ee) prose decimals yield no tokens at all"
+
+# Rule 3 reads FENCE-STRIPPED text (CodeRabbit CLI review of PR for #894). A
+# walkthrough quotes diff hunks in ``` fences, and quoted code carries backticks
+# of its own — a JS template literal is a numeric literal being DISCUSSED, not a
+# commit the bot claims to have read. Without the strip this fixture manufactures
+# a self_report_mismatch out of someone else's source code and withholds coverage
+# from an honest reviewer.
+# Backticks are escaped inside double quotes rather than protected by single
+# quotes: the single-quoted form is equivalent but trips shellcheck SC2016, and
+# the fix here is to write it unambiguously, not to silence the check.
+RF="$(ee_eval "$(printf "Walkthrough of the changed files, covering both call sites in detail.\n\n\`\`\`js\nconst id = \`1234599\`;\n\`\`\`\n")")"
+check_eq "false" "$(echo "$RF" | jq -r '.self_report_mismatch')"       "(ee) fenced code: a template literal is not a self-report"
+check_eq "[]"    "$(echo "$RF" | jq -c '.status_comment_shas')"        "(ee) fenced code: and yields no tokens"
+# Prose is still scanned when a fence appears elsewhere in the same comment —
+# the strip must remove the block, not give up on the whole body.
+RF2="$(ee_eval "$(printf "Reviewed for \`9998887\`, which changed both call sites.\n\n\`\`\`js\nconst id = \`1234599\`;\n\`\`\`\n")")"
+check_eq "true"  "$(echo "$RF2" | jq -r '.self_report_mismatch')"      "(ee) fenced code: a real self-report outside the fence still counts"
+check_eq "9998887" "$(echo "$RF2" | jq -r '.status_comment_shas[0] // "NONE"')" "(ee) fenced code: and only the out-of-fence token is admitted"
+# Rule 2 is NOT fence-stripped, deliberately: it is anchored on HEAD's identity,
+# so a run that matches HEAD is HEAD wherever it appears.
+RF3="$(ee_eval "$(printf "Walkthrough of the changed files, covering both call sites in detail.\n\n\`\`\`\nreviewed 1234567 across both call sites\n\`\`\`\n")")"
+check_eq "true"  "$(echo "$RF3" | jq -r '.status_comment_names_head')" "(ee) rule 2 is not fence-stripped: HEAD is HEAD wherever it appears"
+
+# Rule 1 is untouched: a hex-letter token still works exactly as before, and a
+# hex SHA that is NOT HEAD still mismatches on a decimal-short HEAD.
+R1="$(ee_eval "Re-analysis complete. The reviewed commit for this run was \`abc1234\`, covering the modal root change.")"
+check_eq "true"  "$(echo "$R1" | jq -r '.self_report_mismatch')"       "(ee) rule 1: an older hex SHA still mismatches"
+check_eq "false" "$(echo "$R1" | jq -r '.external_evidence_on_head')"  "(ee) rule 1: and still cannot redeem"
 
 echo "=== (m) evaluator rejects malformed stdin ==="
 echo "not json" | "$EVAL_SUT" >/dev/null 2>&1


### PR DESCRIPTION
## **User description**
Closes #894

## The bug

`review-substance.sh`'s `sha_tokens` extracted SHA-shaped tokens and then discarded any
with no hex letter. That filter is correct in intent — without it an issue number, a date
or a line count reads as a commit id — but it also discards a **genuine** short SHA that
happens to be all decimal. A 7-character short SHA is all decimal with probability
(10/16)^7 ≈ 3.7%; measured against this repo's real history, **15 of the last 431 commits
on `main` (3.5%)**.

For every one of those commits, no comment could name HEAD: `tokens_name_head` could not
fire, `status_comment_names_head` and `external_evidence_on_head` were **structurally**
false, and the stale-approval redemption merged three hours ago in PR #893 could never
fire — reinstating the exact #876 wedge that PR was written to eliminate. A reviewer that
did the work, said so, and named the commit was still not believed, one commit in thirty.

## The fix — three admission rules, deliberately asymmetric

`sha_tokens` stops deciding token-hood purely by **form**. Each addition can move the
verdict in exactly **one** direction, and which direction is a structural property of the
rule, not of the fixture that happens to exercise it.

| # | Rule | Admits | Can grant coverage? | Can withhold coverage? |
|---|---|---|---|---|
| 1 | **FORM** (unchanged, #875) | `\b[0-9a-f]{7,40}\b` with at least one `a-f` | yes | yes |
| 2 | **IDENTITY** (new) | all-decimal `\b[0-9]{7,40}\b` that prefix-matches the known HEAD SHA | yes | yes |
| 3 | **CODE SPAN** (new) | all-decimal run that is a complete inline code span (`` `1234567` ``) | **no — structurally impossible** | yes |

**Rule 2 corroborates against HEAD's identity, not against token form** — precisely the
comparison `tokens_name_head` was about to make anyway, so nothing is guessed. A decimal
run that is a genuine prefix of the actual HEAD SHA is not a coincidence worth guarding
against (~1e-7), and it is the same exposure rule 1 has always carried for hex.

**Rule 3 exists only for the `self_report_mismatch` diagnostic** (issue AC 3). Without it,
a rubber stamp whose status comment names an *older* all-decimal SHA yields no tokens at
all, is therefore not a self-report candidate, and a long-bodied approval naming a
different commit counts as full coverage. That is a real hole, not just a lost message.

### Why rule 3 cannot weaken the gate

Any token admitted by rule 3 and **not** by rules 1-2 is, by construction, an all-decimal
run that does *not* prefix-match HEAD — otherwise rule 2 would already have admitted it.
So a rule-3-only token can never satisfy `tokens_name_head`:

- `status_comment_names_head` is **byte-identical** with and without rule 3;
- `external_evidence_on_head`, and so the #876 redemption, is byte-identical too;
- `$selfrep` is the newest token-bearing comment, so adding a candidate that fails to name
  HEAD can only move `self_report_mismatch` **false → true**, never back.

Rule 3's only reachable effect is to *withhold* coverage. A false positive there blocks a
merge (recoverable — re-review and push); the direction it structurally cannot take is the
one that grants a merge. This is **asserted, not argued**: `merge-gate-review-substance.test.sh`
case `(ee)` pins both flags to `false` on a rule-3-only token.

### Rule 3 reads fence-stripped text

Raised by the CodeRabbit CLI during local review, and valid. A walkthrough quotes diff
hunks inside ``` fences, and quoted code carries backticks of its own — a JS template
literal in a fenced hunk is a numeric literal being *discussed*, not a commit the reviewer
claims to have read. Rules 1-2 keep scanning the whole body on purpose: rule 1 must stay
byte-identical to its pre-#894 behaviour, and rule 2 is anchored on HEAD's identity, so a
run that matches HEAD is HEAD wherever it appears. Only rule 3 infers commit-hood from
surrounding punctuation, so only rule 3 needs that punctuation to be trustworthy.

Writing that strip surfaced a second trap worth recording: the flag is
`gsub("```.*?```"; " "; "m")` — **`m`, not `s`**. jq inverts the PCRE convention: jq's `m`
is what makes `.` match a newline, and its `s` only rebinds `^` and `$`. The first draft
used `s`, the gsub silently matched nothing, and three new assertions caught it.

### Alternatives considered and rejected

- **Drop the `a-f` filter outright.** Any 7-digit issue number, date or epoch becomes a
  commit id, able both to falsely redeem a stale approval and to falsely clear a
  mismatch — the failure the filter exists to prevent, in the direction that grants merges.
- **Rule 2 alone (the HEAD-anchoring sketch).** Fixes the redemption wedge but silently
  drops issue AC 3, leaving the hole described above.
- **Match against a `known_shas` set (the PR's commit list).** Attractive, but the SHA a
  rubber stamp names is typically a *pre-rebase* commit that no longer appears in
  `gh pr view --json commits` — the exact #876 trace — so it would miss the case it was
  added for, at the cost of a new input contract.
- **Cue words (`commit`/`sha`/`for`/`at`).** The cues these bots actually use include
  `for`, `at`, `and`, `between` — broad enough to be meaningless. The inline code-span
  shape is what both bots genuinely emit (`` ## Review summary for `<sha>` ``) and it
  excludes prose numbers, `#1234` refs, and fenced-block contents.

## What is NOT touched

`merge-gate.sh` is unchanged. This fix is **upstream** of the #876 redemption channel: it
alters what `external_evidence_on_head` can *see*, never what redeems. The channel stays
exactly one term wide — `external_evidence_ok` → `external_evidence_on_head`, one
assignment site, gated on the approval already being stale — and **PR #893's parity pin in
`tests/ts-normalizer-parity.test.sh` passes unmodified**.

`CLAUDE.md` and `.claude/rules/*` are untouched; the corpus is unchanged at **11,730**
words and `.budget-soft-cap` is not raised (issue #879 is an open owner decision). The
design rationale went to `.claude/reference/review-substance-evidence.md`, which is not
auto-loaded.

## Interaction with issue #865

Issue #865 (open, not being worked) proposes letting a fresh CR-path `APPROVED` satisfy the
gate while a PR is sticky-assigned to BugBot. This PR does not foreclose any of its three
options: it changes only which tokens `review-substance.sh` extracts, and touches neither
`resolve_reviewer` nor the sticky rule. If #865 lands the "un-stick on a fresh CR-path
approval" option, that approval will be evaluated by the same substance rules as today —
including, now, on all-decimal HEADs. The `corroborating` field stays advisory, as #865's
decision requires.

## Verification

Revert-proof, measured against the final code: restoring the old one-line `sha_tokens`
produces **11 failures** in `merge-gate-codeant-inplace-review.test.sh` and **7** in
`merge-gate-review-substance.test.sh` — 18 in total. The fix cannot be silently removed.

| Suite | Before | After |
|---|---|---|
| `merge-gate-codeant-inplace-review.test.sh` | 44 | **78** |
| `merge-gate-review-substance.test.sh` | 79 | **96** |
| `ts-normalizer-parity.test.sh` (PR #893's pin) | 81 | **81, file unmodified** |
| Full `run-hook-tests.sh` | 58 suites | **58 suites, 0 failed** |

`shellcheck` exits 0 on all three changed shell files — the three new fenced fixtures use
escaped backticks inside double quotes rather than a `shellcheck disable` for SC2016, per
`.claude/rules/cr-local-review.md`. `rule-lint.sh` OK.

**Local review coverage:** cr-only

CodeRabbit CLI ran to a **verified clean pass** (`findings: 0`, no stdout `type: "error"`
record, empty stderr, all four changed files listed as reviewed). It raised two findings on
the way there — the fenced-code-block gap above (major) and a markdown/possessive nit — both
fixed rather than waived.

CodeAnt CLI returned **403 twice** (`API Error: Access denied`) — the known undocumented
daily agent-review cap, not an auth problem, so it was dropped for the session per
`.claude/rules/cr-local-review.md` rather than re-authenticated. Both its runs exited `0`
with an empty `issues` array, i.e. false cleans; classified as **not covered**. The CodeAnt
GitHub App is unaffected and can still satisfy the merge gate on its own.

## Test plan

- [x] A substantive status comment naming an **all-decimal short SHA** redeems a stale
      approval exactly as a hex-containing one does — case `(i)`, asserting `met == true`,
      `status_comment_names_head == true`, `external_evidence_on_head == true`, and that
      the decimal token was actually admitted (`status_comment_shas[0] == "1234567"`,
      empty before the fix)
- [x] Decimal runs that are **not** SHAs (issue number, date, line count in prose) are
      still not treated as SHA tokens — case `(j)` and evaluator case `(ee)`: no
      redemption, no manufactured mismatch, `status_comment_shas == []`. Pre-existing
      hostile case `(k)` still passes unmodified
- [x] `self_report_mismatch` is still recorded when the named all-decimal SHA is an
      **older** commit — case `(k)` (gate) and `(ee)` (evaluator), which also assert that
      the same token yields `status_comment_names_head == false` and
      `external_evidence_on_head == false`
- [x] A **launder attempt** — a long comment naming an older SHA — still mismatches on a
      decimal HEAD: case `(l)` for hex, case `(k)` for decimal
- [x] A **hollow approval** (bodylen 0, no external evidence) on a decimal HEAD still
      blocks on the unchanged #875 reason — case `(m)`
- [x] Rule 1 is **additive, not replaced**: the full 40-char form still redeems on a
      decimal-short HEAD — case `(n)`
- [x] Rule 3 does **not** read inside fenced code blocks: a JS template literal in a
      quoted diff hunk manufactures neither a mismatch nor a token, a real self-report
      *outside* the fence in the same comment still counts, and rule 2 is deliberately
      **not** fence-stripped (HEAD is HEAD wherever it appears) — three `(ee)` assertions
- [x] Redemption is still **evidence, not identity**: CodeRabbit gets the identical
      decimal redemption as CodeAnt — case `(o)`
- [x] **PR #893's parity pin passes unmodified** — `ts-normalizer-parity.test.sh` is not
      edited in this PR and stays green; the redemption channel is still one term wide
- [x] Reverting `sha_tokens` fails loudly — 11 + 7 = 18 assertion failures, verified
- [x] Full `run-hook-tests.sh` green (58 suites), `shellcheck` clean, `rule-lint.sh` OK
- [x] Corpus unchanged at 11,730 words; `.budget-soft-cap` not raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Recognize genuine all-decimal short SHAs without treating ordinary numbers as commits

### What Changed
- Review evidence now recognizes an all-decimal short SHA when it matches the current commit, allowing valid stale-approval redemption on those commits.
- Older all-decimal SHAs in inline code are recorded as mismatches, while dates, issue numbers, line counts, and numbers inside fenced code remain ignored.
- Existing hexadecimal SHA handling and review-gate behavior remain unchanged.
- Added coverage for decimal SHA redemption, mismatch detection, fenced-code handling, false-positive protection, and both supported review bots.
- Documented the SHA recognition rules and their effect on review evidence.

### Impact
`✅ Valid reviews recognized on decimal-short commits`
`✅ Fewer false review mismatches from code examples`
`✅ Issue and date numbers cannot redeem stale approvals`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

