### PR TITLE
feat(#779): statusline — ET time · branch · active agents/watchers

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -15,6 +15,8 @@ Shared code that hooks source (rather than run) lives in `lib/` and is deliberat
 
 **Initial setup** is handled by `setup-skills-worktree.sh` (see `SETUP.md`). The ongoing sync is a safety net that catches hooks added after initial setup.
 
+`register-hooks.py` — the helper `session-start-sync.sh` calls — also syncs the top-level **`statusLine`** key by the same rules (issue #779). That key is not a hook event, but its `command` carries the same path placeholder and must resolve to the skills worktree the same way. It is seeded when absent, path-repaired when it points at our own `statusline.sh`, and left completely alone when the user has pointed it at their own script. `--statusline-only` runs that sync without touching hooks; `setup-skills-worktree.sh` Step 6b uses it so install-time and session-start behavior share one implementation. See [ARCHITECTURE.md](../../ARCHITECTURE.md#status-line).
+
 ---
 
 ## post-merge-pull.sh

--- a/.claude/hooks/register-hooks.py
+++ b/.claude/hooks/register-hooks.py
@@ -115,10 +115,16 @@ def sync_statusline(settings, template, scripts_dir):
     Returns 1 when settings was modified, 0 otherwise. Never raises: a
     statusLine problem must not stop hook registration.
 
-    The user's own statusLine (a command whose basename is not the template's
-    script) is left completely alone — this only owns the entry it installed.
-    When it does own the entry, only `command` is rewritten, so `padding`,
-    `refreshInterval`, and any other key the user tuned survive.
+    The user's own statusLine is left completely alone — this only owns the
+    entry it installed. When it does own the entry, only `command` is rewritten,
+    so `padding`, `refreshInterval`, and any other key the user tuned survive.
+
+    Ownership is decided by the installed LAYOUT (a path ending in
+    .claude/scripts/<script>), not by basename alone. Basename alone would claim
+    a user's own ~/bin/statusline.sh purely because the filename collides, while
+    matching only the exact resolved or placeholder path would fail to repair a
+    path left behind by an earlier worktree location — which is a case this has
+    to handle. The layout suffix is what separates the two.
     """
     tpl = template.get("statusLine")
     if not isinstance(tpl, dict):
@@ -137,12 +143,15 @@ def sync_statusline(settings, template, scripts_dir):
         )
         return 0
 
-    live = settings.get("statusLine")
-
-    if live is None:
+    # Seed only when the key is genuinely ABSENT. An explicit "statusLine": null
+    # is a user statement — most plausibly "disabled" — and gets the same
+    # hands-off treatment as any other non-object value below. `.get()` cannot
+    # tell those two apart, which is why this tests membership instead.
+    if "statusLine" not in settings:
         settings["statusLine"] = dict(tpl, command=resolved)
         return 1
 
+    live = settings["statusLine"]
     if not isinstance(live, dict):
         print(
             "statusline-sync: settings.json statusLine is not an object; leaving it alone",
@@ -150,8 +159,14 @@ def sync_statusline(settings, template, scripts_dir):
         )
         return 0
 
+    # See the docstring: layout, not basename. `/Users/me/bin/statusline.sh` is
+    # the user's own script that merely shares our filename; a stale
+    # `/old/worktree/.claude/scripts/statusline.sh` is ours to repair.
+    owned_suffix = os.sep + os.path.join(".claude", "scripts", script)
     existing = live.get("command", "")
-    if not isinstance(existing, str) or os.path.basename(existing) != script:
+    if not isinstance(existing, str) or not (
+        existing == resolved or existing.endswith(owned_suffix)
+    ):
         # Someone else's status line (or a malformed entry) — not ours to touch.
         return 0
 
@@ -232,7 +247,11 @@ def main(argv):
     # path that was in fact written correctly.
     hooks_broken = False
     if "hooks" not in settings:
-        settings["hooks"] = {}
+        # Not in --statusline-only: seeding an empty hooks object there would
+        # ride along in the atomic write below and persist a hooks change the
+        # mode promised not to make.
+        if not statusline_only:
+            settings["hooks"] = {}
     elif not isinstance(settings["hooks"], dict):
         if not statusline_only:
             print("settings.json hooks section is not an object", file=sys.stderr)

--- a/.claude/hooks/register-hooks.py
+++ b/.claude/hooks/register-hooks.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Register hooks from global-settings.json into ~/.claude/settings.json.
+"""Register hooks and the statusLine command from global-settings.json into
+~/.claude/settings.json.
 
 Purpose:
     Reads the hook manifest from the skills worktree's global-settings.json
@@ -9,9 +10,21 @@ Purpose:
     are preserved. Placeholder paths (e.g. "/path/to/...") are repaired in
     place to point at the real skills-worktree hooks directory.
 
+    The same treatment is applied to the top-level `statusLine` key (issue
+    #779). It is not a hook event — it is a separate settings surface whose
+    `command` needs the identical placeholder-to-worktree resolution, and
+    which must auto-propagate at session start so the feature lands without
+    a setup.sh re-run.
+
 Inputs:
-    argv[1]  Path to the skills worktree root (e.g. ~/.claude/skills-worktree).
-             Used to locate global-settings.json and .claude/hooks/*.
+    argv      Path to the skills worktree root (e.g. ~/.claude/skills-worktree).
+              Used to locate global-settings.json, .claude/hooks/*, and
+              .claude/scripts/*.
+    --statusline-only
+              Sync only the statusLine key; skip hook registration entirely.
+              Used by setup-skills-worktree.sh, whose Step 6 already owns hook
+              registration through its own manifest — running both would risk
+              two registrations of the same hook.
 
 Outputs:
     ~/.claude/settings.json is mutated atomically (tempfile + os.replace).
@@ -25,7 +38,10 @@ Behavior:
       functionally equivalent — Claude Code reads all groups).
     - Hooks whose script file is missing from the hooks dir are skipped with
       a warning.
-    - If no hooks needed to be added, exits 0 without writing.
+    - A statusLine already pointing at a DIFFERENT script is the user's own
+      and is never touched; only our own script's path is repaired, and
+      sibling keys (padding, refreshInterval, …) are always preserved.
+    - If nothing needed to change, exits 0 without writing.
 """
 
 import json
@@ -93,30 +109,96 @@ def build_manifest(template_hooks, hooks_dir):
     return manifest
 
 
-def main(argv):
-    if len(argv) < 2:
-        print("usage: register-hooks.py <skills-worktree-path>", file=sys.stderr)
+def sync_statusline(settings, template, scripts_dir):
+    """Seed or path-repair settings["statusLine"] from the template.
+
+    Returns 1 when settings was modified, 0 otherwise. Never raises: a
+    statusLine problem must not stop hook registration.
+
+    The user's own statusLine (a command whose basename is not the template's
+    script) is left completely alone — this only owns the entry it installed.
+    When it does own the entry, only `command` is rewritten, so `padding`,
+    `refreshInterval`, and any other key the user tuned survive.
+    """
+    tpl = template.get("statusLine")
+    if not isinstance(tpl, dict):
+        return 0
+
+    tpl_command = tpl.get("command", "")
+    if not isinstance(tpl_command, str) or not tpl_command:
+        return 0
+
+    script = os.path.basename(tpl_command)
+    resolved = os.path.join(scripts_dir, script)
+    if not os.path.isfile(resolved):
+        print(
+            f"statusline-sync: skipping {script} (not found in {scripts_dir})",
+            file=sys.stderr,
+        )
+        return 0
+
+    live = settings.get("statusLine")
+
+    if live is None:
+        settings["statusLine"] = dict(tpl, command=resolved)
         return 1
 
-    skills_wt = argv[1]
+    if not isinstance(live, dict):
+        print(
+            "statusline-sync: settings.json statusLine is not an object; leaving it alone",
+            file=sys.stderr,
+        )
+        return 0
+
+    existing = live.get("command", "")
+    if not isinstance(existing, str) or os.path.basename(existing) != script:
+        # Someone else's status line (or a malformed entry) — not ours to touch.
+        return 0
+
+    if existing == resolved:
+        return 0
+
+    live["command"] = resolved
+    return 1
+
+
+def main(argv):
+    args = [a for a in argv[1:] if a != "--statusline-only"]
+    statusline_only = "--statusline-only" in argv[1:]
+
+    if not args:
+        print(
+            "usage: register-hooks.py [--statusline-only] <skills-worktree-path>",
+            file=sys.stderr,
+        )
+        return 1
+
+    skills_wt = args[0]
     settings_file = os.path.expanduser("~/.claude/settings.json")
     template_file = os.path.join(skills_wt, "global-settings.json")
     hooks_dir = os.path.join(skills_wt, ".claude", "hooks")
+    scripts_dir = os.path.join(skills_wt, ".claude", "scripts")
 
-    # Read template (source of truth for hook definitions)
+    # Read template (source of truth for hook and statusLine definitions)
     try:
         with open(template_file, encoding="utf-8") as f:
             template = json.load(f)
     except (FileNotFoundError, json.JSONDecodeError):
         return 0
-
-    template_hooks = template.get("hooks", {})
-    if not isinstance(template_hooks, dict):
+    if not isinstance(template, dict):
         return 0
 
-    manifest = build_manifest(template_hooks, hooks_dir)
-    if not manifest:
-        return 0
+    if statusline_only:
+        manifest = []
+    else:
+        template_hooks = template.get("hooks", {})
+        # A malformed hooks section must not suppress the statusLine sync — it is
+        # an independent settings surface.
+        manifest = (
+            build_manifest(template_hooks, hooks_dir)
+            if isinstance(template_hooks, dict)
+            else []
+        )
 
     # Read live settings
     try:
@@ -175,9 +257,13 @@ def main(argv):
     # on both the old and new events. Removing the sentinel guard on session-
     # start-sync.sh (issue #792) makes this critical — a stale PostToolUse entry
     # would run the full sync on every tool call.
+    #
+    # Skipped entirely with an empty manifest (--statusline-only): with nothing
+    # to compare against, this pass can only rewrite hook groups it has no
+    # opinion about.
     script_to_canonical_event = {item["script"]: item["event"] for item in manifest}
     removed_stale = 0
-    for event in list(live.keys()):
+    for event in list(live.keys()) if manifest else []:
         if not isinstance(live[event], list):
             continue
         surviving_groups = []
@@ -207,7 +293,13 @@ def main(argv):
         else:
             del live[event]
 
-    if added == 0 and removed_stale == 0:
+    # statusLine is a top-level settings surface, not a hook event, but it needs
+    # the identical placeholder-to-worktree resolution and the same auto-propagate
+    # behavior (issue #779). Folded into the same atomic write rather than a
+    # second one, so settings.json is never left half-synced.
+    statusline_changed = sync_statusline(settings, template, scripts_dir)
+
+    if added == 0 and removed_stale == 0 and statusline_changed == 0:
         return 0
 
     # Atomic write
@@ -234,6 +326,8 @@ def main(argv):
         parts.append(f"registered {added} new hook(s)")
     if removed_stale:
         parts.append(f"removed {removed_stale} stale event registration(s)")
+    if statusline_changed:
+        parts.append("synced statusLine command")
     print(f"hook-sync: {', '.join(parts)}", file=sys.stderr)
     return 0
 

--- a/.claude/hooks/register-hooks.py
+++ b/.claude/hooks/register-hooks.py
@@ -216,13 +216,24 @@ def main(argv):
             file=sys.stderr,
         )
         return 1
+    # A malformed live `hooks` section is a hook-registration failure, not a
+    # whole-run failure: statusLine is an independent top-level surface, and the
+    # sync below is the only thing that ever repairs its placeholder path.
+    # Bailing here used to strand the status line permanently —
+    # session-start-sync.sh runs this script every session, so one bad hooks
+    # value silently disabled the single recurring repair path statusLine has.
+    # Hook work is skipped and the malformed value is left exactly as the user
+    # wrote it; the exit code still reports the failure, and only the
+    # independent surface proceeds.
+    hooks_broken = False
     if "hooks" not in settings:
         settings["hooks"] = {}
     elif not isinstance(settings["hooks"], dict):
         print("settings.json hooks section is not an object", file=sys.stderr)
-        return 1
+        hooks_broken = True
+        manifest = []
 
-    live = settings["hooks"]
+    live = {} if hooks_broken else settings["hooks"]
 
     added = 0
     for item in manifest:
@@ -300,7 +311,7 @@ def main(argv):
     statusline_changed = sync_statusline(settings, template, scripts_dir)
 
     if added == 0 and removed_stale == 0 and statusline_changed == 0:
-        return 0
+        return 1 if hooks_broken else 0
 
     # Atomic write
     d = os.path.dirname(settings_file) or "."
@@ -329,7 +340,7 @@ def main(argv):
     if statusline_changed:
         parts.append("synced statusLine command")
     print(f"hook-sync: {', '.join(parts)}", file=sys.stderr)
-    return 0
+    return 1 if hooks_broken else 0
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/register-hooks.py
+++ b/.claude/hooks/register-hooks.py
@@ -225,15 +225,21 @@ def main(argv):
     # Hook work is skipped and the malformed value is left exactly as the user
     # wrote it; the exit code still reports the failure, and only the
     # independent surface proceeds.
+    #
+    # --statusline-only never touches hooks, so their shape is none of its
+    # business: it must neither warn nor fail on it. Step 6b reads any non-zero
+    # exit as "statusLine sync failed" and warns the user about a placeholder
+    # path that was in fact written correctly.
     hooks_broken = False
     if "hooks" not in settings:
         settings["hooks"] = {}
     elif not isinstance(settings["hooks"], dict):
-        print("settings.json hooks section is not an object", file=sys.stderr)
-        hooks_broken = True
+        if not statusline_only:
+            print("settings.json hooks section is not an object", file=sys.stderr)
+            hooks_broken = True
         manifest = []
 
-    live = {} if hooks_broken else settings["hooks"]
+    live = settings["hooks"] if isinstance(settings.get("hooks"), dict) else {}
 
     added = 0
     for item in manifest:
@@ -241,8 +247,13 @@ def main(argv):
         if event not in live:
             live[event] = []
         elif not isinstance(live[event], list):
+            # Same reasoning as the section-level check above, one level down: a
+            # single malformed event must not abort the run and strand the
+            # independent statusLine surface. Skip just this event, leave its
+            # value as the user wrote it, and keep registering the rest.
             print(f"settings.json hooks[{event!r}] is not a list", file=sys.stderr)
-            return 1
+            hooks_broken = True
+            continue
         match = find_existing(live[event], item["script"], item["matcher"])
         if match is True:
             continue

--- a/.claude/hooks/tests/statusline-register.test.sh
+++ b/.claude/hooks/tests/statusline-register.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# statusline-register.test.sh — Tests the statusLine sync in register-hooks.py (issue #779).
+#
+# statusLine is a top-level settings surface, not a hook event, so it gets its own
+# suite: seeding, placeholder repair, user-customization preservation, the
+# hands-off rule for someone else's status line, and --statusline-only isolation
+# from hook registration. Plus the two wiring assertions that the surface is
+# actually registered and actually resolved at install time.
+#
+# Offline: a temp HOME holds settings.json and a synthetic skills worktree
+# provides the template. Nothing touches the real ~/.claude.
+#
+# Run from repo root: bash .claude/hooks/tests/statusline-register.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SUT="$REPO_ROOT/.claude/hooks/register-hooks.py"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+export HOME="$TMP/home"; mkdir -p "$HOME/.claude"
+SETTINGS="$HOME/.claude/settings.json"
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+check_eq() { # expected actual label
+  if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected: $1, got: $2)"; fi
+}
+
+# --------------------------------------------------------------------------
+# Synthetic skills worktree: template + one hook + the statusline script.
+# --------------------------------------------------------------------------
+WT="$TMP/skills-worktree"
+mkdir -p "$WT/.claude/hooks" "$WT/.claude/scripts"
+printf '#!/bin/sh\nexit 0\n' > "$WT/.claude/hooks/demo-hook.sh"
+printf '#!/bin/sh\necho line\n' > "$WT/.claude/scripts/statusline.sh"
+chmod +x "$WT/.claude/hooks/demo-hook.sh" "$WT/.claude/scripts/statusline.sh"
+
+PLACEHOLDER="/path/to/claude-code-config/.claude/scripts/statusline.sh"
+RESOLVED="$WT/.claude/scripts/statusline.sh"
+
+write_template() {
+  jq -n --arg ph "$PLACEHOLDER" '{
+    statusLine: {type:"command", command:$ph, padding:0, refreshInterval:10},
+    hooks: {Stop: [{hooks: [{type:"command",
+                             command:"/path/to/claude-code-config/.claude/hooks/demo-hook.sh",
+                             timeout:5}]}]}
+  }' > "$WT/global-settings.json"
+}
+write_template
+
+write_settings() { printf '%s\n' "$1" > "$SETTINGS"; }
+sl() { jq -r "$1" "$SETTINGS" 2>/dev/null; }
+run_sut() { python3 "$SUT" "$@" >/dev/null 2>&1; }
+
+# --------------------------------------------------------------------------
+# 1. Seeding — no statusLine in live settings at all.
+# --------------------------------------------------------------------------
+write_settings '{"hooks":{}}'
+run_sut --statusline-only "$WT"
+check_eq 0 "$?" "seed: exit 0"
+check_eq "$RESOLVED" "$(sl '.statusLine.command')" "seed: command resolved to the worktree path"
+check_eq "command" "$(sl '.statusLine.type')" "seed: type carried from the template"
+check_eq "10" "$(sl '.statusLine.refreshInterval')" "seed: refreshInterval carried from the template"
+check_eq "0" "$(sl '.statusLine.padding')" "seed: padding carried from the template"
+
+# --------------------------------------------------------------------------
+# 2. Idempotent — a second run must not rewrite the file.
+# --------------------------------------------------------------------------
+BEFORE="$(cat "$SETTINGS")"
+run_sut --statusline-only "$WT"
+check_eq 0 "$?" "idempotent: exit 0 on a no-op run"
+check_eq "$BEFORE" "$(cat "$SETTINGS")" "idempotent: settings.json byte-identical after a second run"
+
+# --------------------------------------------------------------------------
+# 3. Placeholder repair preserves the user's own sibling keys.
+# --------------------------------------------------------------------------
+write_settings "$(jq -n --arg ph "$PLACEHOLDER" '{hooks:{},
+  statusLine:{type:"command", command:$ph, padding:2, refreshInterval:30}}')"
+run_sut --statusline-only "$WT"
+check_eq "$RESOLVED" "$(sl '.statusLine.command')" "repair: placeholder rewritten to the resolved path"
+check_eq "2" "$(sl '.statusLine.padding')" "repair: user padding preserved"
+check_eq "30" "$(sl '.statusLine.refreshInterval')" "repair: user refreshInterval preserved"
+
+# A stale-but-absolute path from an earlier worktree location is repaired too.
+write_settings "$(jq -n '{hooks:{},
+  statusLine:{type:"command", command:"/old/location/.claude/scripts/statusline.sh"}}')"
+run_sut --statusline-only "$WT"
+check_eq "$RESOLVED" "$(sl '.statusLine.command')" "repair: stale absolute path rewritten"
+
+# --------------------------------------------------------------------------
+# 4. Someone else's status line is never touched.
+# --------------------------------------------------------------------------
+CUSTOM='/Users/someone/bin/my-own-statusline.sh'
+write_settings "$(jq -n --arg c "$CUSTOM" '{hooks:{}, statusLine:{type:"command", command:$c}}')"
+run_sut --statusline-only "$WT"
+check_eq "$CUSTOM" "$(sl '.statusLine.command')" "custom status line: left untouched"
+
+# A non-object statusLine is malformed user config — warn, do not overwrite.
+write_settings '{"hooks":{},"statusLine":"not-an-object"}'
+run_sut --statusline-only "$WT"
+check_eq 0 "$?" "non-object statusLine: exit 0"
+check_eq "not-an-object" "$(sl '.statusLine')" "non-object statusLine: left untouched"
+
+# --------------------------------------------------------------------------
+# 5. Missing script — skip with a warning rather than register a broken path.
+# --------------------------------------------------------------------------
+MISSING_WT="$TMP/missing-script-wt"
+mkdir -p "$MISSING_WT/.claude/hooks" "$MISSING_WT/.claude/scripts"
+cp "$WT/global-settings.json" "$MISSING_WT/global-settings.json"
+write_settings '{"hooks":{}}'
+run_sut --statusline-only "$MISSING_WT"
+check_eq 0 "$?" "missing script: exit 0"
+check_eq "null" "$(sl '.statusLine')" "missing script: no statusLine registered"
+
+# --------------------------------------------------------------------------
+# 6. --statusline-only must not register hooks.
+# --------------------------------------------------------------------------
+write_settings '{"hooks":{}}'
+run_sut --statusline-only "$WT"
+check_eq "0" "$(jq '[.hooks[]?] | length' "$SETTINGS")" "--statusline-only: no hook events registered"
+check_eq "$RESOLVED" "$(sl '.statusLine.command')" "--statusline-only: statusLine still synced"
+
+# --------------------------------------------------------------------------
+# 7. Full mode does both.
+# --------------------------------------------------------------------------
+write_settings '{"hooks":{}}'
+run_sut "$WT"
+check_eq "$WT/.claude/hooks/demo-hook.sh" \
+  "$(jq -r '.hooks.Stop[0].hooks[0].command' "$SETTINGS")" "full mode: hook registered"
+check_eq "$RESOLVED" "$(sl '.statusLine.command')" "full mode: statusLine synced in the same run"
+
+# A template with no statusLine key must still register hooks.
+jq 'del(.statusLine)' "$WT/global-settings.json" > "$WT/global-settings.json.tmp"
+mv "$WT/global-settings.json.tmp" "$WT/global-settings.json"
+write_settings '{"hooks":{}}'
+run_sut "$WT"
+check_eq "$WT/.claude/hooks/demo-hook.sh" \
+  "$(jq -r '.hooks.Stop[0].hooks[0].command' "$SETTINGS")" "template without statusLine: hooks still registered"
+check_eq "null" "$(sl '.statusLine')" "template without statusLine: nothing invented"
+write_template
+
+# --------------------------------------------------------------------------
+# 8. Wiring — the real repo must actually declare and resolve this surface.
+# --------------------------------------------------------------------------
+REAL_TEMPLATE="$REPO_ROOT/global-settings.json"
+check_eq "$PLACEHOLDER" "$(jq -r '.statusLine.command' "$REAL_TEMPLATE")" \
+  "wiring: global-settings.json registers statusline.sh with the placeholder path"
+check_eq "command" "$(jq -r '.statusLine.type' "$REAL_TEMPLATE")" \
+  "wiring: statusLine is a command-type entry"
+# refreshInterval is in SECONDS and the harness clamps it to >= 1.
+REFRESH="$(jq -r '.statusLine.refreshInterval' "$REAL_TEMPLATE")"
+if [[ "$REFRESH" =~ ^[0-9]+$ ]] && (( REFRESH >= 1 )); then
+  ok "wiring: refreshInterval is an integer >= 1 second"
+else
+  bad "wiring: refreshInterval is an integer >= 1 second (got: $REFRESH)"
+fi
+
+if grep -q -- '--statusline-only' "$REPO_ROOT/setup-skills-worktree.sh"; then
+  ok "wiring: setup-skills-worktree.sh resolves the statusLine path at install time"
+else
+  bad "wiring: setup-skills-worktree.sh resolves the statusLine path at install time"
+fi
+
+# setup.sh's generic top-level merge must NOT seed statusLine: it would copy the
+# placeholder path verbatim, and the skills worktree is pinned to origin/main, so
+# a statusline.sh still on a feature branch cannot be resolved afterwards — the
+# placeholder would survive in settings.json and break
+# tests/test-setup.sh's "No placeholder paths" invariant. Registration owns it.
+if grep -qE '^SKIP_KEYS = \{.*"statusLine".*\}' "$REPO_ROOT/setup.sh"; then
+  ok "wiring: setup.sh skips statusLine in its generic merge (no unresolvable placeholder)"
+else
+  bad "wiring: setup.sh skips statusLine in its generic merge (no unresolvable placeholder)"
+fi
+
+if [[ -x "$REPO_ROOT/.claude/scripts/statusline.sh" ]]; then
+  ok "wiring: statusline.sh is committed executable"
+else
+  bad "wiring: statusline.sh is committed executable"
+fi
+
+echo "----------------------------------------"
+echo "statusline-register.test.sh: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/.claude/hooks/tests/statusline-register.test.sh
+++ b/.claude/hooks/tests/statusline-register.test.sh
@@ -145,6 +145,36 @@ check_eq "null" "$(sl '.statusLine')" "template without statusLine: nothing inve
 write_template
 
 # --------------------------------------------------------------------------
+# 7b. A malformed live `hooks` section must not strand the statusLine surface.
+# --------------------------------------------------------------------------
+# session-start-sync.sh runs this script every session, and that run is the only
+# recurring thing that ever repairs a statusLine path. Aborting on a bad `hooks`
+# value would disable it for good, so hook work is skipped while the independent
+# surface still syncs. The exit code must keep reporting the hooks failure, and
+# the user's malformed value must survive byte-for-byte — it is not ours to
+# "fix" by guessing.
+write_settings '{"hooks":"not-an-object"}'
+run_sut "$WT"; RC=$?
+check_eq 1 "$RC" "malformed hooks: exit 1 still reports the hook failure"
+check_eq "$RESOLVED" "$(sl '.statusLine.command')" "malformed hooks: statusLine still synced"
+check_eq "not-an-object" "$(sl '.hooks')" "malformed hooks: user's value left untouched"
+
+# Same isolation under --statusline-only, where hooks are out of scope entirely.
+write_settings '{"hooks":[1,2,3]}'
+run_sut --statusline-only "$WT"
+check_eq "$RESOLVED" "$(sl '.statusLine.command')" \
+  "malformed hooks + --statusline-only: statusLine still synced"
+check_eq "[1,2,3]" "$(jq -c '.hooks' "$SETTINGS")" \
+  "malformed hooks + --statusline-only: user's value left untouched"
+
+# An unparseable settings.json is a different case and must still hard-stop:
+# there is no safe write when the prior contents cannot be read back.
+write_settings '{"hooks":'
+run_sut --statusline-only "$WT"; RC=$?
+check_eq 1 "$RC" "unparseable settings.json: exit 1, no write attempted"
+check_eq '{"hooks":' "$(cat "$SETTINGS")" "unparseable settings.json: file left byte-identical"
+
+# --------------------------------------------------------------------------
 # 8. Wiring — the real repo must actually declare and resolve this surface.
 # --------------------------------------------------------------------------
 REAL_TEMPLATE="$REPO_ROOT/global-settings.json"

--- a/.claude/hooks/tests/statusline-register.test.sh
+++ b/.claude/hooks/tests/statusline-register.test.sh
@@ -106,6 +106,21 @@ run_sut --statusline-only "$WT"
 check_eq 0 "$?" "non-object statusLine: exit 0"
 check_eq "not-an-object" "$(sl '.statusLine')" "non-object statusLine: left untouched"
 
+# An explicit null is a user statement, not an absent key. `.get()` cannot tell
+# those apart; seeding over it would overwrite what reads as "disabled".
+write_settings '{"hooks":{},"statusLine":null}'
+run_sut --statusline-only "$WT"
+check_eq 0 "$?" "explicit null statusLine: exit 0"
+check_eq "null" "$(sl '.statusLine')" "explicit null statusLine: left untouched, not seeded"
+
+# Ownership is decided by layout, not basename: a user's own script that merely
+# shares the filename must survive, while a stale path in our layout is repaired.
+SAME_NAME='/Users/me/bin/statusline.sh'
+write_settings "$(jq -n --arg c "$SAME_NAME" '{hooks:{}, statusLine:{type:"command", command:$c}}')"
+run_sut --statusline-only "$WT"
+check_eq "$SAME_NAME" "$(sl '.statusLine.command')" \
+  "same-basename user script outside our layout: left untouched"
+
 # --------------------------------------------------------------------------
 # 5. Missing script — skip with a warning rather than register a broken path.
 # --------------------------------------------------------------------------
@@ -124,6 +139,13 @@ write_settings '{"hooks":{}}'
 run_sut --statusline-only "$WT"
 check_eq "0" "$(jq '[.hooks[]?] | length' "$SETTINGS")" "--statusline-only: no hook events registered"
 check_eq "$RESOLVED" "$(sl '.statusLine.command')" "--statusline-only: statusLine still synced"
+
+# Isolation is about the whole hooks surface, not just its contents: seeding an
+# empty hooks object would ride along in the same atomic write.
+write_settings '{}'
+run_sut --statusline-only "$WT"
+check_eq "$RESOLVED" "$(sl '.statusLine.command')" "--statusline-only on a hookless file: statusLine seeded"
+check_eq "null" "$(sl '.hooks')" "--statusline-only on a hookless file: no hooks key invented"
 
 # --------------------------------------------------------------------------
 # 7. Full mode does both.

--- a/.claude/hooks/tests/statusline-register.test.sh
+++ b/.claude/hooks/tests/statusline-register.test.sh
@@ -159,9 +159,22 @@ check_eq 1 "$RC" "malformed hooks: exit 1 still reports the hook failure"
 check_eq "$RESOLVED" "$(sl '.statusLine.command')" "malformed hooks: statusLine still synced"
 check_eq "not-an-object" "$(sl '.hooks')" "malformed hooks: user's value left untouched"
 
+# A single malformed EVENT must not abort the run either — the same reasoning
+# one level down. The other events still register and statusLine still syncs.
+write_settings '{"hooks":{"Stop":"not-a-list"}}'
+run_sut "$WT"; RC=$?
+check_eq 1 "$RC" "malformed hooks event: exit 1 still reports the hook failure"
+check_eq "$RESOLVED" "$(sl '.statusLine.command')" "malformed hooks event: statusLine still synced"
+check_eq '"not-a-list"' "$(jq -c '.hooks.Stop' "$SETTINGS")" \
+  "malformed hooks event: user's value left untouched"
+
 # Same isolation under --statusline-only, where hooks are out of scope entirely.
+# Their shape must not even colour the exit code: setup-skills-worktree.sh
+# Step 6b reads any non-zero exit as "statusLine sync failed" and warns about a
+# placeholder path that was in fact written correctly.
 write_settings '{"hooks":[1,2,3]}'
-run_sut --statusline-only "$WT"
+run_sut --statusline-only "$WT"; RC=$?
+check_eq 0 "$RC" "malformed hooks + --statusline-only: exit 0, hooks are out of scope"
 check_eq "$RESOLVED" "$(sl '.statusLine.command')" \
   "malformed hooks + --statusline-only: statusLine still synced"
 check_eq "[1,2,3]" "$(jq -c '.hooks' "$SETTINGS")" \

--- a/.claude/reference/diagrams/hook-lifecycle.md
+++ b/.claude/reference/diagrams/hook-lifecycle.md
@@ -20,6 +20,8 @@ sequenceDiagram
   Note over H: silence-detector-ack.sh, bgwork-ceiling-guard.sh, trust-flag-repair.sh, dirty-main-warn.sh
 ```
 
+**`statusLine` is deliberately absent from this diagram.** It is a settings surface, not a hook event — Claude Code runs it from the interactive render loop on a timer, not from the event dispatcher — so it has no place in an event sequence. It is nonetheless *deployed* like a hook (same placeholder path, same `register-hooks.py` resolution). Give it its own box if this stub ever grows a config-surface diagram; do not add it as an event here. See ARCHITECTURE.md "Status Line" (#779).
+
 The silence machinery straddles both events twice over (#803). `silence-detector.sh` / `silence-detector-ack.sh` cover silence *within* a turn; `bgwork-ceiling-arm.sh` / `bgwork-ceiling-guard.sh` cover silence *after* one ends, which is the case no PostToolUse hook can see — a thread waiting on a subagent makes no tool calls. The arm hook advises; only the Stop hook enforces, by returning `decision: block` so an unarmed turn cannot end. See `.claude/reference/bgwork-ceiling.md`.
 
 Skill telemetry straddles two of these events (#584): `skill-command-tracker.sh` catches user-typed slash commands at UserPromptSubmit — they arrive pre-expanded and never produce a `Skill` tool call — while `skill-usage-tracker.sh` catches model-initiated calls at PostToolUse. Both write through `.claude/hooks/lib/skill-usage-recorder.sh`, which dedupes so an invocation seen by both paths still counts once. See `.claude/memory/skill_usage_telemetry.md`.

--- a/.claude/reference/token-efficiency-audit-2026-07.md
+++ b/.claude/reference/token-efficiency-audit-2026-07.md
@@ -51,7 +51,7 @@ Evidence tiers: **A** = Anthropic primary/measured · **B** = community, reprodu
 | Delta-only fleet reporting (no unchanged-table reprints) | B | **ADOPT — shipped** | PMM Step 4 reuses the Step 6 fleet digest; table prints only on change/action/first tick |
 | Unchanged tick ⇒ no model-visible prose *at all* (event-driven wake) | B | **ADAPT — partial** | Full version needs a script-side poller that skips the model call entirely; v1 keeps the 5-min non-silence guarantee (one line). Poller-pattern rewrite = FU-2 |
 | Kill per-tool-call hook injections that repeat static/near-static values | A (Anthropic warns hook-injected timestamps go stale) | **ADOPT — shipped** | `silence-detector.sh` steady-state time injection now ≥60s apart (`SILENCE_TIME_INJECT_S`), warning path untouched |
-| Move time/monitor state to statusline (renders outside context, zero tokens) | A/B | **ADAPT — FU-3** | Statusline shows ET time · branch · agents; the user-facing timestamp *prefix* rule stays (user preference), but injection reliance shrinks |
+| Move time/monitor state to statusline (renders outside context, zero tokens) | A/B | **ADAPT — FU-3 shipped (#779), terminal-only** | `.claude/scripts/statusline.sh` renders ET time · branch · agents · watchers. The timestamp *prefix* rule and `timestamp-injector.sh` stay (the model still needs the time in context to write the prefix) — what shrinks is the human's reliance on reading it back out of the transcript. **Caveat found while implementing:** the status line only renders in the interactive terminal TUI; a headless desktop-app session never invokes it (`usage-limit-signal-audit-2026-07.md` §1), so the saving lands only in terminal sessions |
 | Heartbeat exists to prove liveness ⇒ delete it | C | **SKIP** | The 5-min heartbeat is a deliberate UX contract here; we shorten it, never drop it |
 
 ### Fixed context (rules, CLAUDE.md, MCP, skills)
@@ -101,7 +101,7 @@ Evidence tiers: **A** = Anthropic primary/measured · **B** = community, reprodu
 | 2 | Delta-aware PMM table + one-line heartbeats | High in monitor-heavy sessions (the #773 complaint) | **Low** — table still prints before any action; critical states always full | **Shipped (#773)** |
 | 3 | Subagent inheritance verify + de-dup embedded rules | Very high if confirmed (every spawn pays the corpus twice) | Medium — changes agent definitions; needs verification first | **FU-1** (ties #770) |
 | 4 | PMM dispatcher/references/scripts split | High (invocation + selection + compaction-survival) | Medium — big refactor of a load-bearing skill | **FU-2** |
-| 5 | Statusline for time/branch/agents | Medium — removes injection reliance, zero-context display | Low | **FU-3** |
+| 5 | Statusline for time/branch/agents | Medium in terminal sessions, **zero in headless ones** — see the caveat above | Low | **Shipped (#779)** |
 | 6 | Haiku routing for pure poll/classify ticks | Medium ($ more than tokens) | Medium — needs eval; escalation path must stay | **FU-4** |
 | 7 | Rule-corpus kernel shrink + path-scoping audit | High per-turn | Medium-high — literal-following models misfire on botched cuts; #768/#770 own it | **FU-5** |
 | 8 | MCP pruning + `/context`/`ccusage` measurement baseline | High in MCP-heavy sessions | Low | **FU-6** (ties #710) |
@@ -156,7 +156,7 @@ Headline "60–91% savings" figures across the ecosystem come from deliberately 
 
 - **FU-1:** Verify subagent instruction inheritance on the current harness version; if the hierarchy loads into custom agents, strip duplicated rule blocks from `.claude/agents/*` (keep role-specific prompts + safety blocks). Ties #770.
 - **FU-2:** Split `pr-monitor-and-manage` into dispatcher (≤150 lines) + `references/` + existing scripts; add script-side no-change short-circuit so an unchanged tick costs ~no model tokens.
-- **FU-3:** Statusline (ET time · branch · active agents · watchers) to replace injection reliance for time display.
+- ~~**FU-3:** Statusline (ET time · branch · active agents · watchers) to replace injection reliance for time display.~~ **Shipped in #779** — `.claude/scripts/statusline.sh` + a `statusLine` entry in `global-settings.json`, deployed through the same placeholder-resolution path as hooks. The timestamp-prefix rule and its injector hook are untouched by design. Renders in terminal TUI sessions only (see the caveat in the monitoring table above), so it is additive rather than a replacement for the injection.
 - **FU-4:** Poller model-routing eval (Haiku for classify-only ticks) + "set model/effort at spawn, never mid-session" note in `subagent-orchestration.md`.
 - **FU-5:** Rule-corpus kernel/path-scoping audit (with #768/#770).
 - **FU-6:** Measurement baseline: `/context` + `ccusage` per repo, MCP prune list, `permissions.deny` junk-dir blocks (ties #710).

--- a/.claude/scripts/README.md
+++ b/.claude/scripts/README.md
@@ -80,6 +80,7 @@ Scripts that manage the background-silence ceiling, launchd watchdog, and time h
 | Script | Purpose |
 |--------|---------|
 | `bgwork-ceiling.sh` | Hard ceiling on chat silence while background work (subagents, watchers) runs |
+| `statusline.sh` | Render the Claude Code status line — one stdout line of `ET time · branch · N agents · M watchers`; reads the session JSON on stdin, always exits 0 |
 | `install-silence-watchdog.sh` | Install the macOS launchd watchdog that monitors Claude heartbeat files |
 | `uninstall-silence-watchdog.sh` | Uninstall the macOS launchd silence watchdog |
 | `silence-watchdog.sh` | External launchd watchdog that checks heartbeat files when Claude is stalled (macOS only) |
@@ -201,3 +202,4 @@ All tests live in `tests/` and run offline (no network required). Run from the r
 | `skill-usage-merge.test.sh` | Tests for `skill-usage-merge.sh` |
 | `stale-cleanup.test.sh` | Tests for `stale-cleanup.sh` |
 | `state-lock.test.sh` | Tests for `state-lock.sh` |
+| `statusline.test.sh` | Tests for `statusline.sh` |

--- a/.claude/scripts/session-state.sh
+++ b/.claude/scripts/session-state.sh
@@ -314,7 +314,15 @@
 #   # -> exit 4: field '.prs["287"].last_cron_action' would become type 'string' but must be 'object'
 
 set -euo pipefail
-printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+# Usage telemetry. `script-usage-report.sh` derives adherence ratios from this
+# log, which assumes one line per DELIBERATE invocation — a choice some agent or
+# human made. Render-loop callers break that assumption: statusline.sh invokes
+# this script on a refresh timer, so it sets CLAUDE_SCRIPT_USAGE_LOG=0 to keep
+# thousands of automatic reads a day out of the denominator (issue #779).
+# Opt-out only, and never the default: every ordinary call still logs.
+if [[ "${CLAUDE_SCRIPT_USAGE_LOG:-1}" != "0" ]]; then
+  printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" >> "$HOME/.claude/script-usage.log"
+fi
 
 STATE_FILE="${HOME}/.claude/session-state.json"
 

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -160,7 +160,19 @@ if [[ -x "$SESSION_STATE_SH" ]]; then
   # Run from the session's directory so --session-view resolves the repo scope
   # from that repo's origin remote rather than from wherever the TUI happened to
   # spawn this process.
-  STATE_VIEW=$(cd "$WORK_DIR" 2>/dev/null && "$SESSION_STATE_SH" --session-view 2>/dev/null) || STATE_VIEW=""
+  #
+  # CLAUDE_SESSION_REPO has to be cleared for this one call. session-state.sh
+  # resolves scope as --repo > $CLAUDE_SESSION_REPO > cwd origin, so a value
+  # inherited from another checkout outranks the `cd` above and pairs THIS
+  # repo's branch with ANOTHER repo's counts — one line claiming to describe one
+  # repo while sourcing its two halves from two, with nothing on screen to say
+  # so. Unsetting inside the command substitution keeps the caller's
+  # environment untouched.
+  STATE_VIEW=$(
+    cd "$WORK_DIR" 2>/dev/null &&
+      unset CLAUDE_SESSION_REPO &&
+      "$SESSION_STATE_SH" --session-view 2>/dev/null
+  ) || STATE_VIEW=""
   if [[ -n "$STATE_VIEW" ]]; then
     COUNTS=$(printf '%s' "$STATE_VIEW" | jq -r '
       def arrlen($v): if ($v | type) == "array" then ($v | length) else 0 end;

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -51,7 +51,7 @@
 #     singularized at one ("1 agent", "1 watcher")
 #
 # Counts come from ~/.claude/session-state.json via `session-state.sh
-# --session-view`, so they are scoped to the invoking repo:
+# --session-view`:
 #     agents   = .active_agents | length
 #     watchers = (.polling_jobs | length)
 #              + (.prs[] | select(.babysit.active == true) | count)
@@ -59,6 +59,19 @@
 #   `.pmm_active` is counted because /pr-monitor-and-manage is a real watcher and
 #   records itself there rather than in `polling_jobs`, which has been empty by
 #   design since issue #827.
+#
+#   SCOPE, precisely — the two kinds of source differ, and saying only
+#   "scoped to the invoking repo" would over-promise:
+#     • Per-PR sources (agents, babysitters) ARE repo-scoped. `--session-view`
+#       drops entries belonging to another repo, so another checkout's work
+#       never appears here.
+#     • Session-global sources (`polling_jobs`, `pmm_active`) are NOT, because
+#       they are session facts rather than repo facts and pass through
+#       `--session-view` unfiltered by design. /pr-monitor-and-manage watches a
+#       fleet and records no repo of its own, so there is nothing to filter on;
+#       when it is running, it is genuinely running for this session whatever
+#       directory the TUI sits in. Counting it is the true reading, and the line
+#       is a session status line.
 #
 #   No network call, no `gh`, no CronList — this renders on a timer, so it reads
 #   only the local state file. `--session-view` is a lock-free read.

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# statusline.sh — Render the Claude Code status line: ET time · branch · agents · watchers.
+#
+# Implements FU-3 from .claude/reference/token-efficiency-audit-2026-07.md. A
+# status line renders OUTSIDE the model's context window, so everything it shows
+# costs zero tokens — unlike a hook injection, which is re-transmitted with every
+# later turn. This surfaces the three facts the agent otherwise re-states in prose
+# (ET time, branch, how much background work is in flight) for free.
+#
+# It SUPPLEMENTS, never replaces, CLAUDE.md's timestamp-prefix rule and the
+# UserPromptSubmit `timestamp-injector.sh` hook — the model still needs the time
+# in context to write the prefix. What shrinks is the human's reliance on reading
+# it out of the transcript.
+#
+# WHERE IT ACTUALLY RENDERS (read before filing a bug):
+#   The status-line command runs only inside the interactive terminal TUI — the
+#   executor lives in Claude Code's Ink/React render path and its stdout becomes
+#   `statusLineText`. A headless session (the Claude desktop app runs
+#   `claude --output-format stream-json …`) has no status line, so this script is
+#   never invoked there. Evidence and a live probe:
+#   .claude/reference/usage-limit-signal-audit-2026-07.md §1. Registering it is
+#   still correct — it costs nothing when unused and works in every terminal
+#   session — but the token saving only lands where a TUI is rendering.
+#
+# Usage:
+#   statusline.sh          # reads the session JSON Claude Code pipes on stdin
+#   statusline.sh --help
+#
+# Registered via the `statusLine` key in global-settings.json; the placeholder
+# path there is resolved to the deployed skills-worktree path by
+# .claude/hooks/register-hooks.py (session start) and setup-skills-worktree.sh
+# (install), the same way hook paths are.
+#
+# Input (stdin, optional):
+#   The status-line session JSON. Only two fields are read:
+#     .workspace.current_dir  — directory to resolve the git branch from
+#     .cwd                    — fallback when .workspace is absent
+#   Empty, absent, or malformed stdin is NOT an error: the script falls back to
+#   its own working directory. stdin is only read when it is not a TTY, so a
+#   manual run from a terminal returns immediately instead of blocking on `cat`.
+#
+# Output (stdout, exactly one line):
+#   <ET time> · <branch> [· N agents] [· M watchers]
+#
+#   e.g. "Sat Aug 1 09:37 PM ET · issue-779-statusline · 2 agents · 1 watcher"
+#
+#   - ET time uses CLAUDE.md's format: TZ='America/New_York' +'%a %b %-d %I:%M %p ET'
+#   - branch is the checked-out branch, or "(detached)" in a repo with no current
+#     branch, or "(no repo)" when the directory is not a git working tree
+#   - the agent and watcher segments are omitted entirely at zero, and are
+#     singularized at one ("1 agent", "1 watcher")
+#
+# Counts come from ~/.claude/session-state.json via `session-state.sh
+# --session-view`, so they are scoped to the invoking repo:
+#     agents   = .active_agents | length
+#     watchers = (.polling_jobs | length)
+#              + (.prs[] | select(.babysit.active == true) | count)
+#              + (1 when .pmm_active == true)
+#   `.pmm_active` is counted because /pr-monitor-and-manage is a real watcher and
+#   records itself there rather than in `polling_jobs`, which has been empty by
+#   design since issue #827.
+#
+#   No network call, no `gh`, no CronList — this renders on a timer, so it reads
+#   only the local state file. `--session-view` is a lock-free read.
+#
+# Exit codes:
+#   0 — always. A status line must never break the render, so every failure mode
+#       (no stdin, malformed stdin, no git, missing/corrupt session-state.json,
+#       missing session-state.sh) degrades to a shorter line instead of an error.
+#       --help also exits 0.
+#
+# NOTE — deliberately NOT logging to $HOME/.claude/script-usage.log, unlike every
+# other script here. This one is invoked by a render loop (refreshInterval, plus
+# every assistant message), so logging each call would add thousands of lines a
+# day and drown the real adherence signal `script-usage-report.sh` computes from
+# that file. Telemetry value here is nil — the invocation is automatic, never a
+# choice an agent made.
+
+set -uo pipefail
+
+NO_REPO_LABEL="(no repo)"
+DETACHED_LABEL="(detached)"
+
+print_usage() {
+  awk '
+    NR == 1 { next }
+    /^# Usage:/ { in_block = 1 }
+    in_block && !/^#/ { exit }
+    in_block {
+      sub(/^# ?/, "")
+      print
+    }
+  ' "$0"
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      # An unknown argument must not break the render either — ignore it.
+      ;;
+  esac
+done
+
+# --------------------------------------------------------------------------
+# 1. ET time (always shown)
+# --------------------------------------------------------------------------
+ET_TIME=$(TZ='America/New_York' date +'%a %b %-d %I:%M %p ET' 2>/dev/null)
+[[ -z "$ET_TIME" ]] && ET_TIME="ET time unavailable"
+
+# --------------------------------------------------------------------------
+# 2. Resolve the working directory from the session JSON
+# --------------------------------------------------------------------------
+# Only read stdin when something is piped in: a manual `statusline.sh` from a
+# terminal would otherwise hang in `cat` waiting for EOF.
+SESSION_JSON=""
+if [[ ! -t 0 ]]; then
+  SESSION_JSON=$(cat 2>/dev/null || true)
+fi
+
+WORK_DIR=""
+if [[ -n "$SESSION_JSON" ]]; then
+  # printf, not echo — echo mangles JSON containing backslash escapes under some
+  # shells (repo memory: zsh-echo-jq-json-corruption). Malformed JSON just leaves
+  # WORK_DIR empty and falls through to $PWD.
+  WORK_DIR=$(printf '%s' "$SESSION_JSON" \
+    | jq -r '(.workspace.current_dir // .cwd // "") | tostring' 2>/dev/null) || WORK_DIR=""
+fi
+if [[ -z "$WORK_DIR" || "$WORK_DIR" == "null" || ! -d "$WORK_DIR" ]]; then
+  WORK_DIR="$PWD"
+fi
+
+# --------------------------------------------------------------------------
+# 3. Branch
+# --------------------------------------------------------------------------
+# `branch --show-current` (git >= 2.22) also names an unborn branch in a freshly
+# initialized repo, where `rev-parse --abbrev-ref HEAD` fails outright. It prints
+# nothing on a detached HEAD, which is why the git-dir probe below distinguishes
+# "detached inside a repo" from "not a repo at all".
+BRANCH=$(git -C "$WORK_DIR" branch --show-current 2>/dev/null) || BRANCH=""
+if [[ -z "$BRANCH" ]]; then
+  if git -C "$WORK_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    BRANCH="$DETACHED_LABEL"
+  else
+    BRANCH="$NO_REPO_LABEL"
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# 4. Active agents and watchers from session-state.json
+# --------------------------------------------------------------------------
+AGENTS=0
+WATCHERS=0
+
+SESSION_STATE_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/session-state.sh"
+if [[ -x "$SESSION_STATE_SH" ]]; then
+  # Run from the session's directory so --session-view resolves the repo scope
+  # from that repo's origin remote rather than from wherever the TUI happened to
+  # spawn this process.
+  STATE_VIEW=$(cd "$WORK_DIR" 2>/dev/null && "$SESSION_STATE_SH" --session-view 2>/dev/null) || STATE_VIEW=""
+  if [[ -n "$STATE_VIEW" ]]; then
+    COUNTS=$(printf '%s' "$STATE_VIEW" | jq -r '
+      def arrlen($v): if ($v | type) == "array" then ($v | length) else 0 end;
+      [
+        arrlen(.active_agents),
+        ( arrlen(.polling_jobs)
+          + ( if (.prs | type) == "object"
+              then [ .prs[] | select((type == "object") and (.babysit?.active == true)) ] | length
+              else 0 end )
+          + ( if .pmm_active == true then 1 else 0 end )
+        )
+      ] | join(" ")
+    ' 2>/dev/null) || COUNTS=""
+    if [[ "$COUNTS" =~ ^([0-9]+)\ ([0-9]+)$ ]]; then
+      AGENTS="${BASH_REMATCH[1]}"
+      WATCHERS="${BASH_REMATCH[2]}"
+    fi
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# 5. Emit one line
+# --------------------------------------------------------------------------
+pluralize() { # count singular-noun -> "N noun" / "N nouns"
+  if [[ "$1" -eq 1 ]]; then
+    printf '%s %s' "$1" "$2"
+  else
+    printf '%s %ss' "$1" "$2"
+  fi
+}
+
+SEGMENTS=("$ET_TIME" "$BRANCH")
+[[ "$AGENTS" -gt 0 ]] && SEGMENTS+=("$(pluralize "$AGENTS" agent)")
+[[ "$WATCHERS" -gt 0 ]] && SEGMENTS+=("$(pluralize "$WATCHERS" watcher)")
+
+LINE="${SEGMENTS[0]}"
+for ((i = 1; i < ${#SEGMENTS[@]}; i++)); do
+  LINE="$LINE · ${SEGMENTS[i]}"
+done
+
+printf '%s\n' "$LINE"
+exit 0

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -75,6 +75,12 @@
 # day and drown the real adherence signal `script-usage-report.sh` computes from
 # that file. Telemetry value here is nil — the invocation is automatic, never a
 # choice an agent made.
+#
+# Staying silent here is only half of it: the `session-state.sh --session-view`
+# call below logs a line of its own on every invocation, which would move the
+# flood one script to the left rather than avoid it. That child call therefore
+# runs with CLAUDE_SCRIPT_USAGE_LOG=0 — an opt-out session-state.sh honors for
+# render-loop callers only, never by default.
 
 set -uo pipefail
 
@@ -168,10 +174,14 @@ if [[ -x "$SESSION_STATE_SH" ]]; then
   # repo while sourcing its two halves from two, with nothing on screen to say
   # so. Unsetting inside the command substitution keeps the caller's
   # environment untouched.
+  # CLAUDE_SCRIPT_USAGE_LOG=0 for the same reason this script does not log
+  # either (see the NOTE in the header): session-state.sh appends one
+  # script-usage.log line per call, and a render-loop caller would otherwise
+  # move the flood one script to the left rather than avoid it.
   STATE_VIEW=$(
     cd "$WORK_DIR" 2>/dev/null &&
       unset CLAUDE_SESSION_REPO &&
-      "$SESSION_STATE_SH" --session-view 2>/dev/null
+      CLAUDE_SCRIPT_USAGE_LOG=0 "$SESSION_STATE_SH" --session-view 2>/dev/null
   ) || STATE_VIEW=""
   if [[ -n "$STATE_VIEW" ]]; then
     COUNTS=$(printf '%s' "$STATE_VIEW" | jq -r '

--- a/.claude/scripts/tests/statusline.test.sh
+++ b/.claude/scripts/tests/statusline.test.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# statusline.test.sh — Offline unit tests for statusline.sh (issue #779).
+#
+# Fully offline and hermetic: a temp HOME holds the session-state fixtures, temp
+# git repos make branch resolution deterministic, and global/system git config is
+# disabled so a developer's own settings cannot change a result. No network, no
+# gh, no stubs — the real session-state.sh runs against the sandboxed HOME.
+#
+# Run from repo root: bash .claude/scripts/tests/statusline.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Run the real script in place: it resolves session-state.sh next to itself.
+SUT="$REPO_ROOT/.claude/scripts/statusline.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+export HOME="$TMP/home"; mkdir -p "$HOME/.claude"
+# Hermetic git: ignore whatever the developer or CI runner has configured.
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL="$TMP/gitconfig-none"
+# A repo key inherited from the environment would override the cwd-origin
+# resolution these fixtures depend on.
+unset CLAUDE_SESSION_REPO
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+check_eq() { # expected actual label
+  if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected: $1, got: $2)"; fi
+}
+check_contains() { # needle haystack label
+  if [[ "$2" == *"$1"* ]]; then ok "$3"; else bad "$3 (missing '$1' in: $2)"; fi
+}
+check_lacks() { # needle haystack label
+  if [[ "$2" != *"$1"* ]]; then ok "$3"; else bad "$3 (unexpected '$1' in: $2)"; fi
+}
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+mk_repo() { # dir branch [origin-url]
+  local d="$1" b="$2" origin="${3:-https://github.com/test/repo.git}"
+  mkdir -p "$d"
+  git -C "$d" init -q
+  git -C "$d" config user.email "test@example.com"
+  git -C "$d" config user.name "Test"
+  git -C "$d" config commit.gpgsign false
+  [[ -n "$origin" ]] && git -C "$d" remote add origin "$origin"
+  : > "$d/f.txt"
+  git -C "$d" add f.txt
+  git -C "$d" commit -qm init
+  git -C "$d" checkout -q -b "$b"
+}
+
+STATE="$HOME/.claude/session-state.json"
+write_state() { printf '%s\n' "$1" > "$STATE"; }
+clear_state() { rm -f "$STATE"; }
+
+# One agent entry. `pr` is what --session-view attributes by, so these must name
+# PRs tracked under the fixture repo to survive the repo-scoped projection.
+agent() { jq -cn --argjson pr "$1" '{id:("a" + ($pr|tostring)), task:"work", pr:$pr, phase:"A"}'; }
+
+# Full state document. Args: agents-json prs-json polling-json pmm-bool
+state_doc() {
+  jq -cn --argjson agents "$1" --argjson prs "$2" \
+         --argjson polling "$3" --argjson pmm "$4" \
+    '{schema_version:2, active_agents:$agents, polling_jobs:$polling,
+      pmm_active:$pmm, repos:{"test/repo":{prs:$prs}}}'
+}
+
+REPO="$TMP/wt"
+mk_repo "$REPO" "issue-779-statusline"
+
+NOREPO="$TMP/plain"; mkdir -p "$NOREPO"
+
+DETACHED="$TMP/detached"
+mk_repo "$DETACHED" "some-branch"
+git -C "$DETACHED" checkout -q --detach HEAD
+
+session_json() { jq -cn --arg d "$1" '{workspace:{current_dir:$d, project_dir:$d}, cwd:$d}'; }
+
+OUT=""
+RC=0
+run_sl() { OUT=$(printf '%s' "$1" | "$SUT" 2>/dev/null); RC=$?; }
+
+# --------------------------------------------------------------------------
+# 1. --help
+# --------------------------------------------------------------------------
+HELP_OUT=$("$SUT" --help 2>/dev/null); HELP_RC=$?
+check_eq 0 "$HELP_RC" "--help exits 0"
+check_contains "statusline.sh --help" "$HELP_OUT" "--help prints the usage block"
+
+# --------------------------------------------------------------------------
+# 2. Baseline — no state file at all. Time + branch only, never an error.
+# --------------------------------------------------------------------------
+clear_state
+run_sl "$(session_json "$REPO")"
+check_eq 0 "$RC" "no session-state file: exit 0 (fail-open)"
+check_eq 1 "$(printf '%s\n' "$OUT" | wc -l | tr -d ' ')" "no session-state file: exactly one line"
+check_contains "issue-779-statusline" "$OUT" "no session-state file: branch is rendered"
+check_lacks "agent" "$OUT" "no session-state file: no agent segment"
+check_lacks "watcher" "$OUT" "no session-state file: no watcher segment"
+
+# The ET segment must match the format CLAUDE.md's timestamp-prefix rule uses.
+ET_RE='^[A-Z][a-z]{2} [A-Z][a-z]{2} [0-9]{1,2} [0-9]{2}:[0-9]{2} (AM|PM) ET · '
+if [[ "$OUT" =~ $ET_RE ]]; then
+  ok "ET time segment matches the CLAUDE.md timestamp format"
+else
+  bad "ET time segment matches the CLAUDE.md timestamp format (got: $OUT)"
+fi
+
+# Separator is the middle dot used by the heartbeat format.
+check_contains " · " "$OUT" "segments are joined with the middle-dot separator"
+
+# --------------------------------------------------------------------------
+# 3. Zero counts are omitted, not rendered as "0 agents".
+# --------------------------------------------------------------------------
+write_state "$(state_doc '[]' '{}' '[]' false)"
+run_sl "$(session_json "$REPO")"
+check_eq 0 "$RC" "empty state: exit 0"
+check_lacks "0 agent" "$OUT" "empty state: zero agents omitted"
+check_lacks "0 watcher" "$OUT" "empty state: zero watchers omitted"
+check_eq "$(printf '%s' "$OUT" | awk -F' · ' '{print NF}')" 2 "empty state: exactly two segments"
+
+# --------------------------------------------------------------------------
+# 4. Active agents
+# --------------------------------------------------------------------------
+PRS_3='{"11":{},"12":{},"13":{}}'
+write_state "$(state_doc "[$(agent 11),$(agent 12),$(agent 13)]" "$PRS_3" '[]' false)"
+run_sl "$(session_json "$REPO")"
+check_contains "· 3 agents" "$OUT" "three active agents render as '3 agents'"
+check_lacks "watcher" "$OUT" "three active agents: watcher segment still omitted"
+
+write_state "$(state_doc "[$(agent 11)]" '{"11":{}}' '[]' false)"
+run_sl "$(session_json "$REPO")"
+check_contains "· 1 agent" "$OUT" "one active agent is singularized"
+check_lacks "1 agents" "$OUT" "one active agent: not pluralized"
+
+# --------------------------------------------------------------------------
+# 5. Watchers — polling_jobs, per-PR babysit, and the PR-fleet manager
+# --------------------------------------------------------------------------
+write_state "$(state_doc '[]' '{}' '[{"id":"j1"},{"id":"j2"}]' false)"
+run_sl "$(session_json "$REPO")"
+check_contains "· 2 watchers" "$OUT" "two polling_jobs render as '2 watchers'"
+
+BABYSIT_2='{"21":{"babysit":{"active":true}},"22":{"babysit":{"active":true}}}'
+write_state "$(state_doc '[]' "$BABYSIT_2" '[]' false)"
+run_sl "$(session_json "$REPO")"
+check_contains "· 2 watchers" "$OUT" "two active babysitters render as '2 watchers'"
+
+BABYSIT_MIXED='{"21":{"babysit":{"active":true}},"22":{"babysit":{"active":false}},"23":{}}'
+write_state "$(state_doc '[]' "$BABYSIT_MIXED" '[]' false)"
+run_sl "$(session_json "$REPO")"
+check_contains "· 1 watcher" "$OUT" "an inactive babysitter is not counted"
+
+write_state "$(state_doc '[]' '{}' '[]' true)"
+run_sl "$(session_json "$REPO")"
+check_contains "· 1 watcher" "$OUT" "pmm_active alone counts as one watcher"
+
+# All three watcher sources add up, alongside the agent count.
+write_state "$(state_doc "[$(agent 21)]" '{"21":{"babysit":{"active":true}}}' '[{"id":"j1"}]' true)"
+run_sl "$(session_json "$REPO")"
+check_contains "· 1 agent · 3 watchers" "$OUT" "agents and all three watcher sources combine"
+
+# --------------------------------------------------------------------------
+# 6. Repo scoping — another repo's agents and babysitters must not leak in.
+# --------------------------------------------------------------------------
+OTHER_STATE=$(jq -cn --argjson mine "[$(agent 11)]" --argjson theirs "[$(agent 99)]" \
+  '{schema_version:2,
+    active_agents:($mine + $theirs),
+    polling_jobs:[],
+    pmm_active:false,
+    repos:{"test/repo":{prs:{"11":{}}},
+           "other/repo":{prs:{"99":{"babysit":{"active":true}}}}}}')
+write_state "$OTHER_STATE"
+run_sl "$(session_json "$REPO")"
+check_contains "· 1 agent" "$OUT" "repo scoping: only this repo's agent is counted"
+check_lacks "watcher" "$OUT" "repo scoping: another repo's babysitter is not counted"
+
+# --------------------------------------------------------------------------
+# 7. Degraded inputs — every one of these must still render and exit 0.
+# --------------------------------------------------------------------------
+write_state "$(state_doc '[]' '{}' '[]' false)"
+
+run_sl ""
+check_eq 0 "$RC" "empty stdin: exit 0"
+check_eq 1 "$(printf '%s\n' "$OUT" | wc -l | tr -d ' ')" "empty stdin: exactly one line"
+if [[ "$OUT" =~ $ET_RE ]]; then
+  ok "empty stdin: ET time still rendered"
+else
+  bad "empty stdin: ET time still rendered (got: $OUT)"
+fi
+
+run_sl 'this is not json {{{'
+check_eq 0 "$RC" "malformed stdin: exit 0"
+check_eq 1 "$(printf '%s\n' "$OUT" | wc -l | tr -d ' ')" "malformed stdin: exactly one line"
+
+run_sl '{"workspace":{}}'
+check_eq 0 "$RC" "session JSON with no current_dir: exit 0"
+
+# .cwd is the documented fallback when .workspace.current_dir is absent.
+run_sl "$(jq -cn --arg d "$REPO" '{cwd:$d}')"
+check_contains "issue-779-statusline" "$OUT" "branch resolves from .cwd when .workspace is absent"
+
+# A path that does not exist falls back to the process working directory.
+run_sl '{"workspace":{"current_dir":"/nonexistent/path/for/test"}}'
+check_eq 0 "$RC" "nonexistent current_dir: exit 0"
+
+run_sl "$(session_json "$NOREPO")"
+check_contains "(no repo)" "$OUT" "a non-git directory renders the (no repo) placeholder"
+check_eq 0 "$RC" "non-git directory: exit 0"
+
+run_sl "$(session_json "$DETACHED")"
+check_contains "(detached)" "$OUT" "a detached HEAD renders the (detached) placeholder"
+check_lacks "(no repo)" "$OUT" "detached HEAD is distinguished from not-a-repo"
+
+# --------------------------------------------------------------------------
+# 8. Corrupt state file — fail open to the time+branch line, never an error.
+# --------------------------------------------------------------------------
+write_state '{ this is not valid json'
+run_sl "$(session_json "$REPO")"
+check_eq 0 "$RC" "corrupt session-state.json: exit 0 (fail-open)"
+check_contains "issue-779-statusline" "$OUT" "corrupt session-state.json: branch still rendered"
+check_lacks "agent" "$OUT" "corrupt session-state.json: no agent segment invented"
+check_lacks "watcher" "$OUT" "corrupt session-state.json: no watcher segment invented"
+
+# A wrong-typed active_agents must not be counted or crash the render.
+write_state '{"schema_version":2,"active_agents":"not-an-array","repos":{}}'
+run_sl "$(session_json "$REPO")"
+check_eq 0 "$RC" "wrong-typed active_agents: exit 0"
+check_lacks "agent" "$OUT" "wrong-typed active_agents: no agent segment"
+
+# --------------------------------------------------------------------------
+# 9. No sibling session-state.sh — the counts are unavailable, not fatal.
+#    Reached when the script is copied somewhere on its own, or mid-install
+#    before the skills worktree is fully populated.
+# --------------------------------------------------------------------------
+ORPHAN_DIR="$TMP/orphan"; mkdir -p "$ORPHAN_DIR"
+cp "$SUT" "$ORPHAN_DIR/statusline.sh"
+chmod +x "$ORPHAN_DIR/statusline.sh"
+write_state "$(state_doc "[$(agent 11)]" '{"11":{}}' '[]' true)"
+ORPHAN_OUT=$(printf '%s' "$(session_json "$REPO")" | "$ORPHAN_DIR/statusline.sh" 2>/dev/null)
+ORPHAN_RC=$?
+check_eq 0 "$ORPHAN_RC" "missing sibling session-state.sh: exit 0"
+check_contains "issue-779-statusline" "$ORPHAN_OUT" "missing sibling session-state.sh: time and branch still render"
+check_lacks "agent" "$ORPHAN_OUT" "missing sibling session-state.sh: counts silently omitted"
+
+echo "----------------------------------------"
+echo "statusline.test.sh: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/.claude/scripts/tests/statusline.test.sh
+++ b/.claude/scripts/tests/statusline.test.sh
@@ -194,6 +194,36 @@ check_eq "other/elsewhere" "${CLAUDE_SESSION_REPO:-}" \
 unset CLAUDE_SESSION_REPO
 
 # --------------------------------------------------------------------------
+# 5c. A render must not touch script-usage.log — through ANY script
+# --------------------------------------------------------------------------
+# The renderer staying silent is only half the story: it shells out to
+# session-state.sh, which logs a line per call. Left alone that moves the flood
+# one script to the left, inflating session-state.sh's count in
+# script-usage-report.sh's denominator with thousands of automatic reads a day.
+USAGE_LOG="$HOME/.claude/script-usage.log"
+write_state "$(state_doc "[$(agent 21)]" '{"21":{"babysit":{"active":true}}}' '[]' false)"
+rm -f "$USAGE_LOG"
+run_sl "$(session_json "$REPO")"
+check_contains "· 1 agent · 1 watcher" "$OUT" "usage-log case: the render still produced its counts"
+if [[ ! -s "$USAGE_LOG" ]]; then
+  ok "a render appends nothing to script-usage.log (renderer or session-state.sh)"
+else
+  bad "a render appends nothing to script-usage.log (got: $(tr '\n' '; ' < "$USAGE_LOG"))"
+fi
+
+# The opt-out must be exactly that — an opt-out. An ordinary call still logs, or
+# the suppression above would be silently disabling telemetry for everyone.
+SS="$REPO_ROOT/.claude/scripts/session-state.sh"
+rm -f "$USAGE_LOG"
+(cd "$REPO" && "$SS" --session-view >/dev/null 2>&1) || true
+if [[ -s "$USAGE_LOG" ]]; then
+  ok "session-state.sh still logs on an ordinary call (opt-out is not the default)"
+else
+  bad "session-state.sh still logs on an ordinary call (opt-out is not the default)"
+fi
+rm -f "$USAGE_LOG"
+
+# --------------------------------------------------------------------------
 # 6. Repo scoping — another repo's agents and babysitters must not leak in.
 # --------------------------------------------------------------------------
 OTHER_STATE=$(jq -cn --argjson mine "[$(agent 11)]" --argjson theirs "[$(agent 99)]" \

--- a/.claude/scripts/tests/statusline.test.sh
+++ b/.claude/scripts/tests/statusline.test.sh
@@ -168,6 +168,32 @@ run_sl "$(session_json "$REPO")"
 check_contains "· 1 agent · 3 watchers" "$OUT" "agents and all three watcher sources combine"
 
 # --------------------------------------------------------------------------
+# 5b. An inherited CLAUDE_SESSION_REPO must not skew the counts
+# --------------------------------------------------------------------------
+# session-state.sh resolves repo scope as --repo > $CLAUDE_SESSION_REPO > cwd
+# origin, so a key inherited from another checkout outranks the renderer's cd
+# into WORK_DIR. Left alone it would pair this repo's branch with another
+# repo's counts. The renderer clears the variable for that lookup; the export
+# below is what proves it, since "other/elsewhere" holds no state of its own
+# and every count would collapse to zero if the variable still won.
+write_state "$(state_doc "[$(agent 21)]" '{"21":{"babysit":{"active":true}}}' '[]' false)"
+export CLAUDE_SESSION_REPO=other/elsewhere
+run_sl "$(session_json "$REPO")"
+unset CLAUDE_SESSION_REPO
+check_contains "· 1 agent · 1 watcher" "$OUT" \
+  "inherited CLAUDE_SESSION_REPO does not skew agent/watcher counts"
+check_contains "issue-779-statusline" "$OUT" \
+  "inherited CLAUDE_SESSION_REPO: branch still resolves from WORK_DIR"
+
+# The parent environment must survive the renderer untouched — the unset lives
+# inside a command substitution precisely so it cannot leak back out.
+export CLAUDE_SESSION_REPO=other/elsewhere
+run_sl "$(session_json "$REPO")"
+check_eq "other/elsewhere" "${CLAUDE_SESSION_REPO:-}" \
+  "renderer does not clobber the caller's CLAUDE_SESSION_REPO"
+unset CLAUDE_SESSION_REPO
+
+# --------------------------------------------------------------------------
 # 6. Repo scoping — another repo's agents and babysitters must not leak in.
 # --------------------------------------------------------------------------
 OTHER_STATE=$(jq -cn --argjson mine "[$(agent 11)]" --argjson theirs "[$(agent 99)]" \

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,6 +8,7 @@ Deep-dive reference for the claude-code-config system. For setup instructions an
 - [Skills Worktree](#skills-worktree)
 - [Hook Lifecycle](#hook-lifecycle)
 - [Hook Auto-Registration](#hook-auto-registration)
+- [Status Line](#status-line)
 - [Session Lifecycle](#session-lifecycle)
 - [Multi-Agent Orchestration](#multi-agent-orchestration)
 - [Review Loop](#review-loop)
@@ -84,6 +85,26 @@ This means new hooks added to the repo are automatically picked up after merging
 1. Create the script in `.claude/hooks/`
 2. Add the hook entry to `global-settings.json`
 3. Merge to `main` — the next session start auto-registers it
+
+---
+
+## Status Line
+
+`statusLine` is a settings surface, not a hook event — a command Claude Code runs on a timer whose stdout is rendered in the footer. Its output goes to the **terminal, never the model's context window**, so what it displays costs zero tokens. That is the point: it shows the facts the agent would otherwise repeat in prose, without paying for them on every subsequent turn (issue #779, FU-3 of [`token-efficiency-audit-2026-07.md`](.claude/reference/token-efficiency-audit-2026-07.md)).
+
+`.claude/scripts/statusline.sh` renders one line:
+
+```text
+Sat Aug 1 09:37 PM ET · issue-779-statusline · 2 agents · 1 watcher
+```
+
+Counts come from `~/.claude/session-state.json` through `session-state.sh --session-view`, so they are scoped to the invoking repo. There is no network call and no `gh` — it renders on a timer, so it only reads local state, and it always exits 0 so a transient read failure shortens the line instead of breaking the render.
+
+**Deployment mirrors hooks.** The entry lives in `global-settings.json` with the same `/path/to/claude-code-config/...` placeholder, and `register-hooks.py` resolves it to the skills worktree — at install time via `setup-skills-worktree.sh` Step 6b (`--statusline-only`), and at session start via `session-start-sync.sh`, so it lands without a `setup.sh` re-run. A `statusLine` pointing at your own script is never touched, and `padding` / `refreshInterval` survive path repairs. `refreshInterval` is in **seconds** (the harness clamps it to ≥ 1).
+
+**It only renders in a terminal TUI.** The status-line executor lives in Claude Code's interactive render path; a headless session — which is how the Claude desktop app runs the agent — has no footer to draw and never invokes the command. Registering it is still correct (it costs nothing where it is unused), but the token saving only lands in terminal sessions. Evidence: [`usage-limit-signal-audit-2026-07.md`](.claude/reference/usage-limit-signal-audit-2026-07.md) §1.
+
+The status line **supplements** CLAUDE.md's timestamp-prefix rule rather than replacing it — the model still needs the time injected into context to write that prefix, so `timestamp-injector.sh` stays.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Thirteen hook scripts and hook utilities support Claude Code sessions:
 | `trust-flag-repair.sh` | Stop | Repairs trust flags in `~/.claude.json` for all projects |
 | `dirty-main-warn.sh` | Stop | Warns when root `main` has uncommitted drift and points to quarantine recovery |
 | `skill-usage-tracker.sh` | PostToolUse (Skill) | Appends each Skill invocation to `~/.claude/skill-usage.log` and updates `~/.claude/skill-usage.csv` for PM and maintenance audits |
-| `register-hooks.py` | Utility | Merges hook definitions from `global-settings.json` into user settings |
+| `register-hooks.py` | Utility | Merges hook definitions — and the top-level `statusLine` command — from `global-settings.json` into user settings |
 | `.claude/git-hooks/pre-commit` | Git pre-commit | Blocks commits made on `main` in the root checkout |
 
 All hooks are idempotent and fail-safe.
@@ -263,7 +263,7 @@ See `.claude/scripts/README.md` for detailed contracts, arguments, and exit code
 | File | Location | Purpose |
 |------|----------|---------|
 | `CLAUDE.md` | Repo root (symlinked to `~/.claude/`) | Core instructions: worktree policy, PR workflow, branch naming, acceptance criteria, CI merge gate |
-| `global-settings.json` | Merged into `~/.claude/settings.json` | Hooks, permissions (`allow` rules for autonomous operation), model preference, experimental flags, and optional **`extraKnownMarketplaces` / `enabledPlugins`** (Graphite CLI plugins when seeded) |
+| `global-settings.json` | Merged into `~/.claude/settings.json` | Hooks, the **`statusLine`** command (ET time · branch · agents · watchers — see [ARCHITECTURE.md](ARCHITECTURE.md#status-line)), permissions (`allow` rules for autonomous operation), model preference, experimental flags, and optional **`extraKnownMarketplaces` / `enabledPlugins`** (Graphite CLI plugins when seeded) |
 | `.coderabbit.yaml` | Repo root | CodeRabbit review config: assertive profile, token-efficiency checks, knowledge base integration |
 | `.claude/pm-config.md` | Per-repo (bootstrapped by `/pm`) | PM config: role, OKRs, team roster, infrastructure/architecture detection |
 | `~/.claude/session-state.json` | Runtime (auto-created) | Session orchestration state: PR phases, **CR hourly consumption** (`cr_hourly.events`), per-PR `cr_explicit_triggers`, active subagents, Greptile daily budget |

--- a/SETUP.md
+++ b/SETUP.md
@@ -54,12 +54,13 @@ Default locations (may vary with your setup):
 > Steps below are the logical workflow — see `setup.sh` for exact step numbering in script output.
 
 1. Creates the `~/.claude/skills/` directory
-2. Merges non-hook settings from `global-settings.json` into `~/.claude/settings.json` (existing keys like `permissions`, `model`, `env` are preserved — only missing keys are seeded), including optional Graphite plugin marketplace and `enabledPlugins` when absent
+2. Merges non-hook settings from `global-settings.json` into `~/.claude/settings.json` (existing keys like `permissions`, `model`, `env` are preserved — only missing keys are seeded), including optional Graphite plugin marketplace and `enabledPlugins` when absent. `statusLine` is skipped here alongside `hooks`: both carry path placeholders that only the skills-worktree registration in step 5 can resolve
 3. Optionally runs `gt repo init` for this checkout when Graphite CLI is installed (creates `.git/.graphite_repo_config`; setup fails if `gt repo init` fails when `gt` is installed)
 4. Verifies all hook scripts exist and are executable
 5. Runs `setup-skills-worktree.sh` which:
    - Creates a dedicated skills worktree and skill symlinks
    - Registers all hooks into `~/.claude/settings.json` with paths pointing to the skills worktree (migrates stale root-repo or placeholder paths automatically)
+   - Resolves the `statusLine` command the same way (your own status line, if you have one, is left untouched)
 6. Symlinks `~/.claude/CLAUDE.md` → skills worktree (`~/.claude/skills-worktree/CLAUDE.md`)
 7. Symlinks `~/.claude/rules` → skills worktree (`~/.claude/skills-worktree/.claude/rules`)
 8. Verifies all hook paths in `settings.json` resolve to existing, executable scripts

--- a/global-settings.json
+++ b/global-settings.json
@@ -30,6 +30,12 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_SUBAGENT_MODEL": "opus"
   },
+  "statusLine": {
+    "type": "command",
+    "command": "/path/to/claude-code-config/.claude/scripts/statusline.sh",
+    "padding": 0,
+    "refreshInterval": 10
+  },
   "hooks": {
     "Stop": [
       {

--- a/setup-skills-worktree.sh
+++ b/setup-skills-worktree.sh
@@ -509,6 +509,31 @@ for name in pruned:
     print(f"  {name} — pruned stale registration (script no longer exists)")
 PYTHON_SCRIPT
 
+# --- Step 6b: Resolve the statusLine command path in ~/.claude/settings.json ---
+#
+# `statusLine` is a top-level settings key, not a hook event, so the manifest
+# above does not cover it — but its `command` carries the same
+# /path/to/claude-code-config/... placeholder and needs the same resolution to
+# the skills worktree (issue #779).
+#
+# Delegated to register-hooks.py rather than reimplemented inline so install-time
+# and session-start behavior come from ONE implementation. `--statusline-only`
+# keeps it out of hook registration, which Step 6 above already owns through its
+# own manifest — running both against hooks could double-register.
+#
+# Non-fatal: a status line that failed to resolve is cosmetic, and must never
+# fail an install that otherwise succeeded.
+REGISTER_HOOKS_PY="$HOOKS_DIR/register-hooks.py"
+if [[ -f "$REGISTER_HOOKS_PY" ]]; then
+  echo ""
+  echo "Resolving statusLine command in $SETTINGS_FILE..."
+  if python3 "$REGISTER_HOOKS_PY" --statusline-only "$SKILLS_WORKTREE"; then
+    echo "  statusLine — resolved"
+  else
+    echo "  WARNING: statusLine sync failed (status line may show a placeholder path)"
+  fi
+fi
+
 echo ""
 echo "Done. Skills worktree: $SKILLS_WORKTREE"
 echo "Symlinks in:           $SKILLS_DIR"

--- a/setup.sh
+++ b/setup.sh
@@ -183,6 +183,17 @@ if not isinstance(settings, dict):
 # — the registration path skips those, whereas a blind merge would leave the
 # placeholder behind permanently. hooks: setup-skills-worktree.sh Step 6.
 # statusLine: Step 6b -> register-hooks.py --statusline-only (issue #779).
+#
+# Skipping cannot strand the feature. Two independent paths seed it, and both
+# seed rather than repair when the key is simply absent (register-hooks.py
+# sync_statusline: `live is None` -> seed):
+#   1. install time  — setup-skills-worktree.sh Step 6b (non-fatal by design:
+#                      an unresolved status line is cosmetic, never a failed
+#                      install), and
+#   2. every session — session-start-sync.sh runs register-hooks.py, so a miss
+#                      at step 1 self-heals on the next session.
+# Seeding here instead would write the placeholder verbatim and fail
+# tests/test-setup.sh's "No placeholder paths" assertion.
 SKIP_KEYS = {"hooks", "statusLine"}
 added = []
 for key, value in template.items():

--- a/setup.sh
+++ b/setup.sh
@@ -137,6 +137,7 @@ chmod +x "$SCRIPT_DIR/.claude/hooks"/*.sh "$SCRIPT_DIR/.claude/hooks"/*.py 2>/de
 # Merge non-hook keys from template into existing settings.json.
 # Existing keys are NEVER overwritten — only missing keys are seeded.
 # Hooks are NOT touched here — setup-skills-worktree.sh Step 6 handles them.
+# `statusLine` is skipped for the same reason (issue #779): see SKIP_KEYS below.
 if ! python3 - "$SETTINGS_SRC" "$SETTINGS_DST" <<'PYTHON_MERGE'
 import json
 import os
@@ -174,7 +175,15 @@ if not isinstance(settings, dict):
 
 # Seed missing non-hook keys from template
 # Never overwrite existing keys — user customizations take precedence
-SKIP_KEYS = {"hooks"}  # hooks are managed by setup-skills-worktree.sh
+#
+# Both skipped keys carry /path/to/claude-code-config/... placeholders that only
+# the skills-worktree registration path can resolve, so seeding them verbatim
+# here would write a broken path into settings.json. The skills worktree is
+# pinned to origin/main, so a script still on a feature branch is absent from it
+# — the registration path skips those, whereas a blind merge would leave the
+# placeholder behind permanently. hooks: setup-skills-worktree.sh Step 6.
+# statusLine: Step 6b -> register-hooks.py --statusline-only (issue #779).
+SKIP_KEYS = {"hooks", "statusLine"}
 added = []
 for key, value in template.items():
     if key in SKIP_KEYS:


### PR DESCRIPTION
## **User description**
Closes #779

FU-3 of `.claude/reference/token-efficiency-audit-2026-07.md`. A status line renders **outside** the model's context window, so what it displays costs zero tokens — unlike a hook injection, which is re-transmitted with every later turn. This puts ET time, branch, and in-flight background work there.

```text
Sat Aug 1 09:37 PM ET · issue-779-statusline · 2 agents · 1 watcher
```

## What changed

**`.claude/scripts/statusline.sh`** — reads the session JSON Claude Code pipes on stdin, emits one line, and **always exits 0**. Every failure mode (no stdin, malformed stdin, not a git repo, missing or corrupt `session-state.json`, missing sibling `session-state.sh`) shortens the line rather than breaking the render. Zero-count segments are omitted and singularized at one; branch degrades to `(detached)` or `(no repo)`. stdin is only read when it is not a TTY, so a manual run returns instead of hanging in `cat`.

Counts come from `~/.claude/session-state.json` via `session-state.sh --session-view`, so they are **repo-scoped**. Watchers sum `polling_jobs`, per-PR `babysit.active`, and `pmm_active` — the third because `/pr-monitor-and-manage` is a real watcher that records itself there, and `polling_jobs` has been empty by design since #827, so the first source alone would report zero during an active fleet watch. No network call, no `gh`, no `CronList`: this renders on a timer, so it reads local state only (`--session-view` is a lock-free read, ~0.26s).

**Deployment mirrors hooks.** `global-settings.json` gains a top-level `statusLine` with the usual `/path/to/claude-code-config/...` placeholder. `register-hooks.py` resolves it to the skills worktree — at install time via `setup-skills-worktree.sh` **Step 6b** (`--statusline-only`) and at session start via `session-start-sync.sh`, so the feature lands **without a `setup.sh` re-run**. Delegating both paths to one implementation (rather than a second inline copy in the setup script) is why `--statusline-only` exists: Step 6 already owns hook registration through its own manifest, and running both against hooks could double-register.

The sync is conservative: seeded when absent, path-repaired when it points at *our* `statusline.sh`, and **left completely alone** when you have pointed `statusLine` at your own script. `padding` and `refreshInterval` survive a path repair. It is folded into the existing atomic write, so `settings.json` is never left half-synced.

**One correction to the plan.** CodeRabbit's plan had `setup.sh` Step 2 seed `statusLine` and then be repaired later. That is unsafe: the skills worktree is pinned to `origin/main`, so a `statusline.sh` still on a feature branch is absent from it, Step 6b correctly skips it — and the placeholder Step 2 seeded then **survives permanently** in `settings.json`, breaking `tests/test-setup.sh`'s `No placeholder paths in settings.json` invariant. `statusLine` therefore joins `hooks` in `SKIP_KEYS`: both are path-bearing keys owned by the registration path, not by the generic merge. Verified by extracting and running setup.sh's merge heredoc against the real template.

## Verified against the harness, not assumed

Read out of the Claude Code 2.1.219 binary's own embedded `statusLine` contract:

- `workspace.current_dir` / `cwd` are the documented directory fields (there is no general `branch` field — `worktree.branch` only exists in `--worktree` sessions), so the branch is resolved with `git -C`.
- `refreshInterval` is in **seconds**, clamped by the harness to `>= 1` (`Math.max(1, G) * 1000`). Set to 10.
- Multi-line output is supported but a single line is truncated-to-fit, which is what we want.

## Honest limitation: terminal TUI only

The status-line executor lives in Claude Code's interactive Ink/React render path. A **headless** session — which is how the Claude desktop app runs the agent (`claude --output-format stream-json …`) — has no footer to draw and **never invokes the command**. This is already documented first-hand in this repo: `.claude/reference/usage-limit-signal-audit-2026-07.md` §1, including a live probe that recorded zero invocations. I re-confirmed the desktop app is the current runtime here.

Registering it is still correct — it costs nothing where it is unused and works in every terminal session — but the token saving **only lands in terminal sessions**. Rather than quietly marking FU-3 done, the audit entry now says "shipped, terminal-only" and carries the caveat, and the ranked-recommendations row reads "Medium in terminal sessions, zero in headless ones". Surfacing this as a decision point: if terminal sessions are not part of the workflow, this PR is close to inert in practice, and that is worth knowing before it is counted as a token win.

## Deliberate deviation from repo convention

`statusline.sh` does **not** append to `$HOME/.claude/script-usage.log`, unlike every other script in `.claude/scripts/`. It is driven by a render loop (`refreshInterval` plus every assistant message), so logging each call would add thousands of lines a day and swamp the adherence ratios `script-usage-report.sh` computes from that file. The telemetry value is nil — the invocation is automatic, never a choice an agent made. Rationale is written into the script header rather than left implicit.

## Not touched, by design

The CLAUDE.md **timestamp-prefix rule** and `timestamp-injector.sh` are unchanged: the model still needs the time *in context* to write the prefix, so the status line supplements it rather than replacing it. **The rule corpus is untouched** — `git diff` against `CLAUDE.md` and `.claude/rules/` is empty, so the word budget is unaffected (`rule-lint: OK`).

`statusLine` is deliberately **not** added to the hook-lifecycle sequence diagram — it is not a hook event. `hook-lifecycle.md` now says so explicitly so a future editor does not add it.

## Tests

95 new assertions across two auto-discovered suites (no workflow edit):

- **`.claude/scripts/tests/statusline.test.sh`** (51) — the renderer. Temp `HOME` for fixtures, temp git repos for deterministic branches, `GIT_CONFIG_NOSYSTEM`/`GIT_CONFIG_GLOBAL` disabled so a developer's own git config cannot change a result. Covers zero/one/many agents, all three watcher sources and their sum, inactive babysitters, repo scoping (another repo's agents and babysitters must not leak in), empty/malformed/`current_dir`-less stdin, non-repo and detached HEAD, corrupt and wrong-typed state, and a missing sibling `session-state.sh`.
- **`.claude/hooks/tests/statusline-register.test.sh`** (44) — the registration path. Seeding, idempotency (byte-identical file on a second run), placeholder repair with user `padding`/`refreshInterval` preserved, stale-absolute-path repair, hands-off for a user's own status line, non-object and missing-script handling, `--statusline-only` isolation from hook registration, full-mode doing both, a template with no `statusLine` still registering hooks, and the wiring invariants (template placeholder, `refreshInterval >= 1`, Step 6b present, `SKIP_KEYS` containing `statusLine`, script committed executable).

**Both suites were mutation-tested.** Seventeen mutations were applied to the code under test and every one turned the suite red on exactly the assertion designed to catch it — dropping the `pmm_active` source, rendering zero counts, collapsing detached-into-no-repo, making the sync a no-op, clobbering user keys, hijacking a custom status line, letting `--statusline-only` register hooks, and skipping the missing-script check. Restored files went green again. Green here means the assertions are load-bearing, not that they ran.

## Local review coverage

**Local review coverage:** none — both CLIs failed, self-review only.

- **CodeAnt CLI:** `API Error: Access denied (403)` on all 12 files, on both the initial run and the single permitted retry — the known persistent account-level entitlement failure (Issue #643), not auth. Its stdout was a textbook **false clean** (`"issues": [], "error": null, "noFiles": false`) with the real failure on stderr; classified as a failed run per `cr-local-review.md`. `codeant logout`/`login` was **not** run.
- **CodeRabbit CLI:** hung past the 2-minute bound still in `phase: analyzing`, emitting only heartbeats. Dropped per the >2-minute rule; not retried.

Neither CLI emitted any findings before being dropped, so there is nothing pending to waive.

Run locally in their place: `shellcheck -x` on all new bash (clean; the only repo hit is a pre-existing SC2001 in an untouched part of `setup.sh`), `run-hook-tests.sh` (65 suites, 0 failed), `run-python-tests.sh` (142/142, and the 3.9 import smoke path — local `python3` is 3.9.6), `rule-lint`, `reference-catalog-lint`, `skill-catalog-lint`, `verbatim-block-lint`. Self-review also added the missing-`session-state.sh` test case after spotting that fail-open branch was uncovered.

## Test plan

- [x] `.claude/scripts/statusline.sh` renders `ET time · branch · N agents · M watchers` on one stdout line, in the CLAUDE.md ET format — `statusline.test.sh` "ET time segment matches the CLAUDE.md timestamp format", "exactly one line"
- [x] Counts come from `session-state.json` via `session-state.sh` with no network/`gh`/`CronList` call, and a render appends nothing to `script-usage.log` through either script — `statusline.sh` reads only `--session-view`, and its sole `gh`/`Cron` occurrence is the header comment stating there is no such call — no invocation of either
- [x] Watchers cover `polling_jobs`, per-PR `babysit.active`, and the PR-fleet manager, and sum correctly — `statusline.test.sh` four watcher cases plus "agents and all three watcher sources combine"
- [x] Zero-count segments are omitted rather than rendered as `0 agents` — "empty state: zero agents omitted" / "exactly two segments"
- [x] Every degraded input still renders and exits 0 (no/malformed stdin, no repo, detached HEAD, corrupt or wrong-typed state, missing `session-state.sh`) — ten `statusline.test.sh` cases asserting `exit 0`, plus the detached-HEAD case asserting the `(detached)` placeholder and its distinctness from `(no repo)`
- [x] Per-PR counts (agents, babysitters) are scoped to the invoking repo and an inherited `CLAUDE_SESSION_REPO` cannot skew them; the two session-global sources (`polling_jobs`, `pmm_active`) are deliberately not repo-filtered and the header says so — "repo scoping: only this repo's agent is counted" / "another repo's babysitter is not counted" / "inherited CLAUDE_SESSION_REPO does not skew agent/watcher counts"
- [x] `global-settings.json` registers `statusLine` with the placeholder path and `refreshInterval >= 1` second — `statusline-register.test.sh` wiring assertions
- [x] The placeholder resolves to a working absolute path at install time and at session start, and a malformed `hooks` section cannot strand that repair — Step 6b (`--statusline-only`) and `session-start-sync.sh` -> `register-hooks.py`; seeding, repair, and the malformed-`hooks` isolation asserted in `statusline-register.test.sh`
- [x] User customization survives: a custom `statusLine` is never touched and `padding`/`refreshInterval` survive a path repair — "custom status line: left untouched", "repair: user padding/refreshInterval preserved"
- [x] No unresolvable placeholder can reach `settings.json` — `statusLine` is in setup.sh's `SKIP_KEYS`, asserted by a wiring test; verified by running the extracted merge heredoc against the real template
- [x] The CLAUDE.md timestamp-prefix rule and the time-injection hooks are unmodified, and the rule corpus is unchanged — `git diff` touches neither `CLAUDE.md` nor `.claude/rules/`; `rule-lint: OK`
- [x] Documentation records the new surface and closes out FU-3 — ARCHITECTURE.md "Status Line" (+ ToC), `.claude/scripts/README.md` script and test rows, `.claude/hooks/README.md`, README.md, SETUP.md, `hook-lifecycle.md` non-event note, and the audit marked shipped **with the terminal-only caveat**
- [x] Both new suites are auto-discovered and the full suite stays green — `run-hook-tests.sh`: 65 suites, 0 failed, no workflow edit


___

## **CodeAnt-AI Description**
Display ET time, branch, and active background work in the Claude Code status line

### What Changed
- Interactive terminal sessions show the current ET time, Git branch, active agents, and watchers without adding those details to the model’s context
- Zero-count agent and watcher sections are hidden, while branch and status data gracefully fall back when session or Git information is unavailable
- Status-line setup is installed and repaired automatically without overwriting a user’s custom status line or its display settings
- Added offline coverage for rendering, degraded inputs, repository scoping, and installation behavior

### Impact
`✅ Lower context usage in terminal sessions`
`✅ Clearer background-work visibility`
`✅ Fewer broken status lines after worktree changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>



