### PR TITLE
docs(#879): ratchet cap is a visibility mechanism, not the gate

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -59,6 +59,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `skill-usage-durability.md` — how skill-usage telemetry records survive machine moves, OS reinstalls, and `~/.claude` cleanups (#572)
 - `trust-dialog-repair.md` — why `~/.claude.json` re-prompts per worktree, the three flags, and repair-script behavior (`trust-dialog-fix.md`)
 - `double-loading-fix.md` — decision record for suppressing the duplicate global CLAUDE.md + rules copy via project-local `claudeMdExcludes` (#461)
+- `budget-cap-raise-decision.md` — decision record: the `.budget-soft-cap` ratchet is a visibility mechanism raisable with a PR-body justification line; the 12,000/13,000 word limits are the actual gate (#879)
 - `skill-authoring-patterns.md` — authoring *judgment* for skills/rules (description-as-trigger, match-form-to-failure, bulletproofing); complements CONTRIBUTING.md mechanics
 - `subagent-phase-guardrails.md` — canonical single home for the SAFETY/MINDSET/SKILLS verbatim blocks and RULES placeholder shared by `/subagent` Phase A/B/C spawn-prompt templates; CI-guarded by `verbatim-block-lint.sh` (#805)
 - `verification-evidence-patterns.md` — claim→evidence checklist for AC, exit reports, and merge claims; complements phase protocols (#417 harvest from superpowers)

--- a/.claude/reference/budget-cap-raise-decision.md
+++ b/.claude/reference/budget-cap-raise-decision.md
@@ -1,0 +1,77 @@
+# Budget Cap Raise Decision (#879)
+
+## Decision
+
+**The ratchet cap is a visibility mechanism, not the budget ceiling.** It remains a **blocking CI check**: `.claude/rules/.budget-soft-cap` continues to hold `max(count + 750, 8500)` and `rule-lint.sh` continues to fail when the corpus exceeds it. "Not the gate" describes its *role*, not its severity — the blocking is what forces every increment to appear as a deliberate, reviewable line in a diff, while the absolute budget it is not allowed to raise past lives in the 12,000/13,000 limits below. What changes is when raising it is legitimate:
+
+- **Raising the cap is permitted when it accommodates a justified addition.** The raise requires an explicit **PR-body justification line** naming what was added and why it belongs in the auto-loaded corpus rather than in `.claude/reference/`. No accompanying cuts are required.
+- **The 12,000-word soft warning and 13,000-word hard fail are the actual gate.** They are absolute: no justification line raises them, and `rule-lint.sh` errors above 13,000 regardless of the cap.
+- **`--update-cap` still only lowers or holds.** The one-way ratchet is unchanged, so a cap raise never happens as a side effect of running the tool.
+- **The justification line is a review-time convention, not a CI check.** No workflow reads PR-body text today, and adding that infrastructure is out of proportion to the problem. Reviewers and the merge gate enforce it.
+
+Prior wording in `CLAUDE.md` — "`--update-cap` only after intentional cuts" — is superseded by this record.
+
+### How a raise is actually performed (`config-protection.py`)
+
+**An agent cannot hand-edit the cap.** `.claude/rules/.budget-soft-cap` and `.github/scripts/rule-lint.sh` are both in `PROTECTED_RELATIVE_SUFFIXES` in `.claude/hooks/config-protection.py`, which blocks every Write/Edit/Bash modification of either one. That guard is deliberate and stays — it is what stops a reflexive "raise the number until CI goes green," which this decision does **not** authorize. Permitted-with-justification is not permitted-on-impulse.
+
+Two paths remain, and they cover the cases that matter:
+
+1. **`bash .github/scripts/rule-lint.sh --update-cap --allow-raise`** — the sanctioned in-repo escape hatch (#832). It writes the formula value `count + 750` and prints `old → new (+delta) [--allow-raise]`, so the raise is audited in CI output as well as in the diff. Use this when the formula value is the value you want.
+
+   To be precise about why this works: `config-protection.py` inspects the **tool call**, not a script's internal file writes, so *no* `rule-lint.sh` invocation is intercepted — there is no argument-aware allowlist, and `--allow-raise` is not specially blessed. What the hook actually blocks is a hand-edit of the cap file. The practical effect is still the wanted one — a cap change that goes through the tool is the one that prints its own delta — but do not read the hook as enforcing that.
+2. **An owner edit of `.claude/rules/.budget-soft-cap`** — required when the cap must land on a *specific* number rather than `count + 750`. A human keystroke is the accountability mechanism here, and it is a stronger one than a PR-body line.
+
+Either way the PR-body justification line is still required.
+
+### Pending owner action: align the cap to 12,000
+
+The owner's decision comment on #879 called for a first deliberate application — raising the cap `11749 → 12000` so the ratchet sits exactly on the soft-warning limit, rather than drifting above it where a corpus could cross 12,000 with only a warning. `--allow-raise` cannot produce that number (`count + 750` was ~12,470 here, *above* the soft warning and so self-defeating), and path 2 is an owner action, so **the PR that implemented this decision did not raise the cap**. It did not need to: its `CLAUDE.md` amendment was funded by restatement cuts in the same file, leaving the corpus slightly *below* where it started.
+
+The raise remains worth doing on its own merits, as a one-line owner edit:
+
+```bash
+printf '%s' 12000 > .claude/rules/.budget-soft-cap   # run outside a Claude session; the hook blocks agents
+```
+
+Once it lands, headroom between the cap and the hard fail is 1,000 words, and any future raise runs out of room at 13,000 — where no justification line helps. That is the gate the ratchet is deliberately not.
+
+## Rationale
+
+**The ratchet is a rolling window, not a ceiling.** Because the formula is `count + 750`, every legitimate raise permanently enlarges the corpus that loads into every session. Raising freely defeats the purpose. But `main` sat at 11,732 words against a cap of 11,749 when #879 was filed — under a cuts-only rule, *no* rule addition could land until someone first cut unrelated rules. That makes the corpus effectively immutable and couples every rules change to an unrelated slimming pass.
+
+**A guard that blocks all forward progress gets bypassed.** PR #739 and PR #736 both raised the cap to accommodate an addition with no accompanying cuts, and PR #787's Phase B agent proposed the same. Written rule and practice had already diverged twice before the tension became load-bearing. A rule nobody follows is worse than a weaker rule everyone follows — the honest fix is to write down the rule that is actually being applied, and attach the accountability (a named justification) that makes it defensible.
+
+**Two numbers with clear roles beat one number doing two jobs.** The 12,000/13,000 limits answer "is the corpus too expensive?" — a question about absolute cost, paid on every turn. The ratchet answers "did this PR grow the corpus, and did anyone notice?" — a question about visibility. Collapsing them into a single hard ceiling loses the second signal; dropping the ratchet to a warning loses the first enforcement point. Keeping both, with distinct roles, is what the ticket recommended and what the owner adopted.
+
+**Why the ratchet stays an error rather than becoming a warning.** CodeRabbit's plan for this issue proposed converting the ratchet-cap breach in `rule-lint.sh` from `::error` to `::warning`. That was declined: a warning is not visible in a diff and does not require anyone to act, so the visibility the ratchet exists to provide would be delivered by a line of CI output nobody has to read. Keeping the error means a raise is a committed file change with a justification attached — exactly the accountability that distinguishes this decision from "growth is free". The `.github/scripts/tests/rule-lint.test.sh` case `(h)` pins the hard-fail behavior so a future edit cannot silently soften it back.
+
+**Known stale string.** The breach message in `rule-lint.sh` still reads "Run rule-lint.sh `--update-cap` only after intentional corpus reduction" — the superseded wording. It could not be corrected alongside this decision because `config-protection.py` blocks agent edits of that script (see below); it is cosmetic, since the exit behaviour it describes is unchanged and correct. Whoever next edits the script for another reason should replace it with a pointer to this record. The same phrase in `instruction-set-audit-2026-07.md` is deliberately left alone: that file is a point-in-time audit, exempt from corpus-wide rewrites per `.claude/reference/README.md`.
+
+## Explicitly Rejected
+
+- **Option 1 — enforce the written rule as-is** (every addition paid for by cuts in the same PR). Rejected: it couples unrelated changes, makes #796's weekly slimming pass a hard prerequisite for all rules work, and is the rule that practice had already routed around three times. It also produces a perverse incentive to cut whatever is cheapest to cut rather than whatever is least valuable.
+- **Option 4 — route additions to `.claude/reference/` by default**, treating any auto-loaded growth as needing owner sign-off. Rejected: it turns every rules PR into a judgment call escalated to one person, and the "does this belong in the corpus?" question is already answered — as a written justification — under Option 2's line. `CLAUDE.md`'s standing "Keep growth out of the corpus" guidance already applies the same pressure without the sign-off bottleneck.
+- **A CI check that greps the PR body for the justification line.** Rejected: no existing workflow reads PR-body text, so this is net-new infrastructure for a convention the merge gate already covers at review time. Revisit only if the convention is observably skipped.
+- **Raising the cap via `--update-cap --allow-raise` in the implementing PR**, as a substitute for the 12,000 the owner asked for. Rejected: `count + 750` was ~12,470 at the time, which puts the ratchet *above* the 12,000 soft warning and hands back the drift the alignment was meant to remove. A number that defeats the reason for the change is not a close-enough version of it.
+- **Removing `.claude/rules/.budget-soft-cap` from `config-protection.py` so agents could perform the raise directly.** Rejected: it deletes a live guard to save one owner keystroke, in a PR authored by the very agent the guard constrains — and the two sanctioned paths above already cover both the formula case and the specific-number case. Revisit only if cap raises become frequent enough that the owner keystroke is the actual bottleneck.
+
+## Retroactive: PR #787
+
+PR #787 (issue #785, the `rm`-of-verified-untracked-files exception) is where this tension surfaced: its Phase B agent raised the cap `11749 → 12537` to fit a ~66-word `safety.md` addition, and the parent rejected the raise and sent it back to pay with cuts. It merged that way on 2026-08-01, funding the addition from `cr-github-review.md`, `cr-merge-gate.md`, `scheduling-reliability.md`, and `skill-first.md`.
+
+**That resolution is consistent with this decision and needs no retroactive change.** Paying with cuts is permitted under every option considered — the decision widens the set of legitimate paths, it does not narrow it. What changes going forward is that #787 would no longer have been *required* to cut: a justification line naming the `rm` exception and why a safety prohibition belongs in the auto-loaded corpus would have sufficed. The cap raise it originally proposed was rejected on process grounds (a written rule the owner authored should not be silently overridden), not on the merits — and #879 is the process that resolves it.
+
+## References
+
+- Issue [#879](https://github.com/auerbachb/claude-code-config/issues/879) — this decision; owner-delegated verdict recorded as an issue comment (Option 3 + Option 2's justification line)
+- PR [#787](https://github.com/auerbachb/claude-code-config/pull/787) / Issue [#785](https://github.com/auerbachb/claude-code-config/issues/785) — where the tension surfaced; see the retroactive note above
+- PR [#739](https://github.com/auerbachb/claude-code-config/pull/739), PR [#736](https://github.com/auerbachb/claude-code-config/pull/736) — prior cap raises without cuts, the practice this decision legitimizes and puts a justification behind
+- Issue [#796](https://github.com/auerbachb/claude-code-config/issues/796) — weekly rule-corpus slimming pass; the pressure-relief valve that keeps raises rare rather than routine
+- Issue [#832](https://github.com/auerbachb/claude-code-config/issues/832) — the one-way ratchet and `--allow-raise` escape hatch this decision leaves mechanically unchanged
+- `CLAUDE.md` "Rule File Size Guidelines" — the amended wording this record backs
+- `CONTRIBUTING.md` "Adding a New Rule" — the contributor-facing statement of the same policy
+- `.github/scripts/rule-lint.sh` — enforcement: soft/hard limits, ratchet-cap error, `--update-cap` / `--allow-raise` mechanics
+- `.github/scripts/tests/rule-lint.test.sh` case `(h)` — regression guard pinning the ratchet breach as a hard fail
+- `.claude/rules/.budget-soft-cap` — the committed cap; edit directly to raise, with a PR-body justification line
+- `chip-model-guard-decision.md`, `pm-handoff-chips-decision.md` — the house style this record follows (`## Decision` / `## Rationale` / `## Explicitly Rejected` / `## References`)

--- a/.github/scripts/tests/rule-lint.test.sh
+++ b/.github/scripts/tests/rule-lint.test.sh
@@ -5,7 +5,7 @@
 #   (a) small cut  → formula exceeds current cap  → cap unchanged (ratchet holds)
 #   (b) large cut  → formula below current cap    → cap lowered to formula
 #   (c) --allow-raise                             → cap raised, old/new/delta printed
-# Plus four bonus cases:
+# Plus five bonus cases:
 #   (d) bootstrap  → corrupt/missing prior cap    → formula result written
 #   (e) real repo conformance (default run, no --update-cap)
 #   (f) equal case → formula == current cap       → unchanged, no "would raise" message

--- a/.github/scripts/tests/rule-lint.test.sh
+++ b/.github/scripts/tests/rule-lint.test.sh
@@ -10,6 +10,7 @@
 #   (e) real repo conformance (default run, no --update-cap)
 #   (f) equal case → formula == current cap       → unchanged, no "would raise" message
 #   (g) hermeticity — the real cap file was never written during the run
+#   (h) ratchet breach (no --update-cap)          → hard fail: exit 1 + ::error (#879)
 #
 # HERMETICITY (issue #906)
 # ------------------------
@@ -294,6 +295,54 @@ expect \
   "unchanged.*formula matches cap" \
   "$F_CAP" \
   "$F_CAP"
+
+# ---------------------------------------------------------------------------
+# (h) Ratchet breach is a HARD FAIL, not a warning (issue #879)
+# ---------------------------------------------------------------------------
+# #879 decided that the ratchet cap is a visibility mechanism raisable with a
+# PR-body justification line — and that it stays an ERROR while doing so. The
+# alternative on the table (CodeRabbit's plan for that issue) was to downgrade
+# this branch to ::warning, which would have made a cap breach invisible in the
+# diff and actionable by nobody. This case pins the decided behaviour so a
+# future edit cannot silently soften it back; see
+# .claude/reference/budget-cap-raise-decision.md.
+#
+# Runs WITHOUT --update-cap, so it needs its own runner rather than expect().
+H_CAP=$(( CURRENT_COUNT - 1 ))   # corpus overruns the committed cap by 1 word
+set_cap "$H_CAP"
+h_out=""
+h_got=0
+h_out=$( ( cd "$SANDBOX" && bash "$LINT" 2>&1 ) ) || h_got=$?
+
+# Fingerprint the real cap file before any cleanup runs, matching expect()'s
+# ordering: the check belongs immediately after the lint invocation so nothing
+# in between can mask a transient mutation.
+h_pre_assert_failures=$failures
+assert_real_cap_untouched "during (h) ratchet breach"
+set_cap "$BASELINE_CAP"
+h_ok=1
+if (( failures != h_pre_assert_failures )); then
+  h_ok=0
+fi
+# Assert the guard RAN and failed for the ratchet reason — an exit 1 alone
+# could come from any other check in the script.
+if (( h_got != 1 )); then
+  echo "FAIL — (h) ratchet breach: expected exit 1, got ${h_got}"
+  h_ok=0
+elif ! grep -qE "^::error file=[^:]*\.budget-soft-cap::Auto-loaded word count ${CURRENT_COUNT} exceeds ratchet cap ${H_CAP}" <<< "$h_out"; then
+  echo "FAIL — (h) ratchet breach: no ::error annotation naming the ratchet cap"
+  h_ok=0
+elif grep -qE "^::warning file=[^:]*\.budget-soft-cap::" <<< "$h_out"; then
+  echo "FAIL — (h) ratchet breach: cap breach was emitted as a ::warning"
+  h_ok=0
+fi
+case_num=$(( case_num + 1 ))
+if (( h_ok == 1 )); then
+  echo "ok   — (h) ratchet breach without --update-cap is a hard fail (exit 1 + ::error)"
+else
+  printf '%s\n' "$h_out" | sed 's/^/       /'
+  failures=$(( failures + 1 ))
+fi
 
 # ---------------------------------------------------------------------------
 # (e) Real repo conformance — default run (no --update-cap), read-only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # PR MERGE AUTHORIZATION
 
-When the merge gate passes (`cr-merge-gate.md` Steps 1–1d, 1b) and every Test Plan box verifies (Step 2), **auto-run full `/wrap`** (squash-merge, sync main, follow-ups, session sweep, lessons) — **no approval pause, no pre-merge message**. A clean merge is silent (item #3).
+When the merge gate passes (`cr-merge-gate.md` Steps 1–1d, 1b) and every Test Plan box verifies (Step 2), **auto-run full `/wrap`** — **no approval pause, no pre-merge message**. A clean merge is silent (item #3).
 
 **Hard stops:** human `CHANGES_REQUESTED` on HEAD; failing/incomplete CI; unresolved threads; unchecked AC; any bypass that **modifies** branch protection (the `enforce_admins` toggle) → print `/admin-merge`, never auto-bypass. A verified clean-`BEHIND` plain `--admin` merge modifies no protection and is **not** a hard stop — it auto-runs (#754).
 
@@ -41,7 +41,7 @@ The workflow is fully autonomous. At every phase transition — local review, pu
 **The ONLY action that requires user permission:**
 - Respawning a failed subagent
 
-**Monitoring is never a permission-gated action — babysitting an in-flight PR is the default, never a question.** Arm the watch when a PR is open; never present a "watch it or not?" menu, and never wait for the user to say so first. CR timeout routes autonomously through the escalation chain (`cr-github-review.md`). Use `/loop` — never a continuous poll (`scheduling-reliability.md`). Use existing skills (`/babysit-pr`, `/pr-monitor-and-manage`). When gate + AC pass, auto-dispatch `/wrap` (see "PR MERGE AUTHORIZATION" above).
+**Monitoring is never a permission-gated action — babysitting an in-flight PR is the default, never a question.** Arm the watch when a PR is open; never present a "watch it or not?" menu. CR timeout routes autonomously through the escalation chain (`cr-github-review.md`). Use existing skills (`/babysit-pr`, `/pr-monitor-and-manage`). When gate + AC pass, auto-dispatch `/wrap` (see "PR MERGE AUTHORIZATION" above).
 
 If you catch yourself composing a "should I...?" question about any workflow step, stop — the answer is always yes. Just do it.
 
@@ -124,10 +124,10 @@ These files auto-load for the parent agent session. **Subagents do NOT auto-load
 
 ### Rule File Size Guidelines
 
-Rules load every turn — redundant or contradictory rules misfire. Limits apply to CLAUDE.md + `.claude/rules/*.md`:
+Rules load every turn — redundant or contradictory rules misfire. Limits cover CLAUDE.md + `.claude/rules/*.md`:
 
-- **Soft warning:** 12,000 words. **Hard fail:** 13,000. **Per-file warning:** >2,000 words.
-- **Ratchet cap:** `.claude/rules/.budget-soft-cap` = `max(count + 750, 8500)`. `rule-lint.sh` fails if exceeded; `--update-cap` only after intentional cuts.
+- **The gate:** 12,000-word soft warning, 13,000 hard fail. **Per-file warning:** >2,000 words.
+- **Ratchet cap** (visibility, not the gate): `.claude/rules/.budget-soft-cap` = `max(count + 750, 8500)`; `rule-lint.sh` fails if exceeded. Raise it only with a PR-body line naming the addition and why it belongs here rather than in `.claude/reference/` — `budget-cap-raise-decision.md`.
 - **Verify on any PR touching these files:** `{ cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } | wc -w`
 
 **Keep growth out of the corpus.** Mechanism, rationale, and backward-compat notes go in `.claude/reference/` — not auto-loaded, so free.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,16 +52,21 @@ Rules live in `.claude/rules/<name>.md` and auto-load in every parent-agent sess
 2. **File size limits** (see CLAUDE.md "Rule File Size Guidelines"):
    - **Soft cap:** ~150 lines / ~1,500 words per file — consider splitting if exceeded.
    - **Hard cap:** 200 lines / 2,000 words per file — must split.
-3. **Total budget:** CLAUDE.md + all rule files ≤ **12,000 words** soft / **13,000** hard (matches `.coderabbit.yaml` and `rule-lint.sh`).
-4. **Verification command:**
+3. **Total budget — the gate:** CLAUDE.md + all rule files ≤ **12,000 words** soft warning / **13,000** hard fail (matches `.coderabbit.yaml` and `rule-lint.sh`). These two numbers are absolute: nothing waives them.
+4. **Ratchet cap — visibility, not the gate:** `.claude/rules/.budget-soft-cap` holds `max(count + 750, 8500)` and `rule-lint.sh` fails when the corpus exceeds it. Its job is to make every increment show up as a deliberate line in a diff, not to freeze the corpus. Two ways to stay green:
+   - **Pay for the addition with cuts** so the total stays under the committed cap — always available, and the right default when the growth is restatement you can compress away.
+   - **Raise the cap**, which is legitimate *when accompanied by a PR-body line naming what was added and why it belongs in the auto-loaded corpus rather than in `.claude/reference/`*. Raise it with `bash .github/scripts/rule-lint.sh --update-cap --allow-raise` (writes `count + 750` and prints old → new → delta); a raise to a specific number is an owner edit, because `config-protection.py` blocks agent writes to the cap file. `--update-cap` alone only lowers or holds.
+
+   Full policy and rationale: [`.claude/reference/budget-cap-raise-decision.md`](.claude/reference/budget-cap-raise-decision.md) (Issue #879).
+5. **Verification command:**
 
    ```bash
    { cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } | wc -w
    ```
 
-   Run this on any PR that touches CLAUDE.md or `.claude/rules/`. If the total exceeds 12,000, condense before merging.
-5. **Update the CLAUDE.md rule index table** with a new row for the file (file name + one-line contents summary).
-6. **CI will verify** index alignment and the word-count budget via the `rule-lint` check.
+   Run this on any PR that touches CLAUDE.md or `.claude/rules/`. Compare it against both the committed cap (`cat .claude/rules/.budget-soft-cap`) and the 12,000/13,000 limits before merging. CI lints the merge ref, so leave a margin of ~30 words rather than landing on the number exactly.
+6. **Update the CLAUDE.md rule index table** with a new row for the file (file name + one-line contents summary).
+7. **CI will verify** index alignment, the ratchet cap, and the word-count budget via the `rule-lint` check. A ratchet-cap breach fails the check — that is by design, and the fix is a cut or a justified raise, never a suppression.
 
 ## Adding a New Hook
 


### PR DESCRIPTION
## **User description**
Closes #879

Records the owner-delegated decision on when `.claude/rules/.budget-soft-cap` may be raised — **Option 3 plus Option 2's justification line** — and closes the gap between the written rule and what practice has actually been doing since PR #736.

**Corpus budget justification:** this PR adds ~21 words to `CLAUDE.md`'s "Rule File Size Guidelines" (the amended ratchet-cap bullet) and **pays for them with restatement cuts in the same file**, so no cap raise was needed. Net corpus change: **11724 → 11719 words** (−5), against an unchanged cap of 11749 (30 words of margin) and the 12,000/13,000 limits. The three cuts are all duplicate statements, each still held elsewhere:

| Cut from `CLAUDE.md` | Still stated in |
|---|---|
| `/wrap` phase enumeration on the merge-authorization line | `wrap/SKILL.md`; `cr-merge-gate.md` Step 3 |
| "Use `/loop` — never a continuous poll" in the monitoring paragraph | `CLAUDE.md` item #4 (same file, verbatim mandate) + `scheduling-reliability.md` |
| "and never wait for the user to say so first" | The same sentence's "babysitting an in-flight PR is the default, never a question" + `monitor-mode.md` |

## What the decision says

- The ratchet cap stays a **blocking CI check** but is a **visibility mechanism**, not the budget ceiling: its job is to make every increment show up as a deliberate line in a diff.
- **Raising it is legitimate** when it accommodates a justified addition — no accompanying cuts required — provided the PR body carries a line naming what was added and why it belongs in the auto-loaded corpus rather than in `.claude/reference/`.
- The **12,000-word soft warning and 13,000-word hard fail are the actual gate**, and no justification line raises them.
- `--update-cap` still only lowers or holds; the one-way ratchet is untouched.

## Deviations from the CodeRabbit plan (per the owner decision)

- **`rule-lint.sh` is unchanged.** CR's plan converted the ratchet breach from `::error` to `::warning`; the owner decision keeps the mechanics exactly as they are, and the decision record explains why a warning would deliver the visibility the ratchet exists for as a line of CI output nobody has to read. New test case `(h)` pins the hard-fail behaviour instead.
- **The cap was not raised in this PR.** See below.

## Not done here: the raise to 12,000

The decision comment on Issue #879 called for a first deliberate application — `11749 → 12000`, aligning the ratchet with the soft warning. It is not in this PR, for a reason worth recording rather than working around:

- `.claude/rules/.budget-soft-cap` **and** `.github/scripts/rule-lint.sh` are both in `PROTECTED_RELATIVE_SUFFIXES` in `.claude/hooks/config-protection.py`, which blocks every agent Write/Edit/Bash modification of either one. That guard is correct and stays — permitted-with-justification is not permitted-on-impulse.
- `rule-lint.sh --update-cap --allow-raise` (the sanctioned escape hatch) can only write `count + 750` ≈ 12,470, which lands *above* the 12,000 soft warning and defeats the alignment that motivated the number.

So the raise is recorded in the decision record as a one-line owner action, and nothing is blocked meanwhile — the corpus sits 30 words under the current cap. Removing the cap file from `config-protection.py` was considered and explicitly rejected in the record: it deletes a live guard to save one keystroke, in a PR authored by the agent the guard constrains.

## Follow-ups (not in scope here)

- **Stale string in `rule-lint.sh`.** The ratchet-breach message still reads "Run rule-lint.sh `--update-cap` only after intentional corpus reduction" — the superseded wording. Cosmetic (the exit behaviour it describes is unchanged and correct), and unfixable from a session because the script is protected config. Should be corrected by whoever next edits that script.
- **Non-recursive vs recursive corpus glob.** `rule-lint.sh` counts `.claude/rules/*.md` while the documented verify command and `.coderabbit.yaml` use recursive forms. Dormant today (no nested rule files), pre-existing, and out of scope for this issue.
- The same superseded phrase in `.claude/reference/instruction-set-audit-2026-07.md` is **deliberately left alone** — point-in-time audits are exempt from corpus-wide rewrites per `.claude/reference/README.md`.

## Local review coverage

**Local review coverage:** none — neither CLI produced a verified-successful clean pass.

- **CodeRabbit CLI 0.6.5** overran the 2-minute bound in `cr-local-review.md`, but its run did eventually complete and emit findings, which were preserved and processed rather than discarded: 10 findings, **4 applied**, 5 declined with reasons, 1 converted into the `rule-lint.sh` follow-up above. The confirming re-run after those fixes returned `errorType: rate_limit` (29-minute wait, org-attributed), so there is no clean second pass and the CLI is dropped for the session. Declined: reinstating the `/loop` restatement and the "never wait for the user" clause (both still mandated elsewhere — see the table above); switching the documented corpus glob to a recursive form (would put the doc at odds with the enforcing glob); relabelling "Steps 1–1d, 1b" and the per-file "hard cap" wording (both pre-existing text this PR does not touch, and the latter is a contributor policy deliberately stricter than the lint's warning); and removing the repo's standing auto-`/wrap` merge authorization, which is an owner-set policy in `CLAUDE.md` and not a defect in this change.
- **CodeAnt CLI** returned `API Error: Access denied (403)` on the initial run and on its one permitted retry (Issue #643, account-wide entitlement). No `codeant logout`/`login` was attempted, per `cr-local-review.md`.
- A full self-review was performed in place of the missing clean passes. It does not satisfy the merge gate.

## Test plan

- [x] **AC1 — a decision is recorded on when `--update-cap` is legitimate.** `.claude/reference/budget-cap-raise-decision.md` exists in house style (`## Decision` / `## Rationale` / `## Explicitly Rejected` / `## References`) and states the policy, the two sanctioned raise paths, and the rejected options; indexed in `.claude/reference/README.md` (`reference-catalog-lint.sh` passes: 67 files indexed).
- [x] **AC2 — `CLAUDE.md`'s ratchet-cap wording matches the decision.** The "only after intentional cuts" clause is gone; the bullet now names the ratchet as visibility, requires a PR-body justification line for a raise, marks the 12,000/13,000 limits as the gate, and links the decision record. No occurrence of the superseded phrase remains in the auto-loaded corpus (`grep -rn "intentional cut" CLAUDE.md .claude/rules/` is empty).
- [x] **AC3 — `rule-lint.sh` behavior matches the decision.** The decision keeps the mechanics unchanged, so the script is untouched and still fails on a breach; new test case `(h)` asserts exit 1 + an `::error` naming the cap, and a negative control against a `::warning`-downgraded variant of the script confirms `(h)` fails closed rather than passing vacuously.
- [x] **AC4 — PR #787's resolution is consistent with the decision.** The `## Retroactive: PR #787` section records that its cut-funded merge (verified against commit `1e3991f`: cuts in `cr-github-review.md`, `cr-merge-gate.md`, `scheduling-reliability.md`, `skill-first.md` funding the `safety.md` addition) remains valid, since paying with cuts is permitted under every option — no retroactive change needed.
- [x] **Corpus budget holds.** `{ cat CLAUDE.md; find .claude/rules -name '*.md' -exec cat {} +; } | wc -w` → 11719, under the unchanged cap of 11749 and both limits; `rule-lint.sh` exits 0.
- [x] **No regressions.** `run-hook-tests.sh` (63 suites) and `run-python-tests.sh` (142 tests) pass; `reference-catalog-lint.sh`, `skill-catalog-lint.sh`, `verbatim-block-lint.sh`, `merge-authority-lint.sh` all OK; `shellcheck -S style` clean on the modified test file.


___

## **CodeAnt-AI Description**
Clarify the rule corpus budget policy and preserve hard-fail enforcement

### What Changed
- Documents that the ratchet cap is a visibility check, while the 12,000-word warning and 13,000-word limit remain the absolute budget gate
- Allows a justified cap raise for additions that belong in the auto-loaded rules, with the justification recorded in the PR description
- Updates contributor guidance and adds a decision record explaining approved raise paths and the unchanged one-way cap update behavior
- Adds a regression test confirming that exceeding the ratchet cap remains a failing check with an error, not a warning
- Removes duplicate wording from the main guidance while preserving the existing monitoring and merge behavior

### Impact
`✅ Clearer rule-budget decisions`
`✅ Fewer blocked rule additions requiring unrelated cuts`
`✅ Ratchet breaches remain visible as failing checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

