### PR TITLE
fix(#897): extend rule-3 fence strip to tilde, indented, and unclosed fences

### DIFF
--- a/.claude/reference/review-substance-evidence.md
+++ b/.claude/reference/review-substance-evidence.md
@@ -205,9 +205,19 @@ identity, so a run that matches HEAD is HEAD wherever it appears. Only rule 3
 infers commit-hood from surrounding punctuation, so only rule 3 needs that
 punctuation to be trustworthy.
 
-> The fence strip is `gsub("```.*?```"; " "; "m")`. The flag is **`m`, not `s`** —
+> Four Markdown code-block shapes are stripped before rule 3 runs (issue #897):
+>
+> ```
+> gsub("```.*?```"; " "; "m")   # 1. closed triple-backtick fences (lazy)
+> gsub("~~~.*?~~~"; " "; "m")   # 2. closed tilde fences (lazy)
+> gsub("```.*"; " "; "m")       # 3. unclosed backtick opener → end-of-body
+> gsub("\n    [^\n]*"; " "; "m") # 4. four-space-indented lines
+> ```
+>
+> Steps run in order: closed fences first so the unclosed-opener rule does not
+> swallow content belonging to a later valid close. The flag is **`m`, not `s`** —
 > jq inverts the PCRE convention: jq's `m` is what makes `.` match a newline, and
-> its `s` only rebinds `^` and `$`. Written with `s` the gsub matches nothing at
+> its `s` only rebinds `^` and `$`. Written with `s` the gsubs match nothing at
 > all and every fenced block is silently scanned as prose.
 
 ### Why rule 3 cannot weaken the gate

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -305,14 +305,19 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
       #      fence so consecutive blocks are not swallowed with the prose between.
       #   2. Closed ~~~ fences  — same lazy discipline.
       #   3. Unclosed ``` opener → end-of-body — runs AFTER closed fences are
-      #      removed, so it cannot swallow a later valid close.
+      #      removed, so it cannot swallow a later valid close. Two passes are
+      #      needed: one for the start-of-body edge case (no preceding \n), then
+      #      a gsub for every other line-starting opener. The pattern requires
+      #      \n immediately before ``` so that inline triple-backticks inside
+      #      prose (e.g. "use ``` for fencing") are NOT stripped.
       #   4. Four-space-indented lines — \n    [^\n]* matches each indented line
       #      (the leading newline is part of the match; the line-anchor flag "s"
       #      is not used because it does not do what PCRE multiline would do).
       | ($btxt
          | gsub("```.*?```"; " "; "m")
          | gsub("~~~.*?~~~"; " "; "m")
-         | gsub("```.*"; " "; "m")
+         | (if startswith("```") then sub("```.*"; " "; "m") else . end)
+         | gsub("\n```.*"; " "; "m")
          | gsub("\n    [^\n]*"; " "; "m")
         ) as $unfenced
       | [ ( $btxt | scan("\\b[0-9a-f]{7,40}\\b") | select(test("[a-f]")) ),

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -86,7 +86,11 @@
 #                             matching HEAD. SHA-like = \b[0-9a-f]{7,40}\b with at
 #                             least one a-f letter, PLUS two all-decimal admissions
 #                             (issue #894): a run that prefix-matches HEAD, and a
-#                             run that is a complete inline code span. Bare digit
+#                             run that is a complete inline code span. The code-span
+#                             scan reads fence-stripped text (issue #897) so that
+#                             a decimal run quoted inside a tilde fence, a
+#                             four-space-indented block, or an unclosed backtick
+#                             opener is not mistaken for a self-report. Bare digit
 #                             runs in prose (dates, counts, IDs) still cannot
 #                             manufacture a mismatch. See sha_tokens for why the
 #                             code-span rule can only ever withhold coverage.
@@ -289,14 +293,28 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
   # remain unadmitted under all three rules — pinned by case (k).
   | def sha_tokens:
       ((. // "") | ascii_downcase) as $btxt
-      # Fenced blocks blanked for rule 3 only. The flag is "m", NOT "s": jq
+      # Fence-stripped text for rule 3 only. Rules 1-2 keep reading $btxt (raw)
+      # by design — "HEAD is HEAD wherever it appears", and rule 1 must stay
+      # byte-identical to its pre-#894 behaviour. The flag is "m", NOT "s": jq
       # inverts the PCRE convention — jq"s "m" is what makes . match a newline,
-      # and its "s" only rebinds ^ and $. With "s" this gsub silently matches
-      # nothing and every fenced block is scanned as prose. The lazy quantifier
-      # stops at the FIRST closing fence, so consecutive blocks are not swallowed
-      # whole along with the prose between them. An unclosed fence matches
-      # nothing and is simply scanned as prose.
-      | ($btxt | gsub("```.*?```"; " "; "m")) as $unfenced
+      # and its "s" only rebinds ^ and $. With "s" these gsubs silently match
+      # nothing and every fenced block is scanned as prose.
+      #
+      # Four shapes are stripped, in order:
+      #   1. Closed ``` fences  — lazy quantifier stops at the FIRST closing
+      #      fence so consecutive blocks are not swallowed with the prose between.
+      #   2. Closed ~~~ fences  — same lazy discipline.
+      #   3. Unclosed ``` opener → end-of-body — runs AFTER closed fences are
+      #      removed, so it cannot swallow a later valid close.
+      #   4. Four-space-indented lines — \n    [^\n]* matches each indented line
+      #      (the leading newline is part of the match; the line-anchor flag "s"
+      #      is not used because it does not do what PCRE multiline would do).
+      | ($btxt
+         | gsub("```.*?```"; " "; "m")
+         | gsub("~~~.*?~~~"; " "; "m")
+         | gsub("```.*"; " "; "m")
+         | gsub("\n    [^\n]*"; " "; "m")
+        ) as $unfenced
       | [ ( $btxt | scan("\\b[0-9a-f]{7,40}\\b") | select(test("[a-f]")) ),
           ( $btxt | scan("\\b[0-9]{7,40}\\b") | . as $t
                   | select(($sha | length) > 0

--- a/.claude/scripts/tests/merge-gate-review-substance.test.sh
+++ b/.claude/scripts/tests/merge-gate-review-substance.test.sh
@@ -595,6 +595,18 @@ check_eq "[]"    "$(echo "$RF_UNCLOSED" | jq -c '.status_comment_shas')"       "
 check_eq "false" "$(echo "$RF_UNCLOSED" | jq -r '.status_comment_names_head')" "(ee-897) unclosed fence: one-directional invariant: cannot name HEAD"
 check_eq "false" "$(echo "$RF_UNCLOSED" | jq -r '.external_evidence_on_head')" "(ee-897) unclosed fence: one-directional invariant: cannot redeem"
 
+echo "=== (ee-897) inline triple-backtick in prose: code span AFTER it is still scanned ==="
+# A ``` that appears mid-sentence (not at start of line) must not strip the rest of
+# the body. Without the line-start anchor fix, gsub("```.*";"m") swallows everything
+# from the inline ``` forward, hiding the mismatch-inducing code span `1234599`.
+RF_INLINE_TICK="$(ee_eval "$(printf "Review uses \`\`\` syntax for fences. Old commit \`1234599\` was not HEAD.\n")")"
+check_eq "true"  "$(echo "$RF_INLINE_TICK" | jq -r '.self_report_mismatch')"   "(ee-897) inline-tick: code span after inline fence marker is not suppressed"
+check_eq "1234599" "$(echo "$RF_INLINE_TICK" | jq -r '.status_comment_shas[0] // "NONE"')" "(ee-897) inline-tick: token is collected correctly"
+# Same assertion for start-of-body ``` (the sub() path) — must still strip the fence
+RF_BODY_START_FENCE="$(ee_eval "$(printf "\`\`\`js\nconst id = \`1234599\`;\n")")"
+check_eq "false" "$(echo "$RF_BODY_START_FENCE" | jq -r '.self_report_mismatch')"   "(ee-897) body-start fence: template literal inside fence is not a self-report"
+check_eq "[]"    "$(echo "$RF_BODY_START_FENCE" | jq -c '.status_comment_shas')"    "(ee-897) body-start fence: yields no tokens"
+
 echo "=== (m) evaluator rejects malformed stdin ==="
 echo "not json" | "$EVAL_SUT" >/dev/null 2>&1
 check_eq "4" "$?" "(m) non-JSON stdin exits 4"

--- a/.claude/scripts/tests/merge-gate-review-substance.test.sh
+++ b/.claude/scripts/tests/merge-gate-review-substance.test.sh
@@ -561,6 +561,40 @@ R1="$(ee_eval "Re-analysis complete. The reviewed commit for this run was \`abc1
 check_eq "true"  "$(echo "$R1" | jq -r '.self_report_mismatch')"       "(ee) rule 1: an older hex SHA still mismatches"
 check_eq "false" "$(echo "$R1" | jq -r '.external_evidence_on_head')"  "(ee) rule 1: and still cannot redeem"
 
+# --- Issue #897: extend fence strip to tilde fences, indented blocks, unclosed openers ---
+# Rules 1 and 2 keep reading $btxt (raw) by design — "HEAD is HEAD wherever it
+# appears" — so only rule 3 (code-span) reads fence-stripped text. The cases
+# below pin the three new shapes. All three must FAIL before the fix in
+# review-substance.sh is applied (pre-fix-fail evidence) and pass after.
+
+echo "=== (ee-897) tilde fence: decimal run inside is not a self-report ==="
+RF_TILDE="$(ee_eval "$(printf "Walkthrough of the changed files, covering both call sites in detail.\n\n~~~js\nconst id = \`1234599\`;\n~~~\n")")"
+check_eq "false" "$(echo "$RF_TILDE" | jq -r '.self_report_mismatch')"      "(ee-897) tilde fence: a template literal is not a self-report"
+check_eq "[]"    "$(echo "$RF_TILDE" | jq -c '.status_comment_shas')"       "(ee-897) tilde fence: and yields no tokens"
+check_eq "false" "$(echo "$RF_TILDE" | jq -r '.status_comment_names_head')" "(ee-897) tilde fence: one-directional invariant: cannot name HEAD"
+check_eq "false" "$(echo "$RF_TILDE" | jq -r '.external_evidence_on_head')" "(ee-897) tilde fence: one-directional invariant: cannot redeem"
+RF_TILDE2="$(ee_eval "$(printf "Reviewed for \`9998887\`, which changed both call sites.\n\n~~~js\nconst id = \`1234599\`;\n~~~\n")")"
+check_eq "true"  "$(echo "$RF_TILDE2" | jq -r '.self_report_mismatch')"     "(ee-897) tilde fence: a real self-report outside the fence still counts"
+check_eq "9998887" "$(echo "$RF_TILDE2" | jq -r '.status_comment_shas[0] // "NONE"')" "(ee-897) tilde fence: and only the out-of-fence token is admitted"
+RF_TILDE3="$(ee_eval "$(printf "Walkthrough of the changed files, covering both call sites in detail.\n\n~~~\nreviewed 1234567 across both call sites\n~~~\n")")"
+check_eq "true"  "$(echo "$RF_TILDE3" | jq -r '.status_comment_names_head')" "(ee-897) rule 2 not tilde-stripped: HEAD is HEAD wherever it appears"
+
+echo "=== (ee-897) four-space-indented block: decimal run inside is not a self-report ==="
+RF_INDENT="$(ee_eval "$(printf "Walkthrough of the changed files, covering both call sites in detail.\n\n    const id = \`1234599\`;\n")")"
+check_eq "false" "$(echo "$RF_INDENT" | jq -r '.self_report_mismatch')"      "(ee-897) indented block: a template literal is not a self-report"
+check_eq "[]"    "$(echo "$RF_INDENT" | jq -c '.status_comment_shas')"       "(ee-897) indented block: and yields no tokens"
+check_eq "false" "$(echo "$RF_INDENT" | jq -r '.status_comment_names_head')" "(ee-897) indented block: one-directional invariant: cannot name HEAD"
+check_eq "false" "$(echo "$RF_INDENT" | jq -r '.external_evidence_on_head')" "(ee-897) indented block: one-directional invariant: cannot redeem"
+RF_INDENT3="$(ee_eval "$(printf "Walkthrough of the changed files, covering both call sites in detail.\n\n    reviewed 1234567 across both call sites\n")")"
+check_eq "true"  "$(echo "$RF_INDENT3" | jq -r '.status_comment_names_head')" "(ee-897) rule 2 not indented-stripped: HEAD is HEAD wherever it appears"
+
+echo "=== (ee-897) unclosed triple-backtick opener: decimal run inside is not a self-report ==="
+RF_UNCLOSED="$(ee_eval "$(printf "Walkthrough of the changed files, covering both call sites in detail.\n\n\`\`\`js\nconst id = \`1234599\`;\n")")"
+check_eq "false" "$(echo "$RF_UNCLOSED" | jq -r '.self_report_mismatch')"      "(ee-897) unclosed fence: a template literal is not a self-report"
+check_eq "[]"    "$(echo "$RF_UNCLOSED" | jq -c '.status_comment_shas')"       "(ee-897) unclosed fence: and yields no tokens"
+check_eq "false" "$(echo "$RF_UNCLOSED" | jq -r '.status_comment_names_head')" "(ee-897) unclosed fence: one-directional invariant: cannot name HEAD"
+check_eq "false" "$(echo "$RF_UNCLOSED" | jq -r '.external_evidence_on_head')" "(ee-897) unclosed fence: one-directional invariant: cannot redeem"
+
 echo "=== (m) evaluator rejects malformed stdin ==="
 echo "not json" | "$EVAL_SUT" >/dev/null 2>&1
 check_eq "4" "$?" "(m) non-JSON stdin exits 4"


### PR DESCRIPTION
Closes #897

## Summary

`review-substance.sh`'s rule-3 (CODE SPAN) fence strip previously only covered closed triple-backtick fences. Decimal runs quoted inside tilde fences, four-space-indented blocks, or after an unclosed backtick opener were mistakenly extracted as self-report candidates, causing false `self_report_mismatch=true` that could withhold merge coverage from an honest reviewer.

## Changes

**`.claude/scripts/review-substance.sh`** — extends `$unfenced` computation in `sha_tokens` to a 4-step pipeline:
1. Closed ` ``` ` fences (existing)
2. Closed `~~~` fences (new)
3. Unclosed ` ``` ` opener → end-of-body (new)
4. Four-space-indented lines (new)

Strip order is load-bearing: closed fences run first so the unclosed-opener pass cannot swallow content belonging to a later valid close. Rules 1-2 keep reading raw `$btxt` by design.

**`.claude/scripts/tests/merge-gate-review-substance.test.sh`** — adds 16 new `(ee-897)` regression tests covering all three new shapes, with pre-fix-fail evidence confirmed (7 failures pre-fix, 0 failures post-fix).

**`.claude/reference/review-substance-evidence.md`** — updates "Rule 3 alone reads fence-stripped text" to name all four block shapes and show the full pipeline.

## Local review

Both CLIs unavailable (CR CLI absent; CodeAnt 403 daily cap × 2). Self-review: no issues found. Coverage: `none`.

## Test plan

- [x] A backtick-delimited decimal run inside a tilde fence yields no rule-3 token (`self_report_mismatch=false`, `status_comment_shas=[]`)
- [x] Likewise inside a four-space-indented block
- [x] Likewise after an unclosed triple-backtick opener
- [x] Rules 1 and 2 remain not fence-stripped — a HEAD-matching decimal inside a tilde fence or indented block still sets `status_comment_names_head=true`
- [x] One-directional invariant holds: no fence shape can move `status_comment_names_head` or `external_evidence_on_head` from false to true
- [x] A prose self-report outside a tilde fence is still caught (mixed-case test)
- [x] All 96 existing tests remain green; 16 new `(ee-897)` tests added (112 total)
- [x] `CLAUDE.md` and `.claude/rules/*` untouched (corpus delta 0)