### PR TITLE
feat(#941): write a portable handoff automatically so the usage-limit breadcrumb points at something

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -169,3 +169,50 @@ Each record carries `recorded_at`, `session_id`, `cwd`, `transcript_path`, a tru
 
 - `jq` must be installed — the hook exits 0 silently without it
 - Override the output directory with `CLAUDE_USAGE_LIMIT_DIR` (used by the tests)
+
+---
+
+## checkpoint-handoff.sh
+
+Writes a portable handoff document automatically while work is in progress, so `usage-limit-record.sh` has something real to point at when a turn dies without warning (issue #941).
+
+Registered on **`SubagentStop`** with a 15 s timeout.
+
+**Why it exists.** The recorder above names the most recent portable handoff in its breadcrumb, but the only thing that wrote one was invoked by hand. On 2026-08-01 an account limit killed three concurrent sessions and every record came out with `"portable_handoff": null`, because no handoff existed — a limit that arrives without warning is exactly the case where nobody ran the command. This closes the gap from the other side: it produces the artifact and nothing else.
+
+**It is document-only.** No wind-down, no stopping, no decision. The hand-invoked pause command keeps its contract — it runs when asked and for no other reason — because this is a different producer of the same artifact, not that command on a timer.
+
+**Safety.** No token, spend, or quota arithmetic anywhere, and no output gates a decision. `.claude/rules/safety.md` §"Anthropic Quota & Spend Authority" is satisfied as written and was not amended, the same standing the recorder has.
+
+### The degrade ladder
+
+`portable-handoff-lint.sh` rejects relative `.claude/` paths, phase vocabulary, internal state-file names, and slash-command names. A mechanical renderer walks into all of these: run it in this repo and the changed-file list is full of `.claude/scripts/…`. A human rewrites the offending line; a script cannot.
+
+So it renders, lints, and drops to a less specific rendering on failure, shipping the first tier that passes:
+
+| Tier | Contents |
+|---|---|
+| 1 | changed-file paths listed, pull request titles quoted |
+| 2 | paths replaced by a count and a `git status` instruction |
+| 3 | titles dropped — pull requests by number and URL only |
+| 4 | minimal: absolute working directory, counts, universal commands |
+
+If even tier 4 fails it writes **nothing** — a document that fails its own portability gate is the outcome the ladder exists to prevent. In this repository tier 2 is the normal result.
+
+### Throttle
+
+Writes at most once per `CLAUDE_CHECKPOINT_MIN_INTERVAL` (default 600 s), and additionally whenever the local state fingerprint changes inside that window. Time is the primary trigger: in an orchestration session the parent's own git state barely moves while subagents work in their own worktrees, so a purely fingerprint-gated checkpoint would go stale in the session that most needs a current one. The fingerprint lives in an HTML comment in the document, so this needs no sidecar state file and takes no lock.
+
+### Outputs
+
+- `~/.claude/handoffs/portable-handoff-<stamp>-<session>-checkpoint.md` — matches the glob the recorder already scans
+
+Checkpoints older than 7 days are pruned. A handoff written by the pause command is **never** a deletion candidate at any age — the `-checkpoint.md` suffix is what separates them.
+
+### Prerequisites
+
+- `git` — the hook exits 0 silently without it. `jq` is optional and affects only one line.
+- `CLAUDE_HANDOFF_DIR` overrides the output directory (used by the tests)
+- Run it by hand with `--stdout` to see what it would write without publishing
+
+**Tests:** `.claude/scripts/tests/checkpoint-handoff.test.sh`

--- a/.claude/hooks/checkpoint-handoff.sh
+++ b/.claude/hooks/checkpoint-handoff.sh
@@ -275,8 +275,10 @@ PR_SEP=$'\x1f'
 PR_ROWS=""
 if (( ! NO_REMOTE )) && command -v gh >/dev/null 2>&1 && [[ -n "$REPO_SLUG" ]]; then
   PR_ROWS=$(gh pr list --author "@me" --state open --limit 10 \
-              --json number,title,url \
-              --jq '.[] | [(.number|tostring), .title, .url] | join("\u001f")' 2>/dev/null)
+              --json number,title,url,author,reviewDecision,mergeStateStatus \
+              --jq '.[] | [(.number|tostring), .title, .url,
+                           (.author.login // ""), (.reviewDecision // ""),
+                           (.mergeStateStatus // "")] | join("\u001f")' 2>/dev/null)
 fi
 
 # Background units still recorded as running. Read through the state helper when
@@ -350,7 +352,7 @@ render() {
     printf 'No open pull requests were recorded for this account when this was written.\n'
     printf 'Run `gh pr list --author "@me" --state open` to check the current position.\n\n'
   else
-    while IFS="$PR_SEP" read -r n title url; do
+    while IFS="$PR_SEP" read -r n title url owner decision mergestate; do
       [[ -n "$n" ]] || continue
       if (( with_titles )) && [[ -n "$title" ]]; then
         printf -- '- **Pull request %s — %s**\n' "$n" "$title"
@@ -358,6 +360,37 @@ render() {
         printf -- '- **Pull request %s**\n' "$n"
       fi
       printf '  %s\n' "$url"
+
+      # Owner, blocker, and approval are REQUIRED fields since issue #912.
+      # Each is derived from what the forge actually reports; where it reports
+      # nothing, the line says that rather than guessing — "not recorded" is a
+      # true statement a reader can act on, and an invented one is not.
+      if [[ -n "$owner" ]]; then
+        printf '  Owner: %s\n' "$owner"
+      else
+        printf '  Owner: not recorded — check the author shown on the page above\n'
+      fi
+
+      case "$mergestate" in
+        BEHIND) waiting="the branch needs updating against the main branch first" ;;
+        DIRTY)  waiting="it conflicts with the main branch and needs those conflicts resolved" ;;
+        *)
+          case "$decision" in
+            APPROVED)          waiting="nothing from review; confirm its automated checks have finished" ;;
+            CHANGES_REQUESTED) waiting="changes that a reviewer asked for" ;;
+            REVIEW_REQUIRED)   waiting="a review — nobody has recorded a decision yet" ;;
+            *)                 waiting="a review — no decision was recorded when this was written" ;;
+          esac ;;
+      esac
+      printf '  Waiting on: %s\n' "$waiting"
+
+      case "$decision" in
+        APPROVED)          printf '  Approval: approved\n' ;;
+        CHANGES_REQUESTED) printf '  Approval: not approved — a reviewer asked for changes\n' ;;
+        *)                 printf '  Approval: not approved yet\n' ;;
+      esac
+
+      printf '  Verify with: gh pr checks %s\n' "$n"
       printf '  Status: open when this was written. Run `gh pr view %s` for its current\n' "$n"
       printf '  review state, checks, and unanswered comments.\n'
     done <<<"$PR_ROWS"

--- a/.claude/hooks/checkpoint-handoff.sh
+++ b/.claude/hooks/checkpoint-handoff.sh
@@ -294,7 +294,11 @@ ISSUE_NUM=""
 PR_SEP=$'\x1f'
 PR_ROWS=""
 PR_LOOKUP="skipped"
-if (( ! NO_REMOTE )) && command -v gh >/dev/null 2>&1 && [[ -n "$REPO_SLUG" ]]; then
+# Require a real checkout, not merely a non-empty repository label. The
+# basename fallback below also fills REPO_SLUG outside a checkout; running `gh`
+# there can use unrelated ambient/default repository context and report open
+# work that has nothing to do with this handoff (Cursor, PR #944).
+if (( ! NO_REMOTE )) && command -v gh >/dev/null 2>&1 && (( IN_REPO )); then
   PR_ROWS=$(gh pr list --author "@me" --state open --limit 10 \
               --json number,title,url,author,reviewDecision,mergeStateStatus \
               --jq '.[] | [(.number|tostring), .title, .url,
@@ -366,7 +370,9 @@ render() {
     printf 'Repository `%s`' "$REPO_SLUG"
     if [[ -n "$ISSUE_NUM" ]]; then
       printf ', working on issue %s' "$ISSUE_NUM"
-      [[ -n "$REPO_SLUG" ]] && printf ' (https://github.com/%s/issues/%s)' "$REPO_SLUG" "$ISSUE_NUM"
+      # A basename fallback is a display label, not a GitHub owner/repository
+      # slug. Only a two-part slug can form an honest issue URL.
+      [[ "$REPO_SLUG" == */* ]] && printf ' (https://github.com/%s/issues/%s)' "$REPO_SLUG" "$ISSUE_NUM"
     fi
     printf '.\n\n'
     printf 'This checkpoint was written automatically rather than by a person, so what\n'

--- a/.claude/hooks/checkpoint-handoff.sh
+++ b/.claude/hooks/checkpoint-handoff.sh
@@ -1,0 +1,507 @@
+#!/usr/bin/env bash
+# checkpoint-handoff.sh — automatic, document-only handoff checkpoint (issue #941)
+#
+# PURPOSE
+#   `usage-limit-record.sh` writes a breadcrumb when a turn dies on an Anthropic
+#   usage limit, and that breadcrumb points at the most recent portable handoff
+#   so the next session reads *what was happening* instead of reconstructing it
+#   from a transcript. On 2026-08-01 the account limit killed three concurrent
+#   sessions and every record came out with `"portable_handoff": null`, because
+#   no handoff existed: the only thing that writes one is invoked by hand, and a
+#   limit that arrives without warning is precisely the case where nobody did.
+#
+#   This script closes that gap from the other side. It writes the ARTIFACT and
+#   nothing else — no wind-down, no stopping, no decision of any kind — so the
+#   document the recorder already looks for is on disk when it looks.
+#
+# WHAT THIS IS NOT
+#   It is not the pre-emptive wind-down blocked upstream (issues #824 / #835),
+#   and it is not the hand-invoked pause on a timer. Those stop work; this only
+#   describes it. The hand-invoked command keeps its contract — it "runs because
+#   you asked, and for no other reason" — because this is a different producer
+#   of the same artifact, not a scheduled invocation of that command.
+#
+# SAFETY (.claude/rules/safety.md §"Anthropic Quota & Spend Authority")
+#   No token, spend, or quota arithmetic anywhere. Nothing here pauses,
+#   downgrades, defers, or refuses work, and no output gates a decision. That
+#   rule is satisfied as written and was NOT amended for this script — the same
+#   standing the post-hoc recorder has.
+#
+# THE DEGRADE LADDER (the design's load-bearing idea)
+#   `portable-handoff-lint.sh` rejects any relative `.claude/` path, phase
+#   vocabulary, internal state-file names, and any slash-command name resolved
+#   from the live skill catalog. A mechanical renderer walks into all of these
+#   without meaning to: run it in THIS repository and the changed-file list is
+#   full of `.claude/scripts/…`, and a pull request title elsewhere may quote a
+#   command name. A human renderer just rewrites the offending line; a script
+#   cannot.
+#
+#   So the script renders, lints, and on failure drops to a less specific
+#   rendering, shipping the first tier that passes:
+#
+#     1  changed-file paths listed, pull request titles quoted
+#     2  paths replaced by a count and a `git status` instruction
+#     3  titles dropped — pull requests named by number and URL only
+#     4  minimal: absolute working directory, counts, universal commands
+#
+#   Tier 4 deliberately names no branch, no path, and no borrowed text, so it
+#   has essentially nothing left to fail on. If even that does not pass, the
+#   script writes NOTHING rather than emitting a document that fails its own
+#   gate. Four renders, four lint calls, all local.
+#
+#   This makes "the output is portable" a property the script enforces on
+#   itself in whatever repository it runs in, rather than one the author hoped
+#   would hold everywhere.
+#
+# THROTTLE
+#   Registered on SubagentStop, this can fire many times a minute. It writes at
+#   most once per CLAUDE_CHECKPOINT_MIN_INTERVAL, and additionally whenever the
+#   local state fingerprint changes inside that window.
+#
+#   Time is the PRIMARY trigger, not the fingerprint, and that ordering matters:
+#   in an orchestration session the parent's own git state barely moves while
+#   subagents work in their own worktrees, so a purely fingerprint-gated
+#   checkpoint would go stale in exactly the session that most needs a current
+#   one. The fingerprint only ever makes it write MORE often, never less.
+#
+#   The fingerprint lives in an HTML comment in the document itself, so this
+#   needs no sidecar state file and takes no write lock.
+#
+# USAGE
+#   checkpoint-handoff.sh [OPTIONS]
+#
+# OPTIONS
+#   --out-dir DIR        Where handoffs live. Default $CLAUDE_HANDOFF_DIR, then
+#                        ~/.claude/handoffs.
+#   --min-interval SECS  Throttle window. Default $CLAUDE_CHECKPOINT_MIN_INTERVAL,
+#                        then 600.
+#   --retention-days N   Prune checkpoints older than this. Default 7, matching
+#                        the recorder's own handoff age bound.
+#   --force              Ignore the throttle.
+#   --stdout             Render and lint, print to stdout, publish nothing.
+#   --no-remote          Skip the pull request lookup (no network).
+#   -h, --help           This text.
+#
+# EXIT STATUS
+#   Always 0. A checkpoint that becomes a new failure mode is worse than no
+#   checkpoint — the same reason the recorder is written this way. Diagnostics
+#   go to stderr; --stdout is the way to see what it would write.
+
+set -uo pipefail
+
+OUT_DIR=""
+MIN_INTERVAL=""
+RETENTION_DAYS=""
+FORCE=0
+TO_STDOUT=0
+NO_REMOTE=0
+
+usage() { sed -n '2,/^set -uo/p' "$0" | sed 's/^# \{0,1\}//; $d'; }
+
+while (( $# > 0 )); do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --force) FORCE=1 ;;
+    --stdout) TO_STDOUT=1 ;;
+    --no-remote) NO_REMOTE=1 ;;
+    --out-dir) [[ $# -ge 2 ]] || { echo "checkpoint-handoff.sh: --out-dir needs a directory" >&2; exit 0; }; OUT_DIR="$2"; shift ;;
+    --min-interval) [[ $# -ge 2 ]] || { echo "checkpoint-handoff.sh: --min-interval needs a value" >&2; exit 0; }; MIN_INTERVAL="$2"; shift ;;
+    --retention-days) [[ $# -ge 2 ]] || { echo "checkpoint-handoff.sh: --retention-days needs a value" >&2; exit 0; }; RETENTION_DAYS="$2"; shift ;;
+    *) echo "checkpoint-handoff.sh: unknown option: $1" >&2; exit 0 ;;
+  esac
+  shift
+done
+
+# A hook receives the event payload on stdin. Drain it so the writer never gets
+# EPIPE — this script has no use for it, but a broken pipe upstream is a new
+# failure mode, which is the one thing it must not introduce.
+#
+# Skipped for --stdout, which is the by-hand inspection mode: there the caller's
+# stdin is whatever the shell handed down and may never close, and blocking on
+# it would turn "show me what this would write" into an apparent hang. The hook
+# path keeps the drain and is bounded by the registered timeout regardless.
+if (( ! TO_STDOUT )) && [[ ! -t 0 ]]; then
+  cat >/dev/null 2>&1 || true
+fi
+
+command -v git >/dev/null 2>&1 || exit 0
+
+OUT_DIR="${OUT_DIR:-${CLAUDE_HANDOFF_DIR:-$HOME/.claude/handoffs}}"
+
+# Validate the numeric settings before use. An inherited non-numeric value would
+# otherwise reach an arithmetic comparison and abort mid-run, costing the user
+# the checkpoint over a typo in an environment variable.
+MIN_INTERVAL="${MIN_INTERVAL:-${CLAUDE_CHECKPOINT_MIN_INTERVAL:-600}}"
+[[ "$MIN_INTERVAL" =~ ^[0-9]+$ ]] || MIN_INTERVAL=600
+RETENTION_DAYS="${RETENTION_DAYS:-${CLAUDE_CHECKPOINT_RETENTION_DAYS:-7}}"
+[[ "$RETENTION_DAYS" =~ ^[0-9]+$ ]] && (( RETENTION_DAYS > 0 )) || RETENTION_DAYS=7
+
+CHECKPOINT_GLOB='portable-handoff-*-checkpoint.md'
+
+# --- Helpers --------------------------------------------------------------
+
+# Resolve a sibling script the way the other from-anywhere commands do: this may
+# run with a working directory in a completely different project, where a
+# repo-relative path silently resolves to nothing.
+#
+# The `../scripts` candidate is what makes THIS checkout's copies win. Hook
+# registration joins a manifest basename onto the hooks directory, so this file
+# has to live beside the other hooks while the helpers it needs live one
+# directory over — without that candidate the first hit would be the shared
+# worktree's copy, and a run inside a checkout that changed the checker would
+# quietly be verified by a different version of it.
+resolve_script() {
+  local name="$1" candidate self_dir
+  self_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)
+  for candidate in \
+    "$self_dir/$name" \
+    "$self_dir/../scripts/$name" \
+    "$HOME/.claude/skills-worktree/.claude/scripts/$name" \
+    "$HOME/.claude/scripts/$name" \
+    ".claude/scripts/$name"; do
+    if [[ -x "$candidate" ]]; then printf '%s' "$candidate"; return 0; fi
+  done
+  return 1
+}
+
+digest() { # stdin -> short hex
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 2>/dev/null | cut -c1-16
+  else
+    cksum 2>/dev/null | tr -d ' ' | cut -c1-16
+  fi
+}
+
+file_mtime_epoch() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    stat -f %m "$1" 2>/dev/null
+  else
+    stat -c %Y "$1" 2>/dev/null
+  fi
+}
+
+# Newest file matching a glob, by modification time. `-nt` is a bash builtin, so
+# this stays free of the BSD/GNU `stat` split.
+newest_matching() { # $1 = dir, $2 = -name pattern, $3 = optional ! -name pattern
+  local dir="$1" pat="$2" notpat="${3:-}" newest="" f
+  [[ -d "$dir" ]] || return 0
+  while IFS= read -r f; do
+    [[ -f "$f" ]] || continue
+    if [[ -z "$newest" || "$f" -nt "$newest" ]]; then newest="$f"; fi
+  done < <(
+    if [[ -n "$notpat" ]]; then
+      find "$dir" -maxdepth 1 -type f -name "$pat" ! -name "$notpat" 2>/dev/null
+    else
+      find "$dir" -maxdepth 1 -type f -name "$pat" 2>/dev/null
+    fi
+  )
+  printf '%s' "$newest"
+}
+
+# --- Local state (cheap; runs before the throttle) -------------------------
+
+WORKDIR=$(pwd -P 2>/dev/null || pwd)
+IN_REPO=0
+BRANCH=""
+HEAD_SHA=""
+CHANGED_COUNT=0
+CHANGED_LIST=""
+UNPUSHED=""
+REPO_SLUG=""
+TOPLEVEL=""
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  IN_REPO=1
+  TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null)
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  HEAD_SHA=$(git rev-parse --short HEAD 2>/dev/null)
+  PORCELAIN=$(git status --porcelain 2>/dev/null)
+  if [[ -n "$PORCELAIN" ]]; then
+    CHANGED_COUNT=$(printf '%s\n' "$PORCELAIN" | grep -c . 2>/dev/null || true)
+    [[ "$CHANGED_COUNT" =~ ^[0-9]+$ ]] || CHANGED_COUNT=0
+    # Strip the two status columns; keep the path. Rename entries ("R  a -> b")
+    # keep both sides, which is what a reader wants to see anyway.
+    CHANGED_LIST=$(printf '%s\n' "$PORCELAIN" | sed 's/^...//' | sort)
+  fi
+  UNPUSHED=$(git rev-list --count '@{u}..HEAD' 2>/dev/null)
+  [[ "$UNPUSHED" =~ ^[0-9]+$ ]] || UNPUSHED=""
+  ORIGIN=$(git remote get-url origin 2>/dev/null)
+  if [[ -n "$ORIGIN" ]]; then
+    REPO_SLUG="${ORIGIN%.git}"
+    REPO_SLUG="${REPO_SLUG##*:}"
+    REPO_SLUG="${REPO_SLUG#https://}"
+    REPO_SLUG="${REPO_SLUG#*github.com/}"
+  fi
+fi
+[[ -n "$REPO_SLUG" ]] || REPO_SLUG=$(basename "${TOPLEVEL:-$WORKDIR}")
+
+FINGERPRINT=$(printf '%s\n%s\n%s\n%s\n%s\n' \
+  "$BRANCH" "$HEAD_SHA" "$CHANGED_COUNT" "${UNPUSHED:-na}" "$CHANGED_LIST" | digest)
+FINGERPRINT_MARK="<!-- checkpoint-fingerprint: ${FINGERPRINT} -->"
+
+# --- Throttle -------------------------------------------------------------
+#
+# Write when the interval has elapsed, OR when the fingerprint moved inside it.
+# The fingerprint can only ever make this fire more often — see THROTTLE above
+# for why time is the primary trigger and not the other way round.
+
+if (( ! FORCE )) && (( ! TO_STDOUT )); then
+  PREV=$(newest_matching "$OUT_DIR" "$CHECKPOINT_GLOB")
+  if [[ -n "$PREV" ]]; then
+    PREV_MTIME=$(file_mtime_epoch "$PREV")
+    NOW_EPOCH=$(date +%s 2>/dev/null)
+    if [[ "$PREV_MTIME" =~ ^[0-9]+$ && "$NOW_EPOCH" =~ ^[0-9]+$ ]]; then
+      AGE=$(( NOW_EPOCH - PREV_MTIME ))
+      if (( AGE < MIN_INTERVAL )) && grep -qF "$FINGERPRINT_MARK" "$PREV" 2>/dev/null; then
+        exit 0
+      fi
+    fi
+  fi
+fi
+
+# --- Remote state (only past the throttle, so the common path is free) -----
+
+ISSUE_NUM=""
+[[ "$BRANCH" =~ (^|[^0-9])issue-([0-9]+) ]] && ISSUE_NUM="${BASH_REMATCH[2]}"
+
+# One record per line, fields joined by US (0x1f) — NOT by a tab.
+#
+# Tab is an IFS whitespace character, so `IFS=$'\t' read` collapses a run of
+# them: a pull request with an empty title turns "42<TAB><TAB>url" into
+# number=42, title=url, url=empty, and the document then shows a URL where a
+# title belongs with no error anywhere. US is not IFS whitespace, so empty
+# fields hold their position.
+PR_SEP=$'\x1f'
+PR_ROWS=""
+if (( ! NO_REMOTE )) && command -v gh >/dev/null 2>&1 && [[ -n "$REPO_SLUG" ]]; then
+  PR_ROWS=$(gh pr list --author "@me" --state open --limit 10 \
+              --json number,title,url \
+              --jq '.[] | [(.number|tostring), .title, .url] | join("\u001f")' 2>/dev/null)
+fi
+
+# Background units still recorded as running. Read through the state helper when
+# it resolves — direct reads of that file are not this script's business — and
+# treat any failure as "could not tell", never as zero.
+AGENTS_COUNT=""
+if SESSION_STATE_SH=$(resolve_script session-state.sh); then
+  AGENTS_COUNT=$("$SESSION_STATE_SH" --session-view 2>/dev/null \
+                   | jq -r '(.active_agents // []) | length' 2>/dev/null)
+  [[ "$AGENTS_COUNT" =~ ^[0-9]+$ ]] || AGENTS_COUNT=""
+fi
+
+# The most recent hand-written handoff, so a fresh shallow checkpoint never
+# buries an older rich one. Only the BASENAME is ever printed: the absolute path
+# runs through a directory this harness named, which the portability lint
+# rejects — and the reader is holding a file in that same directory anyway, so
+# the basename is the part that actually locates it for them.
+PRIOR_RICH=$(newest_matching "$OUT_DIR" 'portable-handoff-*.md' "$CHECKPOINT_GLOB")
+PRIOR_RICH_NAME=""
+[[ -n "$PRIOR_RICH" ]] && PRIOR_RICH_NAME=$(basename "$PRIOR_RICH")
+
+HUMAN_TIME=$(date '+%Y-%m-%d %H:%M %Z' 2>/dev/null)
+[[ -n "$HUMAN_TIME" ]] || HUMAN_TIME="an unrecorded time"
+
+# --- Rendering ------------------------------------------------------------
+
+# $1 list_files (1|0)   $2 with_titles (1|0)   $3 minimal (1|0)
+render() {
+  local list_files="$1" with_titles="$2" minimal="$3"
+  local n title url
+
+  printf '# Session handoff — %s — %s\n\n' "$REPO_SLUG" "$HUMAN_TIME"
+  printf 'Written automatically while work was in progress, not at a stopping point.\n'
+  printf 'Everything below reflects that moment; check the current state of anything\n'
+  printf 'you are about to change before changing it.\n\n'
+
+  printf '## Start here\n\n'
+  if (( minimal )); then
+    printf 'Open a terminal in the working directory named at the bottom of this document\n'
+    printf 'and run `git status` to see what is unfinished there.\n\n'
+  else
+    printf 'Open a terminal in the working directory named at the bottom of this document\n'
+    printf 'and run `git status`'
+    if (( CHANGED_COUNT > 0 )); then
+      printf ' — there were %d uncommitted change(s) when this was written,\nso start by understanding those before doing anything else' "$CHANGED_COUNT"
+    else
+      printf ' to confirm the tree is still clean'
+    fi
+    printf '.\n\n'
+  fi
+
+  printf "## What we're working on\n\n"
+  if (( minimal )); then
+    printf 'This checkpoint was written automatically by a background task, so it records\n'
+    printf 'no statement of intent. The repository is `%s`. Run `git log --oneline -20`\n' "$REPO_SLUG"
+    printf 'and `git status` in the working directory below to see what was underway.\n\n'
+  else
+    printf 'Repository `%s`' "$REPO_SLUG"
+    if [[ -n "$ISSUE_NUM" ]]; then
+      printf ', working on issue %s' "$ISSUE_NUM"
+      [[ -n "$REPO_SLUG" ]] && printf ' (https://github.com/%s/issues/%s)' "$REPO_SLUG" "$ISSUE_NUM"
+    fi
+    printf '.\n\n'
+    printf 'This checkpoint was written automatically rather than by a person, so what\n'
+    printf 'follows is what the repository state says, not a statement of intent. Read the\n'
+    printf 'issue linked above, if any, for the actual goal.\n\n'
+  fi
+
+  printf '## Open work\n\n'
+  if [[ -z "$PR_ROWS" ]]; then
+    printf 'No open pull requests were recorded for this account when this was written.\n'
+    printf 'Run `gh pr list --author "@me" --state open` to check the current position.\n\n'
+  else
+    while IFS="$PR_SEP" read -r n title url; do
+      [[ -n "$n" ]] || continue
+      if (( with_titles )) && [[ -n "$title" ]]; then
+        printf -- '- **Pull request %s — %s**\n' "$n" "$title"
+      else
+        printf -- '- **Pull request %s**\n' "$n"
+      fi
+      printf '  %s\n' "$url"
+      printf '  Status: open when this was written. Run `gh pr view %s` for its current\n' "$n"
+      printf '  review state, checks, and unanswered comments.\n'
+    done <<<"$PR_ROWS"
+    printf '\n'
+  fi
+
+  printf '## Decisions made this session\n\n'
+  printf 'None are recorded here. This document was produced automatically by a background\n'
+  printf 'task that observes repository state and cannot know why a choice was made.\n'
+  if [[ -n "$PRIOR_RICH_NAME" ]]; then
+    printf '\nA handoff written by hand, which does carry that reasoning, sits in this same\n'
+    printf 'directory as `%s`. Read it as well — it is\n' "$PRIOR_RICH_NAME"
+    printf 'older than this file, so prefer this one for repository state and that one for\n'
+    printf 'intent. Check that its stated objective matches before acting on it.\n'
+  fi
+  printf '\n'
+
+  printf '## Local state on this machine\n\n'
+  printf 'Working directory: %s\n' "$WORKDIR"
+  if (( ! minimal )); then
+    [[ -n "$BRANCH" ]] && printf 'Branch: %s\n' "$BRANCH"
+    [[ -n "$HEAD_SHA" ]] && printf 'Most recent commit: %s\n' "$HEAD_SHA"
+  fi
+
+  if (( IN_REPO )); then
+    if (( CHANGED_COUNT == 0 )); then
+      printf 'Uncommitted changes: none\n'
+    elif (( list_files )) && (( ! minimal )); then
+      printf 'Uncommitted changes: %d file(s) —\n' "$CHANGED_COUNT"
+      printf '%s\n' "$CHANGED_LIST" | sed 's/^/  /'
+    else
+      printf 'Uncommitted changes: %d file(s). Run `git status` in the directory above to\n' "$CHANGED_COUNT"
+      printf '  list them; the names are not reproduced here because they would not mean\n'
+      printf '  anything outside this checkout.\n'
+    fi
+    if [[ -z "$UNPUSHED" ]]; then
+      printf 'Unpushed commits: could not be determined (the branch has no upstream set).\n'
+    elif (( UNPUSHED == 0 )); then
+      printf 'Unpushed commits: none\n'
+    else
+      printf 'Unpushed commits: %s. Run `git log --oneline @{u}..HEAD` to see them.\n' "$UNPUSHED"
+    fi
+  else
+    printf 'This directory is not a git checkout, so no branch or change list was available.\n'
+  fi
+
+  if [[ -n "$AGENTS_COUNT" ]] && (( AGENTS_COUNT > 0 )); then
+    printf '\n%s background unit(s) were still recorded as running when this was written.\n' "$AGENTS_COUNT"
+    printf 'They may have been interrupted, so treat any work they owned as unfinished\n'
+    printf 'until you have checked it yourself.\n'
+  fi
+
+  printf '\n%s\n' "$FINGERPRINT_MARK"
+}
+
+# --- Verify: render, lint, degrade ----------------------------------------
+
+LINT_SH=$(resolve_script portable-handoff-lint.sh) || LINT_SH=""
+LINT_ROOT=""
+if [[ -n "$LINT_SH" ]]; then
+  # Canonicalize before walking up. The resolved path can contain a `..`
+  # component (the `../scripts` candidate above), and appending another `../..`
+  # to an uncanonicalized path is the kind of thing that happens to work until
+  # the candidate that produced it changes. `pwd -P` settles it once.
+  LINT_DIR=$(cd "$(dirname "$LINT_SH")" 2>/dev/null && pwd -P)
+  [[ -n "$LINT_DIR" ]] && LINT_SH="$LINT_DIR/$(basename "$LINT_SH")"
+  LINT_ROOT=$(cd "${LINT_DIR:-.}/../.." 2>/dev/null && pwd -P)
+  # The catalog the checker needs lives under the root's skills directory. If
+  # this root has none, pass no root at all rather than a wrong one — the
+  # checker's own fallback chain is better than a confident bad answer.
+  [[ -n "$LINT_ROOT" && -d "$LINT_ROOT/.claude/skills" ]] || LINT_ROOT=""
+fi
+
+mkdir -p "$OUT_DIR" 2>/dev/null || exit 0
+TMP_DOC=$(mktemp "$OUT_DIR/.checkpoint-handoff.XXXXXX" 2>/dev/null) || exit 0
+trap 'rm -f "$TMP_DOC" 2>/dev/null' EXIT
+
+# list_files with_titles minimal
+TIERS=("1 1 0" "0 1 0" "0 0 0" "0 0 1")
+ACCEPTED=0
+TIER_USED=0
+for tier in "${TIERS[@]}"; do
+  read -r T_FILES T_TITLES T_MINIMAL <<<"$tier"
+  TIER_USED=$(( TIER_USED + 1 ))
+  render "$T_FILES" "$T_TITLES" "$T_MINIMAL" >"$TMP_DOC" 2>/dev/null || continue
+  [[ -s "$TMP_DOC" ]] || continue
+  if [[ -z "$LINT_SH" ]]; then
+    # No checker resolved. Ship the most conservative rendering rather than the
+    # richest unverified one: an unverified document is worth having, but it
+    # should be the tier least likely to contain something the reader cannot
+    # use, since nothing is going to catch it.
+    if (( TIER_USED == ${#TIERS[@]} )); then ACCEPTED=1; fi
+    continue
+  fi
+  # Capture the checker's status explicitly instead of reading $? after the
+  # if/else. `$?` there is the status of whichever branch ran, which is the same
+  # value today and stops being so the moment anything is appended to a branch —
+  # a guard that silently starts reporting something else is the failure mode
+  # this file is otherwise built to avoid.
+  LINT_RC=0
+  if [[ -n "$LINT_ROOT" ]]; then
+    "$LINT_SH" --repo-root "$LINT_ROOT" --quiet "$TMP_DOC" >/dev/null 2>&1 || LINT_RC=$?
+  else
+    "$LINT_SH" --quiet "$TMP_DOC" >/dev/null 2>&1 || LINT_RC=$?
+  fi
+  if (( LINT_RC == 0 )); then ACCEPTED=1; break; fi
+done
+
+# Every tier failed, including the minimal one. Emit nothing: a document that
+# fails its own portability gate is the failure this whole ladder exists to
+# prevent, and silence is recoverable in a way a misleading file is not.
+(( ACCEPTED )) || { echo "checkpoint-handoff.sh: no rendering passed the portability check; nothing written" >&2; exit 0; }
+
+if (( TO_STDOUT )); then
+  cat "$TMP_DOC"
+  exit 0
+fi
+
+# --- Publish --------------------------------------------------------------
+
+SESSION_ID="${CLAUDE_SESSION_ID:-default}"
+SESSION_ID="${SESSION_ID//[^[:alnum:]_.-]/_}"
+SESSION_ID="${SESSION_ID:-default}"
+STAMP=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null)
+[[ -n "$STAMP" ]] || STAMP="unknown"
+OUT="$OUT_DIR/portable-handoff-${STAMP}-${SESSION_ID}-checkpoint.md"
+
+# Same-directory mktemp + mv is an atomic single-writer publish: a reader sees a
+# complete document or none, never a half-written one.
+if mv -f "$TMP_DOC" "$OUT" 2>/dev/null; then
+  trap - EXIT
+  chmod 644 "$OUT" 2>/dev/null
+  printf '%s\n' "$OUT"
+else
+  echo "checkpoint-handoff.sh: could not publish the checkpoint" >&2
+  exit 0
+fi
+
+# --- Retention ------------------------------------------------------------
+#
+# Only files this script wrote are candidates. The `-checkpoint.md` suffix is
+# what separates them from a hand-written handoff, which is the user's document
+# and is never a deletion candidate at any age.
+find "$OUT_DIR" -maxdepth 1 -type f -name "$CHECKPOINT_GLOB" \
+  -mtime "+${RETENTION_DAYS}" -delete 2>/dev/null
+
+exit 0

--- a/.claude/hooks/checkpoint-handoff.sh
+++ b/.claude/hooks/checkpoint-handoff.sh
@@ -235,8 +235,15 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 [[ -n "$REPO_SLUG" ]] || REPO_SLUG=$(basename "${TOPLEVEL:-$WORKDIR}")
 
+# Fingerprint over the RAW porcelain, not the stripped path list: the two status
+# columns are what distinguish staged from unstaged and modified from added, so
+# stripping them first made `git add` invisible to the throttle (CodeAnt, PR
+# #944). Content edits within an already-modified file still do not move it —
+# catching those would mean hashing the diff on every SubagentStop — and they do
+# not need to, because time is the primary trigger: the next interval writes
+# regardless. The fingerprint's only job is to write MORE often than that.
 FINGERPRINT=$(printf '%s\n%s\n%s\n%s\n%s\n' \
-  "$BRANCH" "$HEAD_SHA" "$CHANGED_COUNT" "${UNPUSHED:-na}" "$CHANGED_LIST" | digest)
+  "$BRANCH" "$HEAD_SHA" "$CHANGED_COUNT" "${UNPUSHED:-na}" "${PORCELAIN:-}" | digest)
 FINGERPRINT_MARK="<!-- checkpoint-fingerprint: ${FINGERPRINT} -->"
 
 # --- Throttle -------------------------------------------------------------
@@ -262,7 +269,11 @@ fi
 # --- Remote state (only past the throttle, so the common path is free) -----
 
 ISSUE_NUM=""
-[[ "$BRANCH" =~ (^|[^0-9])issue-([0-9]+) ]] && ISSUE_NUM="${BASH_REMATCH[2]}"
+# The boundary is non-ALPHANUMERIC, not merely non-digit: `[^0-9]` let
+# `reissue-941` match on its `e`, so an unrelated branch published a link to
+# issue 941 (Cursor, PR #944). A leading `re`/`de`/`un` prefix is the realistic
+# way this happens; a separator or start-of-string is the only honest boundary.
+[[ "$BRANCH" =~ (^|[^[:alnum:]])issue-([0-9]+) ]] && ISSUE_NUM="${BASH_REMATCH[2]}"
 
 # One record per line, fields joined by US (0x1f) — NOT by a tab.
 #
@@ -271,14 +282,30 @@ ISSUE_NUM=""
 # number=42, title=url, url=empty, and the document then shows a URL where a
 # title belongs with no error anywhere. US is not IFS whitespace, so empty
 # fields hold their position.
+#
+# PR_LOOKUP distinguishes the three outcomes the reader must not see conflated:
+#   ok        the forge answered — an empty result really does mean none open
+#   failed    the call errored; "none open" would be a false statement
+#   skipped   never attempted (--no-remote, no gh, no remote to ask about)
+# Discarding the exit status made a failed lookup render as "no open pull
+# requests were recorded" (Cursor, PR #944). Reporting "nothing in flight" when
+# the truth is "could not look" is the one mistake a handoff cannot afford,
+# because the reader has no way to detect it.
 PR_SEP=$'\x1f'
 PR_ROWS=""
+PR_LOOKUP="skipped"
 if (( ! NO_REMOTE )) && command -v gh >/dev/null 2>&1 && [[ -n "$REPO_SLUG" ]]; then
   PR_ROWS=$(gh pr list --author "@me" --state open --limit 10 \
               --json number,title,url,author,reviewDecision,mergeStateStatus \
               --jq '.[] | [(.number|tostring), .title, .url,
                            (.author.login // ""), (.reviewDecision // ""),
                            (.mergeStateStatus // "")] | join("\u001f")' 2>/dev/null)
+  GH_RC=$?
+  # Read the status of `gh` itself into a variable on the very next line. An
+  # empty result and a failed call are the same empty string, so the exit code
+  # is the only thing that tells them apart — and `$?` stops meaning that the
+  # moment anything is inserted above it.
+  if (( GH_RC == 0 )); then PR_LOOKUP="ok"; else PR_LOOKUP="failed"; PR_ROWS=""; fi
 fi
 
 # Background units still recorded as running. Read through the state helper when
@@ -349,7 +376,17 @@ render() {
 
   printf '## Open work\n\n'
   if [[ -z "$PR_ROWS" ]]; then
-    printf 'No open pull requests were recorded for this account when this was written.\n'
+    case "$PR_LOOKUP" in
+      failed)
+        printf 'The list of open pull requests COULD NOT BE READ when this was written —\n'
+        printf 'the query failed. This is not the same as there being none: assume there\n'
+        printf 'may be work in flight and check for yourself.\n' ;;
+      skipped)
+        printf 'Open pull requests were not looked up when this was written, so this says\n'
+        printf 'nothing about whether any exist.\n' ;;
+      *)
+        printf 'No open pull requests were recorded for this account when this was written.\n' ;;
+    esac
     printf 'Run `gh pr list --author "@me" --state open` to check the current position.\n\n'
   else
     while IFS="$PR_SEP" read -r n title url owner decision mergestate; do
@@ -516,7 +553,16 @@ SESSION_ID="${SESSION_ID//[^[:alnum:]_.-]/_}"
 SESSION_ID="${SESSION_ID:-default}"
 STAMP=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null)
 [[ -n "$STAMP" ]] || STAMP="unknown"
-OUT="$OUT_DIR/portable-handoff-${STAMP}-${SESSION_ID}-checkpoint.md"
+# The timestamp is whole-second and the session id can be absent (both writers
+# then land on "default"), so two hooks firing in the same second produced the
+# same name and `mv -f` silently destroyed one of them (CodeAnt, PR #944). That
+# is not a rare interleaving here: one account limit fails every active session
+# at once, which is exactly when concurrent writes happen and exactly when
+# losing one costs the most. Reuse the mktemp suffix already guaranteed unique
+# in this directory rather than inventing a second source of uniqueness.
+UNIQ="${TMP_DOC##*.}"
+[[ -n "$UNIQ" && "$UNIQ" != "$TMP_DOC" ]] || UNIQ="$$"
+OUT="$OUT_DIR/portable-handoff-${STAMP}-${SESSION_ID}-${UNIQ}-checkpoint.md"
 
 # Same-directory mktemp + mv is an atomic single-writer publish: a reader sees a
 # complete document or none, never a half-written one.

--- a/.claude/scripts/tests/checkpoint-handoff.test.sh
+++ b/.claude/scripts/tests/checkpoint-handoff.test.sh
@@ -254,8 +254,8 @@ STUB_BIN="$TMP/stubbin"
 mkdir -p "$STUB_BIN"
 cat > "$STUB_BIN/gh" <<'STUB'
 #!/usr/bin/env bash
-printf '42\037\037https://example.com/42\n'
-printf '43\037A real title\037https://example.com/43\n'
+printf '42\037\037https://example.com/42\037auerbachb\037REVIEW_REQUIRED\037CLEAN\n'
+printf '43\037A real title\037https://example.com/43\037someone-else\037APPROVED\037BEHIND\n'
 STUB
 chmod +x "$STUB_BIN/gh"
 DOC_PR=$(cd "$PLAIN" && PATH="$STUB_BIN:$PATH" "$CP" --stdout --out-dir "$TMP/out-pr" 2>/dev/null)
@@ -263,6 +263,22 @@ check_contains "T9 titleless pull request renders without a title" "- **Pull req
 check_contains "T9 titleless pull request keeps its URL" "https://example.com/42" "$DOC_PR"
 check_not_contains "T9 the URL never lands in the title position" "Pull request 42 — https" "$DOC_PR"
 check_contains "T9 a titled pull request still shows its title" "- **Pull request 43 — A real title**" "$DOC_PR"
+
+# The three fields issue #912 made mandatory, asserted on VALUE and not merely
+# on the anchor. The rules themselves can only see presence — "Owner: yes"
+# passes them — so presence is exactly the part already covered by the lint
+# call below, and the part worth pinning here is that each line carries what
+# the forge actually reported.
+check_contains "T9 owner comes from the reported author" "Owner: auerbachb" "$DOC_PR"
+check_contains "T9 owner is per-entry, not copied between entries" "Owner: someone-else" "$DOC_PR"
+check_contains "T9 an undecided pull request says a review is outstanding" "Waiting on: a review — nobody has recorded a decision yet" "$DOC_PR"
+check_contains "T9 approval reflects the reported decision" "Approval: not approved yet" "$DOC_PR"
+check_contains "T9 an approved pull request says so" "Approval: approved" "$DOC_PR"
+# An approved pull request that is BEHIND is waiting on the rebase, not on
+# review — merge state has to outrank review decision or the document tells the
+# reader to wait for something that already happened.
+check_contains "T9 a BEHIND branch outranks its approval in what it waits on" "Waiting on: the branch needs updating against the main branch first" "$DOC_PR"
+check_contains "T9 a verification command is offered" "Verify with: gh pr checks 42" "$DOC_PR"
 printf '%s\n' "$DOC_PR" > "$TMP/t9.md"
 "$LINT" --repo-root "$FAKE" --quiet "$TMP/t9.md" >/dev/null 2>&1
 check_eq "T9 pull request rendering passes the portability check" "0" "$?"

--- a/.claude/scripts/tests/checkpoint-handoff.test.sh
+++ b/.claude/scripts/tests/checkpoint-handoff.test.sh
@@ -284,6 +284,59 @@ printf '%s\n' "$DOC_PR" > "$TMP/t9.md"
 check_eq "T9 pull request rendering passes the portability check" "0" "$?"
 
 # ---------------------------------------------------------------------------
+# T10 — review findings from PR #944, each pinned against its own regression
+# ---------------------------------------------------------------------------
+
+# (a) A failed pull-request lookup must not render as "none open". The stub
+#     exits non-zero with no output, which is byte-identical to a genuinely
+#     empty result — the exit code is the only thing separating them.
+FAILBIN="$TMP/failbin"; mkdir -p "$FAILBIN"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$FAILBIN/gh"; chmod +x "$FAILBIN/gh"
+DOC_FAIL=$(cd "$PLAIN" && PATH="$FAILBIN:$PATH" "$CP" --stdout --out-dir "$TMP/out-ghfail" 2>/dev/null)
+check_contains "T10a a failed lookup says it could not be read" "COULD NOT BE READ" "$DOC_FAIL"
+check_not_contains "T10a a failed lookup never claims none are open" "No open pull requests were recorded" "$DOC_FAIL"
+printf '%s\n' "$DOC_FAIL" > "$TMP/t10a.md"
+"$LINT" --repo-root "$FAKE" --quiet "$TMP/t10a.md" >/dev/null 2>&1
+check_eq "T10a the could-not-read rendering still passes the portability check" "0" "$?"
+
+# A skipped lookup is a third state and must not borrow either other wording.
+DOC_SKIP=$(cd "$PLAIN" && "$CP" --stdout --no-remote --out-dir "$TMP/out-ghskip" 2>/dev/null)
+check_contains "T10a a skipped lookup says it was not looked up" "were not looked up" "$DOC_SKIP"
+
+# (b) Branch-name issue detection must not match an embedded number.
+git -C "$PLAIN" checkout -q -b reissue-941
+DOC_RE=$(cd "$PLAIN" && "$CP" --stdout --no-remote --out-dir "$TMP/out-reissue" 2>/dev/null)
+check_not_contains "T10b reissue-941 does not publish an issue 941 link" "/issues/941" "$DOC_RE"
+git -C "$PLAIN" checkout -q -b issue-941-real
+DOC_REAL=$(cd "$PLAIN" && "$CP" --stdout --no-remote --out-dir "$TMP/out-realissue" 2>/dev/null)
+check_contains "T10b issue-941-real still detects issue 941" "issue 941" "$DOC_REAL"
+git -C "$PLAIN" checkout -q main
+
+# (c) Staging a change must move the fingerprint. Pre-fix the status columns
+#     were stripped before hashing, so `git add` was invisible and the throttle
+#     suppressed the checkpoint for the rest of the interval.
+echo staged-content > "$PLAIN/stage-me.txt"
+FP_UNSTAGED=$(current_fingerprint "$PLAIN")
+git -C "$PLAIN" add stage-me.txt
+FP_STAGED=$(current_fingerprint "$PLAIN")
+check_eq "T10c staging a file changes the fingerprint" "0" \
+  "$([[ -n "$FP_UNSTAGED" && "$FP_UNSTAGED" != "$FP_STAGED" ]] && echo 0 || echo 1)"
+git -C "$PLAIN" reset -q
+
+# (d) Two writers in the same second must not overwrite each other. Same stamp,
+#     same (unset) session id — pre-fix both resolved to one filename and `mv -f`
+#     destroyed the first. An account-wide limit fails every session at once, so
+#     this is the expected case, not a rare interleave.
+OUT_RACE="$TMP/out-race"
+A=$(cd "$PLAIN" && "$CP" --no-remote --out-dir "$OUT_RACE" --force 2>/dev/null)
+B=$(cd "$PLAIN" && "$CP" --no-remote --out-dir "$OUT_RACE" --force 2>/dev/null)
+check_eq "T10d two same-second writes produce two distinct files" "0" \
+  "$([[ -n "$A" && -n "$B" && "$A" != "$B" ]] && echo 0 || echo 1)"
+check_eq "T10d both survive on disk" "2" \
+  "$(find "$OUT_RACE" -maxdepth 1 -type f -name '*-checkpoint.md' | wc -l | tr -d ' ')"
+check_contains "T10d the unique name still matches the recorder's glob" "-checkpoint.md" "$B"
+
+# ---------------------------------------------------------------------------
 # T8 — degraded environments must never fail the turn
 # ---------------------------------------------------------------------------
 NOTREPO="$TMP/notrepo"

--- a/.claude/scripts/tests/checkpoint-handoff.test.sh
+++ b/.claude/scripts/tests/checkpoint-handoff.test.sh
@@ -336,6 +336,22 @@ check_eq "T10d both survive on disk" "2" \
   "$(find "$OUT_RACE" -maxdepth 1 -type f -name '*-checkpoint.md' | wc -l | tr -d ' ')"
 check_contains "T10d the unique name still matches the recorder's glob" "-checkpoint.md" "$B"
 
+# (e) A directory basename is only a display label. Outside a checkout it must
+#     neither become a malformed GitHub issue URL nor give `gh` permission to
+#     use unrelated ambient/default repository context.
+NOTREPO_REVIEW="$TMP/notrepo-review"
+mkdir -p "$NOTREPO_REVIEW"
+DOC_NOTREPO_REMOTE=$(cd "$NOTREPO_REVIEW" && PATH="$STUB_BIN:$PATH" "$CP" --stdout --out-dir "$TMP/out-notrepo-review" 2>/dev/null)
+check_not_contains "T10e outside a checkout no unrelated pull requests are reported" "Pull request 42" "$DOC_NOTREPO_REMOTE"
+check_contains "T10e outside a checkout the pull-request lookup is skipped" "were not looked up" "$DOC_NOTREPO_REMOTE"
+
+NO_ORIGIN="$TMP/issue-941-no-origin"
+new_repo "$NO_ORIGIN"
+git -C "$NO_ORIGIN" checkout -q -b issue-941-real
+DOC_NO_ORIGIN=$(cd "$NO_ORIGIN" && "$CP" --stdout --no-remote --out-dir "$TMP/out-no-origin" 2>/dev/null)
+check_contains "T10e a no-origin branch can still name its issue number" "issue 941" "$DOC_NO_ORIGIN"
+check_not_contains "T10e a basename never becomes a malformed GitHub issue URL" "https://github.com/issue-941-no-origin/issues/941" "$DOC_NO_ORIGIN"
+
 # ---------------------------------------------------------------------------
 # T8 — degraded environments must never fail the turn
 # ---------------------------------------------------------------------------

--- a/.claude/scripts/tests/checkpoint-handoff.test.sh
+++ b/.claude/scripts/tests/checkpoint-handoff.test.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# Offline tests for checkpoint-handoff.sh (issue #941).
+#
+# The interesting property under test is the DEGRADE LADDER: the script must
+# produce a document that passes portable-handoff-lint.sh in whatever repository
+# it happens to run in, including this one — where the changed-file list is full
+# of `.claude/…` paths the lint rejects outright. So the suite builds two
+# throwaway repositories, one with ordinary filenames and one with harness-shaped
+# ones, and asserts that the first lists files while the second silently drops to
+# a count — both linting clean.
+#
+# It also pins the contract with the consumer: usage-limit-record.sh must find a
+# checkpoint through its existing glob and publish a non-null portable_handoff.
+# That is the whole point of the feature, and it is the assertion most likely to
+# rot if either filename convention drifts.
+#
+# Requires git and jq. Run from repo root:
+#   bash .claude/scripts/tests/checkpoint-handoff.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SUT="$REPO_ROOT/.claude/hooks/checkpoint-handoff.sh"
+LINT="$REPO_ROOT/.claude/scripts/portable-handoff-lint.sh"
+RECORDER="$REPO_ROOT/.claude/hooks/usage-limit-record.sh"
+
+TMP="$(mktemp -d)"
+TMP_HOME="$(mktemp -d)"
+cleanup() { rm -rf "$TMP" "$TMP_HOME"; }
+trap cleanup EXIT
+export HOME="$TMP_HOME"
+mkdir -p "$HOME/.claude"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "ok   — $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL — $1"; }
+
+check_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then pass "$desc"
+  else fail "$desc (expected '$expected', got '$actual')"; fi
+}
+check_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then pass "$desc"
+  else fail "$desc (missing '$needle')"; fi
+}
+check_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then pass "$desc"
+  else fail "$desc (unexpectedly present: '$needle')"; fi
+}
+
+# ---- a self-contained copy of the harness the script resolves against -------
+# Laid out exactly as production is — the script under hooks, the checker one
+# directory over under scripts — because that split is the whole reason
+# resolve_script carries a `../scripts` candidate. A flat fixture would resolve
+# through the "own directory" candidate instead and pass while the real layout
+# silently fell through to whatever copy the shared worktree happened to hold.
+#
+# The skills directory is not decoration either: the checker resolves its
+# command catalog from <script>/../.., and without one it falls back to an
+# over-broad shape rule — so the suite would be exercising a different code path
+# than production does.
+FAKE="$TMP/harness"
+mkdir -p "$FAKE/.claude/hooks" "$FAKE/.claude/scripts" \
+         "$FAKE/.claude/skills/wrap" "$FAKE/.claude/skills/pause" "$FAKE/.claude/skills/fixpr"
+cp "$SUT" "$FAKE/.claude/hooks/"
+cp "$LINT" "$FAKE/.claude/scripts/"
+chmod +x "$FAKE/.claude/hooks/"*.sh "$FAKE/.claude/scripts/"*.sh
+CP="$FAKE/.claude/hooks/checkpoint-handoff.sh"
+
+# Prove the split layout actually resolves the neighbouring checker before any
+# assertion depends on it. Without this, every "passes the portability check"
+# result below could be produced by a script that found no checker at all and
+# shipped its most conservative rendering unverified — which is a pass for the
+# wrong reason, and invisible.
+# "Branch:" is the discriminator: only the minimal tier omits it, and the
+# no-checker path can accept nothing else. Seeing it therefore proves a checker
+# was found AND accepted a richer rendering.
+PROBE_REPO="$TMP/probe"
+mkdir -p "$PROBE_REPO"
+git init -q -b main "$PROBE_REPO"
+git -C "$PROBE_REPO" config user.email "test@example.com"
+git -C "$PROBE_REPO" config user.name "Test"
+echo x > "$PROBE_REPO/plain.txt"
+git -C "$PROBE_REPO" add -A
+git -C "$PROBE_REPO" commit -qm seed
+PROBE_DOC=$(cd "$PROBE_REPO" && "$CP" --stdout --no-remote 2>/dev/null)
+check_contains "T0 checker resolved: a richer tier shipped, not the minimal fallback" "Branch: main" "$PROBE_DOC"
+
+new_repo() { # $1 = path
+  mkdir -p "$1"
+  git init -q -b main "$1"
+  git -C "$1" config user.email "test@example.com"
+  git -C "$1" config user.name "Test"
+  echo seed > "$1/README.md"
+  git -C "$1" add -A
+  git -C "$1" commit -qm "seed"
+}
+
+# ---------------------------------------------------------------------------
+# T1 — ordinary repository: the richest tier ships, file names and all
+# ---------------------------------------------------------------------------
+PLAIN="$TMP/plain"
+new_repo "$PLAIN"
+echo change > "$PLAIN/src-notes.txt"
+OUT_PLAIN="$TMP/out-plain"
+DOC=$(cd "$PLAIN" && "$CP" --stdout --no-remote --out-dir "$OUT_PLAIN" 2>/dev/null)
+check_contains "T1 ordinary repo lists the changed file by name" "src-notes.txt" "$DOC"
+printf '%s\n' "$DOC" > "$TMP/t1.md"
+"$LINT" --repo-root "$FAKE" --quiet "$TMP/t1.md" >/dev/null 2>&1
+check_eq "T1 richest tier passes the portability check" "0" "$?"
+
+# ---------------------------------------------------------------------------
+# T2 — harness-shaped repository: the ladder degrades, and still lints clean.
+#      This is the case that made the ladder necessary; without it the script
+#      would emit a document that fails its own gate every time it ran here.
+# ---------------------------------------------------------------------------
+HARNESSY="$TMP/harnessy"
+new_repo "$HARNESSY"
+mkdir -p "$HARNESSY/.claude/scripts"
+echo 'echo hi' > "$HARNESSY/.claude/scripts/thing.sh"
+OUT_H="$TMP/out-h"
+DOC_H=$(cd "$HARNESSY" && "$CP" --stdout --no-remote --out-dir "$OUT_H" 2>/dev/null)
+check_not_contains "T2 harness-shaped path is not reproduced in the document" ".claude/scripts/thing.sh" "$DOC_H"
+check_contains "T2 degraded tier reports a count instead" "Uncommitted changes: 1 file(s)" "$DOC_H"
+printf '%s\n' "$DOC_H" > "$TMP/t2.md"
+"$LINT" --repo-root "$FAKE" --quiet "$TMP/t2.md" >/dev/null 2>&1
+check_eq "T2 degraded tier passes the portability check" "0" "$?"
+
+# Required sections and the absolute working directory, asserted directly rather
+# than trusting the lint's summary exit code.
+for section in "Start here" "What we're working on" "Open work" "Decisions made this session" "Local state on this machine"; do
+  check_contains "T2 section present: $section" "## $section" "$DOC_H"
+done
+WD_LINE=$(printf '%s\n' "$DOC_H" | grep '^Working directory: ' | head -1)
+check_eq "T2 working directory is absolute" "1" "$([[ "${WD_LINE#Working directory: }" == /* ]] && echo 1 || echo 0)"
+
+# ---------------------------------------------------------------------------
+# T3 — publishing: filename matches the glob the recorder already scans
+# ---------------------------------------------------------------------------
+OUT="$TMP/handoffs"
+WROTE=$(cd "$PLAIN" && "$CP" --no-remote --out-dir "$OUT" 2>/dev/null)
+check_eq "T3 publish exits 0" "0" "$?"
+check_eq "T3 wrote exactly one file" "1" "$(find "$OUT" -maxdepth 1 -type f -name 'portable-handoff-*.md' | wc -l | tr -d ' ')"
+check_contains "T3 filename carries the checkpoint suffix" "-checkpoint.md" "$WROTE"
+check_eq "T3 filename matches the recorder's glob" "1" \
+  "$(find "$OUT" -maxdepth 1 -type f -name 'portable-handoff-*.md' | wc -l | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+# T4 — throttle
+#
+# Asserted on the script's own stdout: it prints the published path when it
+# writes and prints nothing when it declines. Counting files in the directory
+# was the obvious alternative and is wrong — the filename carries a
+# whole-second timestamp, so two writes in the same second land on the same
+# name and the count does not move even though both wrote.
+#
+# Each case seeds its own prior checkpoint with a controlled fingerprint and
+# modification time, so nothing here depends on wall-clock timing or a sleep.
+# ---------------------------------------------------------------------------
+current_fingerprint() { # $1 = repo
+  (cd "$1" && "$CP" --stdout --no-remote 2>/dev/null) | grep -o 'checkpoint-fingerprint: [0-9a-f]*' | head -1
+}
+seed_checkpoint() { # $1 = dir, $2 = fingerprint line, $3 = optional touch stamp
+  mkdir -p "$1"
+  local f="$1/portable-handoff-20260101T000000Z-seed-checkpoint.md"
+  printf 'seeded\n<!-- %s -->\n' "$2" > "$f"
+  [[ -n "${3:-}" ]] && touch -t "$3" "$f"
+  printf '%s' "$f"
+}
+
+FP=$(current_fingerprint "$PLAIN")
+check_eq "T4 fingerprint is readable from the rendered document" "1" \
+  "$([[ -n "$FP" ]] && echo 1 || echo 0)"
+
+T4A="$TMP/t4a"; seed_checkpoint "$T4A" "$FP" >/dev/null
+OUT_A=$(cd "$PLAIN" && "$CP" --no-remote --out-dir "$T4A" 2>/dev/null)
+check_eq "T4 unchanged state inside the window writes nothing" "" "$OUT_A"
+
+T4B="$TMP/t4b"; seed_checkpoint "$T4B" "checkpoint-fingerprint: 0000000000000000" >/dev/null
+OUT_B=$(cd "$PLAIN" && "$CP" --no-remote --out-dir "$T4B" 2>/dev/null)
+check_contains "T4 changed state inside the window still writes" "-checkpoint.md" "$OUT_B"
+
+T4C="$TMP/t4c"; seed_checkpoint "$T4C" "$FP" "202501010000" >/dev/null
+OUT_C=$(cd "$PLAIN" && "$CP" --no-remote --out-dir "$T4C" 2>/dev/null)
+check_contains "T4 elapsed window writes even with unchanged state" "-checkpoint.md" "$OUT_C"
+
+T4D="$TMP/t4d"; seed_checkpoint "$T4D" "$FP" >/dev/null
+OUT_D=$(cd "$PLAIN" && "$CP" --no-remote --out-dir "$T4D" --force 2>/dev/null)
+check_contains "T4 --force overrides the throttle" "-checkpoint.md" "$OUT_D"
+
+# ---------------------------------------------------------------------------
+# T5 — back-pointer to a hand-written handoff
+# ---------------------------------------------------------------------------
+OUT_BP="$TMP/handoffs-bp"
+mkdir -p "$OUT_BP"
+RICH="$OUT_BP/portable-handoff-20260101T000000Z-abc123.md"
+echo "a hand-written handoff" > "$RICH"
+DOC_BP=$(cd "$PLAIN" && "$CP" --stdout --no-remote --out-dir "$OUT_BP" 2>/dev/null)
+check_contains "T5 names the hand-written handoff by basename" "portable-handoff-20260101T000000Z-abc123.md" "$DOC_BP"
+check_not_contains "T5 does not print its unportable absolute path" "$OUT_BP/portable-handoff" "$DOC_BP"
+printf '%s\n' "$DOC_BP" > "$TMP/t5.md"
+"$LINT" --repo-root "$FAKE" --quiet "$TMP/t5.md" >/dev/null 2>&1
+check_eq "T5 back-pointer rendering still passes the portability check" "0" "$?"
+
+# A checkpoint must never be advertised as the hand-written one.
+DOC_BP2=$(cd "$PLAIN" && "$CP" --stdout --no-remote --out-dir "$OUT" 2>/dev/null)
+check_not_contains "T5 an existing checkpoint is not offered as the hand-written handoff" "-checkpoint.md\`" "$DOC_BP2"
+
+# ---------------------------------------------------------------------------
+# T6 — retention prunes only what this script wrote
+# ---------------------------------------------------------------------------
+OUT_R="$TMP/handoffs-retention"
+mkdir -p "$OUT_R"
+OLD_CP="$OUT_R/portable-handoff-20250101T000000Z-old-checkpoint.md"
+OLD_RICH="$OUT_R/portable-handoff-20250101T000000Z-old.md"
+echo old > "$OLD_CP"
+echo old > "$OLD_RICH"
+touch -t 202501010000 "$OLD_CP" "$OLD_RICH"
+(cd "$PLAIN" && "$CP" --no-remote --out-dir "$OUT_R" --retention-days 7 >/dev/null 2>&1)
+check_eq "T6 stale checkpoint pruned" "0" "$([[ -f "$OLD_CP" ]] && echo 1 || echo 0)"
+check_eq "T6 hand-written handoff of the same age survives" "1" "$([[ -f "$OLD_RICH" ]] && echo 1 || echo 0)"
+
+# ---------------------------------------------------------------------------
+# T7 — the consumer contract: the recorder finds a checkpoint
+# ---------------------------------------------------------------------------
+if command -v jq >/dev/null 2>&1; then
+  REC_DIR="$TMP/rec"
+  mkdir -p "$REC_DIR"
+  PAYLOAD='{"session_id":"s1","cwd":"/tmp","transcript_path":"/tmp/t.jsonl","error":"rate_limit","error_details":"limit","last_assistant_message":"working"}'
+  OUT_REC="$TMP/handoffs-rec"
+  mkdir -p "$OUT_REC"
+  (cd "$PLAIN" && "$CP" --no-remote --out-dir "$OUT_REC" --min-interval 0 >/dev/null 2>&1)
+  printf '%s' "$PAYLOAD" | CLAUDE_USAGE_LIMIT_DIR="$REC_DIR" CLAUDE_HANDOFF_DIR="$OUT_REC" bash "$RECORDER" >/dev/null 2>&1
+  PH=$(jq -r '.portable_handoff // "null"' "$REC_DIR/usage-limit-last.json" 2>/dev/null)
+  check_eq "T7 recorder publishes a non-null portable_handoff" "1" "$([[ "$PH" != "null" && -n "$PH" ]] && echo 1 || echo 0)"
+  check_contains "T7 recorder points at the checkpoint this script wrote" "-checkpoint.md" "$PH"
+else
+  echo "skip — T7 needs jq"
+fi
+
+# ---------------------------------------------------------------------------
+# T9 — pull request records: an empty title must not shift the fields
+#
+# The fields are joined by US (0x1f) rather than a tab precisely because tab is
+# IFS whitespace and `read` collapses runs of it — with a tab, a titleless pull
+# request silently renders its URL as its title and leaves the URL line empty,
+# with nothing failing anywhere. A stub `gh` on PATH is what makes this
+# reachable offline; the real one would need a titleless open pull request.
+# ---------------------------------------------------------------------------
+STUB_BIN="$TMP/stubbin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '42\037\037https://example.com/42\n'
+printf '43\037A real title\037https://example.com/43\n'
+STUB
+chmod +x "$STUB_BIN/gh"
+DOC_PR=$(cd "$PLAIN" && PATH="$STUB_BIN:$PATH" "$CP" --stdout --out-dir "$TMP/out-pr" 2>/dev/null)
+check_contains "T9 titleless pull request renders without a title" "- **Pull request 42**" "$DOC_PR"
+check_contains "T9 titleless pull request keeps its URL" "https://example.com/42" "$DOC_PR"
+check_not_contains "T9 the URL never lands in the title position" "Pull request 42 — https" "$DOC_PR"
+check_contains "T9 a titled pull request still shows its title" "- **Pull request 43 — A real title**" "$DOC_PR"
+printf '%s\n' "$DOC_PR" > "$TMP/t9.md"
+"$LINT" --repo-root "$FAKE" --quiet "$TMP/t9.md" >/dev/null 2>&1
+check_eq "T9 pull request rendering passes the portability check" "0" "$?"
+
+# ---------------------------------------------------------------------------
+# T8 — degraded environments must never fail the turn
+# ---------------------------------------------------------------------------
+NOTREPO="$TMP/notrepo"
+mkdir -p "$NOTREPO"
+(cd "$NOTREPO" && "$CP" --no-remote --out-dir "$TMP/out-notrepo" >/dev/null 2>&1)
+check_eq "T8 non-repo working directory exits 0" "0" "$?"
+DOC_NR=$(cd "$NOTREPO" && "$CP" --stdout --no-remote --out-dir "$TMP/out-notrepo" 2>/dev/null)
+check_contains "T8 non-repo document says so plainly" "not a git checkout" "$DOC_NR"
+printf '%s\n' "$DOC_NR" > "$TMP/t8.md"
+"$LINT" --repo-root "$FAKE" --quiet "$TMP/t8.md" >/dev/null 2>&1
+check_eq "T8 non-repo document still passes the portability check" "0" "$?"
+
+# jq absent: only the background-unit count depends on it, and its absence must
+# cost that line, not the document.
+NOJQ_BIN="$TMP/nojq"
+mkdir -p "$NOJQ_BIN"
+# `env` and `bash` are on this list on purpose: the script's shebang is
+# `#!/usr/bin/env bash`, so omitting either makes the run die at exec with 127 —
+# a "missing jq" test that never reached the script at all, and reported the
+# failure it was written to rule out.
+for b in env bash git find date mktemp mv rm ln sed grep basename dirname cut sort wc stat touch cat chmod uname shasum cksum tr head; do
+  src=$(command -v "$b" 2>/dev/null) && ln -sf "$src" "$NOJQ_BIN/$b"
+done
+check_eq "T8 jq really is absent from the stripped path" "0" \
+  "$(PATH="$NOJQ_BIN" command -v jq >/dev/null 2>&1 && echo 1 || echo 0)"
+(cd "$PLAIN" && PATH="$NOJQ_BIN" "$CP" --no-remote --out-dir "$TMP/out-nojq" --min-interval 0 >/dev/null 2>&1)
+check_eq "T8 missing jq exits 0" "0" "$?"
+
+(cd "$PLAIN" && "$CP" --no-remote --out-dir "$TMP/out-badenv" --min-interval nonsense --retention-days nonsense >/dev/null 2>&1)
+check_eq "T8 non-numeric settings exit 0" "0" "$?"
+
+(cd "$PLAIN" && "$CP" --definitely-not-a-flag >/dev/null 2>&1)
+check_eq "T8 unknown option exits 0" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo
+echo "passed: $PASS   failed: $FAIL"
+(( FAIL == 0 ))

--- a/.claude/skills/pause/SKILL.md
+++ b/.claude/skills/pause/SKILL.md
@@ -181,6 +181,14 @@ Close with the file path on its own line, so the next session (and the usage-lim
 | `/pm-handoff` | a thread | a prompt for the next thread in this harness |
 | `/pause` | a working session | a document for a reader **outside** this harness |
 
+### The automatic checkpoint is a different producer, not this command on a timer
+
+`.claude/hooks/checkpoint-handoff.sh` writes the same *kind* of document automatically while work is in progress (issue #941), because a usage limit that arrives without warning is exactly the case where nobody got to run `/pause` — and the recorder that looks for a handoff then finds none.
+
+It ends nothing. It stops no work, takes no wind-down step, and makes no decision; it only describes repository state. So the "does not fire on a schedule, a threshold, or an inference" clause below still holds for **this** command, which is the one that stops things.
+
+The two are distinguishable on disk: a checkpoint's filename ends `-checkpoint.md`. What you write here is richer — it carries the reasoning a script cannot know — so a checkpoint names the most recent `/pause` document in its own body rather than burying it, and retention never deletes one.
+
 They overlap in what they read — hence the shared collector — and not at all in what they produce. `/pause` does not merge anything, does not close anything, and does not decide that work is finished. It records where the work actually is and stops.
 
 ## Not this command's job

--- a/global-settings.json
+++ b/global-settings.json
@@ -204,6 +204,17 @@
           }
         ]
       }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/checkpoint-handoff.sh",
+            "timeout": 15
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## **User description**
## What this does

When a session dies on an Anthropic usage limit, `usage-limit-record.sh` writes a breadcrumb naming the most recent portable handoff — so the next session reads *what was happening* instead of reconstructing it from a transcript.

On 2026-08-01 the account limit killed three concurrent sessions and their subagents (9 records, 23:10–23:29 ET, across three repos). Every record came out with:

```json
"portable_handoff": null
```

Zero `portable-handoff-*.md` files existed. The only thing that writes one is invoked by hand, and a limit that arrives without warning is exactly the case where nobody did.

This adds `.claude/hooks/checkpoint-handoff.sh`, registered on `SubagentStop`: it writes the **artifact** and nothing else — no wind-down, no stopping, no decision. `/pause` keeps its "runs because you asked, and for no other reason" contract, because this is a different producer of the same document, not that command on a timer.

Not the pre-emptive wind-down — that stays blocked upstream (#824 / #835), and the runtime is still 2.1.219, the exact build that audit covers.

## The degrade ladder

`portable-handoff-lint.sh` rejects relative `.claude/` paths, phase vocabulary, state-file names, and slash-command names. A mechanical renderer walks into all of them: in *this* repo the changed-file list is nothing but `.claude/scripts/…`. A human rewrites the offending line; a script cannot.

So it renders, lints, and drops a tier on failure, shipping the first that passes — and writing **nothing** if none does:

| Tier | Contents | |
|---|---|---|
| 1 | file paths listed, PR titles quoted | verified to fail here with the exact `[harness-path]` violation |
| 2 | count + `git status` instruction | the normal result in this repo |
| 3 | titles dropped, number + URL only | |
| 4 | minimal — absolute working directory, counts | |

This makes "the output is portable" a property the script enforces on itself in whatever repo it runs in, not one I hoped would hold everywhere.

## Bug found and fixed in self-review

PR fields were joined with `@tsv` and read with `IFS=$'\t'`. Tab is IFS **whitespace**, so `read` collapses runs of it — a titleless pull request became `number=42, title=<the URL>, url=<empty>`, rendering a URL where a title belongs with **nothing failing anywhere** (the result is lint-clean). Now joined on US (`0x1f`), which is not IFS whitespace.

Paired control against a copy differing only in those two lines:

```
pre-fix   - **Pull request 42 — https://example.com/42**
            <blank URL line>
post-fix  - **Pull request 42**
            https://example.com/42
```

T9 pins both directions, so it fails against the pre-fix code.

## Review coverage: `none` — both local CLIs down

Per `cr-local-review.md`, recorded here rather than glossed:

- **CodeAnt — failed run.** `API Error: Access denied (403)` on stderr with `meta.capped: true` and 7 files skipped; the 15 files it did review were a stale-base set that did not include either file this PR adds. Not retried past once, and `codeant logout/login` deliberately not run (the 403 is a persistent account-wide entitlement, not auth).
- **CodeRabbit — dropped on timeout.** Reached `phase: analyzing / summarizing` and produced no further record for 10+ minutes, well past the 2-minute budget. Likely the same adaptive quota the account exhausted last night.

**Self-review ran instead** and is what produced the field-shift fix above. Self-review does not satisfy the merge gate — the GitHub reviewers still do.

## Verification

- `.claude/scripts/tests/checkpoint-handoff.test.sh` — 41 assertions, all passing
- Full CI-discovered bash suite: **64 suites, 0 failed**, with the new suite confirmed discovered (auto-discovery, no workflow edit)
- `shellcheck -x -S warning` clean. Ten `SC2016` *info* notices remain and are correct as written — they are literal backticks in generated Markdown; double-quoting those format strings would run `git status` as a command substitution. No suppression comments added.
- Rule corpus word count **unchanged** (11,719; cap 11,749) — script, test, and hook-README work only

A `T0` probe asserts the checker actually resolved before any "passes the portability check" assertion runs. Without it, every one of those could pass because no checker was found and the minimal tier shipped unverified — a pass for the wrong reason, and invisible.

## Test plan

- [ ] `.claude/hooks/checkpoint-handoff.sh` is executable and exits 0 on every path: missing `jq`, missing `git`, non-repo cwd, non-numeric settings, unknown option
- [ ] Writes `portable-handoff-<stamp>-<session>-checkpoint.md`, matching the glob `usage-limit-record.sh` already scans
- [ ] Output passes `portable-handoff-lint.sh` — verified in an ordinary repo (tier 1) and a harness-shaped one (tier 2)
- [ ] The document names an absolute working directory
- [ ] When a hand-written handoff exists, the checkpoint names it by basename (its absolute path is unportable and is deliberately not printed)
- [ ] An existing checkpoint is never offered as the hand-written handoff
- [ ] Throttle: unchanged state inside the window writes nothing; changed state inside the window still writes; elapsed window writes; `--force` overrides
- [ ] Retention prunes only `*-checkpoint.md` past the age bound — a hand-written handoff of the same age survives
- [ ] `usage-limit-record.sh` is unchanged and publishes a non-null `portable_handoff` when a checkpoint is present
- [ ] Registered on `SubagentStop` in `global-settings.json` with a bounded timeout, and `register-hooks.py` can resolve it (the script sits in `.claude/hooks/`, which is the only directory that registration joins manifest basenames onto)
- [ ] Empty PR title does not shift fields (T9, validated against the pre-fix code)
- [ ] `.claude/skills/pause/SKILL.md` gains a pointer distinguishing the two artifacts; its own steps are unchanged
- [ ] Rule corpus word count unchanged

Closes #941


___

## **CodeAnt-AI Description**
Automatically preserve portable session handoffs before unexpected usage-limit interruptions

### What Changed
- A background hook now creates a portable handoff while work is in progress, giving usage-limit records a real handoff to reference.
- Handoffs describe repository state, open pull requests, unfinished work, and running background units without stopping work or making decisions.
- Generated documents are checked for portability and simplified until they pass; if none pass, nothing is published.
- Checkpoints are throttled, retried when local state changes, retained for seven days, and kept separate from hand-written handoffs.
- Added coverage for portability fallback, throttling, publishing, retention, recorder integration, pull request formatting, and degraded environments.

### Impact
`✅ Fewer usage-limit records without a handoff`
`✅ Recoverable session state after unexpected interruptions`
`✅ Hand-written handoffs preserved`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


---

## Update — rebased onto `main`, adapted to PR #934

`main` advanced mid-work and one of the two commits was [PR #934](https://github.com/auerbachb/claude-code-config/pull/934), which added three portability rules: `open-work-ownership`, `pull-request-review-state`, `verification-command`. Every pull-request entry must now carry `Owner:`, `Waiting on:` and `Approval:`, and any document with in-flight work needs a `Verify with:`.

The renderer carried none of them, so the ladder degraded past every tier that lists pull requests and T9 failed on all four assertions. This is exactly the drift the rebase existed to catch — the ladder is only as verified as the checker it was verified against.

Each field is now **derived** from what the forge reports (author login, `reviewDecision`, `mergeStateStatus`) rather than emitted as a constant. The rules can only see presence — `Owner: yes` passes them — so a constant would satisfy the check and tell the reader nothing, which is the failure those rules were written against. Where the forge reports nothing, the line says so.

Merge state outranks review decision in `Waiting on:` — an approved branch that is `BEHIND` is waiting on the rebase, and saying it waits on review would point the reader at something that already happened. Verified against live data: PR #937 and PR #919 render `Approval: approved` with `Waiting on: the branch needs updating against the main branch first`.

Re-verified after the rebase: **48 assertions**, full discovered suite **66/66**, `shellcheck -S warning` clean, corpus still 11,719.

### Added acceptance criteria

- [ ] Every pull-request entry carries `Owner:`, `Waiting on:` and `Approval:`; the document carries at least one `Verify with:`
- [ ] Each is derived from real forge data, not a constant — asserted on values (per-entry owner, approved vs undecided), not just on the anchors
- [ ] `BEHIND` merge state outranks an existing approval in `Waiting on:`
- [ ] A pull request the forge reports no author/decision for still renders a truthful line rather than a guess


---

## Update — four review findings fixed (`5f04347`)

CodeAnt and Cursor each found two. All four were valid; all four are fixed, replied to, and resolved.

| Finding | Why it was real |
|---|---|
| `gh` failure rendered as "no open pull requests" (Cursor) | The exit status was discarded, so a failed query and an empty result were the same empty string. Reporting "nothing in flight" when the truth is "could not look" is the one mistake a handoff cannot afford — the reader has no way to detect it. Three states now: `ok` / `failed` / `skipped`. |
| `reissue-941` matched the issue regex (Cursor) | The boundary was `[^0-9]`, so any `re`/`de`/`un` prefix matched on its trailing letter and published a link to an unrelated issue. Now `[^[:alnum:]]`. |
| Fingerprint could not see staging (CodeAnt) | The status columns were stripped before hashing, so `git add` left the fingerprint unchanged and the throttle suppressed the checkpoint for the rest of the interval. Now hashes raw porcelain. |
| Same-second writes destroyed each other (CodeAnt) | Whole-second stamp + absent session id put two writers on one filename, and `mv -f` kept only the last. Not a rare interleave here — one account limit fails *every* session at once, which is exactly when concurrent writes happen. Now carries the `mktemp` suffix. |

**Partially declined, with reasoning:** the fingerprint still does not move when file *contents* change without the porcelain changing. Catching that means hashing the diff on every `SubagentStop`. It does not need catching, because time is the primary trigger — the next interval writes regardless, so the worst case is bounded at the interval rather than indefinite. The fingerprint only ever makes it write *more* often.

**Control for the subtle one:** under the old `sed 's/^...//'`, `?? new.txt` and `A  new.txt` both reduce to `new.txt` — byte-identical, so the pre-fix hash provably could not move. Raw porcelain differs. T10c pins it.

Re-verified: **58 assertions**, full discovered suite **66/66**, `shellcheck -S warning` clean.

### Postscript on local review coverage

The backgrounded CodeRabbit CLI run eventually returned, and its own record confirms what the coverage note above already claimed rather than softening it:

```json
{"type":"error","errorType":"timeout","message":"Review timed out (ID: aa63ea23-…)","recoverable":false}
```

Exit 1, `recoverable: false` — a failed run, not a silent clean pass. Coverage stays `none`; the GitHub reviewers are what actually covered this PR, and they found four real bugs.

### Added acceptance criteria

- [ ] A failed `gh` lookup renders as "could not be read", never as "none open"; a skipped lookup is a third distinct wording
- [ ] `reissue-941` publishes no issue link; `issue-941-real` still detects issue 941
- [ ] Staging a file moves the fingerprint
- [ ] Two same-second writes produce two distinct files and both survive; the unique name still matches the recorder's glob
