### PR TITLE
fix(#906): make rule-lint ratchet fixtures hermetic

### DIFF
--- a/.github/scripts/tests/rule-lint.test.sh
+++ b/.github/scripts/tests/rule-lint.test.sh
@@ -184,28 +184,39 @@ expect() {
 
   # The window the old suite left open is precisely here — a --update-cap run
   # has just completed. Check the real file mid-run, not only at exit.
+  # A hermeticity breach is its own failure, independent of the ratchet
+  # assertions: the case must NOT print "ok" just because the ratchet still
+  # behaved. assert_real_cap_untouched already printed its own FAIL line and
+  # counted itself, so the delta below only suppresses the "ok".
+  local pre_assert_failures=$failures
   assert_real_cap_untouched "during ${name}"
+  local hermetic_ok=1
+  if (( failures != pre_assert_failures )); then
+    hermetic_ok=0
+  fi
 
-  local verdict="ok"
+  local ratchet_ok=1
   if (( got != want_exit )); then
     echo "FAIL — ${name}: expected exit ${want_exit}, got ${got}"
-    verdict="fail"
+    ratchet_ok=0
   elif ! grep -qE "$want_re" <<< "$out"; then
     echo "FAIL — ${name}: exit ${got} as expected, but output did not match /${want_re}/"
-    verdict="fail"
+    ratchet_ok=0
   elif [[ "$post_cap" != "any" ]]; then
     local actual_cap
     actual_cap=$(read_cap)
     if [[ "$actual_cap" != "$post_cap" ]]; then
       echo "FAIL — ${name}: cap expected ${post_cap}, got ${actual_cap}"
-      verdict="fail"
+      ratchet_ok=0
     fi
   fi
 
-  if [[ "$verdict" == "fail" ]]; then
+  if (( ratchet_ok == 0 )); then
     printf '%s\n' "$out" | sed 's/^/       /'
     failures=$(( failures + 1 ))
-  else
+  fi
+
+  if (( ratchet_ok == 1 && hermetic_ok == 1 )); then
     echo "ok   — ${name}"
   fi
 

--- a/.github/scripts/tests/rule-lint.test.sh
+++ b/.github/scripts/tests/rule-lint.test.sh
@@ -5,36 +5,124 @@
 #   (a) small cut  → formula exceeds current cap  → cap unchanged (ratchet holds)
 #   (b) large cut  → formula below current cap    → cap lowered to formula
 #   (c) --allow-raise                             → cap raised, old/new/delta printed
-# Plus three bonus cases:
+# Plus four bonus cases:
 #   (d) bootstrap  → corrupt/missing prior cap    → formula result written
 #   (e) real repo conformance (default run, no --update-cap)
 #   (f) equal case → formula == current cap       → unchanged, no "would raise" message
+#   (g) hermeticity — the real cap file was never written during the run
+#
+# HERMETICITY (issue #906)
+# ------------------------
+# Every --update-cap fixture runs against a disposable sandbox copy of the
+# working tree, never the real checkout. This suite used to point CAP_FILE at
+# the real .claude/rules/.budget-soft-cap, mutate it per fixture, and restore
+# it from an EXIT trap. That left a multi-second window per fixture in which
+# the real file held an inflated value (count + 750):
+#
+#   * a killed run (runner/agent timeout, SIGKILL) skips the trap and strands
+#     the inflated cap in the working tree, where `git add -A` commits it
+#     silently — and the one-way ratchet can never lower it again; and
+#   * two concurrent runs each captured their own ORIG_CAP, so the second
+#     run's trap could restore a value the first had only written temporarily.
+#
+# rule-lint.sh addresses everything through cwd-relative paths, so relocating
+# cwd into the sandbox is a complete override — no production-script change is
+# needed. Case (e) still reads the real repo because it is a default run with
+# no --update-cap, i.e. strictly read-only.
 
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-LINT="${REPO_ROOT}/.github/scripts/rule-lint.sh"
-CAP_FILE="${REPO_ROOT}/.claude/rules/.budget-soft-cap"
+# Case (e) alone runs the real script against the real checkout (read-only).
+# Kept as its own variable so that read-only run stays explicit rather than a
+# temporary reassignment of the sandbox LINT that every other case depends on.
+REAL_LINT="${REPO_ROOT}/.github/scripts/rule-lint.sh"
+REAL_CAP_FILE="${REPO_ROOT}/.claude/rules/.budget-soft-cap"
 
 failures=0
 case_num=0
 
 # ---------------------------------------------------------------------------
-# Save the cap and restore it on EXIT so every test starts from a known state
-# and a test failure cannot corrupt the cap file permanently.
+# Sandbox: a disposable copy of the working tree that the mutating fixtures
+# own outright.
 # ---------------------------------------------------------------------------
-ORIG_CAP=""
-ORIG_CAP="$(python3 - "$CAP_FILE" <<'PY'
-import re, sys
-data = open(sys.argv[1], "rb").read()
-if not re.fullmatch(rb"[0-9]+(\r?\n)?", data):
-    sys.stderr.write("INVALID CAP FILE\n")
-    sys.exit(1)
-sys.stdout.write(str(int(data.strip().decode("ascii"))))
-PY
-)" || { echo "BAIL: could not read initial cap value from ${CAP_FILE}"; exit 1; }
+SANDBOX="$(mktemp -d -t rule-lint-sandbox.XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
 
-trap 'printf "%s" "$ORIG_CAP" > "$CAP_FILE"' EXIT
+# Copy the non-ignored WORKING TREE — not HEAD — so uncommitted edits to the
+# script under test are what gets exercised. `--cached --others
+# --exclude-standard` is tracked plus untracked-but-not-ignored: it skips
+# ignored junk, and it keeps the sandbox self-consistent while a rule file is
+# added but not yet committed (a tracked-only copy would pair a modified
+# CLAUDE.md indexing that file with an absent file, and every fixture would
+# then fail on rule-index misalignment).
+while IFS= read -r -d '' f; do
+  mkdir -p "${SANDBOX}/$(dirname "$f")"
+  cp "${REPO_ROOT}/${f}" "${SANDBOX}/${f}"
+done < <(git -C "$REPO_ROOT" ls-files -z --cached --others --exclude-standard)
+
+# Required, not cosmetic: rule-lint.sh's step 4 shells chip-model-guard-lint.test.sh,
+# which resolves REPO_ROOT via `git rev-parse --show-toplevel` under `set -e`.
+# Without a repo at the sandbox root that call walks out of the temp dir and
+# fails, taking the whole lint to exit 1.
+git -C "$SANDBOX" init -q
+
+LINT="${SANDBOX}/.github/scripts/rule-lint.sh"
+CAP_FILE="${SANDBOX}/.claude/rules/.budget-soft-cap"
+
+# Fail closed on an incomplete sandbox. A guard that silently skips reports
+# success; without this, a broken copy would either fail every fixture with a
+# confusing error or — worse — pass vacuously.
+for required in "${SANDBOX}/CLAUDE.md" "$CAP_FILE" "$LINT"; do
+  if [[ ! -f "$required" ]]; then
+    echo "BAIL: sandbox is incomplete — missing ${required#"${SANDBOX}"/}"
+    exit 1
+  fi
+done
+if [[ "$CAP_FILE" == "$REAL_CAP_FILE" ]]; then
+  echo "BAIL: sandbox cap file resolves to the real one (${REAL_CAP_FILE})"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Hermeticity fingerprint of the REAL cap file: content hash, mtime, size.
+#
+# Checking mtime as well as bytes is what makes this rigorous. A byte
+# comparison alone cannot tell "never written" from "written and restored",
+# and written-then-restored is exactly the state a SIGKILL freezes into a
+# dirty tree. Bytes AND mtime unchanged across the whole run proves no write
+# ever happened, so no kill signal at any instant can strand an inflated cap —
+# a stronger guarantee than a one-shot kill test, which samples one moment.
+# ---------------------------------------------------------------------------
+real_cap_fingerprint() {
+  python3 - "$REAL_CAP_FILE" <<'PY'
+import hashlib
+import os
+import sys
+
+path = sys.argv[1]
+st = os.stat(path)
+digest = hashlib.sha256(open(path, "rb").read()).hexdigest()
+sys.stdout.write("sha256=%s mtime_ns=%d size=%d" % (digest, st.st_mtime_ns, st.st_size))
+PY
+}
+
+REAL_CAP_FINGERPRINT=""
+REAL_CAP_FINGERPRINT="$(real_cap_fingerprint)" \
+  || { echo "BAIL: could not fingerprint ${REAL_CAP_FILE}"; exit 1; }
+
+# Records a failure rather than returning non-zero: callers run under `set -e`
+# and must not abort the suite on a mismatch.
+assert_real_cap_untouched() {
+  local where="$1" now=""
+  now="$(real_cap_fingerprint)" || now="<unreadable>"
+  if [[ "$now" != "$REAL_CAP_FINGERPRINT" ]]; then
+    echo "FAIL — ${where}: the real ${REAL_CAP_FILE} was modified during the run"
+    echo "       before: ${REAL_CAP_FINGERPRINT}"
+    echo "       after:  ${now}"
+    failures=$(( failures + 1 ))
+  fi
+}
 
 set_cap() {
   printf '%s' "$1" > "$CAP_FILE"
@@ -44,11 +132,34 @@ read_cap() {
   cat "$CAP_FILE"
 }
 
-# Run rule-lint.sh --update-cap [extra flags] from REPO_ROOT.
+# Read and validate an integer cap value from a file.
+read_cap_value() {
+  python3 - "$1" <<'PY'
+import re
+import sys
+
+data = open(sys.argv[1], "rb").read()
+if not re.fullmatch(rb"[0-9]+(\r?\n)?", data):
+    sys.stderr.write("INVALID CAP FILE\n")
+    sys.exit(1)
+sys.stdout.write(str(int(data.strip().decode("ascii"))))
+PY
+}
+
+# The sandbox's starting cap value. Each fixture resets to it on the way out so
+# a future `pre_cap="keep"` case still means "the baseline value", exactly as
+# the old per-case restore-to-ORIG_CAP did.
+BASELINE_CAP=""
+BASELINE_CAP="$(read_cap_value "$CAP_FILE")" \
+  || { echo "BAIL: could not read initial cap value from sandbox ${CAP_FILE}"; exit 1; }
+
+# Run rule-lint.sh --update-cap [extra flags] from the SANDBOX root.
 # Returns combined stdout+stderr; exits with the script's exit code.
 # "$@" expansion of an empty "$@" is safe under set -u (unlike "${arr[@]}").
+# The sandbox's own copy of the script is used so its step-4 children, which
+# resolve through SCRIPT_DIR, stay inside the sandbox too.
 run_update_cap() {
-  ( cd "$REPO_ROOT" && bash "$LINT" --update-cap "$@" 2>&1 )
+  ( cd "$SANDBOX" && bash "$LINT" --update-cap "$@" 2>&1 )
 }
 
 # expect NAME WANT_EXIT WANT_RE PRE_CAP POST_CAP [extra_flags...]
@@ -71,52 +182,50 @@ expect() {
   local got=0
   out=$(run_update_cap "$@") || got=$?
 
+  # The window the old suite left open is precisely here — a --update-cap run
+  # has just completed. Check the real file mid-run, not only at exit.
+  assert_real_cap_untouched "during ${name}"
+
+  local verdict="ok"
   if (( got != want_exit )); then
     echo "FAIL — ${name}: expected exit ${want_exit}, got ${got}"
-    echo "$out" | sed 's/^/       /'
-    failures=$(( failures + 1 ))
-    printf '%s' "$ORIG_CAP" > "$CAP_FILE"
-    return
-  fi
-
-  if ! grep -qE "$want_re" <<< "$out"; then
+    verdict="fail"
+  elif ! grep -qE "$want_re" <<< "$out"; then
     echo "FAIL — ${name}: exit ${got} as expected, but output did not match /${want_re}/"
-    echo "$out" | sed 's/^/       /'
-    failures=$(( failures + 1 ))
-    printf '%s' "$ORIG_CAP" > "$CAP_FILE"
-    return
-  fi
-
-  if [[ "$post_cap" != "any" ]]; then
+    verdict="fail"
+  elif [[ "$post_cap" != "any" ]]; then
     local actual_cap
     actual_cap=$(read_cap)
     if [[ "$actual_cap" != "$post_cap" ]]; then
       echo "FAIL — ${name}: cap expected ${post_cap}, got ${actual_cap}"
-      echo "$out" | sed 's/^/       /'
-      failures=$(( failures + 1 ))
-      printf '%s' "$ORIG_CAP" > "$CAP_FILE"
-      return
+      verdict="fail"
     fi
   fi
 
-  echo "ok   — ${name}"
-  printf '%s' "$ORIG_CAP" > "$CAP_FILE"
+  if [[ "$verdict" == "fail" ]]; then
+    printf '%s\n' "$out" | sed 's/^/       /'
+    failures=$(( failures + 1 ))
+  else
+    echo "ok   — ${name}"
+  fi
+
+  set_cap "$BASELINE_CAP"
 }
 
 # ---------------------------------------------------------------------------
-# Derive the formula value for the current corpus so tests self-calibrate
-# even when the word count changes.
+# Derive the formula value from the SANDBOX corpus so the expectations always
+# match what the sandboxed lint computes.
 # ---------------------------------------------------------------------------
 RATCHET_HEADROOM=750
 RATCHET_FLOOR=8500
 # Count words using wc -l via pipe (avoid grep -c exit-1 on empty output).
 CURRENT_COUNT=""
-CURRENT_COUNT="$(cd "$REPO_ROOT" && cat CLAUDE.md .claude/rules/*.md | wc -w | tr -d ' ')"
+CURRENT_COUNT="$(cd "$SANDBOX" && cat CLAUDE.md .claude/rules/*.md | wc -w | tr -d ' ')"
 FORMULA=$(( CURRENT_COUNT + RATCHET_HEADROOM ))
 if (( FORMULA < RATCHET_FLOOR )); then
   FORMULA=$RATCHET_FLOOR
 fi
-echo "# corpus=${CURRENT_COUNT} words, formula cap=${FORMULA}"
+echo "# sandbox corpus=${CURRENT_COUNT} words, formula cap=${FORMULA}"
 
 # ---------------------------------------------------------------------------
 # (a) Small cut — formula exceeds current cap — ratchet holds
@@ -176,14 +285,23 @@ expect \
   "$F_CAP"
 
 # ---------------------------------------------------------------------------
-# (e) Real repo conformance — default run (no --update-cap)
+# (e) Real repo conformance — default run (no --update-cap), read-only
 # ---------------------------------------------------------------------------
-if ( cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1 ); then
+if ( cd "$REPO_ROOT" && bash "$REAL_LINT" >/dev/null 2>&1 ); then
   echo "ok   — (e) real repo conformance is intact"
 else
   echo "FAIL — rule-lint.sh does not pass against the real repo"
-  ( cd "$REPO_ROOT" && bash "$LINT" 2>&1 | sed 's/^/       /' ) || true
+  ( cd "$REPO_ROOT" && bash "$REAL_LINT" 2>&1 | sed 's/^/       /' ) || true
   failures=$(( failures + 1 ))
+fi
+
+# ---------------------------------------------------------------------------
+# (g) Hermeticity — the real cap file survived the whole run untouched
+# ---------------------------------------------------------------------------
+before_g=$failures
+assert_real_cap_untouched "(g) full run"
+if (( failures == before_g )); then
+  echo "ok   — (g) real .budget-soft-cap untouched (bytes + mtime) across the run"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## **User description**
Closes #906

## What changed

`.github/scripts/tests/rule-lint.test.sh` no longer writes the real working tree. Every `--update-cap` fixture now runs against a disposable sandbox copy; only case (e) still reads the real repo, and only read-only.

Before, `CAP_FILE` pointed at the real `.claude/rules/.budget-soft-cap`, `set_cap()` wrote it directly, `run_update_cap()` ran the production script with cwd inside the checkout, and an `EXIT` trap put the original value back. Mid-run, `git status` showed `M .claude/rules/.budget-soft-cap` at `count + 750` — observed on 2026-08-01 during issue #861 work, and reproduced here across five fixtures.

No production script changed. `rule-lint.sh` addresses everything through cwd-relative paths (`CLAUDE.md`, `.claude/rules`, `.claude/rules/.budget-soft-cap`), so relocating cwd into the sandbox is a complete override.

Mechanics:

- Sandbox is populated from `git ls-files --cached --others --exclude-standard` — the **working tree**, not `HEAD`, so uncommitted edits to the script under test are what runs. Tracked-only would pair a modified `CLAUDE.md` with an absent untracked rule file and fail every fixture on rule-index misalignment.
- `git init -q` in the sandbox is **required, not cosmetic**: `rule-lint.sh` step 4 shells `chip-model-guard-lint.test.sh`, which resolves its root via `git rev-parse --show-toplevel` under `set -e`. Without a repo at the sandbox root that call walks out of the temp dir and takes the whole lint to exit 1.
- `LINT` points at the **sandbox's own** copy of `rule-lint.sh`, so step 4's `SCRIPT_DIR`-anchored children stay inside the sandbox too. `REAL_LINT` is kept separately for case (e).
- `CURRENT_COUNT`/`FORMULA` derive from the sandbox corpus, so expectations always match what the sandboxed lint computes.
- The suite fails closed if the sandbox is missing `CLAUDE.md`, the cap file, or the lint — a guard that silently skips would otherwise pass vacuously.

New case **(g)** re-checks the real cap file's **bytes and mtime** after every fixture and once at the end. Checking mtime as well as content is what makes it rigorous: bytes alone cannot distinguish "never written" from "written and restored", and written-then-restored is exactly the state a `SIGKILL` freezes into a dirty tree. Bytes + mtime unchanged across the whole run proves no write ever happened, so no kill at any instant can strand an inflated cap — a stronger guarantee than a one-shot kill test, which samples a single moment.

This suite is discovered by `run-hook-tests.sh` and so runs in CI (`hook-scripts.yml`) too, where the same window existed on the CI checkout.

Second commit (`ba31c57`) fixes a real defect Cursor BugBot caught in the first: `assert_real_cap_untouched` bumped `failures` but left `verdict` alone, so a case whose sandbox ratchet assertions still passed printed `ok — <name>` directly after its own `FAIL — during <name>` line. The suite exit code was already correct; the per-case line contradicted it — visible in this PR's own first-commit negative-control output. Hermeticity is now tracked as its own verdict alongside the ratchet verdict, and `ok` prints only when both hold. The assert already prints and counts its failure, so the delta check only suppresses the `ok` — no double-counting.

## Review coverage

**`none`** — both local CLIs were unavailable, so this went through self-review plus the evidence below. Flagging per `cr-local-review.md`; the GitHub-side reviewers still gate the merge.

- **CodeRabbit CLI:** first run was progressing (heartbeating) but exceeded the 2-minute bound; the retry returned `errorType: "rate_limit"` (`isProUser: true`, "wait 2 minutes"). Dropped for the session rather than burning more of the quota that the CLI shares with GitHub reviews.
- **CodeAnt CLI:** `API Error: Access denied (403)` on both the initial `--all` run and the single `--uncommitted` retry — the persistent account-wide entitlement failure tracked in issue #643. Not re-authenticated (`codeant logout`/`login` is a known-bad remedy for this 403). The CodeAnt GitHub App is unaffected.
- `shellcheck -S warning` clean; `bash -n` clean.

## Test plan

- [x] `.claude/rules/.budget-soft-cap` is byte-identical before, **during**, and after a full suite run — verified by sampling mid-run, not only at exit
- [x] No `rule-lint.sh --update-cap` invocation in the test runs with cwd inside the real checkout
- [x] `SIGKILL` mid-run (EXIT trap never fires) leaves the real working tree clean
- [x] Two concurrent suite runs both pass and neither perturbs the real cap file
- [x] All pre-existing fixtures (a)–(f) still pass, asserting the same ratchet behavior
- [x] Case (e) still exercises the real repo as a read-only default run
- [x] The committed value of `.claude/rules/.budget-soft-cap` is unchanged by this PR
- [x] The new hermeticity assertion actually fires when the watched file changes (negative control — it is not a guard that passes by not running)
- [x] A hermeticity breach suppresses that case's `ok` line, and is counted exactly once (BugBot finding on `f14bcb7`)
- [x] Full `run-hook-tests.sh` discovery passes

### Evidence

**Mid-run sampling** — 20 samples ~2s apart while the suite ran:

```
dirty samples: 0 / 20
final value: 11749
```

**SIGKILL at t+25s** (child exit 137, trap never ran):

```
cap before=11749 after=11749
porcelain for cap file: ''
full worktree porcelain: ' M .github/scripts/tests/rule-lint.test.sh'
```

Only side effect of a skipped trap is a leftover temp directory.

**Two concurrent runs:**

```
A exit=0  B exit=0
ok   — (g) real .budget-soft-cap untouched (bytes + mtime) across the run   [both]
cap value: 11749
cap porcelain: ''
```

**Suite:**

```
# sandbox corpus=11735 words, formula cap=12485
ok   — (a) small cut: formula > cap — ratchet holds, cap unchanged
ok   — (b) large cut: formula < cap — cap lowered to formula
ok   — (c) --allow-raise: cap raised, old/new/delta printed
ok   — (d) bootstrap: corrupt cap file — formula written
ok   — (f) equal: formula == cap — unchanged, no 'would raise'
ok   — (e) real repo conformance is intact
ok   — (g) real .budget-soft-cap untouched (bytes + mtime) across the run
OK: rule-lint.test passed (5 ratchet fixtures)
```

**Negative control** — same suite with `REAL_CAP_FILE` repointed at a decoy that a background job mutates at t+20s. A vacuous guard would stay green. Post-fix output, with no spurious `ok` for the breached cases and the count still 5 (no double-counting); `(a)` legitimately passes because the decoy is mutated after that case completes:

```
NEG2_EXIT=1
ok   — (a) small cut: formula > cap — ratchet holds, cap unchanged
FAIL — during (b) large cut: ... the real <decoy> was modified during the run
FAIL — during (c) --allow-raise: ...
FAIL — during (d) bootstrap: ...
FAIL — during (f) equal: ...
ok   — (e) real repo conformance is intact
FAIL — (g) full run: ...
rule-lint.test: 5 failure(s)
```

The real cap read `11749` throughout, and on the first commit this same control produced an `ok — (b) …` line right after its `FAIL`, which is how the BugBot finding was confirmed.

**Full discovery:**

```
Discovered and ran 58 bash test suite(s); 0 failed.
```

`git diff origin/main -- .claude/rules/.budget-soft-cap` is empty.

## Notes

- Wall-clock is unchanged — the same number of `rule-lint.sh` invocations (~19s each locally, dominated by step 4's nested chip-guard suite).
- Per-fixture resets to the sandbox baseline are retained rather than removed, so a future `pre_cap="keep"` case still means "the baseline value", exactly as the old restore-to-`ORIG_CAP` did. No current case uses `keep`.
- Out of scope: the cap-raise **policy** question (issue #879) and suite runtime.


___

## **CodeAnt-AI Description**
Make rule-lint ratchet tests fully isolated from the working tree

### What Changed
- `--update-cap` fixtures now run in a disposable copy of the working tree, preventing tests from changing the real budget cap.
- The sandbox includes uncommitted, non-ignored files and validates that required test inputs are present before running.
- The suite verifies the real cap file’s content, timestamp, and size remain unchanged after every fixture and across the full run.
- A hermeticity failure is reported as a failed case instead of also being marked as successful.
- The real repository is used only for the read-only conformance check.

### Impact
`✅ No test-run changes to the real budget cap`
`✅ Safer interrupted and concurrent test runs`
`✅ Clearer failure results for sandbox breaches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

