### PR TITLE
refactor(#816): fix 14-file drift in .claude/reference/README.md; add catalog lint

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -13,15 +13,21 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 
 ### Runbooks and long command forms
 
+- `admin-merge-auto-plain.md` — mechanism and contracts for the one `admin-merge.sh --auto-plain` shape Claude may execute itself; plain vs protection-modifying shape distinction (#754)
 - `cli-tool-defaults.md` — installed service CLIs (vercel, neonctl, railway, cloudinary) and common commands; CLI-first over web dashboards
+- `churn-hotspots.md` — mechanism, calibration, and threshold rationale for `churn-hotspots.sh`; exclusion list for by-design catalog files (#755)
 - `cr-polling-commands.md` — full multi-line `gh api` commands for CR review polling and CI verification
 - `cr-rate-limits.md` — full CR rate-limit caps, hourly-state mechanics, and `cr-review-hourly.sh` flags
 - `codeowner-bot-approvals.md` — CODEOWNERS handling for review bots and stale-approval re-trigger commands
 - `capability-discovery-examples.md` — false-walls vs real-walls catalog for try-every-path-before-handoff (`safety.md` Capability Discovery)
 - `browser-capability-rung.md` — rung 4 (browser) detail: in-app vs Chrome surface selection, the single login/authorization ask, bounded attempt, untrusted-page posture, subagent reachability matrix, and the `phase-c-merger` stay-restricted decision (#852)
+- `diff-survival-guard.md` — mechanism and rationale for `diff-survival-check.sh`; the failure mode where clean conflict markers hide a silently dropped fix (#757)
 - `merge-gate-reviewer-paths.md` — per-reviewer merge-gate path details (CR/CodeAnt, BugBot, Greptile)
+- `merge-gate-stale-approval-redemption.md` — CodeAnt in-place review edit: how `merge-gate.sh` redeems a stale approval by evidence rather than by reviewer identity (#876)
+- `merge-sequencing.md` — mechanism and state machine for `merge-sequence.sh`; overlap-aware merge sequencing for PRs touching the same file (#756)
 - `codeant-graphite-supplemental.md` — CodeAnt and Graphite supplemental polling on the CR path
 - `local-review-cli-failure-modes.md` — how CodeAnt/CodeRabbit fake a clean pass on failure, 403 triage, 15-file cap, and binary-absent detection (#642, #819)
+- `review-substance-evidence.md` — why a bot APPROVED requires a substantive review footprint; hollow APPROVED failure mode and evidence checks in `merge-gate.sh` (#875)
 - `wrap-fixpr-delegation.md` — `/wrap` Step 2.1 → full `/fixpr` recovery handoff contract
 - `state-file-contracts.md` — expanded scoping, write-lock, migration, and field-type mechanics for `session-state.json` + handoffs (`handoff-files.md`; #625, #638, #639, #651, #655, #682, #687, #704)
 - `authorship-guard.md` — `pr-authorship.sh` exit-code semantics, the three shared-script fail-safes, and `--allow-nonauthor` override plumbing (`safety.md` §Authorship; #733)
@@ -35,9 +41,12 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 
 ### Workflow decomposition and PM helpers
 
+- `chip-launching.md` — canonical mechanics for one-click coding-thread task chips; model-guard placement and guard preamble shared by all six canonical emitters (#731, #601)
+- `cross-session-durability.md` — why `CronCreate` is not cross-session durable and why the durable `mcp__scheduled-tasks__*` primitive is not used here (#827)
 - `phase-decomposition.md` — phase split reference material
 - `pm-data-patterns.md` — PM skills data patterns and bot filters
 - `pm-monitoring-decision.md` — `/pm` vs `/pr-monitor-and-manage` division of responsibility
+- `pm-output-templates.md` — presentation format templates for `/pm` Step 1B.5; extracted from `pm/SKILL.md` to reduce churn surface on formatting-only blocks
 - `continuous-work-posture.md` — why free capacity (not a finish) triggers refill, fill-vs-ramp, queue vs backlog refill, the human-in-chat stop, and the idle-reason taxonomy (`CLAUDE.md` "KEEP THE PIPELINE FULL"; #823)
 - `pm-handoff-chips-decision.md` — decision record: `/pm-handoff` intentionally does not offer task chips; its portable prompt text is the deliverable (#562)
 - `chip-model-guard-decision.md` — decision record: the chip model-guard preamble rides in both the chip `prompt` and the fallback block, redefining the fallback baseline (#601)
@@ -45,6 +54,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `bgwork-ceiling.md` — why background work arms a turn-independent silence ceiling, why `Monitor` over `ScheduleWakeup`/`CronCreate`, and why the number stays unpublished (#803)
 - `skill-sync-hooks.md` — skills worktree sync and hook registration narrative
 - `skill-symlink-setup.md` — why a dedicated worktree, session-start bootstrap, symlink install, and migration commands (`skill-symlinks.md`)
+- `skill-usage-durability.md` — how skill-usage telemetry records survive machine moves, OS reinstalls, and `~/.claude` cleanups (#572)
 - `trust-dialog-repair.md` — why `~/.claude.json` re-prompts per worktree, the three flags, and repair-script behavior (`trust-dialog-fix.md`)
 - `double-loading-fix.md` — decision record for suppressing the duplicate global CLAUDE.md + rules copy via project-local `claudeMdExcludes` (#461)
 - `skill-authoring-patterns.md` — authoring *judgment* for skills/rules (description-as-trigger, match-form-to-failure, bulletproofing); complements CONTRIBUTING.md mechanics
@@ -61,16 +71,20 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 
 - `ai-review-tool-audit-2026-04.md` — AI review tool chain audit (#368 / #377)
 - `ai-review-tool-audit-2026-06.md` — 30-day AI review tool value audit + keep/cut verdicts (#376)
+- `fixpr-hotspot-decision.md` — diagnosis and extract-not-split decision for `fixpr/SKILL.md` churn (17 PRs in the run-up to #788); verdict: KEEP single file + extract large command forms
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `harness-model-audit-2026-06.md` — harness components vs current model fleet (#49)
 - `script-extraction-audit.md` — deterministic script extraction inventory (#271)
 - `graphite-stacked-prs-research-2026-05.md` — stacked PR economics (#418 / #433)
 - `codeant-code-quality-eval-2026-06.md` — deeper CodeAnt Code Quality integration eval; verdict: keep advisory (#444)
 - `instruction-set-audit-2026-07.md` — 1-month instruction-set size & optimization re-check; verdict: keep caps (#462)
+- `session-state-convergence-audit.md` — post-merge convergence audit of `session-state.json` and all scripts that touch it as one system; verdict: coherent (#651)
 - `token-efficiency-audit-2026-07.md` — token-efficiency playbook: adopt/skip/adapt verdicts, ranked cuts, shipped v1 (one-line heartbeats, delta PMM table, silence-detector dedupe) + FU-1…FU-7 (#773)
 - `pm-routing-audit-2026-07.md` — thread-vs-inline routing effectiveness audit of #613; ground-truth attribution + the shared PM-context inline gate for chip surfaces (#701)
 - `too-big-recalibration-2026-07.md` — re-derivation of the "too big for a subagent" fit bar against current capability: criterion 1 narrowed from size to non-resumability, A/B/C confirmed on grounds independent of the unverified 32K figure, ceiling held, and the chip-gate overflow defect fixed (#776)
+- `skill-prune-audit-2026-07.md` — skill-usage telemetry audit; keep/prune verdicts based on 62-day usage data (#431)
 - `subagent-orchestration-churn-audit-2026-07.md` — churn hotspot analysis for `subagent-orchestration.md` (13 PRs in 14 days); verdict: KEEP single file + dedup Phase A/B/C bullet descriptions toward canonical owners; ownership decisions recorded (#814)
+- `usage-limit-signal-audit-2026-07.md` — audit finding: no trustworthy approaching-limit signal exists for hooks/skills/sessions; the status-line signal has no path into model context (#824)
 
 ### Diagrams (mermaid stubs and indexes)
 

--- a/.claude/scripts/reference-catalog-lint.sh
+++ b/.claude/scripts/reference-catalog-lint.sh
@@ -66,12 +66,15 @@ if [[ ! -d "$REFERENCE_DIR" ]]; then
 fi
 
 # --- 1. Build actual set ---------------------------------------------------
-# Root-level *.md and *.json only; exclude README.md itself and subdirectories.
-# `|| true` keeps a zero-match find (exit 1 on some systems) from aborting.
-actual=$(find "$REFERENCE_DIR" -maxdepth 1 \( -name '*.md' -o -name '*.json' \) \
+# Root-level *.md and *.json regular files only; exclude README.md itself and
+# subdirectories. -type f prevents directories or symlinks named *.md from
+# being counted. find errors (permission/I/O) propagate as non-zero exit so
+# the script fails closed rather than silently under-reporting.
+actual=$(find "$REFERENCE_DIR" -maxdepth 1 -type f \
+  \( -name '*.md' -o -name '*.json' \) \
   ! -name 'README.md' \
   -exec basename {} \; \
-  | sort -u || true)
+  | sort -u)
 
 # --- 2. Build documented set from ## Contents section ----------------------
 # Scope extraction to ## Contents only (stops at the next ## header) so that

--- a/.claude/scripts/reference-catalog-lint.sh
+++ b/.claude/scripts/reference-catalog-lint.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Lint the .claude/reference/ catalog against the directory contents.
+#
+# Validates:
+#   1. Every *.md and *.json file under .claude/reference/ (excluding README.md
+#      itself and the diagrams/ subdirectory) has exactly one bullet in the
+#      ## Contents section of .claude/reference/README.md.
+#   2. Every bullet's filename token exists on disk (no phantom entries).
+#   3. No duplicate filename entries in the index.
+#
+# Companion to .github/scripts/skill-catalog-lint.sh, which enforces the same
+# index-alignment invariant for .claude/skills/ against README.md.
+# Paths are repo-root-relative; run from the repo root.
+#
+# Output uses GitHub Actions annotations (::error::) so issues surface
+# directly on PR checks. Exits 1 on any error condition.
+#
+# Usage:
+#   .claude/scripts/reference-catalog-lint.sh [--help]
+#
+# Agent usage: run before committing any change that adds, removes, or renames
+# a file under .claude/reference/.
+
+set -euo pipefail
+
+REFERENCE_DIR=".claude/reference"
+README="${REFERENCE_DIR}/README.md"
+
+errors=0
+
+usage() {
+  cat <<'EOF'
+Usage: .claude/scripts/reference-catalog-lint.sh [--help]
+
+  Verifies .claude/reference/README.md ## Contents section stays in sync
+  with the files in .claude/reference/ (root level only; diagrams/ excluded).
+  Run from the repo root. Exits 1 on any error.
+
+  Reported as GitHub Actions ::error:: annotations when running in CI.
+EOF
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "::error::Unknown argument: $1"
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ ! -f "$README" ]]; then
+  echo "::error file=${README}::${README} not found — run from the repo root"
+  exit 1
+fi
+
+if [[ ! -d "$REFERENCE_DIR" ]]; then
+  echo "::error::${REFERENCE_DIR} directory not found — run from the repo root"
+  exit 1
+fi
+
+# --- 1. Build actual set ---------------------------------------------------
+# Root-level *.md and *.json only; exclude README.md itself and subdirectories.
+# `|| true` keeps a zero-match find (exit 1 on some systems) from aborting.
+actual=$(find "$REFERENCE_DIR" -maxdepth 1 \( -name '*.md' -o -name '*.json' \) \
+  ! -name 'README.md' \
+  -exec basename {} \; \
+  | sort -u || true)
+
+# --- 2. Build documented set from ## Contents section ----------------------
+# Scope extraction to ## Contents only (stops at the next ## header) so that
+# incidental filename mentions elsewhere in the README don't pollute the set.
+# Extract the leading backtick-quoted token from each bullet line:
+#   - `filename.md` — description …
+# Accepts only basenames (no path separator) that end in .md or .json, so
+# cross-references like `.claude/rules/foo.md` or `~/.claude/session-state.json`
+# are not mistaken for registrations.
+contents_section=$(awk '
+  /^## Contents/ { in_section=1; next }
+  in_section && /^## / { exit }
+  in_section { print }
+' "$README")
+
+documented_all=$(printf '%s\n' "$contents_section" \
+  | grep -oE '^- `[^`/]+\.(md|json)`' \
+  | sed "s/^- \`//; s/\`\$//" \
+  | sort || true)
+documented=$(printf '%s\n' "$documented_all" | sort -u)
+
+# --- 3. Diff both directions -----------------------------------------------
+undocumented=$(comm -23 \
+  <(printf '%s\n' "$actual") \
+  <(printf '%s\n' "$documented") || true)
+
+phantom=$(comm -13 \
+  <(printf '%s\n' "$actual") \
+  <(printf '%s\n' "$documented") || true)
+
+if [[ -n "$undocumented" ]]; then
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    echo "::error file=${README}::File '${f}' exists in ${REFERENCE_DIR}/ but has no entry in the ## Contents index"
+    errors=$((errors + 1))
+  done <<< "$undocumented"
+fi
+
+if [[ -n "$phantom" ]]; then
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    echo "::error file=${README}::README indexes '${f}' but no such file exists in ${REFERENCE_DIR}/"
+    errors=$((errors + 1))
+  done <<< "$phantom"
+fi
+
+# --- 4. Duplicate-entry check ----------------------------------------------
+row_count=$(printf '%s\n' "$documented_all" | grep -c . || true)
+unique_count=$(printf '%s\n' "$documented" | grep -c . || true)
+
+if (( row_count != unique_count )); then
+  printf '%s\n' "$documented_all" | sort | uniq -d | while IFS= read -r dupe; do
+    [[ -z "$dupe" ]] && continue
+    echo "::error file=${README}::'${dupe}' appears more than once in the ## Contents index"
+  done
+  errors=$((errors + row_count - unique_count))
+fi
+
+# --- 5. Result -------------------------------------------------------------
+if (( errors > 0 )); then
+  echo "reference-catalog-lint: ${errors} error(s) — ${unique_count} of $( \
+    printf '%s\n' "$actual" | grep -c . || true) files indexed"
+  exit 1
+fi
+
+echo "reference-catalog-lint: OK (${unique_count} files indexed)"


### PR DESCRIPTION
## Summary

Closes #816

`.claude/reference/README.md` accumulated 14 undocumented files since the last index update. This PR fixes the drift and adds a lint script so the index can't silently fall out of sync again.

**Changes:**
- `.claude/reference/README.md`: added 14 missing entries under the correct category subsections (Runbooks, Workflow helpers, Audits)
- `.claude/scripts/reference-catalog-lint.sh` (new): `comm`-based validator — enumerates `*.md`/`*.json` in `.claude/reference/` root, extracts the leading backtick-quoted filename token from each `## Contents` bullet, reports undocumented/phantom/duplicate entries with GitHub Actions `::error::` annotations

**Index completeness: N=64** (64 files in `.claude/reference/` excluding README.md → 64 index entries; verified by `reference-catalog-lint.sh: OK (64 files indexed)`)

Missing files added:
- **Runbooks:** `admin-merge-auto-plain.md`, `churn-hotspots.md`, `diff-survival-guard.md`, `merge-gate-stale-approval-redemption.md`, `merge-sequencing.md`, `review-substance-evidence.md`
- **Workflow helpers:** `chip-launching.md`, `cross-session-durability.md`, `pm-output-templates.md`, `skill-usage-durability.md`
- **Audits:** `fixpr-hotspot-decision.md`, `session-state-convergence-audit.md`, `skill-prune-audit-2026-07.md`, `usage-limit-signal-audit-2026-07.md`

**Out of scope for this PR:** CI wiring (`.github/workflows/rule-lint.yml`), fixture tests, churn-exclusion update in `churn-hotspots.md` — separate follow-up.

[COVERAGE: both] — CodeRabbit CLI (0 findings, no error records) + CodeAnt CLI (0 findings, not capped)

## Test plan

- [x] Every `.claude/reference/*.md` and `*.json` file is indexed (N=64 files; `reference-catalog-lint.sh: OK (64 files indexed)`)
- [x] Future additions cost ≤1 line (one bullet per entry; lint catches omissions)
- [x] `reference-catalog-lint.sh` correctly rejects phantom entries (files indexed but not on disk)
- [x] `reference-catalog-lint.sh` correctly rejects undocumented files (on disk but not indexed)
- [x] `reference-catalog-lint.sh` correctly rejects duplicate entries
- [x] No stale descriptions retained from the existing entries
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the reference index with new runbook, workflow, audit, and operational guidance documents.

* **Quality Improvements**
  * Added validation to detect missing, duplicate, or outdated entries in the reference index.
  * Validation now reports actionable errors and supports help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->