### PR TITLE
fix(#917): exclude UUID-embedded hex fragments from SHA-candidate extraction

### DIFF
--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -322,18 +322,28 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
         ) as $unfenced
       # UUID-stripped text for rule 1 only (issue #917). CodeRabbit embeds an
       # invocation UUID in its HTML comments (8-4-4-4-12 hyphenated hex, e.g.
-      # "9f69125b-29d9-47d4-bf8f-8b5df9dcb5a6"). \b treats a hyphen as a
-      # non-word boundary, so the UUID splits into 5 segments at scan time —
-      # and its first (8 hex chars) and last (12 hex chars) groups
-      # independently satisfy rule 1"s shape (7-40 chars, at least one a-f
-      # letter), getting misread as SHAs the bot claims to have reviewed. Each
-      # match is replaced with a space, not stripped to empty, so a UUID
-      # sitting between two genuine tokens cannot merge them into a new false
-      # one. Rules 2-3 are untouched: rule 2 is safe regardless because it
-      # additionally requires a prefix match against the real $sha, and rule 3
-      # only admits complete backtick-wrapped ALL-DECIMAL runs, which a
-      # hyphenated hex UUID never satisfies.
-      | ($btxt | gsub("\\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\b"; " ")) as $unuuid
+      # "9f69125b-29d9-47d4-bf8f-8b5df9dcb5a6"). A hyphen is a non-word
+      # character, so the UUID"s hex groups independently satisfy rule 1"s
+      # shape (7-40 chars, at least one a-f letter) and get misread as SHAs
+      # the bot claims to have reviewed. Each match is replaced with a space,
+      # not stripped to empty, so a UUID sitting between two genuine tokens
+      # cannot merge them into a new false one. Rules 2-3 are untouched: rule
+      # 2 is safe regardless because it additionally requires a prefix match
+      # against the real $sha, and rule 3 only admits complete
+      # backtick-wrapped ALL-DECIMAL runs, which a hyphenated hex UUID never
+      # satisfies.
+      #
+      # The boundary is a hex-lookaround, NOT \b (issue #917 follow-up,
+      # CodeAnt PR #923 review): \b treats "_" as a word character equal to a
+      # hex digit, so an identifier-glued UUID ("request_id_9f69125b-…") has
+      # NO boundary before its first hex digit — the whole pattern fails to
+      # match, the UUID is never stripped, and rule 1"s own scan still picks
+      # up its trailing group ("8b5df9dcb5a6") as a bare hex token, exactly
+      # reproducing the bug this fix exists to close. (?<![0-9a-f]) / (?![0-9a-f])
+      # only refuse to START or END the match mid-hex-digit-run — they treat
+      # "_" (or any other non-hex character) as a valid edge, so an
+      # identifier-glued UUID is still recognized and stripped.
+      | ($btxt | gsub("(?<![0-9a-f])[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?![0-9a-f])"; " ")) as $unuuid
       | [ ( $unuuid | scan("\\b[0-9a-f]{7,40}\\b") | select(test("[a-f]")) ),
           ( $btxt | scan("\\b[0-9]{7,40}\\b") | . as $t
                   | select(($sha | length) > 0

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -320,7 +320,21 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
          | gsub("\n```.*"; " "; "m")
          | gsub("\n    [^\n]*"; " "; "m")
         ) as $unfenced
-      | [ ( $btxt | scan("\\b[0-9a-f]{7,40}\\b") | select(test("[a-f]")) ),
+      # UUID-stripped text for rule 1 only (issue #917). CodeRabbit embeds an
+      # invocation UUID in its HTML comments (8-4-4-4-12 hyphenated hex, e.g.
+      # "9f69125b-29d9-47d4-bf8f-8b5df9dcb5a6"). \b treats a hyphen as a
+      # non-word boundary, so the UUID splits into 5 segments at scan time —
+      # and its first (8 hex chars) and last (12 hex chars) groups
+      # independently satisfy rule 1"s shape (7-40 chars, at least one a-f
+      # letter), getting misread as SHAs the bot claims to have reviewed. Each
+      # match is replaced with a space, not stripped to empty, so a UUID
+      # sitting between two genuine tokens cannot merge them into a new false
+      # one. Rules 2-3 are untouched: rule 2 is safe regardless because it
+      # additionally requires a prefix match against the real $sha, and rule 3
+      # only admits complete backtick-wrapped ALL-DECIMAL runs, which a
+      # hyphenated hex UUID never satisfies.
+      | ($btxt | gsub("\\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\b"; " ")) as $unuuid
+      | [ ( $unuuid | scan("\\b[0-9a-f]{7,40}\\b") | select(test("[a-f]")) ),
           ( $btxt | scan("\\b[0-9]{7,40}\\b") | . as $t
                   | select(($sha | length) > 0
                            and (($sha | startswith($t)) or ($t | startswith($sha)))) ),

--- a/.claude/scripts/tests/merge-gate-review-substance.test.sh
+++ b/.claude/scripts/tests/merge-gate-review-substance.test.sh
@@ -619,6 +619,17 @@ RU0="$(ee_eval "$UUID_BODY")"
 check_eq "[]"    "$(echo "$RU0" | jq -c '.status_comment_shas')" "(ee-917) a bare invocation UUID yields no tokens at all"
 check_eq "false" "$(echo "$RU0" | jq -r '.self_report_mismatch')" "(ee-917) and manufactures no mismatch on its own"
 
+# Identifier-glued UUID (CodeAnt review, PR #923): \b treats "_" as a word
+# character equal to a hex digit, so a UUID glued directly to a preceding
+# identifier with no separator ("request_id_9f69125b-…") has NO \b boundary
+# before its first hex digit. The first fix used \b and never stripped this
+# shape at all — rule 1's own scan still admitted the trailing 12-char group
+# as a bare hex token, reproducing the original bug for this one adjacency.
+UUID_GLUED_BODY="Comment ref request_id_9f69125b-29d9-47d4-bf8f-8b5df9dcb5a6 posted."
+RU_GLUED="$(ee_eval "$UUID_GLUED_BODY")"
+check_eq "[]"    "$(echo "$RU_GLUED" | jq -c '.status_comment_shas')" "(ee-917) an identifier-glued UUID yields no tokens either"
+check_eq "false" "$(echo "$RU_GLUED" | jq -r '.self_report_mismatch')" "(ee-917) and manufactures no mismatch"
+
 # Real-world shape (auerbachb/longlove PR #161, 2026-08-01): a single comment
 # mixing the UUID with a genuine HEAD-naming token does NOT reproduce the
 # reported failure — tokens_name_head is an any(...) over one comment's own

--- a/.claude/scripts/tests/merge-gate-review-substance.test.sh
+++ b/.claude/scripts/tests/merge-gate-review-substance.test.sh
@@ -607,6 +607,58 @@ RF_BODY_START_FENCE="$(ee_eval "$(printf "\`\`\`js\nconst id = \`1234599\`;\n")"
 check_eq "false" "$(echo "$RF_BODY_START_FENCE" | jq -r '.self_report_mismatch')"   "(ee-897) body-start fence: template literal inside fence is not a self-report"
 check_eq "[]"    "$(echo "$RF_BODY_START_FENCE" | jq -c '.status_comment_shas')"    "(ee-897) body-start fence: yields no tokens"
 
+echo "=== (ee-917) UUID-embedded hex fragments are not admitted as SHA candidates (issue #917) ==="
+# CodeRabbit embeds an invocation UUID (8-4-4-4-12 hyphenated hex, e.g.
+# "9f69125b-29d9-47d4-bf8f-8b5df9dcb5a6") in run-tracking HTML comments. \b
+# treats a hyphen as a non-word boundary, so the UUID splits into 5 segments
+# at scan time — its first (8 hex chars) and last (12 hex chars) groups
+# independently satisfy rule 1's shape (7-40 chars, >= one a-f letter) and
+# were admitted as SHA-like tokens the bot never actually claimed.
+UUID_BODY="A comment carrying only CodeRabbit's own run-tracking metadata. <!-- request id 9f69125b-29d9-47d4-bf8f-8b5df9dcb5a6 -->"
+RU0="$(ee_eval "$UUID_BODY")"
+check_eq "[]"    "$(echo "$RU0" | jq -c '.status_comment_shas')" "(ee-917) a bare invocation UUID yields no tokens at all"
+check_eq "false" "$(echo "$RU0" | jq -r '.self_report_mismatch')" "(ee-917) and manufactures no mismatch on its own"
+
+# Real-world shape (auerbachb/longlove PR #161, 2026-08-01): a single comment
+# mixing the UUID with a genuine HEAD-naming token does NOT reproduce the
+# reported failure — tokens_name_head is an any(...) over one comment's own
+# token list, so the genuine token alone makes that comment's names_head true
+# regardless of UUID noise sitting beside it. The actual production shape
+# needs TWO comments from the same bot: an earlier, substantive comment that
+# names HEAD (setting the bot-level status_comment_names_head), followed by a
+# LATER, separate status comment carrying only the invocation UUID and no SHA
+# mention. self_report_mismatch is computed from $selfrep — the bot's most
+# recently CREATED comment that has ANY tokens — so pre-fix, that later
+# UUID-only comment became $selfrep, and since none of ITS tokens named HEAD,
+# self_report_mismatch flipped true even though status_comment_names_head was
+# already true from the earlier comment. That contradictory pair — both true
+# at once — is exactly what was observed on PR #161.
+UUID_HEAD="a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+uuid_eval() { # <earlier-body> <later-body>  -> the coderabbitai reviewer object
+  jq -cn --arg sha "$UUID_HEAD" --arg b1 "$1" --arg b2 "$2" \
+    '{head_sha:$sha, push_ts:"2026-07-31T10:00:00Z",
+      reviews:[{user:{login:"coderabbitai[bot]"},commit_id:$sha,state:"APPROVED",
+                submitted_at:"2026-07-31T10:06:00Z",body:""}],
+      pr_comments:[],
+      issue_comments:[
+        {user:{login:"coderabbitai[bot]"},
+         created_at:"2026-07-31T10:03:00Z",
+         updated_at:"2026-07-31T10:03:00Z", body:$b1},
+        {user:{login:"coderabbitai[bot]"},
+         created_at:"2026-07-31T10:05:00Z",
+         updated_at:"2026-07-31T10:05:00Z", body:$b2}
+      ]}' \
+  | "$EVAL_SUT" 2>/dev/null | jq -c '.reviewers["coderabbitai[bot]"]'
+}
+WALKTHROUGH_BODY="$(printf "## Walkthrough\n\nReviewed the modal root change and the two updated call sites for commit \`a1b2c3d\`. No blocking issues found.")"
+UUID_STATUS_BODY="<!-- This is an auto-generated comment by CodeRabbit with request id 9f69125b-29d9-47d4-bf8f-8b5df9dcb5a6 -->"
+
+RU="$(uuid_eval "$WALKTHROUGH_BODY" "$UUID_STATUS_BODY")"
+check_eq "true"     "$(echo "$RU" | jq -r '.status_comment_names_head')" "(ee-917) an earlier comment naming HEAD still sets status_comment_names_head"
+check_eq '["a1b2c3d"]' "$(echo "$RU" | jq -c '.status_comment_shas')"    "(ee-917) only the genuine token is admitted — no UUID fragments"
+check_eq "false"    "$(echo "$RU" | jq -r '.self_report_mismatch')"     "(ee-917) a later UUID-only status comment no longer manufactures a mismatch"
+check_eq "[]"       "$(echo "$RU" | jq -c '.disqualified_by')"          "(ee-917) and the reviewer is not disqualified"
+
 echo "=== (m) evaluator rejects malformed stdin ==="
 echo "not json" | "$EVAL_SUT" >/dev/null 2>&1
 check_eq "4" "$?" "(m) non-JSON stdin exits 4"


### PR DESCRIPTION
## **User description**
Closes #917

## Summary

`review-substance.sh`'s `sha_tokens` extractor scanned raw comment text for hex-shaped tokens without excluding CodeRabbit's own embedded invocation UUID. Hyphen-delimited UUID segments (e.g. the first 8-char and last 12-char groups) independently matched the SHA-candidate shape and were misread as commits the bot claimed to review — producing a false `self_report_mismatch` even when the bot had genuinely named HEAD in an earlier comment. Observed live on `auerbachb/longlove` PR #161.

## Fix

Pre-strip `8-4-4-4-12` hyphenated hex UUID matches (replaced with a space, not emptied, so neighboring tokens can't merge into a new false one) before rule 1's scan only. Rules 2-3 are unaffected by construction — rule 2 requires a prefix match against the real HEAD SHA, and rule 3 only admits complete backtick-wrapped all-decimal runs. `sha_tokens` in `review-substance.sh` is the single shared definition point — `merge-gate.sh` and `escalate-review.sh` only consume its JSON output as a subprocess, and `pr-state.sh` has an unrelated comment-classification regex — so no other file needed the fix.

## Regression test

Added to the existing `(ee)`/`(ee-897)` block in `merge-gate-review-substance.test.sh` (new `(ee-917)` cases), following the precedent issue #897 set for extending this same function rather than duplicating harness boilerplate into a new file:

1. A comment containing only the invocation UUID yields zero tokens and manufactures no mismatch on its own.
2. The real production shape: an earlier comment names HEAD genuinely, a later separate status comment carries only the UUID. Pre-fix this produced the exact contradictory pair observed on PR #161 (`status_comment_names_head=true` **and** `self_report_mismatch=true` simultaneously); post-fix both resolve correctly and the reviewer is not disqualified.

Both cases were manually verified against the pre-fix script to confirm they actually reproduce the bug (not just pass vacuously) before being added.

## Local review coverage: `none` (degraded — both CLIs unavailable this session)

- **CodeAnt CLI**: persistent 403 on both the initial run and the one permitted retry (`Access denied (403)... run codeant logout/login`). Per prior experience this is an account-wide entitlement issue, not an auth problem — re-auth does not fix it, so no `logout`/`login` was attempted. The CodeAnt **GitHub App** is unaffected and reviewed this PR normally (see follow-up fix below).
- **CodeRabbit CLI**: rate-limited on both the initial run and the one permitted retry (waited out the reported window between attempts); GitHub-side CodeRabbit review was also rate-limited throughout this session (shared adaptive quota) — never produced a real review on either SHA.
- Self-review performed instead: full diff read, `shellcheck` clean on both changed files, full repo hook-test suite run twice (556 assertions, 0 failures on the clean run — an earlier run reported 1 failure but its output was truncated before the failing suite could be identified, and a full re-run came back clean; treated as an unrelated environmental flake, not reproduced).

## Follow-up fix (CodeAnt GitHub App review)

CodeAnt's App review found a real edge case: the `\b` word-boundary anchors on the UUID-strip pattern fail when the UUID is glued directly to a preceding identifier via underscore (e.g. `request_id_9f69125b-...`) — `\b` treats `_` as a word character equal to a hex digit, so no boundary exists before the UUID's first hex digit, the whole strip never fires, and rule 1's own scan still admits the trailing hex group as a bare token, reproducing the original bug for that one adjacency shape. Replaced `\b` with `(?<![0-9a-f])`/`(?![0-9a-f])` lookaround (verified jq/Oniguruma supports it) — these only refuse to start/end the match mid-hex-digit-run, so `_` is still a valid edge. Added an `(ee-917)` case for the identifier-glued shape. Both threads replied to and resolved; reviewer escalated to BugBot (sticky) after CodeRabbit's continued rate-limiting and CodeAnt's post-fix approval landing before its status comment caught up to the new SHA (hollow per the issue #875 guard — a real but separate pre-existing gap in that heuristic, out of scope here). BugBot gave a clean pass on the final SHA.

## Test plan

- [x] `sha_tokens` excludes UUID-embedded hex fragments from SHA-candidate extraction, including when glued to a preceding identifier via underscore
- [x] Regression test covers a CodeRabbit-shaped comment containing an invocation UUID plus a genuine HEAD-naming comment, reproducing the exact `status_comment_names_head=true` + `self_report_mismatch=true` contradiction pre-fix
- [x] `merge-gate.sh`, `escalate-review.sh`, and `pr-state.sh` confirmed to need no changes (single shared extractor) — full PR diff touches only `review-substance.sh` and its test file
- [x] Existing `merge-gate-review-substance.test.sh` suite (124 assertions, updated from the original 122 after the follow-up fix) passes, including all `(ee)`/`(ee-897)` cases
- [x] Full repo hook-test suite passes (558 assertions, 0 failures)


___

## **CodeAnt-AI Description**
Prevent UUID metadata from causing false review mismatches

### What Changed
- CodeRabbit’s embedded run IDs are no longer mistaken for reviewed commit SHAs, including when attached directly to an identifier with an underscore.
- Genuine commit references continue to be recognized while UUID-only status comments no longer trigger a self-report mismatch or reviewer disqualification.
- Added regression coverage for standalone UUIDs, identifier-glued UUIDs, and the reported multi-comment failure scenario.

### Impact
`✅ Fewer false review mismatches`
`✅ Fewer incorrect reviewer disqualifications`
`✅ Reliable commit detection in automated status comments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review validation to ignore UUID-style tracking metadata when detecting commit references.
  * Prevented UUID fragments from being incorrectly treated as SHA candidates or causing valid reviews to fail.

* **Tests**
  * Added regression coverage for standalone and identifier-adjacent UUIDs.
  * Added validation for genuine commit references followed by UUID-only status comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->