### PR TITLE
fix(#889): point pmm-lifecycle's resume cross-refs at the steps that exist

### DIFF
--- a/.claude/skills/pr-monitor-and-manage/references/pmm-lifecycle.md
+++ b/.claude/skills/pr-monitor-and-manage/references/pmm-lifecycle.md
@@ -14,12 +14,12 @@ Pause marker fields live under nested `.pmm.*`. Existing runtime fields
 | Field | Type | Written by | Read by |
 |-------|------|-----------|---------|
 | `.pmm.paused_at` | ISO-8601 string | Main skill Pause step 4 | Step 0a, `-wake` Step 2 |
-| `.pmm.fleet_at_pause` | `[{pr, head_sha, state}]` | Main skill Pause step 3 | `-wake` Step 4a |
-| `.pmm.config_at_pause` | object | Main skill Pause step 3 | Step 0a, `-wake` Step 4b |
+| `.pmm.fleet_at_pause` | `[{pr, head_sha, state}]` | Main skill Pause step 4 (built in step 3) | `-wake` Step 4a |
+| `.pmm.config_at_pause` | object | Main skill Pause step 4 (built in step 3) | Step 0a, `-wake` Step 4a, `-wake` Step 4b |
 
 `config_at_pause` fields: `author`, `repo`, `cadence`, `max_parallel`, `idle_pause_after`, `auto_wake`, `auto_wake_cadence`, `confirm_merges`.
 
-> **Wake coupling:** `/pr-monitor-and-manage-wake` Step 4b rebuilds `PMM_FLAGS` from the `config_at_pause` blob — including `--confirm-merges` when `confirm_merges` is true — before re-arming the loop. The main skill's Step 0a uses the same blob for flag merging on direct re-invocation.
+> **Wake coupling:** `/pr-monitor-and-manage-wake` Step 4b rebuilds `PMM_FLAGS` from the `config_at_pause` blob — including `--confirm-merges` when `confirm_merges` is true — before re-arming the loop. The main skill's Step 0a uses the same blob for flag merging on direct re-invocation. `-wake` Step 4a reads it too, but only for `author` / `repo`, to scope its lightweight fleet scan (issue #871) — which is why a missing blob fails that scan closed rather than resuming.
 
 ---
 
@@ -57,7 +57,7 @@ fi
 
 > **The digest reset has two owners, one per resume path.** The branch above is guarded on a non-null `.pmm.paused_at`, so it covers only **direct re-invocation** of this skill. On the **`-wake`** path, Step 4b clears the marker before re-arming the loop — this branch is already skipped by the time the loop's first tick runs — so `-wake` Step 4b nulls `.pmm_digest` and `.pmm_row_digest` in its own atomic `--set` batch (issue #872). The guarantee "both digests are null after **any** resume" holds only while both sides do it; neither is redundant.
 
-Resume logic is shared with `/pr-monitor-and-manage-wake` — see `.claude/skills/pr-monitor-and-manage-wake/SKILL.md` Step 2 (re-scan teardown) and Step 3 (marker clear + loop re-arm). When resuming via re-invoking this skill (not `-wake`), apply the precedence rule in Step 1 after parsing `$ARGUMENTS`: any flag explicitly supplied on this invocation wins; omitted flags inherit from `.pmm.config_at_pause`. After resume, continue with Step 1 using the merged config and run a full discovery tick at **base** cadence (not the widened backoff cadence).
+Resume logic is shared with `/pr-monitor-and-manage-wake` — see `.claude/skills/pr-monitor-and-manage-wake/SKILL.md` Step 3 (re-scan teardown) and Step 4b (marker clear + loop re-arm). When resuming via re-invoking this skill (not `-wake`), apply the precedence rule in Step 1 after parsing `$ARGUMENTS`: any flag explicitly supplied on this invocation wins; omitted flags inherit from `.pmm.config_at_pause`. After resume, continue with Step 1 using the merged config and run a full discovery tick at **base** cadence (not the widened backoff cadence).
 
 A stale marker left by a killed session is safely reconciled here: the next `/pr-monitor-and-manage` invocation reads it, resumes (or the user runs `/pmm-stop`), and re-runs discovery from scratch.
 


### PR DESCRIPTION
## **User description**
Closes #889

## What was wrong

`pmm-lifecycle.md`'s shared-resume pointer sent readers **one step short on both hops**:

| Pointer said | `-wake/SKILL.md` actually has |
|---|---|
| Step 2 — re-scan teardown | Step 2 is **Check pause marker**; the teardown is **Step 3** |
| Step 3 — marker clear + loop re-arm | Step 3 is the teardown; marker clear + re-arm is **Step 4b** |

Left behind when the `-wake` skill grew its Step 4a/4b split.

## Not a duplicate of #872, and not already fixed by #887

The issue carried a `Possibly duplicates #872` caveat, so this was checked first rather than
assumed. #872 owned the **digest-reset** half of the same paragraph region and was closed by
PR #887 — which did change `-wake` Step 4b (it now nulls `.pmm_digest` / `.pmm_row_digest` in
the same atomic `--set` batch). But #887 never touched these step *numbers*, and line 60 is
still wrong on `03af457`. The overlap is positional, exactly as the issue described.

## Changes (one file, documentation only, no behavior change)

**1. The filed defect** — the shared-resume cross-reference now names `-wake` **Step 3**
(re-scan teardown) and **Step 4b** (marker clear + loop re-arm). The rest of the sentence
(flag precedence, base-cadence guidance) was already correct and is unchanged; no surrounding
prose described the old sequence.

Re-checking the pause-marker table per the issue's third AC turned up two more pointers of the
same class. A single off-by-one is rarely alone, so they are corrected together — but they are
second-order findings, **not** part of the filed report, and either can be dropped without
touching change 1:

**2. `.pmm.config_at_pause` "Read by" omitted `-wake` Step 4a.** PR #887 added a
`.pmm.config_at_pause` read to Step 4a, which pulls `author` / `repo` to scope its fail-closed
lightweight fleet scan (#871). The column listed only `Step 0a, -wake Step 4b`. The Wake-coupling
note below the table had the same gap — it read as though Step 4b were the only consumer — so it
gains one clause naming Step 4a's narrower read.

**3. "Written by" cited Pause step 3 for two rows.** Pause step 3 only *builds* the two shell
variables; all three marker fields are written to `session-state.json` by step 4's atomic
`--set` batch — which is what the `.pmm.paused_at` row already said. Same failure mode as the
filed defect: a reader chasing "where is this written" lands one step short.

## Sweep for the same drift elsewhere

`git grep -E "wake[^.]{0,60}Step [0-9]"` across all tracked files, plus every `pmm-lifecycle.md`
and `pr-monitor-and-manage*/SKILL.md` cross-reference. **Nothing else is drifted:** lines 16, 22,
58, `pr-monitor-and-manage/SKILL.md:42`, `-wake/SKILL.md:182,186`, and
`.claude/reference/cross-session-durability.md:46` all verify correct against the current skills.
Hits under `.claude/worktrees/` are other agents' in-flight branches and are out of scope.

## Verification

`SKILL.md` and reference prose have **no automated coverage** in this repo — `.claude/scripts/tests/`
covers shell scripts, not prose, and committed regression coverage for skill-embedded bash is
deliberately deferred under issue #888. No test is claimed here. Verification was by direct
reading, plus every lint the repo does have:

- Each edited step number read back against the literal `##` headings in `-wake/SKILL.md`
  (`Step 1: Parse mode` / `Step 2: Check pause marker` / `Step 3: Cancel the auto-wake re-scan` /
  `Step 4a: --auto-check branch` / `Step 4b: Resume`).
- `rule-lint.sh` OK · `skill-catalog-lint.sh` OK (29 commands) · `verbatim-block-lint.sh` OK
  (6 copy surfaces) · `merge-authority-lint.sh` OK (5 emitters) · `chip-model-guard-lint` 42
  fixtures passed · `skill-conventions-audit.sh` 0 errors (44 pre-existing description warnings,
  none in the touched file, no frontmatter changed).
- Corpus **11,730 words against the 11,749 cap — unchanged**. The edited file is outside
  `CLAUDE.md` / `.claude/rules/`, so the delta is zero by construction.
  `.claude/rules/.budget-soft-cap` is untouched (#879 is an open owner decision).

**Local review coverage:** cr-only

CodeAnt 403'd on its undocumented daily agent-review cap on both the initial run and the single
permitted retry (`API Error: Access denied (403)`, exit 0 both times — a false clean caught on
stderr). Dropped for the session per `cr-local-review.md`; no `logout`/`login` attempted, since
the cause is the cap, not auth. CodeRabbit returned `review_completed` with **0 findings** on the
changed file, no NDJSON `type: "error"` record, empty stderr.

## Test plan

- [x] Line 60's cross-reference names `-wake` **Step 3** for the re-scan teardown
- [x] It names `-wake` **Step 4b** for the marker clear + loop re-arm
- [x] Both numbers match the literal `##` headings in `pr-monitor-and-manage-wake/SKILL.md`
- [x] The pause-marker state table is re-checked against the current `-wake` skill: Step 4a is
      listed as a reader of `.pmm.config_at_pause`, and the two `Written by` cells cite Pause step 4
- [x] No other `-wake` / `-stop` step cross-reference in the repo carries the same drift
- [x] No corpus (`CLAUDE.md` / `.claude/rules/*.md`) word-count change, and `.budget-soft-cap`
      is untouched
- [x] No behavior change — the diff is prose and table cells only, in a single reference doc


___

## **CodeAnt-AI Description**
Correct PMM lifecycle pause and resume references

### What Changed
- Corrected the referenced `-wake` steps for resume teardown and marker clearing so readers are directed to the steps that perform those actions.
- Updated pause-marker documentation to show that fleet and configuration data are written in Step 4 and that configuration data is also read during the Step 4a fleet scan.
- Clarified that a missing pause configuration causes the lightweight fleet scan to fail closed.

### Impact
`✅ Accurate resume instructions`
`✅ Clearer pause-marker ownership`
`✅ Safer fail-closed fleet scans`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified when pause-state markers are created and saved.
  - Documented how wake and resume workflows rebuild or merge pause-state flags.
  - Updated cross-references for the relevant wake workflow steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
