### PR TITLE
fix(#930): make state-lock give real mutual exclusion on Linux

### DIFF
--- a/.claude/scripts/cr-review-hourly.sh
+++ b/.claude/scripts/cr-review-hourly.sh
@@ -234,10 +234,10 @@ write_merged_state() {
     exit 5
   fi
 
-  if ! mv "$tmp" "$STATE_FILE" 2>/dev/null; then
-    echo "cr-review-hourly.sh: could not write $STATE_FILE" >&2
-    exit 5
-  fi
+  # Guarded commit: refuses to write if this process's lock was broken and
+  # re-taken while it was reading and transforming, which would drop the other
+  # writer's update (issue #930).
+  state_lock_commit "$tmp" "$STATE_FILE" || exit $?
   cleanup_tmp
   trap 'state_lock_release' EXIT
 }

--- a/.claude/scripts/greptile-budget.sh
+++ b/.claude/scripts/greptile-budget.sh
@@ -282,10 +282,10 @@ write_state() {
   fi
   rm -f "$jq_err" 2>/dev/null || true
 
-  if ! mv "$tmp" "$STATE_FILE" 2>/dev/null; then
-    echo "greptile-budget.sh: could not write $STATE_FILE" >&2
-    exit 5
-  fi
+  # Guarded commit: refuses to write if this process's lock was broken and
+  # re-taken while it was reading and transforming, which would drop the other
+  # writer's update (issue #930).
+  state_lock_commit "$tmp" "$STATE_FILE" || exit $?
 }
 
 print_state() {

--- a/.claude/scripts/handoff-state.sh
+++ b/.claude/scripts/handoff-state.sh
@@ -77,6 +77,30 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOCK_LIB="${SCRIPT_DIR}/state-lock.sh"
 HANDOFF_DIR="${HOME}/.claude/handoffs"
 
+# Saved before any parsing shifts them, so a read-modify-write whose lock was
+# stolen mid-flight can be retried from scratch (see _rmw_retry_or_fail).
+ORIG_ARGS=("$@")
+
+# Re-run this whole invocation after the lock was broken underneath us.
+#
+# The transform has to start over from a fresh read: the value we computed came
+# from a snapshot another writer has replaced, so re-committing it would drop
+# their update. Re-exec is the cheapest correct reset — it re-acquires the lock
+# and redoes read → transform → commit with no leftover state. Bounded, because
+# a lock that keeps being stolen is a real problem and must eventually surface
+# rather than spin (issue #930).
+_rmw_retry_or_fail() {
+  local n="${CLAUDE_STATE_RMW_RETRY:-0}" max="${CLAUDE_STATE_RMW_MAX_RETRY:-8}"
+  if (( n < max )); then
+    export CLAUDE_STATE_RMW_RETRY=$(( n + 1 ))
+    # Stagger the retries so contending writers do not re-collide in lockstep.
+    sleep "0.0$(( (RANDOM % 8) + 1 ))"
+    exec bash "$0" ${ORIG_ARGS[@]+"${ORIG_ARGS[@]}"}
+  fi
+  echo "handoff-state.sh: lock was broken by another writer $max times running; giving up with $HANDOFF_FILE unchanged (retry)" >&2
+  exit "$STATE_LOCK_EXIT_TIMEOUT"
+}
+
 # ---------------------------------------------------------------------------
 # Load the lock library (required for all write paths).
 # ---------------------------------------------------------------------------
@@ -291,6 +315,17 @@ _atomic_write() {
     state_lock_release
     exit 5
   }
+  # Fail closed if the lock was broken and re-taken while we were reading and
+  # transforming. $content was computed from a snapshot another writer has
+  # since replaced, so committing it would silently discard their update —
+  # the exact lost-append failure in issue #930. Exit 6 ("unchanged, retry")
+  # instead: a loud, retryable error beats a silent overwrite. This sits as
+  # late as possible, immediately before the commit.
+  if ! state_lock_assert_held; then
+    rm -f "$tmp" 2>/dev/null || true
+    state_lock_release
+    _rmw_retry_or_fail
+  fi
   if ! mv "$tmp" "$HANDOFF_FILE"; then
     rm -f "$tmp" 2>/dev/null || true
     echo "handoff-state.sh: mv to $HANDOFF_FILE failed" >&2

--- a/.claude/scripts/session-state-audit.sh
+++ b/.claude/scripts/session-state-audit.sh
@@ -692,8 +692,16 @@ fi
 # Guarded commit: refuses to write if this process's lock was broken and
 # re-taken while it was reading and repairing, which would drop the other
 # writer's update (issue #930).
-state_lock_commit "$OUT_TMP" "$STATE_FILE" \
-  || die_error "could not write $STATE_FILE (backup: $BACKUP)"
+state_lock_commit "$OUT_TMP" "$STATE_FILE" || {
+  COMMIT_RC=$?
+  # Propagate the commit's own status rather than flattening it into
+  # EXIT_ERROR. Exit 6 means "lock broken mid-update, file unchanged, retry" —
+  # a transient serialization failure. Reporting it as a permanent environment
+  # error would tell callers to investigate the filesystem instead of simply
+  # re-running (CodeAnt, PR #937).
+  echo "session-state-audit.sh: could not write $STATE_FILE (backup: $BACKUP)" >&2
+  exit "$COMMIT_RC"
+}
 
 RESULT="$(jq -c -n \
   --argjson moves "$MOVE_SET" --argjson prunes "$PRUNE_SET" --argjson heals "$HEAL_SET" \

--- a/.claude/scripts/session-state-audit.sh
+++ b/.claude/scripts/session-state-audit.sh
@@ -689,7 +689,11 @@ if (( POST_VIOLATION_COUNT > PRE_VIOLATION_COUNT )); then
   die_error "repair introduced new type-contract violations ($NEW_VIOLATIONS) — $STATE_FILE left unmodified (backup: $BACKUP)"
 fi
 
-mv "$OUT_TMP" "$STATE_FILE" || die_error "could not write $STATE_FILE (backup: $BACKUP)"
+# Guarded commit: refuses to write if this process's lock was broken and
+# re-taken while it was reading and repairing, which would drop the other
+# writer's update (issue #930).
+state_lock_commit "$OUT_TMP" "$STATE_FILE" \
+  || die_error "could not write $STATE_FILE (backup: $BACKUP)"
 
 RESULT="$(jq -c -n \
   --argjson moves "$MOVE_SET" --argjson prunes "$PRUNE_SET" --argjson heals "$HEAL_SET" \

--- a/.claude/scripts/session-state.sh
+++ b/.claude/scripts/session-state.sh
@@ -327,7 +327,8 @@ fi
 STATE_FILE="${HOME}/.claude/session-state.json"
 
 # Saved before any parsing consumes them, so a read-modify-write whose lock was
-# stolen mid-flight can be retried from scratch (see _rmw_retry_or_fail).
+# stolen mid-flight can be retried from scratch by re-exec'ing this script (see
+# the state_lock_assert_held branch just before the commit, near the end).
 ORIG_ARGS=("$@")
 
 # Sibling reference file that is the single source of truth for the

--- a/.claude/scripts/session-state.sh
+++ b/.claude/scripts/session-state.sh
@@ -326,6 +326,10 @@ fi
 
 STATE_FILE="${HOME}/.claude/session-state.json"
 
+# Saved before any parsing consumes them, so a read-modify-write whose lock was
+# stolen mid-flight can be retried from scratch (see _rmw_retry_or_fail).
+ORIG_ARGS=("$@")
+
 # Sibling reference file that is the single source of truth for the
 # FIELD-TYPE CONTRACT (issues #625, #640) — resolved relative to this
 # script's own location (not $STATE_FILE's directory) so it works from every
@@ -1364,6 +1368,28 @@ if [[ -n "$BAD_SCOPE" ]]; then
   bad_actual="${BAD_SCOPE##*$'\x1f'}"
   echo "session-state.sh: refusing to write — field '$bad_path' would become type '$bad_actual' but must be 'object' (see issue #638); $STATE_FILE left unmodified" >&2
   exit 4
+fi
+
+# Fail closed if the lock was broken and re-taken while we were reading and
+# transforming: $OUT_TMP was computed from a snapshot another writer has since
+# replaced, so committing it would silently discard their update (issue #930).
+# Placed immediately before the commit — everything after this check is
+# unprotected. Rather than fail outright, redo the whole read-modify-write
+# against the current file; re-exec is the cheapest correct reset, and the
+# retry budget keeps a persistently-stolen lock from spinning forever.
+if ! state_lock_assert_held; then
+  _n="${CLAUDE_STATE_RMW_RETRY:-0}"; _max="${CLAUDE_STATE_RMW_MAX_RETRY:-8}"
+  if (( _n < _max )); then
+    export CLAUDE_STATE_RMW_RETRY=$(( _n + 1 ))
+    state_lock_release
+    rm -f "$OUT_TMP" "$JQ_ERR" ${SEEDED_TMP:+"$SEEDED_TMP"} 2>/dev/null || true
+    trap - EXIT
+    # Stagger the retries so contending writers do not re-collide in lockstep.
+    sleep "0.0$(( (RANDOM % 8) + 1 ))"
+    exec bash "$0" ${ORIG_ARGS[@]+"${ORIG_ARGS[@]}"}
+  fi
+  echo "session-state.sh: lock was broken by another writer $_max times running; giving up with $STATE_FILE unchanged (retry)" >&2
+  exit "$STATE_LOCK_EXIT_TIMEOUT"
 fi
 
 if ! mv "$OUT_TMP" "$STATE_FILE" 2>/dev/null; then

--- a/.claude/scripts/state-lock.sh
+++ b/.claude/scripts/state-lock.sh
@@ -27,18 +27,29 @@
 #
 # LOCK LAYOUT
 #   Lock directory:  <state-file>.lock/            (e.g. session-state.json.lock)
-#   Owner metadata:  <state-file>.lock/owner       (written immediately after
-#                    the mkdir wins) containing:
+#   Owner metadata:  <state-file>.lock/owner       (published atomically right
+#                    after the mkdir wins) containing:
 #       pid=<holder pid>
 #       host=<hostname>
 #       epoch=<unix seconds when the lock was taken>
 #       started=<ISO 8601 UTC>
 #       cmd=<basename of the holding script>
+#       token=<unique per-acquisition id>
+#
+#   The owner file is written to a temp path INSIDE the lock directory and
+#   renamed onto `owner`, so it is never observable half-written. That matters
+#   because "owner unreadable" used to be indistinguishable from "holder is
+#   gone" — see STALENESS POLICY (issue #930).
+#
+#   `token` identifies one ACQUISITION, not one process. A bare pid cannot
+#   distinguish this acquisition from a later one by the same pid, so every
+#   ownership decision (release, and the state_lock_assert_held check below)
+#   compares tokens.
 #
 # STALENESS POLICY
 #   A lock is considered stale — and may be broken — when EITHER holds:
-#     1. The owner metadata names THIS host and `kill -0 <pid>` says that
-#        process no longer exists (holder died mid-write).
+#     1. The owner metadata is PRESENT, names THIS host, and `kill -0 <pid>`
+#        says that process no longer exists (holder died mid-write).
 #     2. The lock is older than STALE_AGE seconds (default 120, override with
 #        CLAUDE_STATE_LOCK_STALE_AGE). This is the cross-host / unparseable-
 #        metadata fallback: a foreign hostname makes the local pid check
@@ -46,6 +57,16 @@
 #        `epoch=` line, falling back to the lock directory's own mtime.
 #   A real write holds the lock for single-digit milliseconds, so a 120s age
 #   ceiling carries roughly four orders of magnitude of headroom.
+#
+#   AN INDETERMINATE AGE IS NOT STALE. Both conditions above require positive
+#   evidence; when neither the `epoch=` line nor the directory mtime can be
+#   read, the lock is left ALONE and the caller's timeout bounds the wait.
+#   The inverse — "cannot tell, therefore stale" — is what broke live holders
+#   on Linux (issue #930): `stat -f %m` is BSD spelling, and GNU coreutils
+#   parses `-f` as --file-system and `%m` as a FILE operand, so the age lookup
+#   returned a non-numeric blob and every unreadable owner aged out instantly.
+#   Missing owner metadata is a routine, sub-millisecond state (a lock being
+#   acquired or released), NOT a death certificate.
 #
 #   Breaking is guarded against the classic double-steal (two waiters both
 #   declare the same lock stale, both break it, and one then destroys the
@@ -61,11 +82,14 @@
 #     the lock within one poll interval. The state file itself is untouched,
 #     because the killed writer's partial output only ever existed in its
 #     temp file — the `mv` is all-or-nothing.
-#   • Holder alive but wedged >STALE_AGE: the lock IS broken and the wedged
-#     process could, in principle, still complete its `mv` afterwards and lose
-#     one interleaved write. Chosen deliberately: the alternative (never break
-#     a live holder's lock) wedges every future session in the fleet forever,
-#     which is the exact failure this issue exists to prevent.
+#   • Holder alive but wedged >STALE_AGE: the lock IS broken. Chosen
+#     deliberately: the alternative (never break a live holder's lock) wedges
+#     every future session in the fleet forever, which is the exact failure
+#     this issue exists to prevent. The wedged victim can no longer lose an
+#     interleaved write silently, though — breaking a lock rotates the token,
+#     so the victim's state_lock_assert_held fails and it MUST abandon its
+#     read-modify-write instead of committing (issue #930). Callers surface
+#     that as exit 6, "unchanged, retry".
 #   • Shared/network HOME: pid liveness is not meaningful across hosts, so
 #     cross-host locks fall back to the age rule alone.
 #   • Lock directory not writable: acquisition fails fast rather than writing
@@ -83,12 +107,22 @@
 #                                acquire of the SAME lock a no-op so a holder
 #                                that shells out to another state-writing
 #                                script cannot deadlock against itself.
+#   CLAUDE_STATE_LOCK_TOKEN      set alongside it, so a nested writer can still
+#                                verify the inherited lock with
+#                                state_lock_assert_held.
 #
 # EXIT / RETURN CODE
 #   state_lock_acquire returns 0 on success and STATE_LOCK_EXIT_TIMEOUT (6)
 #   when the lock could not be acquired within the timeout. Callers propagate
 #   6 so a writer that cannot serialize exits non-zero with a distinct code
 #   INSTEAD of writing anyway.
+#
+#   state_lock_assert_held returns 0 while this process still holds the lock it
+#   acquired (or the one it inherited) and non-zero once the lock has been
+#   broken and re-acquired by somebody else. EVERY caller must check it
+#   immediately before committing its read-modify-write — that is the whole
+#   defence against a stolen lock turning into a silently dropped update, and
+#   the check must sit as close to the commit `mv` as possible.
 #
 # DEPENDENCIES
 #   mkdir, mv, rm, date, sleep, hostname (all POSIX / base macOS).
@@ -98,7 +132,16 @@
 STATE_LOCK_EXIT_TIMEOUT=6
 
 # Path of the lock directory currently held by THIS process ("" when none).
+# Release authority: set ONLY when this process won the mkdir itself, so a
+# nested (re-entrant) writer can never release its ancestor's lock.
 STATE_LOCK_DIR=""
+
+# Path this process is covered by — its own lock OR one inherited through
+# CLAUDE_STATE_LOCK_HELD. state_lock_assert_held checks against this.
+STATE_LOCK_HELD_DIR=""
+
+# Token of the acquisition covering this process ("" when none).
+STATE_LOCK_TOKEN=""
 
 # Current unix time. Uses bash's printf time format when available (a builtin,
 # no fork) and falls back to date(1) on bash 3.2 — macOS system bash. Forks are
@@ -144,17 +187,46 @@ _state_lock_meta() {
   # The redirect is guarded too: the lock can be released (and the owner file
   # unlinked) between the test above and the open below — a benign race that
   # would otherwise print "No such file or directory" to stderr.
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    case "$line" in
-      "$key="*) printf '%s' "${line#*=}"; return 0 ;;
-    esac
-  done < "$file" 2>/dev/null
+  #
+  # The suppression has to wrap the WHOLE group rather than trail the `done`.
+  # Redirections are applied left to right, so `done < "$file" 2>/dev/null`
+  # opens the (missing) input file while stderr is still the real one and the
+  # message escapes anyway — observed leaking during the issue #930 repro.
+  { while IFS= read -r line || [[ -n "$line" ]]; do
+      case "$line" in
+        "$key="*) printf '%s' "${line#*=}"; return 0 ;;
+      esac
+    done < "$file"; } 2>/dev/null
   return 0
 }
 
-# Age in seconds of the lock at $1. Prefers the recorded epoch; falls back to
-# the lock directory's mtime; prints a very large number when neither can be
-# determined so an inscrutable lock still ages out rather than wedging forever.
+# Modification time of $1 in unix seconds, printed on stdout; returns non-zero
+# when it cannot be determined.
+#
+# `stat` is not portable between GNU and BSD, and — critically — the wrong
+# spelling does NOT fail cleanly on either. GNU treats `-f` as --file-system
+# and `%m` as a FILE operand: it prints a multi-line filesystem dump on stdout
+# and exits non-zero, so a naive `stat -f %m … || stat -c %Y …` chain CONCATENATES
+# the dump with the real mtime and yields a non-numeric string. Only a numeric
+# result may be trusted, so each spelling is validated rather than chained on
+# exit status alone (issue #930).
+_state_lock_file_mtime() {
+  local path="$1" m
+  m="$(stat -c %Y "$path" 2>/dev/null)"      # GNU coreutils
+  if [[ "$m" =~ ^[0-9]+$ ]]; then printf '%s' "$m"; return 0; fi
+  m="$(stat -f %m "$path" 2>/dev/null)"      # BSD / macOS
+  if [[ "$m" =~ ^[0-9]+$ ]]; then printf '%s' "$m"; return 0; fi
+  return 1
+}
+
+# Age in seconds of the lock at $1, printed on stdout. Prefers the recorded
+# epoch and falls back to the lock directory's mtime. Returns non-zero (and
+# prints nothing) when NEITHER can be determined.
+#
+# There is deliberately no "very large number" sentinel any more. Reporting an
+# unknowable age as ancient makes every unreadable owner file look like a dead
+# holder, which is precisely how live holders got their locks broken (#930).
+# An unknown age is now the caller's problem to treat conservatively.
 _state_lock_age() {
   local lock_dir="$1" epoch mtime now
   now="$(_state_lock_now)"
@@ -163,31 +235,49 @@ _state_lock_age() {
     printf '%s' "$(( now - epoch ))"
     return 0
   fi
-  # `stat` is not portable between GNU and BSD; try both spellings.
-  mtime="$(stat -f %m "$lock_dir" 2>/dev/null || stat -c %Y "$lock_dir" 2>/dev/null || true)"
-  if [[ "$mtime" =~ ^[0-9]+$ ]]; then
+  if mtime="$(_state_lock_file_mtime "$lock_dir")"; then
     printf '%s' "$(( now - mtime ))"
     return 0
   fi
-  printf '%s' 999999
+  return 1
 }
 
 # 0 when the lock at $1 qualifies as stale under STALENESS POLICY above.
+# Both rules require POSITIVE evidence; absent evidence means "not stale".
 _state_lock_is_stale() {
   local lock_dir="$1" stale_age="$2" pid host age
-  age="$(_state_lock_age "$lock_dir")"
-  if [[ "$age" -ge "$stale_age" ]]; then
+  if age="$(_state_lock_age "$lock_dir")" && [[ "$age" -ge "$stale_age" ]]; then
     return 0
   fi
   pid="$(_state_lock_meta "$lock_dir/owner" pid)"
   host="$(_state_lock_meta "$lock_dir/owner" host)"
-  # A pid check only means something on the host that recorded it.
-  if [[ "$host" == "$(_state_lock_hostname)" && "$pid" =~ ^[0-9]+$ ]]; then
+  # A pid check only means something on the host that recorded it — and only
+  # when a pid was actually recorded. An ABSENT owner file means the lock is
+  # mid-acquire or mid-release (both sub-millisecond, both routine), never
+  # that the holder died; reading it as a dead holder is the #930 bug.
+  if [[ -n "$pid" && "$host" == "$(_state_lock_hostname)" && "$pid" =~ ^[0-9]+$ ]]; then
     if ! kill -0 "$pid" 2>/dev/null; then
       return 0
     fi
   fi
   return 1
+}
+
+# Remove a lock directory we are entitled to remove, atomically from the point
+# of view of everyone else: rename it out of the way first, THEN delete it.
+#
+# A plain `rm -rf "$lock_dir"` unlinks `owner` before it removes the directory,
+# so the lock spends the whole teardown visible-but-ownerless — one of the two
+# windows that made #930 fire. `rename` collapses that to a single atomic step:
+# other processes see the lock as fully present or entirely gone, never as an
+# orphan worth breaking.
+_state_lock_destroy() {
+  local lock_dir="$1" aside="${1}.rel.$$-${RANDOM}"
+  if mv "$lock_dir" "$aside" 2>/dev/null; then
+    rm -rf "$aside" 2>/dev/null || true
+  else
+    rm -rf "$lock_dir" 2>/dev/null || true
+  fi
 }
 
 # Break a stale lock, guarded against the double-steal described above.
@@ -200,10 +290,20 @@ _state_lock_break() {
   [[ -d "$lock_dir" ]] || return 0
   after="$(cat "$lock_dir/owner" 2>/dev/null || printf '__no_owner__')"
   # Different bytes ⇒ a live holder rewrote it or the lock was re-acquired by
-  # someone else in the interim. Never break in that case.
+  # someone else in the interim. Never break in that case. Each acquisition
+  # stamps a fresh `token=`, so a lock that changed hands never compares equal
+  # even if the same pid re-took it.
   [[ "$before" == "$after" ]] || return 1
+  # Re-sampling identical "__no_owner__" bytes proves nothing on its own — an
+  # acquire and a release both pass through that state, and under CPU
+  # contention a holder can sit in it longer than the resample window. The
+  # decision is left to _state_lock_is_stale, which for an owner-less lock
+  # falls back to the DIRECTORY's mtime: fresh ⇒ leave it alone (a live holder
+  # mid-acquire), older than STALE_AGE ⇒ genuinely orphaned and breakable, so
+  # a holder that died between mkdir and publishing `owner` still recovers
+  # rather than wedging the fleet forever (#930).
   _state_lock_is_stale "$lock_dir" "$stale_age" || return 1
-  aside="${lock_dir}.stale.$$"
+  aside="${lock_dir}.stale.$$-${RANDOM}"
   # Rename-aside is atomic: at most one racer can move this exact directory.
   if mv "$lock_dir" "$aside" 2>/dev/null; then
     local dead_pid
@@ -230,6 +330,11 @@ state_lock_acquire() {
   # passes CLAUDE_STATE_LOCK_HELD down through the environment. Re-acquiring
   # the same lock in that subtree is a no-op instead of a self-deadlock.
   if [[ "${CLAUDE_STATE_LOCK_HELD:-}" == "$lock_dir" ]]; then
+    # Adopt the ancestor's token so this process can still verify the lock via
+    # state_lock_assert_held. STATE_LOCK_DIR stays EMPTY on purpose: only the
+    # process that won the mkdir may release it.
+    STATE_LOCK_HELD_DIR="$lock_dir"
+    STATE_LOCK_TOKEN="${CLAUDE_STATE_LOCK_TOKEN:-}"
     return 0
   fi
 
@@ -248,24 +353,38 @@ state_lock_acquire() {
       # One stamp call for both fields, and $HOSTNAME instead of hostname(1):
       # acquisition sits in the hot path of every state write, so each avoided
       # fork is measurable.
-      local stamp
+      local stamp token owner_tmp
       stamp="$(_state_lock_stamp)"
-      {
-        printf 'pid=%s\n' "$$"
+      # Unique per ACQUISITION: pid alone repeats (same process re-acquiring,
+      # and pid reuse across processes), and every ownership decision downstream
+      # depends on telling two acquisitions apart. $RANDOM is a bash builtin —
+      # no fork on the hot path.
+      token="$$-${stamp%% *}-${RANDOM}${RANDOM}"
+      owner_tmp="$lock_dir/.owner.$$"
+      # Publish atomically: build the file under a temp name, then rename it
+      # into place. A direct `> owner` is a sequence of separate writes, so
+      # readers can catch it existing-but-incomplete — and an owner file
+      # missing its `epoch=` line used to read as "ancient, break it" (#930).
+      { printf 'pid=%s\n' "$$"
         printf 'host=%s\n' "$(_state_lock_hostname)"
         printf 'epoch=%s\n' "${stamp%% *}"
         printf 'started=%s\n' "${stamp#* }"
         printf 'cmd=%s\n' "${0##*/}"
-      } > "$lock_dir/owner" 2>/dev/null || {
+        printf 'token=%s\n' "$token"
+      } > "$owner_tmp" 2>/dev/null && mv "$owner_tmp" "$lock_dir/owner" 2>/dev/null || {
         # Ownership is proven by this file at release time, so a lock we
         # cannot stamp is a lock we could never safely release. Give it back
         # immediately rather than holding something unreleasable.
-        rm -rf "$lock_dir" 2>/dev/null || true
+        rm -f "$owner_tmp" 2>/dev/null || true
+        _state_lock_destroy "$lock_dir"
         echo "state-lock: could not write owner metadata to $lock_dir/owner — releasing" >&2
         return "$STATE_LOCK_EXIT_TIMEOUT"
       }
       STATE_LOCK_DIR="$lock_dir"
+      STATE_LOCK_HELD_DIR="$lock_dir"
+      STATE_LOCK_TOKEN="$token"
       export CLAUDE_STATE_LOCK_HELD="$lock_dir"
+      export CLAUDE_STATE_LOCK_TOKEN="$token"
       # Chain onto whatever EXIT trap the caller already installed for its own
       # temp files, so releasing the lock never silently drops their cleanup.
       _state_lock_install_trap
@@ -297,24 +416,53 @@ state_lock_acquire() {
 # and safe to call when the lock was already broken by someone else — the
 # owner pid is re-checked so we never delete a lock that is no longer ours.
 state_lock_release() {
-  local lock_dir="$STATE_LOCK_DIR" owner_pid
+  local lock_dir="$STATE_LOCK_DIR" token="$STATE_LOCK_TOKEN" owner_token
+  # STATE_LOCK_DIR is empty for a re-entrant caller, so an inner writer can
+  # never release the lock its ancestor owns.
   [[ -n "$lock_dir" ]] || return 0
   STATE_LOCK_DIR=""
+  STATE_LOCK_HELD_DIR=""
+  STATE_LOCK_TOKEN=""
   unset CLAUDE_STATE_LOCK_HELD
+  unset CLAUDE_STATE_LOCK_TOKEN
   [[ -d "$lock_dir" ]] || return 0
-  owner_pid="$(_state_lock_meta "$lock_dir/owner" pid)"
-  # Delete ONLY on a positive ownership match. An empty/unreadable owner pid
-  # is NOT ours by default: it also occurs in the window between another
-  # process winning `mkdir` and writing its owner file, so treating empty as
-  # "probably still mine" would delete a lock that just changed hands
-  # (CodeAnt, PR #662). Declining to delete is the safe error — a lock we
-  # fail to release ages out via the staleness rules; one we wrongly delete
-  # lets two writers into the critical section at once.
-  if [[ "$owner_pid" != "$$" ]]; then
+  owner_token="$(_state_lock_meta "$lock_dir/owner" token)"
+  # Delete ONLY on a positive ownership match, and match on the TOKEN rather
+  # than the pid: a pid match cannot distinguish our acquisition from a later
+  # one, and a lock broken as stale then re-taken by a recycled pid would be
+  # deleted out from under its new owner. An empty/unreadable token is NOT
+  # ours by default either — that is also the window between another process
+  # winning `mkdir` and publishing its owner file (CodeAnt, PR #662).
+  # Declining to delete is the safe error: a lock we fail to release ages out
+  # via the staleness rules; one we wrongly delete lets two writers into the
+  # critical section at once.
+  if [[ -z "$token" || "$owner_token" != "$token" ]]; then
     return 0
   fi
-  rm -rf "$lock_dir" 2>/dev/null || true
+  _state_lock_destroy "$lock_dir"
   return 0
+}
+
+# 0 while this process still holds the lock covering it, non-zero once that
+# lock has been broken and re-acquired by somebody else.
+#
+# Breaking a stale lock can never be perfectly safe — a wedged-but-alive holder
+# may wake up and finish its write. The defence is that the victim can find
+# out: a break rotates the token, so the check below fails and the caller must
+# ABANDON its read-modify-write rather than commit a value computed from a
+# snapshot someone else has since replaced. Call it immediately before the
+# commit `mv`, not earlier: everything between the check and the commit is
+# still unprotected (#930).
+state_lock_assert_held() {
+  local lock_dir="$STATE_LOCK_HELD_DIR" owner_token
+  [[ -n "$lock_dir" ]] || return 1
+  # An inherited lock with no token predates this library version (a parent
+  # still running the old code). Unverifiable, but it is not ours to police,
+  # and failing closed there would break re-entrant writers for no gain.
+  [[ -n "$STATE_LOCK_TOKEN" ]] || return 0
+  [[ -d "$lock_dir" ]] || return 1
+  owner_token="$(_state_lock_meta "$lock_dir/owner" token)"
+  [[ "$owner_token" == "$STATE_LOCK_TOKEN" ]]
 }
 
 # Install an EXIT trap that releases the lock, preserving any trap the caller

--- a/.claude/scripts/state-lock.sh
+++ b/.claude/scripts/state-lock.sh
@@ -465,16 +465,35 @@ state_lock_release() {
 # standing between a broken lock and a silently dropped update, and a check
 # that each writer has to remember independently is one that some writer will
 # eventually skip — as three of them already had (CodeAnt, PR #937).
+#
+# RESIDUAL WINDOW (deliberate, documented rather than papered over)
+#   The assertion and the `mv` are two operations, so in principle a breaker
+#   could steal the lock between them and this function would still commit.
+#   POSIX shell has no compare-and-swap that would close that gap, so the
+#   window is narrowed instead of eliminated, on two fronts:
+#     • Nothing forks between the check and the `mv` — the gap is microseconds,
+#       against the entire read-modify-write it used to span.
+#     • Breaking a live lock now requires POSITIVE evidence: a dead holder pid,
+#       or an age past STALE_AGE (120s default). A holder that reaches this
+#       function within its first two minutes is not breakable at all, so the
+#       residual applies only to a holder already wedged past that ceiling —
+#       the case the header's FAILURE MODES section accepts on purpose.
+#   Do not read this as "the race is fixed". It is bounded and evidence-gated;
+#   a caller that needs more must not share one state file across writers.
 state_lock_commit() {
-  local tmp="$1" dest="$2"
+  local tmp="$1" dest="$2" mv_err
   if ! state_lock_assert_held; then
     rm -f "$tmp" 2>/dev/null || true
     echo "state-lock: lock was broken by another writer mid-update; refusing to commit $dest (unchanged, retry)" >&2
     return "$STATE_LOCK_EXIT_TIMEOUT"
   fi
-  if ! mv "$tmp" "$dest" 2>/dev/null; then
+  # Capture mv's own diagnostic. A commit fails for distinct reasons — a
+  # read-only filesystem, ENOSPC, a permission change, a cross-device temp —
+  # and each needs a different response, so swallowing stderr leaves the
+  # operator with one indistinguishable message (CodeRabbit, PR #937).
+  if ! mv_err="$(mv "$tmp" "$dest" 2>&1)"; then
     rm -f "$tmp" 2>/dev/null || true
-    echo "state-lock: could not write $dest" >&2
+    echo "state-lock: could not write $dest${mv_err:+ — $mv_err}" >&2
     return 5
   fi
   return 0

--- a/.claude/scripts/state-lock.sh
+++ b/.claude/scripts/state-lock.sh
@@ -453,6 +453,33 @@ state_lock_release() {
 # snapshot someone else has since replaced. Call it immediately before the
 # commit `mv`, not earlier: everything between the check and the commit is
 # still unprotected (#930).
+# state_lock_commit <tmp-file> <destination>
+#
+# The guarded commit every read-modify-write writer should use: assert we still
+# hold the lock, then move the temp file into place. Returns
+# STATE_LOCK_EXIT_TIMEOUT (6) without committing when the lock was broken
+# underneath us, and 5 when the move itself fails; the temp file is removed on
+# either failure.
+#
+# This exists so the assertion cannot be forgotten. It is the ONLY thing
+# standing between a broken lock and a silently dropped update, and a check
+# that each writer has to remember independently is one that some writer will
+# eventually skip — as three of them already had (CodeAnt, PR #937).
+state_lock_commit() {
+  local tmp="$1" dest="$2"
+  if ! state_lock_assert_held; then
+    rm -f "$tmp" 2>/dev/null || true
+    echo "state-lock: lock was broken by another writer mid-update; refusing to commit $dest (unchanged, retry)" >&2
+    return "$STATE_LOCK_EXIT_TIMEOUT"
+  fi
+  if ! mv "$tmp" "$dest" 2>/dev/null; then
+    rm -f "$tmp" 2>/dev/null || true
+    echo "state-lock: could not write $dest" >&2
+    return 5
+  fi
+  return 0
+}
+
 state_lock_assert_held() {
   local lock_dir="$STATE_LOCK_HELD_DIR" owner_token
   [[ -n "$lock_dir" ]] || return 1

--- a/.claude/scripts/tests/state-lock.test.sh
+++ b/.claude/scripts/tests/state-lock.test.sh
@@ -239,6 +239,13 @@ check_eq "age of a fresh owner-less lock is numeric" "1" \
   "$([[ "$AGE" =~ ^[0-9]+$ ]] && echo 1 || echo 0)"
 check_eq "age of a fresh owner-less lock is small, not the old 999999 sentinel" "1" \
   "$([[ "$AGE" =~ ^[0-9]+$ && "$AGE" -lt 60 ]] && echo 1 || echo 0)"
+# The other half of the contract: with NEITHER a recorded epoch nor a readable
+# directory mtime, _state_lock_age must return non-zero and print nothing —
+# never a fabricated age. That "unknown" is what makes the caller fail safe, so
+# it needs its own assertion (CodeRabbit, PR #937).
+UNKNOWN_OUT="$(bash -c 'source "$1"; _state_lock_age "/nonexistent/lock/path/for/930"' _ "$LOCK_LIB" 2>/dev/null)"; RC=$?
+check_eq "unknowable age returns non-zero" "1" "$([[ "$RC" -ne 0 ]] && echo 1 || echo 0)"
+check_eq "unknowable age prints nothing (no fabricated number)" "" "$UNKNOWN_OUT"
 # Same directory, evaluated through the staleness rule that acts on it.
 bash -c 'source "$1"; _state_lock_is_stale "$2" 120' _ "$LOCK_LIB" "$LOCK_DIR"; RC=$?
 check_eq "a fresh owner-less lock is NOT stale (mid-acquire, not dead)" "1" "$RC"
@@ -276,7 +283,13 @@ reset_state
 T1="$(bash -c 'source "$1"; state_lock_acquire "$2" || exit 6; sed -n "s/^token=//p" "$2.lock/owner"' _ "$LOCK_LIB" "$STATE_FILE")"
 T2="$(bash -c 'source "$1"; state_lock_acquire "$2" || exit 6; sed -n "s/^token=//p" "$2.lock/owner"' _ "$LOCK_LIB" "$STATE_FILE")"
 check_eq "a token is published" "1" "$([[ -n "$T1" ]] && echo 1 || echo 0)"
-check_eq "two acquisitions get different tokens" "1" "$([[ "$T1" != "$T2" ]] && echo 1 || echo 0)"
+# Both must be nonempty before comparing them. An empty T2 — the second acquire
+# failing, e.g. a release regression that made it block to timeout — compares
+# unequal to T1, so the uniqueness check below would pass having tested nothing
+# (CodeRabbit, PR #937).
+check_eq "the second acquisition also published a token" "1" "$([[ -n "$T2" ]] && echo 1 || echo 0)"
+check_eq "two acquisitions get different tokens" "1" \
+  "$([[ -n "$T1" && -n "$T2" && "$T1" != "$T2" ]] && echo 1 || echo 0)"
 rm -rf "$LOCK_DIR"
 
 echo

--- a/.claude/scripts/tests/state-lock.test.sh
+++ b/.claude/scripts/tests/state-lock.test.sh
@@ -313,22 +313,56 @@ rm -rf "$STATE_FILE.lock" "$STATE_FILE.lock.stolen"
 
 echo
 echo "== issue #930: a stolen read-modify-write is retried, never committed blind =="
-# Same theft, but through the real write path. The pre-existing value must
-# survive: the writer either redoes its transform against current content or
-# exits 6 — it must never overwrite with the stale snapshot.
+# The theft has to land MID-FLIGHT — after the writer has acquired the lock and
+# read its snapshot, but before it commits. Stealing the lock beforehand only
+# proves that acquire times out; the writer never reaches assert_held, the
+# commit, or the retry, so a regression in any of them would still pass
+# (CodeAnt, PR #937).
+#
+# A `jq` shim earlier on PATH makes the timing deterministic instead of raced:
+# the writer's first post-acquire jq call parks on a FIFO-style sentinel, the
+# test steals the lock while it is parked, then releases it to continue into
+# its commit.
 reset_state
 run --set '.keep="original"'
-BEFORE="$(jq -r '.keep' "$STATE_FILE")"
-OUT="$(CLAUDE_STATE_RMW_MAX_RETRY=1 CLAUDE_STATE_LOCK_TIMEOUT=2 bash -c '
-  source "$1"
-  # Hold a foreign lock so the retry cannot re-acquire, forcing the give-up path.
-  mkdir -p "$2.lock"
-  printf "pid=%s\nhost=%s\nepoch=%s\ntoken=foreign\n" "$$" "$(hostname)" "$(date +%s)" > "$2.lock/owner"
-  bash "$3" --set ".keep=clobbered"; echo "rc=$?"
-' _ "$LOCK_LIB" "$STATE_FILE" "$SCRIPT" 2>&1)"
-check_eq "writer that cannot serialize exits 6" "1" "$(grep -c 'rc=6' <<<"$OUT")"
-check_eq "the original value was not clobbered" "$BEFORE" "$(jq -r '.keep' "$STATE_FILE")"
-rm -rf "$LOCK_DIR"
+BEFORE="$(cat "$STATE_FILE")"
+SHIM_BIN="$TMP_HOME/shimbin"; mkdir -p "$SHIM_BIN"
+REAL_JQ="$(command -v jq)"
+cat > "$SHIM_BIN/jq" <<SHIM
+#!/usr/bin/env bash
+# Park exactly once — on the first call made while the arm file exists — so we
+# interpose after state_lock_acquire and before the commit.
+if [[ -e "$TMP_HOME/arm" ]]; then
+  rm -f "$TMP_HOME/arm"
+  : > "$TMP_HOME/parked"
+  for _ in \$(seq 1 200); do [[ -e "$TMP_HOME/go" ]] && break; sleep 0.05; done
+fi
+exec "$REAL_JQ" "\$@"
+SHIM
+chmod +x "$SHIM_BIN/jq"
+rm -f "$TMP_HOME/arm" "$TMP_HOME/parked" "$TMP_HOME/go"
+: > "$TMP_HOME/arm"
+# max-retry 0 forces the give-up path, so the assertion below proves the writer
+# REFUSED to commit rather than merely having been lucky on a retry.
+( PATH="$SHIM_BIN:$PATH" CLAUDE_STATE_RMW_MAX_RETRY=0 CLAUDE_STATE_LOCK_TIMEOUT=5 \
+    bash "$SCRIPT" --set '.keep="clobbered"' >"$TMP_HOME/w.out" 2>&1; echo "$?" > "$TMP_HOME/w.rc" ) &
+WRITER=$!
+for _ in $(seq 1 200); do [[ -e "$TMP_HOME/parked" ]] && break; sleep 0.05; done
+check_eq "writer parked mid-transform while holding the lock" "1" \
+  "$([[ -e "$TMP_HOME/parked" && -d "$LOCK_DIR" ]] && echo 1 || echo 0)"
+# Steal it: replace the lock directory and publish a different token, exactly
+# as breaking a stale lock and re-acquiring would.
+rm -rf "$LOCK_DIR.thief"; mv "$LOCK_DIR" "$LOCK_DIR.thief" 2>/dev/null
+mkdir -p "$LOCK_DIR"
+printf 'pid=1\nhost=%s\nepoch=%s\ntoken=thief-token\n' "$(hostname)" "$(date +%s)" > "$LOCK_DIR/owner"
+: > "$TMP_HOME/go"
+wait "$WRITER" 2>/dev/null
+WRC="$(cat "$TMP_HOME/w.rc" 2>/dev/null)"
+check_eq "robbed writer exits 6 (unchanged, retry) instead of committing" "6" "$WRC"
+check_eq "it reported the broken lock rather than failing silently" "1" \
+  "$(grep -c 'lock was broken' "$TMP_HOME/w.out")"
+check_eq "the file it would have clobbered is byte-identical" "$BEFORE" "$(cat "$STATE_FILE")"
+rm -rf "$LOCK_DIR" "$LOCK_DIR.thief" "$SHIM_BIN" "$TMP_HOME/arm" "$TMP_HOME/parked" "$TMP_HOME/go"
 
 echo
 echo "== summary: $PASS passed, $FAIL failed =="

--- a/.claude/scripts/tests/state-lock.test.sh
+++ b/.claude/scripts/tests/state-lock.test.sh
@@ -226,6 +226,111 @@ check_eq "no lock directory left behind (scoped path)" "0" "$([[ -e "$LOCK_DIR" 
 unset CLAUDE_SESSION_REPO
 
 echo
+echo "== issue #930: age lookup is portable and never invents an ancient lock =="
+# The GNU/BSD `stat` split, directly. `-f` means --file-system on GNU coreutils
+# and `%m` is then read as a FILE operand, so the old
+# `stat -f %m … || stat -c %Y …` chain printed a filesystem dump AND the mtime
+# and matched neither as a number — every unreadable owner file aged out to the
+# 999999 sentinel, i.e. "instantly stale", on Linux only.
+reset_state
+mkdir -p "$LOCK_DIR"          # a lock directory with NO owner file yet
+AGE="$(bash -c 'source "$1"; _state_lock_age "$2"' _ "$LOCK_LIB" "$LOCK_DIR")"
+check_eq "age of a fresh owner-less lock is numeric" "1" \
+  "$([[ "$AGE" =~ ^[0-9]+$ ]] && echo 1 || echo 0)"
+check_eq "age of a fresh owner-less lock is small, not the old 999999 sentinel" "1" \
+  "$([[ "$AGE" =~ ^[0-9]+$ && "$AGE" -lt 60 ]] && echo 1 || echo 0)"
+# Same directory, evaluated through the staleness rule that acts on it.
+bash -c 'source "$1"; _state_lock_is_stale "$2" 120' _ "$LOCK_LIB" "$LOCK_DIR"; RC=$?
+check_eq "a fresh owner-less lock is NOT stale (mid-acquire, not dead)" "1" "$RC"
+# ...but a genuinely orphaned one still ages out, so a holder that died between
+# mkdir and publishing `owner` can never wedge the fleet forever.
+bash -c 'source "$1"; _state_lock_is_stale "$2" 0' _ "$LOCK_LIB" "$LOCK_DIR"; RC=$?
+check_eq "an owner-less lock past STALE_AGE IS still breakable" "0" "$RC"
+rm -rf "$LOCK_DIR"
+
+echo
+echo "== issue #930: a live holder's lock survives a contending acquirer =="
+# The end-to-end shape of the bug: while one process holds the lock, another
+# must never conclude "stale" and steal it. Deterministic — the holder is real
+# and alive, no timing window is being raced.
+reset_state
+run --set '.notes=held'
+bash -c 'source "$1"; state_lock_acquire "$2" || exit 6; printf "held\n" > "$3"; sleep 30' \
+  _ "$LOCK_LIB" "$STATE_FILE" "$TMP_HOME/held930" &
+HOLDER930=$!
+for _ in $(seq 1 100); do [[ -f "$TMP_HOME/held930" ]] && break; sleep 0.05; done
+HELD_TOKEN="$(sed -n 's/^token=//p' "$LOCK_DIR/owner" 2>/dev/null)"
+OUT="$(CLAUDE_STATE_LOCK_TIMEOUT=2 run --set '.notes=stolen' 2>&1)"; RC=$?
+check_eq "contending writer times out (exit 6) instead of stealing" "6" "$RC"
+check_eq "no stale-break was reported against the live holder" "0" \
+  "$(grep -c 'broke stale lock' <<<"$OUT")"
+check_eq "the live holder still owns the lock (token unchanged)" "$HELD_TOKEN" \
+  "$(sed -n 's/^token=//p' "$LOCK_DIR/owner" 2>/dev/null)"
+check_eq "the contending write did NOT land" "held" "$(jq -r '.notes' "$STATE_FILE")"
+kill -9 "$HOLDER930" 2>/dev/null; wait "$HOLDER930" 2>/dev/null
+rm -rf "$LOCK_DIR"
+
+echo
+echo "== issue #930: owner metadata carries a per-acquisition token =="
+reset_state
+T1="$(bash -c 'source "$1"; state_lock_acquire "$2" || exit 6; sed -n "s/^token=//p" "$2.lock/owner"' _ "$LOCK_LIB" "$STATE_FILE")"
+T2="$(bash -c 'source "$1"; state_lock_acquire "$2" || exit 6; sed -n "s/^token=//p" "$2.lock/owner"' _ "$LOCK_LIB" "$STATE_FILE")"
+check_eq "a token is published" "1" "$([[ -n "$T1" ]] && echo 1 || echo 0)"
+check_eq "two acquisitions get different tokens" "1" "$([[ "$T1" != "$T2" ]] && echo 1 || echo 0)"
+rm -rf "$LOCK_DIR"
+
+echo
+echo "== issue #930: a robbed holder fails closed instead of committing =="
+# Simulate the theft deterministically: acquire, then let a DIFFERENT process
+# take the path over (exactly what breaking a stale lock does), and confirm the
+# original holder notices. Without this the victim would commit a value it
+# computed from a snapshot the thief has already replaced — a silent lost
+# update, which is the whole failure in issue #930.
+reset_state
+OUT="$(bash -c '
+  source "$1"
+  # Positive control first: without this, every "theft detected" assertion below
+  # would also pass against a library that simply lacks the function (the call
+  # fails, the `||` branch fires) — a guard that passes by not running.
+  declare -F state_lock_assert_held >/dev/null && echo "assert-fn-exists=yes"
+  state_lock_acquire "$2" || exit 6
+  state_lock_assert_held && echo "held-before=yes"
+  # Someone else breaks our lock and takes it: the directory is replaced and a
+  # new token published.
+  mv "$2.lock" "$2.lock.stolen"
+  mkdir "$2.lock"
+  printf "pid=1\nhost=%s\nepoch=%s\ntoken=someone-else\n" "$(hostname)" "$(date +%s)" > "$2.lock/owner"
+  state_lock_assert_held || echo "detected-theft=yes"
+  # ...and our release must not delete the thief lock we no longer own.
+  state_lock_release
+  [[ -d "$2.lock" ]] && echo "thief-lock-intact=yes"
+' _ "$LOCK_LIB" "$STATE_FILE" 2>&1)"
+check_eq "state_lock_assert_held exists (positive control)" "1" "$(grep -c 'assert-fn-exists=yes' <<<"$OUT")"
+check_eq "assert_held is true while genuinely held" "1" "$(grep -c 'held-before=yes' <<<"$OUT")"
+check_eq "assert_held detects the theft" "1" "$(grep -c 'detected-theft=yes' <<<"$OUT")"
+check_eq "release leaves the thief's lock alone" "1" "$(grep -c 'thief-lock-intact=yes' <<<"$OUT")"
+rm -rf "$STATE_FILE.lock" "$STATE_FILE.lock.stolen"
+
+echo
+echo "== issue #930: a stolen read-modify-write is retried, never committed blind =="
+# Same theft, but through the real write path. The pre-existing value must
+# survive: the writer either redoes its transform against current content or
+# exits 6 — it must never overwrite with the stale snapshot.
+reset_state
+run --set '.keep="original"'
+BEFORE="$(jq -r '.keep' "$STATE_FILE")"
+OUT="$(CLAUDE_STATE_RMW_MAX_RETRY=1 CLAUDE_STATE_LOCK_TIMEOUT=2 bash -c '
+  source "$1"
+  # Hold a foreign lock so the retry cannot re-acquire, forcing the give-up path.
+  mkdir -p "$2.lock"
+  printf "pid=%s\nhost=%s\nepoch=%s\ntoken=foreign\n" "$$" "$(hostname)" "$(date +%s)" > "$2.lock/owner"
+  bash "$3" --set ".keep=clobbered"; echo "rc=$?"
+' _ "$LOCK_LIB" "$STATE_FILE" "$SCRIPT" 2>&1)"
+check_eq "writer that cannot serialize exits 6" "1" "$(grep -c 'rc=6' <<<"$OUT")"
+check_eq "the original value was not clobbered" "$BEFORE" "$(jq -r '.keep' "$STATE_FILE")"
+rm -rf "$LOCK_DIR"
+
+echo
 echo "== summary: $PASS passed, $FAIL failed =="
 if [[ "$FAIL" -gt 0 ]]; then
   echo "FAILED: state-lock tests" >&2


### PR DESCRIPTION
## **User description**
## What this fixes

`state-lock.sh` did not reliably provide mutual exclusion on Linux. Under contention, two or more writers entered the critical section at once, each completed its read-modify-write, and **each exited 0** while one update was silently discarded.

The reported symptom was an intermittent `handoff-state.test.sh` failure on unrelated PRs (`FAIL — all 20 unique filenames present (expected '20', got '19')`). **This is a real bug, not a flaky test** — the assertion was correctly reporting an invariant the lock failed to uphold, which is why it also fails on markdown-only diffs and passes on a plain re-run.

The blast radius is wider than the test: the same library serializes `session-state.json` and the per-PR handoff files for nine production writers (`session-state.sh`, `handoff-state.sh`, `polling-state-gate.sh`, `dismiss-stale-bot-changes.sh`, `greptile-budget.sh`, `cr-review-hourly.sh`, `session-scheduling-reconcile.sh`, `session-state-audit.sh`). Concurrent orchestrators could silently lose watermark, reviewer, and findings writes — the exact failure #639 and #682 were opened to prevent.

## Root causes

**A — `_state_lock_age` used BSD `stat` syntax, and the wrong spelling does not fail cleanly.** On GNU coreutils `-f` is `--file-system` and `%m` is parsed as a *file operand*: the command fails on `%m` but still prints a multi-line filesystem dump to stdout, so the `stat -f %m … || stat -c %Y …` chain **concatenated** the dump with the real mtime. The result never matched `^[0-9]+$`, so the function returned its `999999` "ancient" sentinel. On Linux, **any lock whose `owner` file was momentarily unreadable was instantly classified stale.** macOS took the working branch — hence local-pass / CI-fail.

**B — two routine windows per lock cycle leave `owner` unreadable,** so A fired constantly: acquire wrote the owner file with five separate `printf`s (observable half-written), and release's `rm -rf` unlinked `owner` *before* removing the directory.

**C — the double-steal guard was a 0.2 s resample,** which CPU contention defeats: `before == after == "__no_owner__"` and the break proceeds against a live holder.

**D — a robbed holder never found out.** It referred to the lock only by path, so it did not error, kept `STATE_LOCK_DIR` set, and committed anyway — both writers exit 0, one update vanishes.

**E — minor/latent:** `done < "$file" 2>/dev/null` applies redirections left-to-right, so a failed input redirect printed to the real stderr despite the intended suppression.

## Approach

- **Portable, validated age lookup** — try `stat -c %Y` then `stat -f %m`, accept only numeric output.
- **Indeterminate age fails safe.** Both staleness rules now require *positive* evidence; absent evidence means "not stale". A lock orphaned before publishing `owner` still recovers via the directory's mtime once it passes `STALE_AGE`, so nothing wedges the fleet.
- **Atomic owner publication** — build under a temp name inside the lock dir, then `rename` into place. `owner` is never observable partially written.
- **Per-acquisition token.** A pid cannot distinguish this acquisition from a later one, so release and the new assert key off `token=`.
- **Atomic teardown** — `rename` the directory aside, *then* delete, so the lock is never visible-but-ownerless.
- **`state_lock_assert_held` (fail closed).** Breaking a stale lock can never be perfectly safe, so the victim must be able to detect the theft. `handoff-state.sh` and `session-state.sh` call it immediately before their commit and redo the read-modify-write from a fresh read (bounded retry, then exit 6) rather than committing a stale snapshot.

## Verification

Linux container (`ubuntu:latest`, `--cpus=1`) reproducing CI's contention:

| | before | after |
|---|---|---|
| 20-writer append race, rounds losing an append | **12 / 12** | **0 / 12** |
| Observed simultaneous lock holders (direct probe) | up to **15** | — |
| Non-zero exits while updates were lost | **0** (silent) | n/a |

Not a container artifact: violations also reproduced on `tmpfs` and a bind mount, and GitHub Actions `ubuntu-latest` runs on ext4.

Full auto-discovered suite on Linux — `origin/main` fails **5** suites *including both* `handoff-state.test.sh` and `state-lock.test.sh`; this branch fails **3**. The remaining 3 (`babysit-tick-watchdog`, `merge-gate-review-substance`, `poll-watermarks`) fail **identically on `main`** and are container artifacts (`gh` absent; root can write an "unwritable" dir).

New regression tests are deterministic — no timing races — and were run against the **pre-fix** library on Linux as a negative control, where 5 of the new assertions fail as intended. A positive control (`declare -F state_lock_assert_held`) keeps the theft-detection assertions from passing merely because the function is absent.

The 20-writer assertion is unchanged at `== 20` — **not** loosened.

## Review coverage

Degraded — **`none`**. CodeAnt CLI returned `403` twice (the known persistent entitlement issue, #643; the GitHub App is unaffected). CodeRabbit CLI ran 5 minutes emitting only heartbeat/status records and was terminated per the 2-minute rule. Self-review was performed; the GitHub-side bots still gate this PR.

## Test plan

- [x] `_state_lock_age` returns a correct, numeric age on Linux for a lock directory with no owner file (never the `999999` sentinel)
- [x] A fresh owner-less lock is **not** classified stale; one past `STALE_AGE` still is (no wedge)
- [x] A live holder's lock survives a contending acquirer — contender exits 6, no stale-break, holder's token unchanged, the contending write does not land
- [x] Owner metadata carries a per-acquisition token, and two acquisitions get different tokens
- [x] A robbed holder detects the theft via `state_lock_assert_held` and its release leaves the thief's lock alone
- [x] A stolen read-modify-write is retried or exits 6 — never committed blind over the current value
- [x] 20 concurrent `--append` writers: all 20 land, every writer exits 0, assertion still `== 20`
- [x] `state-lock.test.sh` and `handoff-state.test.sh` both pass repeatedly on Linux under CPU contention
- [x] No new failures versus `origin/main` in the full auto-discovered suite

Closes #930

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state updates to prevent overwriting newer changes when a lock is lost or reclaimed.
  * Added safer lock ownership verification, cleanup, release behavior, and bounded retries after lock conflicts.
  * Improved handling of stale, missing, or damaged lock metadata.

* **Tests**
  * Added regression coverage for lock theft, stale locks, ownership validation, timeout behavior, and protected state commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent concurrent state updates from being lost on Linux

### What Changed
- State locks now reliably keep concurrent writers out of the same update, including during lock creation, release, and stale-lock recovery.
- Live locks are no longer mistaken for abandoned locks when metadata is incomplete or Linux and macOS timestamp formats differ.
- Each lock acquisition has unique ownership data, preventing a previous holder from releasing or deleting a lock that belongs to a new holder.
- Writers detect when their lock was taken over and refuse to commit outdated changes; affected state and handoff updates retry from a fresh read or exit with a retryable error.
- Added coverage for Linux timestamp handling, live-holder protection, ownership changes, and preventing stolen updates from overwriting newer state.
- Lock and file-write failures now preserve useful error details and leave state unchanged when serialization cannot be verified.

### Impact
`✅ No silently lost concurrent state updates`
`✅ Fewer Linux-only lock takeovers`
`✅ Safe retry when a lock is broken mid-update`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
