### PR TITLE
fix(#935): distinguish "BugBot never invited" from "BugBot failed" in escalate-review.sh

### DIFF
--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -153,7 +153,7 @@ If CR remains silent or cannot produce a current-HEAD approval, keep using the R
 
 ## BugBot Review Path (when `reviewer` = `bugbot`)
 
-BugBot auto-reviews every push — no manual trigger needed. Poll for `cursor[bot]` reviews on all 3 endpoints every 60 seconds.
+**Invite BugBot before polling it.** BugBot does NOT auto-review pushes — something has to post `@cursor review`, normally the `cursor-review-pr-comment.yml` CI job, which posts nothing when `CURSOR_REVIEW_PAT` is unprovisioned (issue #905). So `switch_bugbot` now also arrives for a PR BugBot was never invited to (issue #935): if `cursor[bot]` has no review/comment and there is no `Cursor Bugbot` check-run on HEAD, post `gh pr comment {{PR_NUMBER}} --body "@cursor review"` first — duplicates are OK. Then poll for `cursor[bot]` reviews on all 3 endpoints every 60 seconds.
 
 ### Polling
 

--- a/.claude/scripts/escalate-review.sh
+++ b/.claude/scripts/escalate-review.sh
@@ -17,8 +17,15 @@
 #                             CodeAnt has a valid APPROVED review on current HEAD) —
 #                             do not escalate; the merge gate will pick this up
 #     STATUS=polling_cr       keep polling CodeRabbit/BugBot grace window
-#     STATUS=switch_bugbot    BugBot has responded; make BugBot sticky reviewer
-#     STATUS=trigger_greptile CR failed and BugBot is absent/timed out; trigger Greptile
+#     STATUS=switch_bugbot    BugBot has responded — OR BugBot was never invited
+#                             (no footprint on HEAD and no fresh `@cursor review`
+#                             trigger comment). Make BugBot the sticky reviewer;
+#                             when it has no footprint yet, post the manual
+#                             `@cursor review` trigger before polling
+#     STATUS=trigger_greptile CR failed AND BugBot either failed outright or was
+#                             invited and then timed out; trigger Greptile. NOT
+#                             emitted for a BugBot that was never invited — that
+#                             case is switch_bugbot above
 #     STATUS=budget_exhausted Greptile budget is exhausted; do not trigger Greptile
 #     STATUS=self_review      PR is already marked for self-review fallback
 #
@@ -301,7 +308,17 @@ if [[ -z "$PUSH_TIMESTAMP" ]]; then
   exit 4
 fi
 
-AGE_SECONDS="$(python3 - "$PUSH_TIMESTAMP" <<'PY'
+# Age in seconds of an ISO-8601 timestamp, clamped at 0. Two callers share it —
+# the push-age grace window below and the BugBot trigger-comment freshness test
+# further down — so both timestamps are parsed by ONE rule and then compared as
+# integers. That deliberately avoids a second lexicographic timestamp compare in
+# this file: the jq `canon_ts` mirror is pinned byte-for-byte against
+# merge-gate.sh's norm_ts (issue #885, tests/ts-normalizer-parity.test.sh
+# requires exactly one `def canon_ts:` here), and a near-copy under another name
+# would reintroduce exactly the drift that guard exists to prevent.
+# An unparseable value yields 0 — see each call site for what that means there.
+iso_age_seconds() {
+  python3 - "$1" <<'PY'
 from datetime import datetime, timezone
 import sys
 
@@ -318,7 +335,9 @@ if ts.tzinfo is None:
     ts = ts.replace(tzinfo=timezone.utc)
 print(max(0, int((datetime.now(timezone.utc) - ts).total_seconds())))
 PY
-)"
+}
+
+AGE_SECONDS="$(iso_age_seconds "$PUSH_TIMESTAMP")"
 
 CR_RATE_LIMITED="$(jq -r '
   def text: [(.title // ""), (.description // ""), (.state // ""), (.conclusion // "")] | join(" ");
@@ -389,6 +408,46 @@ BUGBOT_CHECK_PRESENT="$(jq -r '
   [.check_runs.all[] | select((.name // "") == "Cursor Bugbot")] | length > 0
 ' "$STATE_PATH")"
 
+# Was BugBot ever INVITED on this HEAD? (issue #935.) BugBot does not auto-review
+# pushes — something has to post `@cursor review`, normally the
+# cursor-review-pr-comment.yml CI job. Without CURSOR_REVIEW_PAT that job
+# concludes success while posting NOTHING (issue #905), so "no BugBot footprint"
+# means "never asked", not "asked and failed". This separates the two.
+#
+# Newest matching comment only; the freshness compare happens in bash below.
+# Scoped to `.comments.conversation` (the PR conversation) because that is where
+# a trigger is posted, and to non-`cursor[bot]` authors because BugBot quoting
+# the phrase back is not an invitation. Narrow on purpose: a missed invite costs
+# one duplicate `@cursor review` (harmless per bugbot.md), while a false one
+# costs a paid Greptile review. No new gh api call — the bundle is already here
+# (meta-guard scenario L).
+BUGBOT_TRIGGER_TS="$(jq -r '
+  [.comments.conversation[]?
+   | select((.user.login // "") != "cursor[bot]")
+   | select((.body // "") | test("@cursor\\s+review"; "i"))
+   | (.created_at // .submitted_at // "")
+   | select(. != "")]
+  | sort | last // ""
+' "$STATE_PATH")" || {
+  echo "escalate-review.sh: failed to scan for a BugBot trigger comment" >&2
+  exit 4
+}
+
+# Only a trigger that POSTDATES the HEAD commit counts. A trigger left over from
+# an earlier SHA must not mask a still-unprovisioned auto-trigger on the new one.
+# Both sides go through iso_age_seconds, so this is an integer compare: the
+# trigger is fresh when it is no older than the push.
+# An unparseable comment timestamp yields age 0, i.e. "fresh" — that keeps the
+# pre-#935 escalation behaviour on data we cannot read rather than newly
+# granting switch_bugbot on it.
+BUGBOT_TRIGGER_PRESENT=false
+if [[ -n "$BUGBOT_TRIGGER_TS" ]]; then
+  BUGBOT_TRIGGER_AGE="$(iso_age_seconds "$BUGBOT_TRIGGER_TS")"
+  if [[ "$BUGBOT_TRIGGER_AGE" -le "$AGE_SECONDS" ]]; then
+    BUGBOT_TRIGGER_PRESENT=true
+  fi
+fi
+
 CACHED_BUGBOT_INSTALLED="$("$SESSION_STATE" --get ".prs[\"$PR_NUMBER\"].bugbot_installed // \"\"" 2>/dev/null || true)"
 case "$CACHED_BUGBOT_INSTALLED" in
   true|false)
@@ -432,6 +491,30 @@ fi
 # budget check below (mirrors the CodeRabbit "rate limit" fast-path).
 if [[ "$BUGBOT_FAILED" != "true" && "$BUGBOT_INSTALLED" == "true" && "$AGE_SECONDS" -lt 600 ]]; then
   emit "polling_cr"
+fi
+
+# BugBot was NEVER INVITED (issue #935; observed on PRs #929 and #932). With
+# CURSOR_REVIEW_PAT unprovisioned the post-cursor-review CI job greens without
+# posting anything (issue #905), so cursor[bot] has zero footprint and no
+# `Cursor Bugbot` check-run ever appears — the same signature as "BugBot is not
+# installed here". Escalating on that jumps the chain past a tier that was never
+# asked, which greptile.md forbids ("never before both CR AND BugBot have
+# failed") and which spends paid Greptile budget for nothing. The remedy is the
+# manual `@cursor review` trigger the switch_bugbot arm posts; both times this
+# was hit live, BugBot answered within seconds of being asked.
+#
+# BUGBOT_TRIGGER_PRESENT is what keeps this from looping (the #552 hazard in
+# reverse): once an invite postdating HEAD exists and BugBot is still silent past
+# the grace window, that is invited-but-silent and falls through to the Greptile
+# escalation below exactly as before.
+#
+# BUGBOT_GENUINE is already false here (it emits above); restated so the branch
+# reads as a complete statement of the state it claims. BUGBOT_INSTALLED cached
+# true from an earlier SHA also keeps this branch shut — that PR stays on today's
+# path, adjacent to issue #552 and deliberately out of scope here.
+if [[ "$BUGBOT_FAILED" != "true" && "$BUGBOT_GENUINE" != "true" \
+      && "$BUGBOT_INSTALLED" != "true" && "$BUGBOT_TRIGGER_PRESENT" != "true" ]]; then
+  emit "switch_bugbot"
 fi
 
 BUDGET_CHECK_RC=0

--- a/.claude/scripts/tests/escalate-review.test.sh
+++ b/.claude/scripts/tests/escalate-review.test.sh
@@ -177,6 +177,13 @@ failure_comment_alt() {
 genuine_comment() {
   printf '{"user": {"login": "cursor[bot]"}, "created_at": "%s", "body": "Found 1 bug in this PR: possible null dereference on line 42."}' "$1"
 }
+# The `@cursor review` invitation (issue #935) — posted by CI via
+# CURSOR_REVIEW_PAT, or by hand. Author is deliberately NOT cursor[bot]: the
+# script ignores the phrase in BugBot's own comments, since quoting it back is
+# not an invitation.
+trigger_comment() {
+  printf '{"user": {"login": "test-user"}, "created_at": "%s", "body": "@cursor review"}' "$1"
+}
 
 ############################################################################
 echo "== Scenario (a): usage-limit failure comment + completed check-run -> trigger_greptile =="
@@ -536,6 +543,82 @@ write_state "[$BUGBOT_CHECK_RUN_SUCCESS]" "[]" "[]" "[]"
 OUT=$(run_script); RC=$?
 check_eq "exit 0" 0 "$RC"
 check_eq "STATUS=switch_bugbot" "STATUS=switch_bugbot" "$OUT"
+
+############################################################################
+# "BugBot never invited" vs "BugBot failed" (issue #935)
+#
+# Every scenario above hands the script a `Cursor Bugbot` check-run, so the
+# never-invited state — no check-run AND no cursor[bot] comment, the signature
+# an unprovisioned CURSOR_REVIEW_PAT produces (issue #905) — was never
+# exercised, and the script escalated straight to a PAID Greptile review on a
+# tier nobody had asked. Seen live on PRs #929 and #932; both Phase B agents
+# declined the verdict, posted `@cursor review` by hand, and BugBot answered in
+# seconds.
+#
+# n1/n2/n3 are Scenarios A/B/C of the implementation plan. n4 and n5 are the
+# negative controls that keep the two new terms from being deletable in silence:
+# without n4 the freshness filter is dead weight, without n5 the new branch
+# could preempt the grace window and nothing would notice.
+############################################################################
+echo
+echo "== Scenario (n1): never invited — no check-run, no cursor[bot] comment, past the grace window -> switch_bugbot (issue #935) =="
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+write_state "[]" "[]" "[]" "[]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=switch_bugbot" "STATUS=switch_bugbot" "$OUT"
+
+############################################################################
+echo "== Scenario (n2): genuine BugBot failure in the SAME no-check-run shape -> trigger_greptile (parity with pre-#935) =="
+# Differs from (n1) by exactly one thing: a cursor[bot] usage-limit comment. A
+# classified failure means BugBot WAS asked and could not run, so escalation is
+# still correct — the fix must not swallow it. Scenario (a) covers this with a
+# check-run present; this pins it in the shape (n1) now diverts.
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+FAILURE_COMMENT_N2="$(failure_comment "$(ts_seconds_ago 3000)")"
+write_state "[]" "[]" "[]" "[$FAILURE_COMMENT_N2]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=trigger_greptile" "STATUS=trigger_greptile" "$OUT"
+
+############################################################################
+echo "== Scenario (n3): invited but silent — fresh @cursor review, no BugBot response, past the grace window -> trigger_greptile =="
+# Loop avoidance (the issue #552 hazard in reverse): once the invite exists on
+# this HEAD and BugBot still says nothing, re-emitting switch_bugbot would just
+# post another invite forever. Escalation is the right answer here.
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+TRIGGER_COMMENT_N3="$(trigger_comment "$(ts_seconds_ago 3000)")"
+write_state "[]" "[]" "[]" "[$TRIGGER_COMMENT_N3]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=trigger_greptile" "STATUS=trigger_greptile" "$OUT"
+
+############################################################################
+echo "== Scenario (n4): trigger comment PREDATES the HEAD commit -> switch_bugbot (a stale invite must not mask an unprovisioned one) =="
+# Same fixture as (n3) with the timestamps swapped: the invite is older than the
+# push, so it belongs to an earlier SHA. Without the freshness filter this reads
+# as "already invited" and every subsequent push escalates to paid Greptile.
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+TRIGGER_COMMENT_N4="$(trigger_comment "$(ts_seconds_ago 9000)")"
+write_state "[]" "[]" "[]" "[$TRIGGER_COMMENT_N4]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=switch_bugbot" "STATUS=switch_bugbot" "$OUT"
+
+############################################################################
+echo "== Scenario (n5): never invited but still INSIDE the 600s grace window -> polling_cr (the new branch must not preempt the wait) =="
+# (n1) with a recent push. BugBot may simply not have reported yet, so the
+# grace window still owns this cycle; switch_bugbot here would cut it short.
+reset_state
+write_commits "$(ts_seconds_ago 120)"
+write_state "[]" "[]" "[]" "[]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=polling_cr" "STATUS=polling_cr" "$OUT"
 
 echo
 echo "== summary: $PASS passed, $FAIL failed =="


### PR DESCRIPTION
## **User description**
## Problem

With `CURSOR_REVIEW_PAT` unprovisioned, the `post-cursor-review` CI job concludes `success` while posting **nothing** (Issue #905). So `cursor[bot]` has zero footprint and no `Cursor Bugbot` check-run exists on HEAD — which is byte-identical to "BugBot is not installed here."

`escalate-review.sh` read that as *BugBot failed* and returned `STATUS=trigger_greptile`, jumping the chain past a tier that was never actually invited. `greptile.md` forbids Greptile before BugBot has failed, and the escalation spends **paid** budget for nothing.

Observed twice on 2026-08-01, on PR #929 and PR #932, by two independent Phase B agents. Both declined the script's verdict, posted the manual `@cursor review`, and BugBot responded within seconds — proof it had never been asked. Zero Greptile budget was spent only because both agents refused the verdict.

## Change

**`.claude/scripts/escalate-review.sh`**

- New `BUGBOT_TRIGGER_PRESENT` signal derived entirely from the already-fetched `pr-state.sh` bundle — **no new `gh api` call** (meta-guard scenario L still passes). Matches `@cursor review` (case-insensitive, whitespace-tolerant) in `.comments.conversation`, excluding `cursor[bot]` authors, since BugBot quoting the phrase back is not an invitation.
- **Freshness:** only a trigger postdating the HEAD commit counts, so a stale invite from an earlier SHA cannot mask a still-unprovisioned auto-trigger on the new one.
- New verdict branch, after the `BUGBOT_GENUINE` emit and after the grace-window guard, before the Greptile budget check: emit `switch_bugbot` when BugBot has no footprint, did not fail, and was never invited.
- New `iso_age_seconds()` helper parses both timestamps under **one** rule and compares them as integers. This deliberately avoids adding a second lexicographic timestamp rule to this file — `tests/ts-normalizer-parity.test.sh` (Issue #885) requires exactly one `def canon_ts:` here, and a near-copy under another name is the exact drift that guard exists to prevent.
- STATUS legend updated for both changed verdicts.

**`.claude/agents/phase-b-reviewer.md`** — the BugBot Review Path claimed "BugBot auto-reviews every push — no manual trigger needed", which contradicts `bugbot.md` and would have made this fix **inert**: a never-invited PR would reach `switch_bugbot`, poll 10 minutes for a review nobody requested, then escalate to Greptile anyway. It now posts `@cursor review` first when BugBot has no footprint.

### Deliberate boundaries

- **`BUGBOT_INSTALLED` cached `true` from an earlier SHA** keeps the new branch shut — that PR stays on today's path. That state is adjacent to Issue #552 and out of scope here.
- **Rule-corpus files untouched** (`CLAUDE.md`, `.claude/rules/*.md`). No word-count impact. `greptile.md` already says "never before both CR AND BugBot have failed" — this change makes the script *obey* that rule rather than contradicting it, so no rule text becomes false. `.claude/reference/merge-gate-reviewer-paths.md` names neither verdict, so nothing there becomes stale either.
- **Issue #933** (`review-substance.sh`) is queued separately and was not touched.

## Verification

`escalate-review.test.sh`: **48 -> 58 assertions, 0 failed.** Full auto-discovered bash suite: **65 suites, 0 failed.** `ts-normalizer-parity.test.sh`: 81 passed (still exactly one `def canon_ts:`). `rule-lint.sh`: OK. `shellcheck -S style` clean on both changed shell files.

**Negative control** — the 5 new fixtures replayed against `HEAD`'s (pre-change) `escalate-review.sh`: `(n1)` and `(n4)` **fail**, both returning `STATUS=trigger_greptile`. That is the live PR #929/#932 bug reproduced, and it proves the two new terms are load-bearing rather than passing vacuously. `(n2)`, `(n3)`, `(n5)` pass on both sides — they are parity pins.

**Local review coverage:** none — CodeAnt returned a 403 on both attempts (persistent account-wide entitlement failure, Issue #643; per `cr-local-review.md` its `logout`/`login` message is never followed), and the CodeRabbit CLI is rate-limited with a 26-minute wait. That quota is shared with the GitHub merge gate, so it was reserved for the GitHub review rather than burned locally. One self-review was done instead, plus the direct jq-filter probe noted below.

## Test plan

- [x] **Never-invited routes to `switch_bugbot`** — scenario `(n1)`: no `Cursor Bugbot` check-run, no `cursor[bot]` comment, no trigger comment, push age past the 600s grace window -> `STATUS=switch_bugbot`.
- [x] **Genuine BugBot failure still escalates** — scenario `(n2)`: the same no-check-run shape plus a `cursor[bot]` usage-limit comment -> `STATUS=trigger_greptile`. Differs from `(n1)` by exactly one comment, so it pins that the fix does not swallow real failures.
- [x] **Invited-but-silent still escalates (no loop)** — scenario `(n3)`: a fresh `@cursor review` postdating HEAD, no BugBot response, past the grace window -> `STATUS=trigger_greptile`.
- [x] **Stale invite does not count as invited** — scenario `(n4)`: trigger comment predating the HEAD commit -> `STATUS=switch_bugbot`. Without the freshness filter this reads as "already invited" and every later push escalates.
- [x] **The new branch does not preempt the grace window** — scenario `(n5)`: never-invited but push age under 600s -> `STATUS=polling_cr`.
- [x] **Both directions verified against the pre-change script** — replaying the new fixtures on `HEAD`'s `escalate-review.sh` fails `(n1)` and `(n4)` with `trigger_greptile` and passes `(n2)`/`(n3)`/`(n5)`.
- [x] **No new `gh api` call** — meta-guard scenario L passes: no direct `commits/<sha>/check-runs` fetch, and the script still reads `check_runs.all` from the bundle.
- [x] **`#885` parity guard intact** — `ts-normalizer-parity.test.sh` passes and `escalate-review.sh` still contains exactly one `def canon_ts:`.
- [x] **No pre-existing regressions** — all 48 original assertions still pass; the full auto-discovered bash suite is green (65 suites).
- [x] **Author/format handling of the trigger phrase** — a `cursor[bot]` comment quoting `@cursor review` is not counted, while `@Cursor   Review` from another author is (case- and whitespace-tolerant), and a missing `conversation` key yields no match rather than an error.
- [x] **Caller actually posts the invite** — `phase-b-reviewer.md`'s BugBot Review Path instructs posting `@cursor review` when BugBot has no footprint on HEAD, so `switch_bugbot` produces an invitation instead of a silent 10-minute wait.

Closes #935


___

## **CodeAnt-AI Description**
Distinguish uninvited BugBot reviews from failed BugBot reviews

### What Changed
- When BugBot has no response and was never invited for the current commit, escalation now selects BugBot and prompts a manual `@cursor review` instead of immediately using Greptile.
- Invitations from earlier commits and BugBot’s own quoted messages no longer count as current invitations.
- Genuine BugBot failures and invited-but-silent reviews continue to escalate to Greptile, while recent pushes remain within the normal waiting window.
- The reviewer guidance now instructs agents to invite BugBot before polling for its response.
- Added regression coverage for uninvited, stale-invitation, failed, invited-but-silent, and grace-window cases.

### Impact
`✅ Fewer unnecessary Greptile reviews`
`✅ BugBot is invited before escalation`
`✅ Correct escalation for genuine BugBot failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

