### PR TITLE
docs(#926): align skill-bash.sh anchoring-rule header with its actual blank-line tolerance

### DIFF
--- a/.claude/scripts/tests/lib/skill-bash.sh
+++ b/.claude/scripts/tests/lib/skill-bash.sh
@@ -30,9 +30,9 @@
 #   either turns every editorial reshuffle into a red build — a maintenance tax
 #   that gets the test deleted rather than the skill fixed.
 #
-#   So the anchor is an explicit HTML comment on its own line, immediately
-#   before the opening fence, reusing the `<!-- key: value -->` idiom already in
-#   this repo (`<!-- churn-hotspot: … -->`, `<!-- harness-audit: … -->`):
+#   So the anchor is an explicit HTML comment on its own line above the opening
+#   fence, reusing the `<!-- key: value -->` idiom already in this repo
+#   (`<!-- churn-hotspot: … -->`, `<!-- harness-audit: … -->`):
 #
 #       <!-- test-anchor: pmm-wake-step-4a-scan -->
 #       ```bash
@@ -55,7 +55,7 @@
 #   2  Usage error (wrong argument count, unreadable Markdown file).
 #   3  Anchor not found.
 #   4  Anchor is ambiguous (matched more than once in the file).
-#   5  Anchor is not immediately followed by an opening ```bash fence.
+#   5  First non-blank line after the anchor is not an opening ```bash fence.
 #   6  Opening fence is never closed.
 #   7  Extracted block body is empty.
 #
@@ -118,7 +118,7 @@ extract_skill_bash() {
 
   if [ "$anchor_count" -eq 0 ]; then
     echo "extract_skill_bash: anchor not found in $md_path: $marker" >&2
-    echo "extract_skill_bash: add the anchor on its own line immediately before the target bash fence" >&2
+    echo "extract_skill_bash: add the anchor on its own line above the target bash fence (blank lines between the two are fine)" >&2
     return 3
   fi
   if [ "$anchor_count" -gt 1 ]; then
@@ -160,7 +160,7 @@ extract_skill_bash() {
   awk_rc=$?
 
   if [ "$awk_rc" -eq 5 ]; then
-    echo "extract_skill_bash: anchor at line $anchor_line of $md_path is not immediately followed by an opening bash fence" >&2
+    echo "extract_skill_bash: first non-blank line after the anchor at line $anchor_line of $md_path is not an opening bash fence" >&2
     return 5
   fi
   if [ "$awk_rc" -eq 6 ]; then

--- a/.claude/scripts/tests/lib/skill-bash.sh
+++ b/.claude/scripts/tests/lib/skill-bash.sh
@@ -41,8 +41,8 @@
 #
 #   It is invisible in rendered prose, survives reordering and rewording, is
 #   greppable from the call site, and announces to the next editor that
-#   something depends on this block. A single blank line between the anchor and
-#   the fence is tolerated; anything else between them is an error, because a
+#   something depends on this block. Blank lines between the anchor and the
+#   fence are tolerated; anything else between them is an error, because a
 #   drifted anchor must not quietly extract a neighbouring block.
 #
 # FAIL LOUD, NEVER EMPTY

--- a/.claude/scripts/tests/pmm-wake-step-4a.test.sh
+++ b/.claude/scripts/tests/pmm-wake-step-4a.test.sh
@@ -526,7 +526,10 @@ echo not-mine
 MD
 
 out="$(extract_skill_bash "$FIXDIR/adrift.md" gamma 2>&1)"; rc=$?
-if [ "$rc" -ne 0 ] && contains "not immediately followed" "$out"; then
+# The needle pins the diagnostic's wording, not just its exit code: it must name
+# the *first non-blank line* as the thing that has to be a fence, so it can never
+# drift back into implying that a blank line is what got rejected (issue #926).
+if [ "$rc" -ne 0 ] && contains "first non-blank line after the anchor" "$out"; then
   pass "extractor: anchor separated from its fence exits non-zero (rc=$rc) rather than grabbing the next block"
 else
   fail "extractor: drifted anchor — expected non-zero + diagnostic, got rc=$rc: $out"

--- a/.claude/scripts/tests/pmm-wake-step-4a.test.sh
+++ b/.claude/scripts/tests/pmm-wake-step-4a.test.sh
@@ -532,6 +532,29 @@ else
   fail "extractor: drifted anchor — expected non-zero + diagnostic, got rc=$rc: $out"
 fi
 
+# The flip side of adrift.md: blank lines alone are tolerated, however many.
+# Only a non-blank line between anchor and fence is an error, so an editorial
+# double newline never turns into a red build (issue #926).
+cat > "$FIXDIR/tolerant.md" <<'MD'
+<!-- test-anchor: eta -->
+
+
+
+```bash
+echo tolerated one
+echo tolerated two
+```
+MD
+
+out="$(extract_skill_bash "$FIXDIR/tolerant.md" eta 2>&1)"; rc=$?
+expected='echo tolerated one
+echo tolerated two'
+if [ "$rc" -eq 0 ] && [ "$out" = "$expected" ]; then
+  pass "extractor: multiple blank lines between anchor and fence are tolerated (rc 0)"
+else
+  fail "extractor: multi-blank tolerance — expected rc 0 and the block body, got rc=$rc, body=<$out>"
+fi
+
 cat > "$FIXDIR/unclosed.md" <<'MD'
 <!-- test-anchor: delta -->
 ```bash


### PR DESCRIPTION
## **User description**
Closes #926

Follow-up from PR #921 (Issue #888). `.claude/scripts/tests/lib/skill-bash.sh` documented a narrower anchor-to-fence tolerance than it implements.

## What changed

**Documentation, not behavior.** The "THE ANCHORING RULE" header said *"A single blank line between the anchor and the fence is tolerated"*. The pass-2 awk's `state == 0` branch skips **any** number of blank lines before requiring the opening `` ```bash `` fence, so an anchor followed by three blank lines extracts successfully (rc 0) where the header implied rc 5.

This takes **option 1** from the issue — relax the doc, keep the forgiving behavior:

- **`.claude/scripts/tests/lib/skill-bash.sh`** — the anchoring rule now reads `"Blank lines between the anchor and the fence are tolerated"`, and (after review round 1, below) every other description of the rc-5 trigger matches it. The second clause is untouched: anything that is *not* a blank line between them is still an error, because a drifted anchor must not quietly extract a neighbouring block.
- **`.claude/scripts/tests/pmm-wake-step-4a.test.sh`** — adds the previously-uncovered tolerance case (three blank lines -> rc 0 with the exact block body), sitting next to the existing `adrift.md` rejection case as its deliberate flip side.

The pass-2 awk inside `extract_skill_bash` is **unchanged** — every exit status and extracted body is identical to `main`. Option 2 (tighten the implementation to match the old wording) was declined for the reason the issue gives: it would make an editorial double newline a red build, the exact maintenance tax the anchoring rule was designed to avoid.

## Review round 1 — the rest of the file still said "immediately"

CodeAnt (inline, on the header) and the CodeRabbit CLI (independently, on the local pass) both caught that relaxing one sentence was half the fix: four other places still framed the anchor as *immediately* before the fence, so the exit-status contract kept over-stating when rc 5 fires. Someone reading the EXIT STATUS table would still conclude a blank line yields rc 5. Fixed in `5acd1e2`:

| where | before | after |
| --- | --- | --- |
| `EXIT STATUS` 5 | Anchor is not **immediately followed by** an opening fence | **First non-blank line after the anchor** is not an opening fence |
| rc-5 runtime diagnostic | anchor at line N ... is not **immediately followed by** an opening bash fence | **first non-blank line after the anchor** at line N ... is not an opening bash fence |
| rc-3 hint | add the anchor ... **immediately before** the target bash fence | add the anchor ... **above** the target bash fence (blank lines between the two are fine) |
| design-rationale prose | on its own line, **immediately before** the opening fence | on its own line **above** the opening fence |

`grep -n immediately .claude/scripts/tests/lib/skill-bash.sh` now returns nothing. The canonical example directly below that prose still shows the zero-gap placement, so the *recommended* form is unchanged — only the claim that anything else gets rejected is gone. Two stderr strings changed; the awk did not, so rc values and extracted bodies stay byte-identical.

The `adrift.md` assertion now pins the new wording (`first non-blank line after the anchor`) rather than just the exit code, so the diagnostic cannot silently drift back to implying a blank line was the problem.

## Why the new test isn't vacuous

A "tolerance is tolerated" assertion passes trivially if the code never rejects anything, so I ran a negative control against a patched copy of the library with the awk capped at one blank line (re-run at `5acd1e2`):

| library | 3 blank lines | 1 blank line | non-blank prose (`adrift`) |
| --- | --- | --- | --- |
| shipped (this branch) | rc 0 | rc 0 | rc 5 |
| tightened (control) | **rc 5** | rc 0 | rc 5 |

The new case flips 0 -> 5 under the tightened variant, so it genuinely pins the behavior. `adrift.md` stays rc 5 in both columns, confirming the control discriminates rather than breaking everything indiscriminately.

Round 1's message rewording got its own control, since an assertion on wording is just as capable of passing vacuously: restoring the old rc-5 string flips the `adrift.md` case to **FAIL** (22 passed / 1 failed), so that needle is load-bearing too.

**Local review coverage:** `cr-only` for the original push — CodeRabbit CLI gave a verified-successful clean pass (explicit `complete` record, `findings: 0`, both changed files in `reviewedFiles`, no NDJSON `type: "error"` record, empty stderr). CodeAnt CLI produced the documented false-clean (exit 0 with empty `issues`) masking `API Error: Access denied (403)` on both the initial run and the single permitted retry, so it was dropped for the session per `cr-local-review.md` (no `codeant logout`/`login` — Issue #643); it emitted zero findings before the drop.

**For the round-1 fix push, coverage degrades to `none`.** The CodeRabbit CLI produced two further verified-successful passes — those are what raised the rc-5 and rc-3 findings above, and both were fixed — but the third, confirming pass returned an NDJSON `type: "error"` record with `errorType: "rate_limit"` (33-minute wait, no `complete` record), which is a failed run and not a clean pass, so CR is dropped for the session as well. The only change since the last verified-successful CR pass is the one-line rc-3 stderr reword CodeRabbit itself dictated. Self-review stands in and is recorded above; the CodeAnt GitHub App is unaffected and gates this PR independently.

## Test plan

- [x] The "THE ANCHORING RULE" header no longer claims a *single* blank line and instead describes the implemented tolerance (blank lines, plural)
- [x] The second clause survives verbatim: a non-blank line between anchor and fence is still an error, because a drifted anchor must not quietly extract a neighbouring block
- [x] `extract_skill_bash`'s pass-2 awk is unmodified — the only non-comment lines in the `lib/skill-bash.sh` diff are two stderr strings (the rc-3 hint and the rc-5 diagnostic), so every exit status and extracted body is identical *(reworded in review round 1: this box originally claimed the diff touches only comment lines, which stopped being true once the rc-5 message was corrected)*
- [x] No other file in the repo restates the "single blank line" claim — `grep -rn "single blank line" .claude .github` returns nothing
- [x] New suite case asserts rc 0 **and** exact body equality for three blank lines between anchor and fence
- [x] The `adrift.md` case still rejects non-blank prose with rc 5; its needle now pins the reworded diagnostic instead of `not immediately followed` *(reworded in review round 1: this box originally claimed the case was unchanged)*
- [x] *(added in review round 1)* No occurrence of "immediately" survives in `lib/skill-bash.sh` — EXIT STATUS 5, the rc-5 diagnostic, the rc-3 hint and the design prose all describe the *first non-blank line*, matching the awk
- [x] *(added in review round 1)* The reworded rc-5 diagnostic is pinned by an assertion, not merely emitted: restoring the old message flips the `adrift.md` case to FAIL (22 passed / 1 failed)
- [x] `bash .claude/scripts/tests/pmm-wake-step-4a.test.sh` is green: **23 passed, 0 failed** — all 22 pre-existing cases still pass, plus the one new case
- [x] Full auto-discovered CI suite passes locally: `bash .github/scripts/run-hook-tests.sh` -> 63 suites, 0 failed
- [x] Negative control proves the tolerance case is not vacuous: tightening the awk to one blank line flips it to rc 5 while `adrift.md` stays rc 5
- [x] `shellcheck` is clean (exit 0) on both changed files, and on `main`'s copy of `lib/skill-bash.sh` — no new findings
- [x] Scope held: no `.claude/rules/` or `CLAUDE.md` edits, so `rule-lint` is unaffected (`git diff --name-only origin/main` returns only the two test files)


___

## **CodeAnt-AI Description**
Align anchoring guidance with accepted blank-line formatting

### What Changed
- Documents that any number of blank lines may appear between a test anchor and its fenced Bash block
- Adds coverage confirming that multiple blank lines still extract the correct block
- Keeps drifted anchors that contain non-blank text rejected

### Impact
`✅ Fewer false test failures from editorial blank lines`
`✅ Clearer anchoring rules`
`✅ Preserved protection against extracting the wrong block`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

