### PR TITLE
feat(#912): fold cold-read gaps into the portable handoff (3 new lint rules)

### DIFF
--- a/.claude/reference/portable-handoff.md
+++ b/.claude/reference/portable-handoff.md
@@ -33,7 +33,9 @@ Verification happens on the temp file, before the `mv` — see below.
 
 ## Portability is enforced, not asserted
 
-`.claude/scripts/portable-handoff-lint.sh` is the gate. It rejects harness paths, phase vocabulary, state-file names, skill invocations, unfilled template placeholders, and missing-or-empty required sections.
+`.claude/scripts/portable-handoff-lint.sh` is the gate. It rejects harness paths, phase vocabulary, state-file names, skill invocations, unfilled template placeholders, and missing-or-empty required sections. Since the cold read in issue #912 it also rejects an in-flight item that does not say who owns it, a pull request that does not say whether it is approved, and a document with work in flight and no command for checking any of it.
+
+Those last three check that a field is present and has a value; they cannot check that the value is any good. That limit is the finding, not a shortcoming — the checker proves an absence of jargon, and only a real reader can find out whether the document says enough, which is why #912 was a manual test.
 
 This is a script rather than a paragraph in the skill because the failure is silent: a document saying "resume at Phase B" still looks like a handoff, still writes successfully, and only fails much later, for a reader who by then has no context to repair it with. Prose that a renderer may or may not follow cannot catch that; an exit code can.
 

--- a/.claude/scripts/portable-handoff-lint.sh
+++ b/.claude/scripts/portable-handoff-lint.sh
@@ -24,16 +24,42 @@
 #                            catalog, not guessed from a regex
 #     unrendered-placeholder {LIKE_THIS} — a template that never got filled in
 #
-#   Plus two structural rules:
+#   Plus five structural rules:
 #     required-sections      every required heading present AND non-empty
 #     working-directory-absolute
 #                            the "Working directory:" line exists and names an
 #                            absolute path. It is the one address the reader
 #                            needs to find uncommitted work, and a relative one
 #                            resolves against a checkout they are not in.
+#     open-work-ownership    every entry under "Open work" says who owns it
+#     pull-request-review-state
+#                            every pull-request entry says what it is waiting on
+#                            AND whether it is approved
+#     verification-command   at least one "Verify with:" command, whenever there
+#                            is any in-flight work to verify
 #
 #   The section list is the contract with the template; keep the two in step.
 #     .claude/skills/pause/references/portable-handoff-template.md
+#
+# WHAT THE LAST THREE RULES CAN AND CANNOT PROVE (issue #912)
+#   They came out of a cold read: a document that passed every rule above was
+#   handed to an agent holding the repository and nothing else. It answered what
+#   to do first, which pull requests were open, and what each was waiting on —
+#   and could not say who owned the half-finished work, whether anything was
+#   approved, or how to check that a change worked.
+#
+#   So these three check that the field is PRESENT and has a value. They cannot
+#   check that the value is any good: "Owner: yes" passes. That limit is the
+#   point of the exercise rather than a shortcoming of it — no grep decides
+#   whether a document says enough, which is why the cold read was a manual test
+#   and why the template carries judgement rules these rules do not mirror.
+#
+#   Entries are recognized by the template's own shape: a top-level list item
+#   (`- `, `* `, `+ ` at column zero) inside "Open work". An indented sub-bullet
+#   continues the entry it sits under rather than starting a new one, so an
+#   entry may be as long as it needs to be. A renderer that abandons the bullet
+#   form altogether is off-template in a way this rule cannot see; the template
+#   is the contract, and these rules enforce it, not replace it.
 #
 # THE ONE EXEMPTION
 #   An ABSOLUTE path containing `/.claude/worktrees/` is allowed anywhere in the
@@ -79,9 +105,10 @@
 #   1  violations found (reported on stdout unless --quiet)
 #   2  usage error
 #   3  the document could not be read
-#   4  internal fault — a line produced an empty scan buffer, so the rules could
-#      not have run against it. Reported rather than passed: a checker that can
-#      say "clean" while checking nothing is the failure this script prevents.
+#   4  internal fault — either a line produced an empty scan buffer, or the
+#      scan stopped before the end of the document, so the rules did not run
+#      against everything. Reported rather than passed: a checker that can say
+#      "clean" while checking nothing is the failure this script prevents.
 #
 # SAFETY (.claude/rules/safety.md §"Anthropic Quota & Spend Authority")
 #   This script reads one Markdown file and the skill directory listing. It
@@ -89,7 +116,7 @@
 
 set -uo pipefail
 
-RULES="harness-path phase-vocabulary state-file skill-invocation unrendered-placeholder required-sections working-directory-absolute"
+RULES="harness-path phase-vocabulary state-file skill-invocation unrendered-placeholder required-sections working-directory-absolute open-work-ownership pull-request-review-state verification-command"
 
 usage() {
   sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
@@ -121,6 +148,14 @@ WORKTREE_PATH_PREFIX="/.claude/worktrees/"
 # here, which is why a MISSING anchor is a violation rather than a silent skip.
 WORKDIR_SECTION="Local state on this machine"
 WORKDIR_ANCHOR="Working directory:"
+
+# Per-entry field anchors, same contract: reword one in the template and the
+# matching rule must be reworded here, or it stops firing without saying so.
+OPEN_WORK_SECTION="Open work"
+OWNER_ANCHOR="Owner:"
+WAITING_ANCHOR="Waiting on:"
+APPROVAL_ANCHOR="Approval:"
+VERIFY_ANCHOR="Verify with:"
 
 DOC=""
 REPO_ROOT=""
@@ -208,6 +243,12 @@ RE_HARNESS_PATH='\.claude/'
 RE_PHASE_VOCAB='(^|[^[:alnum:]_-])([Pp]hase[[:space:]]+[ABCabc]|[Mm]erge_[Rr]eady|[Pp]hase-[abcABC]-[a-zA-Z]+)([^[:alnum:]_-]|$)'
 RE_STATE_FILE='(session-state|session_state|handoff-state|handoff_state|pr-[0-9]+-handoff)'
 RE_PLACEHOLDER='\{[A-Z][A-Z0-9_]*\}'
+# A top-level list item at column zero starts an entry; an indented one
+# continues the entry above it, so an entry can carry sub-bullets.
+RE_ENTRY_BULLET='^[-*+][[:space:]]+[^[:space:]]'
+# Leading non-alphanumerics are skipped so `**Pull request 903 — …**` is
+# recognized without depending on how the title was emphasized.
+RE_PR_ENTRY='^[^[:alnum:]]*([Pp]ull[[:space:]]+[Rr]equest|[Pp][Rr])[[:space:]]+#?[0-9]+'
 if (( CATALOG_RESOLVED )) && [[ -n "$COMMAND_ALTERNATION" ]]; then
   RE_SKILL_INVOCATION="(^|[^[:alnum:]_/-])/(${COMMAND_ALTERNATION})([^[:alnum:]_-]|\$)"
 else
@@ -263,6 +304,41 @@ strip_open_delims() {
   case "$v" in *']('*) v="${v##*](}" ;; esac
   while [[ -n "$v" && "$v" == [\`\(\[\<\"\'*_~]* ]]; do v="${v:1}"; done
   printf '%s' "$v"
+}
+
+# Leading emphasis (and a blockquote marker) at the START OF A LINE. Not
+# strip_open_delims: that one jumps past a Markdown link destination, which is
+# right for a single token and wrong for a whole line — a field line reading
+# `Owner: mine, see [the note](https://x)` would lose its own label and the
+# field would read as absent.
+strip_leading_emphasis() {
+  local v="$1"
+  while :; do
+    case "$v" in
+      [\`*_~\>]*)   v="${v:1}" ;;
+      [[:space:]]*) v="${v#"${v%%[![:space:]]*}"}" ;;
+      *) break ;;
+    esac
+  done
+  printf '%s' "$v"
+}
+
+# A field whose value is only markup is the empty-shell failure at field scale:
+# `Owner:` with nothing after it, or `Owner: **`, answers the reader's question
+# with the shape of an answer. Emphasis and backticks are stripped before the
+# emptiness test so that `Owner: **mine**` — a perfectly good answer — counts.
+field_value_nonempty() {
+  local v="$1" backtick
+  # Via a variable, NOT inline: `${v//$'\x60'/}` expands the escape first and
+  # leaves a bare backtick inside the braces, which reads as an unterminated
+  # command substitution and aborts the caller mid-loop. Quoting the expansion
+  # of a variable keeps the character as data.
+  backtick=$'\140'
+  v="${v//[[:space:]]/}"
+  v="${v//\*/}"
+  v="${v//_/}"
+  v="${v//"$backtick"/}"
+  [[ -n "$v" ]]
 }
 
 # A URL is an address any reader can open, so a repository link that happens to
@@ -340,6 +416,38 @@ report() { # rule, lineno, section, line
   REPORT+=$'\n'
 }
 
+# --- Open-work entry state ------------------------------------------------
+# An entry runs from its top-level bullet to the next one, or to the next
+# heading, or to end of file. Judged at that boundary rather than inline,
+# because "the field is missing" is only knowable once the entry is over.
+ENTRY_ACTIVE=0
+ENTRY_LINENO=0
+ENTRY_LABEL=""
+ENTRY_IS_PR=0
+ENTRY_HAS_OWNER=0
+ENTRY_HAS_WAITING=0
+ENTRY_HAS_APPROVAL=0
+OPEN_WORK_ENTRIES=0
+VERIFY_SEEN=0
+
+flush_entry() {
+  (( ENTRY_ACTIVE )) || return 0
+  ENTRY_ACTIVE=0
+  if (( ! ENTRY_HAS_OWNER )); then
+    report "open-work-ownership" "$ENTRY_LINENO" "$OPEN_WORK_SECTION" \
+      "no \"$OWNER_ANCHOR\" line on \"$ENTRY_LABEL\" — an unmarked item reads as free to take"
+  fi
+  (( ENTRY_IS_PR )) || return 0
+  if (( ! ENTRY_HAS_WAITING )); then
+    report "pull-request-review-state" "$ENTRY_LINENO" "$OPEN_WORK_SECTION" \
+      "no \"$WAITING_ANCHOR\" line on \"$ENTRY_LABEL\" — the reader cannot tell what is blocking it"
+  fi
+  if (( ! ENTRY_HAS_APPROVAL )); then
+    report "pull-request-review-state" "$ENTRY_LINENO" "$OPEN_WORK_SECTION" \
+      "no \"$APPROVAL_ANCHOR\" line on \"$ENTRY_LABEL\" — unblocked is not the same as allowed to merge"
+  fi
+}
+
 # --- Scan -----------------------------------------------------------------
 declare -a SEEN_SECTIONS=()
 declare -a NONEMPTY_SECTIONS=()
@@ -370,6 +478,12 @@ while IFS= read -r line || [[ -n "$line" ]]; do
     '```'*|'~~~'*) IN_FENCE=$(( IN_FENCE ? 0 : 1 )) ;;
   esac
 
+  # A heading closes any open entry — before `section` changes under it, or the
+  # entry would be judged against the section it does not belong to.
+  if (( ! IN_FENCE )) && [[ "$line" =~ ^#{1,6}([[:space:]]|$) ]]; then
+    flush_entry
+  fi
+
   IS_HEADING=0
   if (( ! IN_FENCE )) && [[ "$line" == '## '* ]]; then
     section="${line#'## '}"
@@ -392,6 +506,51 @@ while IFS= read -r line || [[ -n "$line" ]]; do
   if (( ! IS_HEADING )) && (( ! IS_STRUCTURAL_ONLY )) && [[ -n "$section" ]]; then
     NONEMPTY_SECTIONS+=("$section")
   fi
+
+  # --- Open-work entries ---------------------------------------------------
+  # Ownership, review state, and a way to verify. Tracked here, judged at the
+  # entry boundary in flush_entry.
+  trimmed="${line#"${line%%[![:space:]]*}"}"
+  field=$(strip_leading_emphasis "$trimmed")
+
+  # The content test excludes a thematic break written as `* * *`, which is a
+  # horizontal rule the reader sees as a divider, not an item to own.
+  if (( ! IN_FENCE )) && [[ "$section" == "$OPEN_WORK_SECTION" ]] \
+     && [[ "$line" =~ $RE_ENTRY_BULLET ]] \
+     && [[ -n "${line//[-*+_[:space:]]/}" ]]; then
+    flush_entry
+    ENTRY_ACTIVE=1
+    ENTRY_LINENO=$lineno
+    ENTRY_HAS_OWNER=0
+    ENTRY_HAS_WAITING=0
+    ENTRY_HAS_APPROVAL=0
+    OPEN_WORK_ENTRIES=$((OPEN_WORK_ENTRIES + 1))
+    ENTRY_LABEL="${line#[-*+]}"
+    ENTRY_LABEL="${ENTRY_LABEL#"${ENTRY_LABEL%%[![:space:]]*}"}"
+    ENTRY_LABEL="${ENTRY_LABEL//\*/}"
+    ENTRY_LABEL="${ENTRY_LABEL:0:60}"
+    ENTRY_IS_PR=0
+    [[ "$ENTRY_LABEL" =~ $RE_PR_ENTRY ]] && ENTRY_IS_PR=1
+  fi
+
+  if (( ENTRY_ACTIVE )); then
+    case "$field" in
+      "$OWNER_ANCHOR"*)
+        field_value_nonempty "${field#"$OWNER_ANCHOR"}" && ENTRY_HAS_OWNER=1 ;;
+      "$WAITING_ANCHOR"*)
+        field_value_nonempty "${field#"$WAITING_ANCHOR"}" && ENTRY_HAS_WAITING=1 ;;
+      "$APPROVAL_ANCHOR"*)
+        field_value_nonempty "${field#"$APPROVAL_ANCHOR"}" && ENTRY_HAS_APPROVAL=1 ;;
+    esac
+  fi
+
+  # Document-scoped: one runnable check somewhere is the bar, not one per entry.
+  # A queued issue nobody has started has nothing to verify, and demanding a
+  # command there would buy filler instead of an answer.
+  case "$field" in
+    "$VERIFY_ANCHOR"*)
+      field_value_nonempty "${field#"$VERIFY_ANCHOR"}" && VERIFY_SEEN=$((VERIFY_SEEN + 1)) ;;
+  esac
 
   # The working-directory field: present, and an absolute path.
   IS_WORKDIR_LINE=0
@@ -424,6 +583,30 @@ while IFS= read -r line || [[ -n "$line" ]]; do
   [[ "$scan" =~ $RE_SKILL_INVOCATION ]] && report "skill-invocation" "$lineno" "$section" "$line"
   [[ "$scan" =~ $RE_PLACEHOLDER ]] && report "unrendered-placeholder" "$lineno" "$section" "$line"
 done < "$DOC"
+
+# Did the scan actually reach the end? A fatal expansion inside the loop body
+# terminates the loop where it stands, and everything after that line goes
+# unchecked while the script carries on to print a verdict. That was not
+# hypothetical: an inline `$'\x60'` in a substitution pattern did exactly this
+# during development, and the run still ended in a confident report. Counting
+# what was read against what exists turns silent truncation into exit 4.
+# `awk END{NR}` matches the loop's semantics, final unterminated line included.
+DOC_LINES=$(LC_ALL=C awk 'END { print NR }' "$DOC" 2>/dev/null)
+if [[ ! "$DOC_LINES" =~ ^[0-9]+$ ]] || (( lineno != DOC_LINES )); then
+  echo "portable-handoff-lint.sh: internal error — scanned ${lineno} of ${DOC_LINES:-?} lines of $DOC; refusing to report a result" >&2
+  exit 4
+fi
+
+# The last entry ends at end of file, not at a boundary the loop can see.
+flush_entry
+
+# In-flight work the reader cannot check is work they cannot finish. Scoped to
+# documents that HAVE in-flight work: "Nothing is in flight." is a complete
+# answer, and a command demanded there would be invented to satisfy the rule.
+if (( OPEN_WORK_ENTRIES > 0 && VERIFY_SEEN == 0 )); then
+  report "verification-command" "0" "$OPEN_WORK_SECTION" \
+    "no \"$VERIFY_ANCHOR\" line anywhere — $OPEN_WORK_ENTRIES item(s) in flight and no way given to check any of them"
+fi
 
 # --- Structural rule ------------------------------------------------------
 # An "empty shell" — correct headings, nothing under them — is the failure mode

--- a/.claude/scripts/portable-handoff-lint.sh
+++ b/.claude/scripts/portable-handoff-lint.sh
@@ -325,10 +325,43 @@ strip_leading_emphasis() {
 
 # A field whose value is only markup is the empty-shell failure at field scale:
 # `Owner:` with nothing after it, or `Owner: **`, answers the reader's question
-# with the shape of an answer. Emphasis and backticks are stripped before the
-# emptiness test so that `Owner: **mine**` — a perfectly good answer — counts.
+# with the shape of an answer. The test is what the reader SEES, so every
+# construct that renders to nothing has to come out before the emptiness check
+# — `Owner: **mine**` is a perfectly good answer and must survive it.
+#
+# Deleting characters one class at a time is not enough on its own: an HTML
+# comment and an empty Markdown link both leave non-whitespace behind while
+# rendering to nothing at all, so `Owner: <!-- -->` and `Owner: [](/note)` would
+# each answer the question with a blank. Two constructs are therefore REDUCED
+# rather than deleted, because one of them can carry visible text: a comment
+# renders nothing and comes out whole, a link renders as its TEXT, so
+# `Owner: [mine](url)` keeps "mine" and `Owner: [](/note)` keeps nothing.
 field_value_nonempty() {
-  local v="$1" backtick
+  local v="$1" backtick head rest text after
+
+  # `<!-- ... -->`: cut from the FIRST opener to the first closer AFTER it.
+  # Taking the first closer in the whole string can land left of the opener and
+  # reassemble into something longer, which would never terminate. Each pass
+  # here removes at least the seven delimiter characters and adds none.
+  while [[ "$v" == *'<!--'*'-->'* ]]; do
+    head="${v%%'<!--'*}"
+    rest="${v#*'<!--'}"
+    [[ "$rest" == *'-->'* ]] || break
+    v="$head${rest#*'-->'}"
+  done
+
+  # `[text](dest)` -> `text`. The destination is an address, not something that
+  # appears on the page; the text is the part the reader can actually read.
+  while [[ "$v" == *'['*']('*')'* ]]; do
+    head="${v%%'['*}"
+    rest="${v#*'['}"
+    [[ "$rest" == *']('* ]] || break
+    text="${rest%%']('*}"
+    after="${rest#*']('}"
+    [[ "$after" == *')'* ]] || break
+    v="$head$text${after#*')'}"
+  done
+
   # Via a variable, NOT inline: `${v//$'\x60'/}` expands the escape first and
   # leaves a bare backtick inside the braces, which reads as an unterminated
   # command substitution and aborts the caller mid-loop. Quoting the expansion
@@ -337,6 +370,7 @@ field_value_nonempty() {
   v="${v//[[:space:]]/}"
   v="${v//\*/}"
   v="${v//_/}"
+  v="${v//\~/}"
   v="${v//"$backtick"/}"
   [[ -n "$v" ]]
 }
@@ -533,7 +567,13 @@ while IFS= read -r line || [[ -n "$line" ]]; do
     [[ "$ENTRY_LABEL" =~ $RE_PR_ENTRY ]] && ENTRY_IS_PR=1
   fi
 
-  if (( ENTRY_ACTIVE )); then
+  # Fenced text is a sample, not an answer — the entry bullet, the headings and
+  # the working-directory field all already refuse to read it, and a field that
+  # still did would let an example vouch for the entry containing it. The
+  # sharpest case is the one the fence tracking exists for: Step 6 prints the
+  # finished document inside a fence, so a render that captured its own fence
+  # would supply every field from its own sample copy.
+  if (( ENTRY_ACTIVE )) && (( ! IN_FENCE )); then
     case "$field" in
       "$OWNER_ANCHOR"*)
         field_value_nonempty "${field#"$OWNER_ANCHOR"}" && ENTRY_HAS_OWNER=1 ;;
@@ -546,11 +586,15 @@ while IFS= read -r line || [[ -n "$line" ]]; do
 
   # Document-scoped: one runnable check somewhere is the bar, not one per entry.
   # A queued issue nobody has started has nothing to verify, and demanding a
-  # command there would buy filler instead of an answer.
-  case "$field" in
-    "$VERIFY_ANCHOR"*)
-      field_value_nonempty "${field#"$VERIFY_ANCHOR"}" && VERIFY_SEEN=$((VERIFY_SEEN + 1)) ;;
-  esac
+  # command there would buy filler instead of an answer. Document-scoped makes
+  # the fence gate matter MORE, not less: one fenced sample anywhere would
+  # otherwise answer for the whole document.
+  if (( ! IN_FENCE )); then
+    case "$field" in
+      "$VERIFY_ANCHOR"*)
+        field_value_nonempty "${field#"$VERIFY_ANCHOR"}" && VERIFY_SEEN=$((VERIFY_SEEN + 1)) ;;
+    esac
+  fi
 
   # The working-directory field: present, and an absolute path.
   IS_WORKDIR_LINE=0

--- a/.claude/scripts/tests/portable-handoff-lint.test.sh
+++ b/.claude/scripts/tests/portable-handoff-lint.test.sh
@@ -354,6 +354,31 @@ assert_doc "a bolded owner label" 0 \
 assert_doc "an owner line containing a Markdown link" 0 \
   "$PR_HEAD"$'\n''  Owner: mine, see [the note](https://example.com/n)'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"
 
+# Markup that renders to NOTHING is the same empty shell as `Owner: **`, and
+# leaves more behind than a character-class strip removes: both of these carry
+# non-whitespace and both show the reader a blank where the answer goes.
+assert_doc "an owner field holding only an empty Markdown link" 1 \
+  "$PR_HEAD"$'\n''  Owner: [](/note)'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY" \
+  'open-work-ownership'
+assert_doc "an owner field holding only an HTML comment" 1 \
+  "$PR_HEAD"$'\n''  Owner: <!-- fill this in -->'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY" \
+  'open-work-ownership'
+# The same treatment reaches the other three fields, which share the check.
+assert_doc "an approval field holding only an HTML comment" 1 \
+  "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n''  Approval: <!-- TODO -->'$'\n'"$PR_VERIFY" \
+  'pull-request-review-state'
+assert_doc "a verify field holding only an empty Markdown link" 1 \
+  "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n''  Verify with: []()' \
+  'verification-command'
+
+# The negative control for all four: a link is reduced to its TEXT, not deleted,
+# so a value written entirely as a link still answers the question. Without this
+# the fix above would be indistinguishable from banning links in field values.
+assert_doc "an owner field written entirely as a Markdown link" 0 \
+  "$PR_HEAD"$'\n''  Owner: [mine](https://example.com/n)'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"
+assert_doc "an owner field with a real answer beside a comment" 0 \
+  "$PR_HEAD"$'\n''  Owner: mine <!-- confirmed at 11:50 -->'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"
+
 # Review state: what is blocking it, and whether it may merge once unblocked.
 assert_doc "a pull request with no approval line" 1 \
   "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_VERIFY" \
@@ -390,6 +415,29 @@ assert_doc "a sub-bullet does not start a new entry" 0 \
 # false positive that gets a checker bypassed.
 assert_doc "a thematic break is not an entry" 0 \
   "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"$'\n\n''* * *'
+
+# Fenced text is a sample, not an answer. The entry bullet, the headings and the
+# working-directory field already refuse to read it; a field that still did
+# would let an example vouch for the entry that contains it. The document-scoped
+# verify rule is the worst of the three, because ONE fenced sample anywhere
+# would answer for the whole document — including a render that captured the
+# fence Step 6 prints the finished document inside.
+FENCE='  ```'
+assert_doc "a fenced sample cannot supply the owner" 1 \
+  "$PR_HEAD"$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"$'\n''  Other entries look like this:'$'\n'"$FENCE"$'\n''  Owner: mine'$'\n'"$FENCE" \
+  'open-work-ownership'
+assert_doc "a fenced sample cannot supply the approval" 1 \
+  "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_VERIFY"$'\n'"$FENCE"$'\n''  Approval: nobody yet'$'\n'"$FENCE" \
+  'pull-request-review-state'
+assert_doc "a fenced command cannot satisfy the verify rule" 1 \
+  "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$FENCE"$'\n'"$PR_VERIFY"$'\n'"$FENCE" \
+  'verification-command'
+
+# The negative control: gating on the fence must not make an ordinary fenced
+# snippet break the entry around it. Fields OUTSIDE the fence still count, and
+# the portability rules still read the fenced lines themselves.
+assert_doc "a fenced snippet beside real fields is fine" 0 \
+  "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"$'\n'"$FENCE"$'\n''  git status'$'\n'"$FENCE"
 
 # Entries are judged one at a time: a complete first entry must not vouch for
 # an incomplete second one.

--- a/.claude/scripts/tests/portable-handoff-lint.test.sh
+++ b/.claude/scripts/tests/portable-handoff-lint.test.sh
@@ -378,6 +378,11 @@ assert_doc "an owner field written entirely as a Markdown link" 0 \
   "$PR_HEAD"$'\n''  Owner: [mine](https://example.com/n)'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"
 assert_doc "an owner field with a real answer beside a comment" 0 \
   "$PR_HEAD"$'\n''  Owner: mine <!-- confirmed at 11:50 -->'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"
+# Reduction needs the whole `[text](dest)` shape. Brackets on their own are
+# ordinary visible characters, and a checker that deleted them outright would
+# reject a bracketed answer nobody would think twice about writing.
+assert_doc "an owner field written in brackets" 0 \
+  "$PR_HEAD"$'\n''  Owner: [unowned]'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"
 
 # Review state: what is blocking it, and whether it may merge once unblocked.
 assert_doc "a pull request with no approval line" 1 \

--- a/.claude/scripts/tests/portable-handoff-lint.test.sh
+++ b/.claude/scripts/tests/portable-handoff-lint.test.sh
@@ -55,8 +55,14 @@ session ending on a usage limit does not lose where the work stood.
 
 - **Pull request 903 — add the pause command**
   https://github.com/auerbachb/claude-code-config/pull/903
+  Owner: mine — nobody else is on this branch.
   Waiting on: the automated reviewer to re-run after the last push.
+  Approval: nobody yet; this repository needs one approving review and green
+  checks before it can merge.
+  Files: portable-handoff-lint.sh and the skill that calls it — find them with
+  `git ls-files '*portable-handoff*'`.
   What is left: answer whatever it raises, then merge once checks are green.
+  Verify with: bash .github/scripts/run-hook-tests.sh
 
 ## Decisions made this session
 
@@ -251,6 +257,230 @@ out=$(run_lint "$DUPE" 2>&1); rc=$?
 printf '%s' "$out" | grep -q 'appears 2 times' \
   || fail "duplicate heading was not reported as a duplicate"$'\n'"got: $out"
 
+# --- 5b. Open-work entries: ownership, review state, verification --------
+# These three rules came out of the cold read in issue #912: a document that
+# passed every rule above went to an agent with the repository and nothing
+# else, and it could not say who owned the half-finished work, whether anything
+# was approved, or how to check that a change worked.
+#
+# Each fixture is a whole document rather than the golden plus a line, because
+# what is under test is an ABSENCE inside one entry — and you cannot append an
+# absence.
+make_doc() { # $1 = path, $2 = body of the "Open work" section
+  local f="$1" body="$2"
+  cat >"$f" <<EOF
+# Session handoff — auerbachb/claude-code-config — 2026-08-01 11:50 ET
+
+## Start here
+
+Read the two unresolved review comments on pull request 903 and answer them.
+
+## What we're working on
+
+Adding a command that produces a handoff document any agent can act on.
+
+## Open work
+
+$body
+
+## Decisions made this session
+
+- Reused the existing stop flag rather than adding a second one — two flags
+  would need handling in every later reader forever.
+
+## Local state on this machine
+
+Branch: issue-901-clean-pause
+Working directory: /Users/b/Develop/claude-code-config
+Uncommitted changes: none
+Unpushed commits: none
+EOF
+}
+
+PR_OWNER='  Owner: mine — nobody else is on this branch.'
+PR_WAITING='  Waiting on: the automated reviewer to re-run after the last push.'
+PR_APPROVAL='  Approval: nobody yet; one approving review and green checks are required.'
+PR_VERIFY='  Verify with: bash .github/scripts/run-hook-tests.sh'
+PR_HEAD='- **Pull request 903 — add the pause command**
+  https://github.com/auerbachb/claude-code-config/pull/903'
+PR_TAIL='  What is left: answer whatever it raises, then merge.'
+
+assert_doc() { # description, expected-rc, body, [expected substring...]
+  local desc="$1" want_rc="$2" body="$3"; shift 3
+  local f="$TMP_DIR/entry.md" out rc needle
+  make_doc "$f" "$body"
+  out=$(run_lint "$f" 2>&1); rc=$?
+  [[ "$rc" -eq "$want_rc" ]] \
+    || fail "$desc: expected exit $want_rc, got $rc"$'\n'"got: $out"
+  for needle in "$@"; do
+    printf '%s' "$out" | grep -q -- "$needle" \
+      || fail "$desc: expected output to mention '$needle'"$'\n'"got: $out"
+  done
+}
+
+# A complete entry passes — the baseline these rules are measured against.
+assert_doc "a fully described pull request" 0 \
+  "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_TAIL"$'\n'"$PR_VERIFY"
+
+# Ownership. The highest-cost miss in the cold read: an approved, green pull
+# request belonging to another session looks maximally inviting.
+assert_doc "a pull request with no owner" 1 \
+  "$PR_HEAD"$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY" \
+  'open-work-ownership' 'Pull request 903'
+
+# An issue entry is an in-flight item too — ownership is not a pull-request rule.
+assert_doc "an issue entry with no owner" 1 \
+  '- **Issue 782 — compact output contracts**
+  https://github.com/auerbachb/claude-code-config/issues/782
+  Status: queued behind the statusline work.
+  Verify with: bash .github/scripts/run-hook-tests.sh' \
+  'open-work-ownership' 'Issue 782'
+
+# A label with no value is the empty-shell failure at field scale.
+assert_doc "an owner field with no value" 1 \
+  "$PR_HEAD"$'\n''  Owner:'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY" \
+  'open-work-ownership'
+assert_doc "an owner field holding only markup" 1 \
+  "$PR_HEAD"$'\n''  Owner: **'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY" \
+  'open-work-ownership'
+
+# ...but a bolded LABEL is an ordinary way to write the same answer, and
+# rejecting it would train renderers to fight the checker.
+assert_doc "a bolded owner label" 0 \
+  "$PR_HEAD"$'\n''  **Owner:** mine'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"
+
+# A field line that also contains a Markdown link must still be recognized —
+# the destination-jump used for single tokens would eat the label here.
+assert_doc "an owner line containing a Markdown link" 0 \
+  "$PR_HEAD"$'\n''  Owner: mine, see [the note](https://example.com/n)'$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"
+
+# Review state: what is blocking it, and whether it may merge once unblocked.
+assert_doc "a pull request with no approval line" 1 \
+  "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_VERIFY" \
+  'pull-request-review-state' 'Approval:'
+assert_doc "a pull request with no waiting-on line" 1 \
+  "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY" \
+  'pull-request-review-state' 'Waiting on:'
+
+# Those two are pull-request rules. An issue has neither a reviewer nor a merge
+# button, and demanding the fields there would buy filler.
+assert_doc "an owned issue needs no approval line" 0 \
+  '- **Issue 782 — compact output contracts**
+  https://github.com/auerbachb/claude-code-config/issues/782
+  Owner: unowned — nobody has started it.
+  Status: queued behind the statusline work.
+  Verify with: bash .github/scripts/run-hook-tests.sh'
+
+# Verification: in-flight work the reader cannot check is work they cannot finish.
+assert_doc "in-flight work with no way to verify it" 1 \
+  "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_TAIL" \
+  'verification-command'
+
+# ...and the rule is scoped to documents that HAVE in-flight work. "Nothing is
+# in flight." is a complete answer; a command demanded there is invented.
+assert_doc "nothing in flight needs no verify command" 0 "Nothing is in flight."
+
+# An indented sub-bullet continues its entry rather than starting a new one, so
+# a long entry does not have to repeat its own ownership line.
+assert_doc "a sub-bullet does not start a new entry" 0 \
+  "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n''  - it also touches the installer'$'\n'"$PR_VERIFY"
+
+# A thematic break written with asterisks is a divider the reader sees, not an
+# item anybody owns. Demanding an owner for a horizontal rule is the kind of
+# false positive that gets a checker bypassed.
+assert_doc "a thematic break is not an entry" 0 \
+  "$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"$'\n\n''* * *'
+
+# Entries are judged one at a time: a complete first entry must not vouch for
+# an incomplete second one.
+TWO_ENTRIES="$PR_HEAD"$'\n'"$PR_OWNER"$'\n'"$PR_WAITING"$'\n'"$PR_APPROVAL"$'\n'"$PR_VERIFY"$'\n\n''- **Issue 782 — compact output contracts**
+  https://github.com/auerbachb/claude-code-config/issues/782
+  Status: queued.'
+assert_doc "a second entry is judged on its own" 1 "$TWO_ENTRIES" 'open-work-ownership' 'Issue 782'
+make_doc "$TMP_DIR/entry.md" "$TWO_ENTRIES"
+OWNERSHIP_HITS=$(run_lint "$TMP_DIR/entry.md" 2>&1 | grep -c 'open-work-ownership')
+[[ "$OWNERSHIP_HITS" -eq 1 ]] \
+  || fail "expected exactly 1 ownership violation across two entries, got $OWNERSHIP_HITS"
+
+# The last entry ends at end of file, where there is no boundary to notice.
+# Section order is not enforced, so "Open work" can genuinely come last.
+EOF_ENTRY="$TMP_DIR/eof-entry.md"
+cat >"$EOF_ENTRY" <<'EOF'
+# Session handoff — auerbachb/claude-code-config — 2026-08-01 11:50 ET
+
+## Start here
+
+Read the review comments on pull request 903.
+
+## What we're working on
+
+Adding a command that produces a handoff document any agent can act on.
+
+## Decisions made this session
+
+- Reused the existing stop flag rather than adding a second one.
+
+## Local state on this machine
+
+Branch: issue-901-clean-pause
+Working directory: /Users/b/Develop/claude-code-config
+Uncommitted changes: none
+Unpushed commits: none
+
+## Open work
+
+- **Pull request 903 — add the pause command**
+  https://github.com/auerbachb/claude-code-config/pull/903
+  Waiting on: the automated reviewer.
+  Approval: nobody yet.
+  Verify with: bash .github/scripts/run-hook-tests.sh
+EOF
+out=$(run_lint "$EOF_ENTRY" 2>&1); rc=$?
+[[ "$rc" -eq 1 ]] || fail "an entry ending at EOF must still be judged (got $rc)"
+printf '%s' "$out" | grep -q 'open-work-ownership' \
+  || fail "the final entry in the file was never flushed"$'\n'"got: $out"
+
+# --- 5c. The cold read, as a regression -----------------------------------
+# The exact shape of the document issue #912 handed to a naive reader: every
+# pull request says what it is waiting on, no entry says who owns it, no entry
+# says whether it is approved, and nothing anywhere says how to check the work.
+# The document this shape is taken from passed the seven rules that existed
+# then, and was still short three answers. It must not pass these ten.
+COLD_READ_SHAPE='- **Pull request 929 — align a header with what the code does**
+  https://github.com/auerbachb/claude-code-config/pull/929
+  Waiting on: one unresolved reviewer comment and nine unticked boxes.
+  What is left: answer the comment, tick the boxes, merge.
+
+- **Issue 779 — a status line for the terminal**
+  https://github.com/auerbachb/claude-code-config/issues/779
+  Status: being written right now, nothing committed yet.'
+assert_doc "the pre-#912 document shape" 1 "$COLD_READ_SHAPE" \
+  'open-work-ownership' 'pull-request-review-state' 'verification-command'
+
+# --- 5d. The scan must reach the end of the document ----------------------
+# A fatal expansion inside the read loop ends the loop where it stands and the
+# script goes on to print a verdict about lines it never saw. The line count is
+# the backstop; these two cases are where an off-by-one in it would surface as
+# exit 4 on a perfectly good document.
+#
+# Only that direction is testable from here, and the asymmetry is worth stating
+# rather than leaving a later reader to assume otherwise: the fault the guard
+# exists for cannot be induced without editing the script, so deleting the
+# guard leaves this suite green. What these fixtures pin is that it does not
+# misfire — which is the half that would otherwise break real documents.
+NO_EOL="$TMP_DIR/no-trailing-newline.md"
+printf '%s' "$(cat "$GOLDEN")" >"$NO_EOL"      # command substitution strips the final newline
+[[ -s "$NO_EOL" ]] || fail "the no-trailing-newline fixture is empty"
+[[ "$(tail -c1 "$NO_EOL" | od -An -c | tr -d ' ')" != '\n' ]] \
+  || fail "the no-trailing-newline fixture still ends in a newline"
+run_lint "$NO_EOL" >/dev/null 2>&1 \
+  || { run_lint "$NO_EOL" >&2; fail "a document with no trailing newline must still pass"; }
+
+EMPTY_FILE="$TMP_DIR/zero-bytes.md"
+: >"$EMPTY_FILE"
+run_lint "$EMPTY_FILE" >/dev/null 2>&1; rc=$?
+[[ "$rc" -eq 1 ]] || fail "an empty document should report missing sections (1), not a fault (got $rc)"
+
 # --- 6. The template's section list and the checker's agree --------------
 # These are two files that must describe the same document. When they drift,
 # every rendered handoff fails a rule nobody changed on purpose.
@@ -299,6 +529,17 @@ printf '%s' "$out" | grep -q 'working-directory-absolute' \
 grep -q 'Working directory:' "$TEMPLATE" \
   || fail "template lacks the 'Working directory:' anchor the checker requires"
 
+# The per-entry fields are the same kind of contract, and the same kind of
+# silent failure: reword one on either side and the rule stops firing on a
+# document nobody changed. Both directions are asserted, because a rename in
+# the checker alone is just as invisible as a rename in the template alone.
+for anchor in 'Owner:' 'Waiting on:' 'Approval:' 'Verify with:'; do
+  grep -qF "$anchor" "$TEMPLATE" \
+    || fail "template lacks the '$anchor' anchor the checker requires"
+  grep -qF "\"$anchor\"" "$LINT" \
+    || fail "checker no longer names the '$anchor' anchor the template emits"
+done
+
 # --- 7. CLI contract ------------------------------------------------------
 run_lint --list-rules >/dev/null 2>&1 || fail "--list-rules should exit 0"
 # Capture ONCE rather than re-running the pipeline per rule. Under `pipefail`,
@@ -307,9 +548,10 @@ run_lint --list-rules >/dev/null 2>&1 || fail "--list-rules should exit 0"
 # found — intermittently, depending on whether the write completed first.
 RULES_OUT=$(run_lint --list-rules)
 RULE_COUNT=$(printf '%s\n' "$RULES_OUT" | grep -c .)
-[[ "$RULE_COUNT" -eq 7 ]] || fail "expected 7 rules, got $RULE_COUNT"
+[[ "$RULE_COUNT" -eq 10 ]] || fail "expected 10 rules, got $RULE_COUNT"
 for r in harness-path phase-vocabulary state-file skill-invocation \
-         unrendered-placeholder required-sections working-directory-absolute; do
+         unrendered-placeholder required-sections working-directory-absolute \
+         open-work-ownership pull-request-review-state verification-command; do
   printf '%s\n' "$RULES_OUT" | grep -qx "$r" || fail "--list-rules omits '$r'"
 done
 

--- a/.claude/skills/pause/references/portable-handoff-template.md
+++ b/.claude/skills/pause/references/portable-handoff-template.md
@@ -4,6 +4,8 @@ Referenced from `pause/SKILL.md` Step 4. The SKILL.md keeps the wind-down, the c
 
 Everything below is written for one reader: **someone who has the repository and this document, and nothing else.** No rules loaded, no state files, no idea what any of our commands do — possibly not even Claude. Write for a competent engineer joining mid-task who will not ask a follow-up question, because they cannot. When a sentence would only make sense to someone inside this harness, it has failed, and `portable-handoff-lint.sh` will say so.
 
+The per-item fields and the last group of rendering rules exist because of a real cold read (issue #912). A document rendered from live state went to an agent holding the repository and nothing else. It could say what to do first, which pull requests were open, and what each was waiting on — and could not say who owned the half-finished work, whether anything was approved, or how to check that a change worked. Every field added below is one question that reader could not answer.
+
 ## The template
 
 ```
@@ -31,11 +33,18 @@ serves the goal.}
 
 - **Pull request {N} — {TITLE}**
   {URL}
+  Owner: {"mine" | "another session, still active — do not touch" | "unowned"}
   Waiting on: {PLAIN_ENGLISH_BLOCKER}
+  Approval: {who has approved it and on which commit, or "nobody yet" — and what
+  this repository requires before it can merge}
+  Files: {the files this change touches}
   What is left: {REMAINING_WORK}
+  Verify with: {a command that shows whether it works}
 
 - **Issue {N} — {TITLE}**
   {URL}
+  Owner: {as above — and when work has already been started, where the
+  uncommitted files are and whether to continue them or leave them alone}
   Status: {PLAIN_ENGLISH_STATUS}
 
 ## Decisions made this session
@@ -50,8 +59,11 @@ its "why" is the thing a later reader is most likely to undo by accident. Write
 
 Branch: {BRANCH_NAME}
 Working directory: {ABSOLUTE_PATH}
-Uncommitted changes: {FILE_LIST or "none"}
+Uncommitted changes: {FILE_LIST or "none" — and when the directory above is
+clean because the work sits in other checkouts, say so on this line}
 Unpushed commits: {COUNT_AND_SUMMARY or "none"}
+Other checkouts with uncommitted work: {one per line: the absolute path, what
+is in it, who owns it} or "none"
 
 {Anything else a reader would be surprised by — a stashed change, a half-applied
 rebase, a running process, a file deliberately left broken.}
@@ -78,3 +90,19 @@ rebase, a running process, a file deliberately left broken.}
 - **Commands are allowed when they are universal.** `git status`, `gh pr view 903`, a test runner — anything a fresh checkout can run. Commands that only exist inside this harness are not; describe the intent instead.
 - **The in-thread block and the file on disk are byte-identical.** Render once into a single buffer, verify that buffer, then write it and print that same buffer. Never re-render for display — a second render is a second document, and the reader has no way to know which one they got.
 - **Verify before emitting.** `portable-handoff-lint.sh` is the gate, not a suggestion. If it reports a violation, rewrite the offending line and re-run it; do not emit a document that fails it, and do not narrow the check to make a line pass.
+
+## Rules the cold read added
+
+Each of these answers a question a real reader asked of a document that had already passed the checker (issue #912). Three are mechanically enforced — ownership by `open-work-ownership`, approval by `pull-request-review-state`, a runnable check by `verification-command` — and even those prove only that the field is present with something in it, never that the answer is any good. The rest are judgement, and no grep can hold them.
+
+- **Every in-flight item says who owns it.** "Mine", "another session, still active — do not touch", or "unowned". This is the highest-cost thing to get wrong: a pull request belonging to someone else looks most inviting exactly when it is approved, green, and one rebase from merging, and two sessions editing one branch lose somebody's work. Silence reads as "unowned", so an unmarked item is an invitation you did not mean to send.
+- **Work already started but not committed carries its disposition.** Where the files are (absolute path), and whether the reader should finish them, leave them, or start over. "Being written right now" tells a reader who arrives after you stopped nothing at all.
+- **Every pull request says whether it is approved, and what this repository requires before it can merge.** "Waiting on" answers what is blocking; it does not answer whether the thing is allowed to merge once unblocked. Name who approved it and on which commit — an approval attached to an older commit is not an approval of what is there now.
+- **Give a command that shows whether the work is done.** Test suite, linter, build — anything the reader can run from a fresh checkout. "The tests named in the pull request body" is a pointer to a pointer. At least one such command must appear in the document.
+- **Name the files, and name them in a form the reader can resolve.** Repo-relative is fine. When the path starts with one of this repository's dot-directories, the portability rule forbids writing it, so give the file name plus a command that finds it — `git ls-files '*skill-bash.sh'` — rather than dropping the location entirely.
+- **Point at a live list; do not copy it.** Checklists and acceptance criteria live in the pull request or issue and will change after you stop writing. Say where they are and that the copy there is the authoritative one. A transcription is a second version that is wrong the moment either side moves.
+- **Say what happens after the first action succeeds.** The next thing to pick up, or "stop and reassess". A document that ends at the first merge leaves the reader guessing at precisely the moment they have earned the right to keep going.
+- **If the remaining work changes code, say the review starts over.** A new commit means the checks re-run and any approval attaches to the old one. Writing "then merge" after "make this edit" describes a path that does not exist.
+- **A fact with an expiry carries its timestamp and how to re-check it.** "The reviewer is rate-limited for another 13 minutes" is true when written and unknowable when read. Give the wall-clock time it was true and the command that answers it now.
+- **Tie a decision to the item it governs.** When a decision in the decisions section bears on an open item — the same argument already settled — say so on that item. Otherwise the reader re-litigates a question this session already answered.
+- **Be specific where a reader would otherwise guess.** Name the file rather than gesturing at "a reference index". Name the items behind a count — "five earlier changes merged tonight" is not information until they are listed. And when a name disagrees with its subject — a branch named for one issue, a title closing another — explain it in one line, because an unexplained mismatch reads as a mistake worth investigating.


### PR DESCRIPTION
## **User description**
Closes #912

PR #910 shipped a checker that proves a **negative** — the handoff contains no harness paths, no phase vocabulary, no state-file names, no skill invocations, no unfilled placeholders. It cannot prove the **positive**: that a reader who has never seen this project can act on the document. Only a real reader finds that gap. This is that reader's findings, folded back.

## The experiment

| | |
|---|---|
| **Document** | Rendered from live session state at the pause: 2 open pull requests (one of them another session's), 3 issues, 4 decisions, 2 checkouts holding uncommitted work |
| **Pre-check** | `portable-handoff-lint.sh` exit 0, under both `--repo-root` and auto-detection |
| **Non-vacuous?** | Yes. Negative control: injecting a harness path, phase vocabulary, a state-file name, a slash-command and an unrendered placeholder into one line of a copy produced exactly 5 violations and exit 1. The clean result reflects a checker that ran. |
| **Reader** | A Sonnet agent given the repository and the document only — no harness rules, no state files, no session memory. (`claude -p` was unavailable, as #910 recorded; this is the ticket's second permitted reader.) |
| **Asked** | From the document alone: what to do first, which pull requests are open, what each is waiting on |

## Verdict: the core acceptance criteria passed

The reader named the right first action with the right sub-steps, listed **exactly** the two open pull requests (correctly excluding the three merged earlier and correctly refusing to count issues as pull requests), and got both blockers right — including the discriminator, that the blockers were human actions rather than a wait on a reviewer. It also extracted all five non-obvious facts the answer key graded for, the do-not-touch pull request among them.

Then it produced 10 gaps and 6 ambiguities. Those are the deliverable.

## What the reader could not answer, and where each one went

Every gap is stated as a template defect unless the evidence says it belongs to that one render.

| # | What it could not answer | Verdict | Where it went |
|---|---|---|---|
| 1 | The nine verification boxes themselves (only their themes were named) | Template, partly | Rule: name where a live checklist lives and say that copy is authoritative. Declined the transcription — a copied checklist is wrong the moment either side moves |
| 2 | How to run anything — no test, lint, or build command anywhere | **Template** | `Verify with:` field + **lint rule `verification-command`** |
| 3 | Which files the change touches | **Template** | `Files:` field + guidance on naming a file whose path sits in a dot-directory the portability rule forbids writing |
| 4 | Whether the pull request is approved at all | **Template** | `Approval:` field + **lint rule `pull-request-review-state`** |
| 5 | That an edit restarts the review — "then merge" was optimistic | Template | Rendering rule |
| 6 | Merge mechanics: what this repository requires before merge | Template | Folded into `Approval:` |
| 7 | Disposition of two checkouts of uncommitted work — finish, leave, who owns it now | **Template** | `Owner:` field incl. disposition + **lint rule `open-work-ownership`** |
| 8 | Acceptance criteria for two issues; an unnamed "reference index" | Split | Named-file rule folded; transcribing acceptance criteria declined (same staleness argument as #1 — the URL is in the document) |
| 9 | What to do after the first action succeeds | Template | Rendering rule |
| 10 | Which four other changes merged that evening | Template | Rendering rule: a count without the items is not information |
| A | A branch named for one issue whose title closes another | Template | Rendering rule: explain a mismatch in one line |
| B | Ownership marked on one item and not the others | **Template** | Same rule as #7 — uniformity is exactly what a lint buys |
| C | A recorded decision that bears on an open item, not cross-referenced | Template | Rendering rule |
| D | A 13-minute rate-limit window, possibly expired by read time | Template | Rendering rule: perishable facts carry their timestamp and a re-check command |
| E | How the new cap value interacts with the warning threshold | **Instance** | Declined — a one-decision omission; the template already demands the reasoning |
| F | A "clean" checkout while uncommitted work exists elsewhere | Template | `Other checkouts with uncommitted work:` line, and the uncommitted line says so itself rather than three sentences later |

**13 template defects → 3 lint rules + 11 rendering rules. 2 declined, with reasons above.**

## The three new rules

`open-work-ownership` · `pull-request-review-state` · `verification-command` — 7 rules to 10.

They check that a field is **present and has a value**. They cannot check that the value is any good: `Owner: yes` passes. That limit is the finding, not a shortcoming — it is why #912 was a manual test, and why the eleven judgement rules live in the template with no lint mirror. Both files say so out loud.

The rules reproduce the harvest mechanically. Run against the very document the reader was given, they fire **exactly** the gaps it reported: 5 × missing owner, 2 × missing approval state, 1 × no way to verify. That shape is pinned as a regression fixture (`5c`), so the pre-#912 document can never pass again.

## Also fixed here

A fatal expansion inside the checker's read loop ends the loop where it stands, and the script goes on to print a confident verdict about lines it never read. Not hypothetical — an inline `$'\x60'` did exactly that while this was being built, and the run still reported findings. The scan now compares lines read against lines present and returns exit 4 instead. Only the no-false-positive direction is testable from outside; the test says so rather than implying coverage it does not have.

## Deviation from the CodeRabbit plan

Its Phase 3 Task 3 wanted a dated verification log under `.claude/reference/` indexed in that directory's README. Declined: another session is editing that index right now (it is named in the very handoff this experiment used), and a collision there costs more than the record is worth. This PR body and the issue are the record. The one reference edit here is a stale-enumeration fix in `portable-handoff.md`, which listed the checker's rules.

## Local review coverage

**Local review coverage:** none — both CLIs unavailable, self-review only.

- **CodeRabbit** — rate limited. Stdout NDJSON carried `{"type":"error","errorType":"rate_limit"}` with a reported 19-minute wait. Under `cr-local-review.md` that is a failed run, not a clean pass. No retry: the CLI named its own wait window, and the CLI shares one adaptive quota with the GitHub reviews that gate this PR.
- **CodeAnt** — 403 twice. Both runs exited 0 with `"issues": []` while stderr carried `API Error: Access denied (403)` — the documented false-clean shape. One retry per the rule, then dropped. No `codeant logout`/`login` was run.
**Round 2 (commit `8500745`) — coverage still `none`, deliberately.** CodeAnt's GitHub app posted two Major findings; both were verified against the code and fixed. Neither CLI was re-run: CodeAnt's 403 is the persistent account-level entitlement failure (issue #643), and spending a CodeRabbit CLI review would draw down the same adaptive quota as the GitHub review this PR's merge gate needs — CodeRabbit's own comment on this PR reported a 27-minute wait. In place of a CLI pass the two fixes carry an explicit non-vacuity control: each new fixture was run against the pre-fix checker at `db4394b` and against this branch, and the pre-fix/branch exit-code pair was read for every one.

- **Self-review instead**, and it found and fixed real defects rather than rubber-stamping: three inaccurate claims in my own template prose, a nested placeholder, an exit-4 doc that no longer matched behavior, an unnecessary shell escape, and a horizontal-rule false positive.

## Test plan

Acceptance criteria from #912:

- [x] A portable handoff was rendered from a session with at least two in-flight pull requests
- [x] It was handed to a reader with repository access and no harness rules loaded
- [x] That reader stated, from the document alone: what to do first, which pull requests are open, and what each is waiting on
- [x] What the reader could not answer is recorded, as template defects rather than reader defects
- [x] Every gap is folded into `portable-handoff-template.md`, and every mechanically-checkable one into `portable-handoff-lint.sh` as a named rule with passing and failing fixtures

Verification of this change:

- [x] `bash .claude/scripts/tests/portable-handoff-lint.test.sh` passes, with ~30 new fixtures covering all three rules and the two round-2 review findings
- [x] Each new rule has both a passing and a failing fixture, and each is proven non-vacuous: disabling that rule in the checker makes the suite fail naming that rule's fixture (4 mutation controls run; the checker was restored byte-for-byte and the suite re-verified green)
- [x] The rules do not fire where they should not: an issue entry needs no approval line, "Nothing is in flight." needs no verify command, an indented sub-bullet does not start a new entry, a `* * *` divider is not an item, a bolded `**Owner:**` label counts, and a field line containing a Markdown link is still recognized
- [x] Entries are judged individually — a complete first entry does not vouch for an incomplete second one (asserted by exact violation count), and the final entry in a file is still judged
- [x] `--list-rules` reports 10 rules and the test asserts every id by name
- [x] Template and checker agree in both directions: each of `Owner:`, `Waiting on:`, `Approval:`, `Verify with:` is asserted present in the template *and* named in the checker, so a rename on either side fails loudly instead of silently disabling a rule
- [x] Full auto-discovered suite green on this branch: 63 bash suites, 0 failed; 142 Python tests OK (`main` has since added two suites of its own; CI is green on the merge ref)
- [x] `shellcheck` finding multiset is identical to `main` for both changed shell files (SC2016 ×1, SC2086 ×3, SC2129 ×1 — all pre-existing); no suppressions added
- [x] `rule-lint.sh`, `skill-catalog-lint.sh`, `verbatim-block-lint.sh`, `merge-authority-lint.sh` all pass; no rule-corpus file was touched, so the word budget is unchanged
- [x] Round-2 review findings fixed and covered: a field value that renders to nothing (`Owner: [](/note)`, `Owner: <!-- -->`) no longer counts as an answer, and fenced sample text can no longer supply `Owner:`/`Waiting on:`/`Approval:` for the entry containing it or satisfy the document-scoped `Verify with:` rule. Seven new fixtures flip 0 to 1 against the pre-fix checker; three negative controls hold in the other direction (a value written entirely as a link with real text, a real answer beside a trailing comment, an ordinary fenced snippet beside real fields), so the fix is not just a ban on links, comments, or fences
- [x] The experiment's evidence files were not modified


___

## **CodeAnt-AI Description**
Require portable handoffs to identify ownership, review status, and verification steps

### What Changed
- Open work items must state who owns them; pull requests must state what is blocking them and whether they are approved.
- Handoffs with work in progress must include a runnable command for checking the work.
- Empty field values, markup-only samples, and fenced examples no longer satisfy these requirements, while valid Markdown links and formatting remain supported.
- The lint scan now detects incomplete reads as internal faults instead of reporting a result for only part of a document.
- The handoff template and reference documentation now explain the required fields and additional cold-read guidance.

### Impact
`✅ Clearer ownership of unfinished work`
`✅ Fewer accidental changes to another session's work`
`✅ Runnable checks for in-flight work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

