### PR TITLE
fix(#874): scope session-scheduling-reconcile purge to verifiably-dead sessions

### DIFF
--- a/.claude/hooks/tests/session-start-sync-reconcile.test.sh
+++ b/.claude/hooks/tests/session-start-sync-reconcile.test.sh
@@ -16,12 +16,27 @@ trap cleanup EXIT
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok() { echo "ok   — $*"; }
 
+# Build state fixtures.  The reconcile script is fail-closed: only records with
+# a verifiable dead-owner stamp are purged.  The STAMPED variant carries a dead
+# PID so startup can provably purge it; UNSTAMPED has no stamp and must survive
+# startup unchanged (fail-closed guarantee).
+( : ) &
+_DEAD_PID=$!
+wait "$_DEAD_PID" 2>/dev/null || true
+_THIS_HOST="${HOSTNAME:-$(hostname 2>/dev/null || echo "localhost")}"
+STAMPED_STATE="$(printf \
+  '{"polling_jobs":[{"id":"live_job","owner_session":{"pid":%s,"host":"%s"}}],"pmm":{"auto_wake_cron_id":"live_cron","auto_wake_owner_session":{"pid":%s,"host":"%s"}}}' \
+  "$_DEAD_PID" "$_THIS_HOST" "$_DEAD_PID" "$_THIS_HOST")"
+UNSTAMPED_STATE='{"polling_jobs":[{"id":"live_job"}],"pmm":{"auto_wake_cron_id":"live_cron"}}'
+
 CASE_N=0
 OUT=""
 STATE=""
-# run_hook <source-json> — fresh HOME seeded with purgeable state.
+# run_hook <source-json> [initial-state] — fresh HOME seeded with scheduling state.
 # Sets $STATE and $OUT in the CALLER's scope: a command substitution would run
 # this in a subshell and the $STATE assignment would never escape it.
+# The optional second argument overrides the initial state written to $STATE;
+# defaults to UNSTAMPED_STATE when omitted.
 run_hook() {
   CASE_N=$((CASE_N + 1))
   export HOME="$TMP_DIR/home$CASE_N"
@@ -33,17 +48,25 @@ run_hook() {
   mkdir -p "$HOME/.claude/skills-worktree/.claude/skills"
   : > "$HOME/.claude/skills-worktree/.git"
   STATE="$HOME/.claude/session-state.json"
-  printf '%s' '{"polling_jobs":[{"id":"live_job"}],"pmm":{"auto_wake_cron_id":"live_cron"}}' > "$STATE"
+  printf '%s' "${2:-$UNSTAMPED_STATE}" > "$STATE"
   OUT="$(printf '%s' "$1" | bash "$HOOK" 2>/dev/null)"
 }
 
-# --- 1. startup purges -------------------------------------------------------
-run_hook '{"source":"startup"}'
+# --- 1. startup purges dead-stamped records ----------------------------------
+run_hook '{"source":"startup"}' "$STAMPED_STATE"
 [[ "$(jq -c '.polling_jobs' "$STATE")" == "[]" ]] \
-  || fail "startup should purge polling_jobs, got $(jq -c '.polling_jobs' "$STATE")"
+  || fail "startup should purge dead-stamped polling_jobs, got $(jq -c '.polling_jobs' "$STATE")"
 [[ "$(jq -r '.pmm.auto_wake_cron_id' "$STATE")" == "null" ]] \
-  || fail "startup should clear auto_wake_cron_id"
-ok "source=startup purges dead scheduling bookkeeping"
+  || fail "startup should clear dead-stamped auto_wake_cron_id"
+ok "source=startup purges dead-stamped scheduling bookkeeping"
+
+# --- 1b. fail-closed: startup must NOT purge unstamped records ---------------
+run_hook '{"source":"startup"}'
+[[ "$(jq -c '.polling_jobs' "$STATE")" == '[{"id":"live_job"}]' ]] \
+  || fail "startup must NOT purge unstamped polling_jobs (fail-closed), got $(jq -c '.polling_jobs' "$STATE")"
+[[ "$(jq -r '.pmm.auto_wake_cron_id' "$STATE")" == "live_cron" ]] \
+  || fail "startup must NOT clear unstamped auto_wake_cron_id (fail-closed)"
+ok "source=startup preserves unstamped records (fail-closed)"
 
 # --- 2. compact/resume/clear must NOT purge ----------------------------------
 # These fire inside a live session: the recorded job may still be running.

--- a/.claude/scripts/session-scheduling-reconcile.sh
+++ b/.claude/scripts/session-scheduling-reconcile.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # session-scheduling-reconcile.sh — reconcile durable scheduling state at
-# session start (issue #827).
+# session start (issues #827, #874).
 #
 # CronCreate jobs are in-memory and session-scoped: every job recorded by a
 # previous session is already gone by the time this runs. Rather than trying to
@@ -8,12 +8,27 @@
 # bookkeeping and surfaces the durable on-disk records that DO survive — a
 # harness-audit month that came due, a paused PR fleet waiting to resume.
 #
-# Rationale and the per-feature decisions: .claude/reference/cross-session-durability.md
+# Issue #874 FIX — multi-session safety:
+#   SessionStart fires across concurrent sessions sharing the same HOME.
+#   A newly-started session must NOT purge bookkeeping that belongs to a live
+#   sibling session.
 #
-# Invoked by the SessionStart hook (.claude/hooks/session-start-sync.sh), which
-# passes --check on every source except `startup` — compact/resume/clear fire
-# inside a live session, where a recorded job may still be running and a watcher
-# may be about to refresh its own last_tick_at.
+#   For .polling_jobs[] and .pmm.auto_wake_cron_id each record now carries an
+#   optional owner_session stamp ({pid, host}). This script checks that stamp
+#   with kill -0 — the same dead-holder test state-lock.sh uses — and reaps
+#   ONLY records whose owning process is provably dead on this host.
+#
+#   Fail-closed: a record with no stamp, a cross-host stamp, or a stamp whose
+#   liveness cannot be determined is SKIPPED, not purged. A notice is surfaced
+#   so the operator can see it.
+#
+#   .repos[*].prs[*].babysit.active is already protected by the freshness
+#   window (max(3 x cadence, BABYSIT_DISPATCH_TTL_MIN)): a live watcher in a
+#   sibling session ticks recently enough that its last_tick_at is inside the
+#   window and it is never reaped. No change to that path.
+#
+# Rationale: .claude/reference/cross-session-durability.md
+#
 # Fail-soft by contract: a missing, unreadable, or corrupt state file must
 # never block a session from starting, so every failure path still exits 0.
 
@@ -26,8 +41,8 @@ usage() {
   cat <<'EOF'
 PURPOSE
   Reconcile durable scheduling state at session start: purge scheduler
-  bookkeeping that cannot have survived the previous session, and report the
-  on-disk records that did.
+  bookkeeping whose owning session is provably dead, and report the on-disk
+  records that did survive.
 
 USAGE
   session-scheduling-reconcile.sh [--check] [--format text|json]
@@ -37,13 +52,18 @@ USAGE
   --format json    {"purged":{...},"notices":[...]} for the hook to embed.
 
 WHAT IT PURGES (writes go through session-state.sh, the locked single writer)
-  .polling_jobs                        -> []
-  .pmm.auto_wake_cron_id               -> null
-  .repos[*].prs[*].babysit.cron_job_id -> null
+  .polling_jobs[]                      -> entry removed when owner_session.pid
+                                          is dead on this host (kill -0 fails).
+                                          Entries with no stamp or cross-host
+                                          stamp are SKIPPED (fail-closed).
+  .pmm.auto_wake_cron_id               -> null when auto_wake_owner_session.pid
+                                          is dead on this host. Skipped without
+                                          a verifiable dead-owner stamp.
+  .repos[*].prs[*].babysit.cron_job_id -> null (always dead: CronCreate jobs
+                                          are in-memory and session-scoped)
   .repos[*].prs[*].babysit.active      -> false, but ONLY past /babysit-pr's
                                           own freshness window (its A2 check;
-                                          canonical definition and the reason
-                                          both copies must agree:
+                                          canonical definition:
                                           .claude/reference/cross-session-durability.md
                                           "Freshness window"). SessionStart also
                                           fires on compact, when a live watcher's
@@ -52,6 +72,7 @@ WHAT IT PURGES (writes go through session-state.sh, the locked single writer)
 WHAT IT SURFACES (durable, still meaningful)
   harness-audit due this month  (~/.claude/harness-audit/last-run.json)
   a paused PR fleet             (.pmm.paused_at)
+  unverifiable scheduling records (skipped due to unknown ownership)
 
 EXIT STATUS
   0  Always. This runs on the session-start path; it never blocks a session.
@@ -87,6 +108,23 @@ NOTICES=()   # human-facing lines the hook forwards into session context
 PURGED_JSON='{}'
 
 # ---------------------------------------------------------------------------
+# Session liveness helper — mirrors the dead-holder test in state-lock.sh.
+# Fail-closed: anything we cannot verify is NOT treated as dead.
+# ---------------------------------------------------------------------------
+CURRENT_HOST="$(hostname 2>/dev/null || echo "")"
+
+# session_is_dead <pid> <host>
+# Exit 0 (true) only when the owning session is provably dead on THIS host.
+# Exit 1 (false) for alive, unknown, cross-host, or malformed input.
+session_is_dead() {
+  local pid="$1" host="$2"
+  [[ -z "$pid" || -z "$host" || -z "$CURRENT_HOST" ]] && return 1   # unknown
+  [[ "$host" != "$CURRENT_HOST" ]]                      && return 1   # cross-host
+  [[ "$pid" =~ ^[0-9]+$ ]]                              || return 1   # malformed
+  ! kill -0 "$pid" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
 # 1. Purge dead scheduler bookkeeping
 # ---------------------------------------------------------------------------
 # Counting and rewriting happen in one jq pass over the whole document so the
@@ -104,6 +142,68 @@ SESSION_STATE_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/sess
 # looked successful and changed nothing that matters.
 if [[ -f "$STATE_FILE" && -x "$SESSION_STATE_SH" && "$CHECK_ONLY" -eq 0 ]]; then
   "$SESSION_STATE_SH" --migrate >/dev/null 2>&1 || true
+fi
+
+# ---------------------------------------------------------------------------
+# Pre-compute per-record liveness verdicts for .polling_jobs[] and
+# .pmm.auto_wake_cron_id before the main jq plan.
+#
+# These two fields lack the freshness-window protection that babysit watchers
+# have, so we need explicit owner liveness checks. We do this in bash (kill -0
+# is not available in jq) and pass the results in as JSON for the plan to use.
+#
+# Verdict values: "dead" | "alive" | "unknown"
+# Fail-closed: unknown ownership => verdict "unknown" => skip (do not purge).
+# ---------------------------------------------------------------------------
+PJ_VERDICTS_JSON="[]"    # per-index verdict array for .polling_jobs[]
+AW_VERDICT="unknown"     # verdict for .pmm.auto_wake_cron_id
+
+if [[ -f "$STATE_FILE" ]]; then
+  # --- .polling_jobs[] -------------------------------------------------------
+  # Read (index, pid, host) tuples from every polling_job entry; build a
+  # verdict for each aligned to the array so the jq plan can filter by index.
+  if jq -e '(.polling_jobs // []) | length > 0' "$STATE_FILE" >/dev/null 2>&1; then
+    VERDICTS=()
+    while IFS=$'\t' read -r _idx pid host; do
+      if session_is_dead "$pid" "$host"; then
+        VERDICTS+=("\"dead\"")
+      elif [[ -n "$pid" && -n "$host" && "$host" == "$CURRENT_HOST" ]]; then
+        VERDICTS+=("\"alive\"")
+      else
+        VERDICTS+=("\"unknown\"")
+      fi
+    done < <(jq -r '
+      .polling_jobs | to_entries[] |
+      [ (.key | tostring),
+        (.value.owner_session.pid  // "" | tostring),
+        (.value.owner_session.host // "")
+      ] | @tsv
+    ' "$STATE_FILE" 2>/dev/null)
+    if (( ${#VERDICTS[@]} > 0 )); then
+      # IFS=, in a subshell to join without a trailing newline (printf avoids
+      # the echo newline that would corrupt the JSON literal).
+      PJ_VERDICTS_JSON="[$(IFS=,; printf '%s' "${VERDICTS[*]}")]"
+    fi
+  fi
+
+  # --- .pmm.auto_wake_cron_id -----------------------------------------------
+  # Check the sibling auto_wake_owner_session stamp; fail-closed if absent.
+  if jq -e '(.pmm.auto_wake_cron_id? // null) != null' "$STATE_FILE" >/dev/null 2>&1; then
+    RC_AW=0
+    AW_OWNER="$(jq -rc '.pmm.auto_wake_owner_session // empty' "$STATE_FILE" 2>/dev/null)" \
+      || RC_AW=$?
+    if [[ -n "${AW_OWNER:-}" && "$RC_AW" -eq 0 ]]; then
+      AW_PID="$(jq -r  '.pid  // ""' <<<"$AW_OWNER" 2>/dev/null || echo "")"
+      AW_HOST="$(jq -r '.host // ""' <<<"$AW_OWNER" 2>/dev/null || echo "")"
+      if session_is_dead "$AW_PID" "$AW_HOST"; then
+        AW_VERDICT="dead"
+      elif [[ -n "$AW_PID" && -n "$AW_HOST" && "$AW_HOST" == "$CURRENT_HOST" ]]; then
+        AW_VERDICT="alive"
+      fi
+      # else: cross-host or malformed → stays "unknown"
+    fi
+    # No stamp at all → stays "unknown"
+  fi
 fi
 
 if [[ -f "$STATE_FILE" ]]; then
@@ -126,6 +226,8 @@ if [[ -f "$STATE_FILE" ]]; then
   # and a raw jq+mv here would clobber a concurrent --set that held the lock).
   PLAN="$(jq -c \
       --argjson now "$NOW_EPOCH" \
+      --argjson pj_verdicts "$PJ_VERDICTS_JSON" \
+      --arg aw_verdict "$AW_VERDICT" \
       --argjson ttl "${BABYSIT_DISPATCH_TTL_MIN:-30}" '
     def prs_paths:
       [paths(type == "object" and has("babysit"))]
@@ -161,16 +263,40 @@ if [[ -f "$STATE_FILE" ]]; then
         | ($p + ["babysit","cron_job_id"] | as_path) ] as $cron_ids
     | [ $pp[] as $p | ($doc | getpath($p)).babysit as $b
         | select($b.active == true and watcher_dead($b))
-        | ($p + ["babysit","active"] | as_path) ] as $dead
-    | (if ((.polling_jobs? // []) | type == "array") then (.polling_jobs | length) else 0 end) as $pj
-    | (if (.pmm.auto_wake_cron_id? // null) != null then 1 else 0 end) as $aw
+        | ($p + ["babysit","active"] | as_path) ] as $dead_watchers
+
+    # polling_jobs: per-record verdict from the bash precompute above.
+    # Index into $pj_verdicts by array position; treat out-of-range as "unknown"
+    # (fail-closed: a concurrent write could have shifted the array).
+    | ( if ((.polling_jobs? // []) | type == "array") then
+          ( (.polling_jobs // []) | to_entries
+            | { dead:    map(select(($pj_verdicts[.key] // "unknown") == "dead"))    | length,
+                unknown: map(select(($pj_verdicts[.key] // "unknown") == "unknown")) | length,
+                kept:    map(select(($pj_verdicts[.key] // "unknown") != "dead"))
+                         | map(.value) }
+          )
+        else {dead: 0, unknown: 0, kept: []} end ) as $pj
+
+    # auto_wake_cron_id: only clear when the bash precompute determined "dead".
+    | ( (.pmm.auto_wake_cron_id? // null) != null ) as $aw_exists
+    | ( if $aw_exists then
+          { clear:   ($aw_verdict == "dead"),
+            unknown: (if $aw_verdict == "unknown" then 1 else 0 end) }
+        else {clear: false, unknown: 0} end ) as $aw
+
     | {
-        counts: {polling_jobs: $pj, auto_wake_cron_id: $aw,
-                 babysit_cron_ids: ($cron_ids | length), babysit_watchers: ($dead | length)},
-        sets: (( if $pj > 0 then [".polling_jobs=[]"] else [] end)
-             + ( if $aw > 0 then [".pmm.auto_wake_cron_id=null"] else [] end)
-             + ( $cron_ids | map(. + "=null"))
-             + ( $dead     | map(. + "=false")))
+        counts: { polling_jobs:       $pj.dead,
+                  polling_jobs_skip:  $pj.unknown,
+                  auto_wake_cron_id:  (if $aw.clear then 1 else 0 end),
+                  auto_wake_skip:     $aw.unknown,
+                  babysit_cron_ids:   ($cron_ids | length),
+                  babysit_watchers:   ($dead_watchers | length) },
+        sets: ( ( if $pj.dead > 0 then
+                    [".polling_jobs=" + ($pj.kept | tojson)]
+                  else [] end )
+              + ( if $aw.clear then [".pmm.auto_wake_cron_id=null"] else [] end )
+              + ( $cron_ids    | map(. + "=null") )
+              + ( $dead_watchers | map(. + "=false") ) )
       }
   ' "$STATE_FILE" 2>/dev/null)" || PLAN=""
 
@@ -181,7 +307,7 @@ if [[ -f "$STATE_FILE" ]]; then
 
     if (( CHECK_ONLY == 0 && TOTAL > 0 )); then
       if [[ -x "$SESSION_STATE_SH" ]]; then
-        # One atomic multi---set call under the helper's lock, not N writes.
+        # One atomic multi-set call under the helper's lock, not N writes.
         SET_ARGS=()
         while IFS= read -r assignment; do
           [[ -n "$assignment" ]] && SET_ARGS+=(--set "$assignment")
@@ -210,6 +336,17 @@ if [[ -f "$STATE_FILE" ]]; then
         NOTICES+=("Cleared $TOTAL dead scheduling record(s) left by a previous session (CronCreate jobs do not survive session exit).")
       fi
     fi
+
+    # Surface skipped records so the operator can see them and knows they were
+    # not silently discarded. Skipping is the fail-closed safe action; records
+    # with provably dead owners are cleared on the next session start once the
+    # owning session stamps them correctly.
+    SKIP_PJ="$(jq -r '(.counts.polling_jobs_skip // 0)' <<<"$PLAN" 2>/dev/null || echo 0)"
+    SKIP_AW="$(jq -r '(.counts.auto_wake_skip   // 0)' <<<"$PLAN" 2>/dev/null || echo 0)"
+    [[ "$SKIP_PJ" =~ ^[0-9]+$ ]] || SKIP_PJ=0
+    [[ "$SKIP_AW" =~ ^[0-9]+$ ]] || SKIP_AW=0
+    (( SKIP_PJ > 0 )) && NOTICES+=("scheduling-reconcile: $SKIP_PJ polling_job record(s) have no verified dead owner — skipped to protect a possible live sibling session (fail-closed).")
+    (( SKIP_AW > 0 )) && NOTICES+=("scheduling-reconcile: auto_wake_cron_id has no verified dead owner — skipped to protect a possible live sibling session (fail-closed).")
   fi
 fi
 

--- a/.claude/scripts/session-scheduling-reconcile.sh
+++ b/.claude/scripts/session-scheduling-reconcile.sh
@@ -272,14 +272,20 @@ if [[ -f "$STATE_FILE" ]]; then
     # polling_jobs: per-record verdict from the bash precompute above.
     # Index into $pj_verdicts by array position; treat out-of-range as "unknown"
     # (fail-closed: a concurrent write could have shifted the array).
+    #
+    # We compute dead fingerprints (pid+host pairs) from the snapshot rather than
+    # a "kept" list, then filter the LIVE .polling_jobs at write time.  Using the
+    # live array means jobs added by sibling sessions after the snapshot was taken
+    # are preserved — writing the snapshot kept-list would silently drop them.
     | ( if ($pj_snapshot | type == "array") then
           ( $pj_snapshot | to_entries
-            | { dead:    map(select(($pj_verdicts[.key] // "unknown") == "dead"))    | length,
-                unknown: map(select(($pj_verdicts[.key] // "unknown") == "unknown")) | length,
-                kept:    map(select(($pj_verdicts[.key] // "unknown") != "dead"))
-                         | map(.value) }
+            | { dead:     map(select(($pj_verdicts[.key] // "unknown") == "dead"))    | length,
+                unknown:  map(select(($pj_verdicts[.key] // "unknown") == "unknown")) | length,
+                dead_fps: map(select(($pj_verdicts[.key] // "unknown") == "dead"))
+                          | map(.value | {pid:  (.owner_session.pid  // "" | tostring),
+                                          host: (.owner_session.host // "")}) }
           )
-        else {dead: 0, unknown: 0, kept: []} end ) as $pj
+        else {dead: 0, unknown: 0, dead_fps: []} end ) as $pj
 
     # auto_wake_cron_id: only clear when the bash precompute determined "dead".
     | ( (.pmm.auto_wake_cron_id? // null) != null ) as $aw_exists
@@ -296,7 +302,15 @@ if [[ -f "$STATE_FILE" ]]; then
                   babysit_cron_ids:   ($cron_ids | length),
                   babysit_watchers:   ($dead_watchers | length) },
         sets: ( ( if $pj.dead > 0 then
-                    [".polling_jobs=" + ($pj.kept | tojson)]
+                    [".polling_jobs=" + (
+                       (.polling_jobs? // [])
+                       | map(
+                           (. | {pid:  (.owner_session.pid  // "" | tostring),
+                                 host: (.owner_session.host // "")}) as $fp
+                           | select($pj.dead_fps | map(. == $fp) | any | not)
+                         )
+                       | tojson
+                     )]
                   else [] end )
               + ( if $aw.clear then [".pmm.auto_wake_cron_id=null"] else [] end )
               + ( $cron_ids    | map(. + "=null") )

--- a/.claude/scripts/session-scheduling-reconcile.sh
+++ b/.claude/scripts/session-scheduling-reconcile.sh
@@ -111,7 +111,7 @@ PURGED_JSON='{}'
 # Session liveness helper — mirrors the dead-holder test in state-lock.sh.
 # Fail-closed: anything we cannot verify is NOT treated as dead.
 # ---------------------------------------------------------------------------
-CURRENT_HOST="$(hostname 2>/dev/null || echo "")"
+CURRENT_HOST="${HOSTNAME:-$(hostname 2>/dev/null || echo "")}"
 
 # session_is_dead <pid> <host>
 # Exit 0 (true) only when the owning session is provably dead on THIS host.
@@ -156,13 +156,16 @@ fi
 # Fail-closed: unknown ownership => verdict "unknown" => skip (do not purge).
 # ---------------------------------------------------------------------------
 PJ_VERDICTS_JSON="[]"    # per-index verdict array for .polling_jobs[]
+PJ_SNAPSHOT="[]"         # snapshot of .polling_jobs used for jq plan (index-aligned)
 AW_VERDICT="unknown"     # verdict for .pmm.auto_wake_cron_id
 
 if [[ -f "$STATE_FILE" ]]; then
   # --- .polling_jobs[] -------------------------------------------------------
-  # Read (index, pid, host) tuples from every polling_job entry; build a
-  # verdict for each aligned to the array so the jq plan can filter by index.
-  if jq -e '(.polling_jobs // []) | length > 0' "$STATE_FILE" >/dev/null 2>&1; then
+  # Capture exactly one snapshot so the verdict index stays aligned with what
+  # the jq plan sees: a concurrent --set between the bash read and the jq pass
+  # would otherwise shift entries and mis-classify their verdicts.
+  PJ_SNAPSHOT="$(jq -c '.polling_jobs // []' "$STATE_FILE" 2>/dev/null || echo "[]")"
+  if jq -e 'length > 0' <<<"$PJ_SNAPSHOT" >/dev/null 2>&1; then
     VERDICTS=()
     while IFS=$'\t' read -r _idx pid host; do
       if session_is_dead "$pid" "$host"; then
@@ -173,12 +176,12 @@ if [[ -f "$STATE_FILE" ]]; then
         VERDICTS+=("\"unknown\"")
       fi
     done < <(jq -r '
-      .polling_jobs | to_entries[] |
+      to_entries[] |
       [ (.key | tostring),
         (.value.owner_session.pid  // "" | tostring),
         (.value.owner_session.host // "")
       ] | @tsv
-    ' "$STATE_FILE" 2>/dev/null)
+    ' <<<"$PJ_SNAPSHOT" 2>/dev/null)
     if (( ${#VERDICTS[@]} > 0 )); then
       # IFS=, in a subshell to join without a trailing newline (printf avoids
       # the echo newline that would corrupt the JSON literal).
@@ -227,6 +230,7 @@ if [[ -f "$STATE_FILE" ]]; then
   PLAN="$(jq -c \
       --argjson now "$NOW_EPOCH" \
       --argjson pj_verdicts "$PJ_VERDICTS_JSON" \
+      --argjson pj_snapshot "$PJ_SNAPSHOT" \
       --arg aw_verdict "$AW_VERDICT" \
       --argjson ttl "${BABYSIT_DISPATCH_TTL_MIN:-30}" '
     def prs_paths:
@@ -268,8 +272,8 @@ if [[ -f "$STATE_FILE" ]]; then
     # polling_jobs: per-record verdict from the bash precompute above.
     # Index into $pj_verdicts by array position; treat out-of-range as "unknown"
     # (fail-closed: a concurrent write could have shifted the array).
-    | ( if ((.polling_jobs? // []) | type == "array") then
-          ( (.polling_jobs // []) | to_entries
+    | ( if ($pj_snapshot | type == "array") then
+          ( $pj_snapshot | to_entries
             | { dead:    map(select(($pj_verdicts[.key] // "unknown") == "dead"))    | length,
                 unknown: map(select(($pj_verdicts[.key] // "unknown") == "unknown")) | length,
                 kept:    map(select(($pj_verdicts[.key] // "unknown") != "dead"))

--- a/.claude/scripts/tests/session-scheduling-reconcile.test.sh
+++ b/.claude/scripts/tests/session-scheduling-reconcile.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tests for session-scheduling-reconcile.sh — session-start reconciliation of
-# durable scheduling state (issue #827).
+# durable scheduling state (issues #827, #874).
 #
 # HOME is redirected into a temp dir for every case, so the suite never reads
 # or writes the real ~/.claude/session-state.json or audit watermark.
@@ -38,7 +38,39 @@ stamp_minutes_ago() {
     || date -u -d "$1 minutes ago" +"%Y-%m-%dT%H:%M:%SZ"
 }
 
+# Get a provably dead PID and the current hostname for ownership-stamp tests
+# (issue #874). A subshell that exits immediately guarantees the PID is dead
+# by the time we read it, with no race on macOS or Linux.
+( : ) &
+_DEAD_PID=$!
+wait $_DEAD_PID 2>/dev/null || true
+CURRENT_HOST="$(hostname 2>/dev/null || echo "localhost")"
+
+# FULL_STATE: polling_jobs and auto_wake_cron_id carry owner_session stamps
+# pointing at the dead PID above. Tests that expect purging require stamped
+# records; unstamped-record behaviour is tested separately in test 1a.
 FULL_STATE=$(cat <<JSON
+{
+  "polling_jobs": [
+    {"id":"cron_a","owner":"harness-audit","owner_session":{"pid":${_DEAD_PID},"host":"${CURRENT_HOST}"}},
+    {"id":"cron_b","owner":"pmm","owner_session":{"pid":${_DEAD_PID},"host":"${CURRENT_HOST}"}}
+  ],
+  "pmm": {
+    "auto_wake_cron_id": "cron_b",
+    "auto_wake_owner_session": {"pid":${_DEAD_PID},"host":"${CURRENT_HOST}"}
+  },
+  "repos": {"o/r": {"prs": {
+    "10": {"babysit": {"active": true, "cron_job_id": "cron_c", "last_tick_at": "$PAST"}},
+    "11": {"babysit": {"active": true, "cron_job_id": null, "last_tick_at": "$FUTURE"}}
+  }}},
+  "root_repo": "/keep/me"
+}
+JSON
+)
+
+# UNSTAMPED_STATE: same structure but polling_jobs/auto_wake carry NO
+# owner_session stamp. The fail-closed rule (issue #874) must NOT purge these.
+UNSTAMPED_STATE=$(cat <<JSON
 {
   "polling_jobs": [{"id":"cron_a","owner":"harness-audit"},{"id":"cron_b","owner":"pmm"}],
   "pmm": {"auto_wake_cron_id": "cron_b"},
@@ -61,21 +93,77 @@ awk 'NR>1 && /^  . "\$STATE_FILE"/{inblock=0} inblock && /'"'"'/{print NR; found
   || fail "apostrophe inside the single-quoted jq program — it will break quoting"
 ok "the embedded jq program contains no quote-breaking apostrophes"
 
-# --- 1. Dead scheduler bookkeeping is purged ---------------------------------
+# --- 1. Dead-owner stamped records are purged (issue #874) -------------------
+# polling_jobs and auto_wake_cron_id with owner_session stamps pointing at a
+# verifiably dead PID must be reaped, just like they were before the fix.
 new_home "$FULL_STATE"
 "$SCRIPT" >/dev/null
 [[ "$(jq -c '.polling_jobs' "$STATE")" == "[]" ]] \
-  || fail "polling_jobs should be emptied, got $(jq -c '.polling_jobs' "$STATE")"
+  || fail "polling_jobs with dead-owner stamp should be emptied, got $(jq -c '.polling_jobs' "$STATE")"
 [[ "$(jq -r '.pmm.auto_wake_cron_id' "$STATE")" == "null" ]] \
-  || fail "pmm.auto_wake_cron_id should be null"
+  || fail "pmm.auto_wake_cron_id with dead-owner stamp should be null"
 [[ "$(jq -r '.repos["o/r"].prs["10"].babysit.cron_job_id' "$STATE")" == "null" ]] \
   || fail "babysit.cron_job_id should be null"
-ok "purges polling_jobs, auto_wake_cron_id, and babysit.cron_job_id"
+ok "purges dead-stamped polling_jobs, auto_wake_cron_id, and babysit.cron_job_id"
+
+# --- 1a. Unstamped records are NOT purged — fail-closed (issue #874) ---------
+# If an entry in polling_jobs or auto_wake_cron_id has no owner_session stamp
+# we cannot verify liveness. Fail-closed: skip the purge and surface a notice.
+# This is the core regression test for the concurrent-session bug.
+new_home "$UNSTAMPED_STATE"
+BEFORE_PJ="$(jq -c '.polling_jobs' "$STATE")"
+"$SCRIPT" >/dev/null
+[[ "$(jq -c '.polling_jobs' "$STATE")" == "$BEFORE_PJ" ]] \
+  || fail "unstamped polling_jobs must NOT be purged (fail-closed), got $(jq -c '.polling_jobs' "$STATE")"
+[[ "$(jq -r '.pmm.auto_wake_cron_id' "$STATE")" != "null" ]] \
+  || fail "unstamped auto_wake_cron_id must NOT be cleared (fail-closed)"
+ok "unstamped polling_jobs and auto_wake_cron_id are preserved (fail-closed)"
+
+# Babysit bookkeeping (freshness-window path) is still reconciled normally even
+# when polling_jobs is unstamped.
+[[ "$(jq -r '.repos["o/r"].prs["10"].babysit.cron_job_id' "$STATE")" == "null" ]] \
+  || fail "babysit.cron_job_id should still be cleared for stale watcher"
+[[ "$(jq -r '.repos["o/r"].prs["10"].babysit.active' "$STATE")" == "false" ]] \
+  || fail "stale babysit watcher should still be deactivated"
+ok "babysit freshness-window path is unaffected when polling_jobs are unstamped"
+
+# A skip notice must be surfaced so the operator knows the record was seen.
+SKIP_OUT="$("$SCRIPT")"
+echo "$SKIP_OUT" | grep -q "scheduling-reconcile:" \
+  || fail "skipped unstamped records should emit a notice, got: $SKIP_OUT"
+ok "a skip notice is surfaced when polling_jobs have no owner stamp"
+
+# --- 1b. Live-session records are NOT purged ---------------------------------
+# A polling_job stamped with the CURRENT session PID (kill -0 succeeds)
+# must not be reaped — that record belongs to this running session.
+LIVE_PID=$$
+LIVE_STATE=$(cat <<JSON
+{
+  "polling_jobs": [
+    {"id":"live_cron","owner":"pmm","owner_session":{"pid":${LIVE_PID},"host":"${CURRENT_HOST}"}}
+  ],
+  "pmm": {
+    "auto_wake_cron_id": "live_cron",
+    "auto_wake_owner_session": {"pid":${LIVE_PID},"host":"${CURRENT_HOST}"}
+  }
+}
+JSON
+)
+new_home "$LIVE_STATE"
+"$SCRIPT" >/dev/null
+PJ_AFTER="$(jq -c '.polling_jobs' "$STATE")"
+[[ "$PJ_AFTER" != "[]" ]] \
+  || fail "polling_job owned by a live PID must not be reaped, got: $PJ_AFTER"
+[[ "$(jq -r '.pmm.auto_wake_cron_id' "$STATE")" != "null" ]] \
+  || fail "auto_wake_cron_id owned by a live PID must not be cleared"
+ok "polling_jobs and auto_wake_cron_id owned by a live PID are preserved"
 
 # --- 2. Only watchers that cannot be alive are deactivated -------------------
 # The freshness test is what keeps this from reaping a watcher armed seconds
 # ago in the current session — the exact failure that would make a re-arm
 # reconciler worse than no reconciler at all.
+new_home "$FULL_STATE"
+"$SCRIPT" >/dev/null
 [[ "$(jq -r '.repos["o/r"].prs["10"].babysit.active' "$STATE")" == "false" ]] \
   || fail "stale watcher (last tick in the past) should be deactivated"
 [[ "$(jq -r '.repos["o/r"].prs["11"].babysit.active' "$STATE")" == "true" ]] \
@@ -272,6 +360,13 @@ new_home '{}'
 jq -e '.notices == []' <<<"$("$SCRIPT" --format json)" >/dev/null \
   || fail "an empty state should yield an empty notices array, not [\"\"]"
 ok "--format json emits an empty notices array when there is nothing to say"
+
+# Unstamped records produce a non-zero skip count in the purged object.
+new_home "$UNSTAMPED_STATE"
+J_SKIP="$("$SCRIPT" --format json)"
+jq -e '(.purged.polling_jobs_skip // 0) >= 1' <<<"$J_SKIP" >/dev/null \
+  || fail "unstamped polling_jobs should appear as polling_jobs_skip, got: $J_SKIP"
+ok "--format json reports skipped unstamped records in polling_jobs_skip"
 
 # --- 11. A failed write must not report counts it did not land ---------------
 # `purged` is a claim about what changed. If the write fails, reporting the


### PR DESCRIPTION
## Summary

- Adds `session_is_dead()` helper (mirrors `state-lock.sh`'s `kill -0` dead-holder test) to determine per-record liveness before purging scheduling bookkeeping
- Precomputes verdict (`dead` / `alive` / `unknown`) for each `.polling_jobs[]` entry and for `.pmm.auto_wake_cron_id` in bash, then passes the verdicts into the jq PLAN via `--argjson`
- **Fail-closed:** records with no `owner_session` stamp, a cross-host stamp, or a live-PID stamp are skipped — never purged — and a `scheduling-reconcile:` notice is surfaced
- Babysit freshness-window path unchanged; live watchers in sibling sessions are already protected there

Closes #874

## Test plan

- [x] Test 1: dead-owner-stamped `polling_jobs` and `auto_wake_cron_id` are still purged (existing behavior preserved)
- [x] Test 1a: unstamped `polling_jobs` / `auto_wake_cron_id` are NOT purged (fail-closed regression guard)
- [x] Test 1b: live-PID-stamped records are NOT purged
- [x] Test 0: no apostrophe inside the single-quoted jq program
- [x] All 33 existing + new tests pass (`bash .claude/scripts/tests/session-scheduling-reconcile.test.sh`)
- [x] Both CLIs unavailable (CR CLI absent; CodeAnt 403 after one retry — daily cap, not auth); self-review performed; no issues found

[COVERAGE: none — CR CLI absent; CodeAnt 403 (daily cap); self-review only]