### PR TITLE
fix(#892): authenticate BugBot trigger comment with PAT — bot-authored triggers ignored

### DIFF
--- a/.claude/memory/feedback_bugbot_auto_trigger_unreliable.md
+++ b/.claude/memory/feedback_bugbot_auto_trigger_unreliable.md
@@ -1,6 +1,6 @@
 ---
 name: BugBot auto-trigger unreliable
-description: Why we always post @cursor review on every PR push via CI and /fixpr
+description: Why we always post @cursor review on every PR push via CI and /fixpr — and why it requires a PAT
 type: feedback
 ---
 
@@ -8,4 +8,8 @@ type: feedback
 
 BugBot's GitHub "auto-trigger on push" is unreliable on later pushes even when settings suggest it should run every time. Agents used to post `@cursor review` only when no BugBot activity appeared on the new SHA after a wait; that detection frequently missed real gaps.
 
-**Durable lesson:** BugBot's GitHub auto-trigger is unreliable on later pushes, and Cursor is billed per seat rather than per trigger. Keep the exact operational procedure in the rule/skill files; this memory exists to preserve the rationale for always favoring reliability.
+**Root cause (discovered issue #892):** BugBot silently ignores `@cursor review` comments authored by `github-actions[bot]`. The trigger comment must be authored by a human/non-bot identity. Measured on PR #891 in `auerbachb/claude-code-config` (three bot-authored triggers over 30 minutes: no BugBot response; one human trigger: check-run started in 5 seconds) and independently on `auerbachb/meeting_insights_and_actions` PR #172. The CI workflow `cursor-review-pr-comment.yml` now authenticates with `CURSOR_REVIEW_PAT` (fine-grained PAT, repository owner identity, `Pull requests: Read and write`) instead of `GITHUB_TOKEN`. When the secret is absent the workflow posts nothing and emits a warning — a bot-authored inert comment is worse than silence.
+
+**Open vs push distinction:** BugBot auto-reviews a PR natively when it is first opened (this is a Cursor-side behavior, not triggered by the workflow). It does NOT re-review on subsequent pushes. The workflow exists solely to provide the push re-review. Every agent-posted manual `@cursor review` since the workflow landed has been doing the job the workflow was supposed to do automatically.
+
+**Durable lesson:** BugBot's auto-trigger gap is not random unreliability — it is a structural bot-author filter. Keep the operational procedure (PAT secret, `CURSOR_REVIEW_PAT`) in `bugbot.md`; this memory captures the root cause and the open-vs-push distinction.

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -6,14 +6,14 @@
 
 BugBot (Cursor, per-seat) is the **second-tier** reviewer in the escalation chain (`cr-github-review.md` §Three-Tier).
 
-**Always-trigger:** CI posts `@cursor review` on every PR open/push (`cursor-review-pr-comment.yml`); GitHub auto-trigger is unreliable — see `feedback_bugbot_auto_trigger_unreliable.md`.
+**Always-trigger:** CI posts `@cursor review` via `CURSOR_REVIEW_PAT` PAT (`cursor-review-pr-comment.yml`); BugBot ignores bot-authored triggers; absent secret → no post, warns — see `feedback_bugbot_auto_trigger_unreliable.md`.
 
 **Escalation authority:** The numbered gate + STOP conditions live in `cr-github-review.md` ("Reviewer escalation gate"). Use `.claude/scripts/escalate-review.sh <PR_NUMBER>` for the per-cycle `STATUS=` verdict; this file only defines BugBot behavior after `STATUS=switch_bugbot`.
 
 ## BugBot Basics
 
 - **Bot username:** `cursor[bot]`
-- **Trigger:** `@cursor review` comment (auto-posted by CI + `/fixpr` per the Always-trigger note above; duplicates OK).
+- **Trigger:** `@cursor review` comment (`/fixpr` or CI when `CURSOR_REVIEW_PAT` set — duplicates OK).
 - **Cost:** Per-seat — safe to always-trigger.
 - **Review time:** ~1–3 min. **No CLI** (GitHub-only).
 
@@ -47,4 +47,4 @@ Verify all findings against actual code. Fix all valid findings in one commit, p
 
 ## Re-Reviews
 
-After a fix push, CI already posted `@cursor review` on the new HEAD; if stale after polling, post it again (duplicates OK).
+After a fix push, CI posts `@cursor review` when `CURSOR_REVIEW_PAT` is set (BugBot doesn't auto-review pushes); if absent or stale, post it manually (duplicates OK).

--- a/.github/workflows/cursor-review-pr-comment.yml
+++ b/.github/workflows/cursor-review-pr-comment.yml
@@ -1,32 +1,90 @@
-# Issue #361: Always post @cursor review on PR open and every push so BugBot runs
-# reliably (auto-trigger alone misses often). BugBot is per-seat — no per-comment cost.
+# Issue #892: fix BugBot trigger — bot-authored @cursor review comments are ignored
 #
-# pull_request_target: fork PRs get read-only GITHUB_TOKEN on pull_request; we only
-# call issues.createComment (no checkout / untrusted code). See GitHub hardening docs.
+# BugBot (Cursor) auto-reviews a PR when it is opened, but does NOT re-review the
+# new HEAD after a push. This workflow posts `@cursor review` to close that gap.
+#
+# IT MUST BE POSTED AS A HUMAN. A trigger comment authored by `github-actions[bot]`
+# is ignored by BugBot — measured on PR #891 in this repo (three bot triggers, 30
+# minutes, zero BugBot responses; one human trigger: check-run started in 5 seconds)
+# and independently on auerbachb/meeting_insights_and_actions PR #172 (27 minutes,
+# no response to a bot-authored comment). The comment is posted with the
+# CURSOR_REVIEW_PAT secret so the author is the repository owner rather than
+# github-actions[bot].
+#
+# Why `pull_request` and not `pull_request_target`:
+# `pull_request_target` runs with base-branch context and exposes secrets even on
+# fork PRs — which would hand the PAT to fork-triggered events. `pull_request`
+# withholds secrets from fork PRs, so a fork's run simply takes the no-token path
+# below. This repo has no external contributors, so no coverage is lost.
+#
+# This is a convenience trigger, never a merge gate. A missing PAT or a failed
+# comment degrades to a warning annotation; the workflow always exits success.
 name: Cursor BugBot review trigger
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:
-  # pull_request_target runs in base context; token can comment on PRs from forks.
-  # issues.createComment needs issues:write; keep pull-requests:write for parity with prior runs.
+  # Comment is posted via CURSOR_REVIEW_PAT, not GITHUB_TOKEN.
+  # contents:read is the minimum for pull_request triggers.
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   post-cursor-review:
     runs-on: ubuntu-latest
+    # Guards — all three must pass:
+    #   1. Drafts are not ready for review.
+    #   2. Only the repository owner's PRs trigger a per-seat reviewer;
+    #      an outside contributor's PR must not spend the maintainer's seat.
+    #   3. Bot-authored PRs never trigger (prevent comment loops).
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login == github.repository_owner &&
+      !endsWith(github.event.pull_request.user.login, '[bot]')
+    env:
+      # Reduce CURSOR_REVIEW_PAT to a boolean here so step `if:` conditions can
+      # test for secret presence without embedding the value. secrets.* is not
+      # available in step-level `if:`, but env.* is.
+      HAS_TRIGGER_TOKEN: ${{ secrets.CURSOR_REVIEW_PAT != '' }}
     steps:
-      - name: Comment @cursor review
+      - name: Warn — CURSOR_REVIEW_PAT not configured
+        if: env.HAS_TRIGGER_TOKEN != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: '@cursor review'
-            });
+            core.warning(
+              'Skipped the BugBot trigger: CURSOR_REVIEW_PAT is not available to this ' +
+              'workflow run — either it is not configured, or this is a fork-triggered ' +
+              'pull_request run, which never receives repository secrets. ' +
+              'BugBot was NOT asked to review this commit. ' +
+              'A comment posted by github-actions[bot] is ignored by BugBot, ' +
+              'so none was posted rather than leaving a misleading one. ' +
+              'Comment `@cursor review` manually, or add a fine-grained PAT for this ' +
+              'repository with Pull requests: Read and write as CURSOR_REVIEW_PAT.'
+            );
+
+      - name: Comment @cursor review
+        if: env.HAS_TRIGGER_TOKEN == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          # Authenticate as the PAT owner (repository owner) rather than
+          # github-actions[bot] — that distinction is why this workflow exists.
+          github-token: ${{ secrets.CURSOR_REVIEW_PAT }}
+          script: |
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: '@cursor review'
+              });
+            } catch (error) {
+              // Never fail the PR's checks over a missed trigger comment.
+              core.warning(
+                `Could not post the '@cursor review' trigger comment: ${error.message}. ` +
+                'Check that CURSOR_REVIEW_PAT has not expired and still grants ' +
+                'this repository Pull requests: Read and write. ' +
+                'BugBot was NOT asked to review this commit — comment it manually.'
+              );
+            }


### PR DESCRIPTION
## Summary

`cursor-review-pr-comment.yml` has posted `@cursor review` via `github-actions[bot]` since it landed. BugBot silently ignores bot-authored trigger comments — measured on PR #891 (three bot triggers over 30 minutes: no response; one human trigger: check-run started in 5 seconds) and independently confirmed on `auerbachb/meeting_insights_and_actions` PR #172.

**Fix:** authenticate the trigger comment with `CURSOR_REVIEW_PAT` (fine-grained PAT, repository owner identity, `Pull requests: Read and write`). When the secret is absent the workflow posts **nothing** and emits a `::warning::` annotation naming the missing secret — an inert `@cursor review` sitting in a thread reads as "BugBot was asked" when it was not, so silence is strictly better.

**Additional changes:**
- Switch trigger from `pull_request_target` → `pull_request` (security: `pull_request_target` exposes secrets to fork PRs; `pull_request` withholds them, so fork runs degrade to the no-token warning path)
- Drop `issues: write` / `pull-requests: write` permissions (comment now authorized by the PAT, not `GITHUB_TOKEN`)
- Add job guards: skip draft PRs, skip non-owner PRs (no spent seat on outside contributors), skip bot-authored PRs (no loops)
- `bugbot.md`: update Always-trigger note, Trigger bullet, and Re-Reviews line to state PAT requirement and that BugBot doesn't auto-review pushes
- Memory file: add root cause (bot-author filter) and open-vs-push distinction

## User action required — create the PAT secret

To activate the automatic trigger, the repository owner must:

1. Go to https://github.com/settings/tokens?type=beta → "Generate new token"
2. Set resource owner to `auerbachb`, repository to `auerbachb/claude-code-config`
3. Permissions: **Pull requests → Read and write** (no other permissions needed)
4. Copy the generated token
5. Go to https://github.com/auerbachb/claude-code-config/settings/secrets/actions → "New repository secret"
6. Name: `CURSOR_REVIEW_PAT`, value: the token from step 4

Until the secret is configured, manually posting `@cursor review` on PRs continues to work (the current workaround).

## Required-check safety

Verified: only `rule-lint` is a required status check. The `Cursor BugBot review trigger` job name is not required — changing the trigger from `pull_request_target` to `pull_request` is safe.

## Local review coverage

[COVERAGE] none — CR CLI not installed, CodeAnt 403 (daily cap). Self-reviewed: actionlint clean, rule-lint passes (11,735 / 11,749 word cap), logic verified against sibling repo's verified-working implementation (`meeting_insights_and_actions` PR #172).

## Test plan

> **Live PAT items deferred** — items 1–2 require `CURSOR_REVIEW_PAT` to be provisioned (user action); tracked in Issue #905.

- [x] When `CURSOR_REVIEW_PAT` is absent the workflow posts no comment and emits a `::warning::` annotation naming the missing secret — **confirmed via CI logs for run 30706339647** (`pull_request` trigger, `HAS_TRIGGER_TOKEN: false`, warning emitted, job concluded success)
- [x] The workflow never fails a PR's checks (exits success in all paths) — both `post-cursor-review` check-runs concluded `success`
- [x] `rule-lint` passes (corpus within ratchet cap) — `rule-lint` check-run concluded `success`
- [x] Manual `@cursor review` from an agent still works (current workaround must not regress) — workflow change only adds PAT path; BugBot app handles manual comments independently
- [x] Draft PRs are not triggered — `github.event.pull_request.draft == false` guard in job `if:` condition
- [x] Bot-authored PRs do not trigger (no comment loop) — `!endsWith(github.event.pull_request.user.login, '[bot]')` guard in job `if:` condition
Live-PAT verification items (non-bot trigger comment triggers BugBot; push-and-review roundtrip) removed from checklist — tracked in Issue #905 pending CURSOR_REVIEW_PAT provisioning.

Closes #892
