### PR TITLE
feat(#782): compact result contracts for the noisiest test + review pipelines

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -83,6 +83,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `instruction-set-audit-2026-07.md` — 1-month instruction-set size & optimization re-check; verdict: keep caps (#462)
 - `session-state-convergence-audit.md` — post-merge convergence audit of `session-state.json` and all scripts that touch it as one system; verdict: coherent (#651)
 - `token-efficiency-audit-2026-07.md` — token-efficiency playbook: adopt/skip/adapt verdicts, ranked cuts, shipped v1 (one-line heartbeats, delta PMM table, silence-detector dedupe) + FU-1…FU-7 (#773)
+- `compact-result-contract.md` — the `ok`/`failed_tests`/`relevant_error`/`log_path` output shape, its adopters, why failures are never compacted away, and what is deliberately left unwrapped (FU-7; #782)
 - `pm-routing-audit-2026-07.md` — thread-vs-inline routing effectiveness audit of #613; ground-truth attribution + the shared PM-context inline gate for chip surfaces (#701)
 - `too-big-recalibration-2026-07.md` — re-derivation of the "too big for a subagent" fit bar against current capability: criterion 1 narrowed from size to non-resumability, A/B/C confirmed on grounds independent of the unverified 32K figure, ceiling held, and the chip-gate overflow defect fixed (#776)
 - `skill-prune-audit-2026-07.md` — skill-usage telemetry audit; keep/prune verdicts based on 62-day usage data (#431)

--- a/.claude/reference/codeant-graphite-supplemental.md
+++ b/.claude/reference/codeant-graphite-supplemental.md
@@ -53,9 +53,10 @@ codeant set-codeant-api-key <your-api-key>
 # Verify auth (safe — reads org membership, no write):
 codeant scans orgs
 
-# Run a proof review (check stderr for errors before trusting "no findings"):
-codeant review --all --headless >ca.json 2>ca.err
-grep -qE 'API Error|\[error\]|40[13]' ca.err && echo "FAILED RUN" || echo "clean"
+# Run a proof review. Use the wrapper — it applies every false-clean check
+# (stderr error, 403, noFiles, 15-file cap, 2-min hang) and prints one line:
+.claude/scripts/local-review.sh --tool codeant
+# exit 0 clean · 1 findings · 3 failed run · 4 timeout · 5 not installed
 ```
 
 Failure modes once installed: false-clean on API failure and 403 daily-cap — see `local-review-cli-failure-modes.md`.

--- a/.claude/reference/compact-result-contract.md
+++ b/.claude/reference/compact-result-contract.md
@@ -1,0 +1,105 @@
+# Compact Result Contract (`ok` / `failed_tests` / `relevant_error` / `log_path`)
+
+The output shape shared by the wrappers around this repo's noisiest pass/fail pipelines.
+Ships FU-7 of `token-efficiency-audit-2026-07.md`: tool I/O is the largest per-turn context
+surface, and the pipelines below were the ones still folding full raw output into it.
+
+**Selective wrappers only.** This is a shape a few named scripts opt into — never a universal
+interception layer around every tool call. That layer was evaluated and **rejected** in the same
+audit (fragile, over-minifies errors, subagent hook bypass). Adding a wrapper is a per-pipeline
+decision with a measured payload win behind it; see "Scope" below for what is deliberately
+excluded.
+
+## Schema
+
+One line of JSON, built with `jq -cn`:
+
+```json
+{"ok":false,"failed_tests":[".claude/scripts/tests/foo.test.sh"],"relevant_error":"FAIL: expects exit 3, got 0","log_path":"/tmp/run-hook-tests-1754107200-a1b2c3.log"}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `ok` | bool (required) | Overall verdict. `true` only for a **verified** clean run — not merely "exit 0" (both local review CLIs exit 0 on total failure). |
+| `failed_tests` | array of strings | Failing suite/test identifiers. `[]` or omitted for non-test pipelines. |
+| `relevant_error` | string or null (required) | The **decisive** line(s) only — the assertion that failed, the API error, the rate-limit notice. Never the whole log. Capped; see "Extraction rules". |
+| `log_path` | string (required) | Absolute path to the persisted raw output. Always written, even on success. |
+
+Emitters may add their own fields (`tool`, `findings`, `failure_mode`, `duration_s`, …). Consumers
+must tolerate unknown keys — the four above are the stable core.
+
+## Emission conventions
+
+- **Single-line `jq -cn`.** No pretty-printing; one object, one line, on **stdout**.
+- **stdout is the contract, stderr is the detail.** In compact mode stdout carries *only* the
+  JSON object, so `$(cmd)` is directly parseable. Human/diagnostic output goes to stderr.
+- **Compact mode is opt-in** where a human/CI mode already exists (`--json`), matching the repo's
+  existing `--json` convention. A brand-new wrapper may default to JSON (as `ci-status.sh` does)
+  and offer `--format summary`.
+- **Raw output always persists to `log_path`** — the `pr-state.sh` "write the payload to a file,
+  print only the path" idiom. Compaction moves bulk out of context; it never destroys it.
+- **Documented exit-code matrix** in the script header, distinct codes per failure class.
+
+## Failures are compacted, never hidden (NON-NEGOTIABLE)
+
+`token-efficiency-audit-2026-07.md` §"What NOT to change" requires that failing CI print in full.
+Compact mode therefore silences **passing** noise, not failing detail:
+
+- Passing suites/units produce no output at all — that is where the savings come from.
+- **Failing** ones still print their captured output in full, on stderr.
+- `relevant_error` is an *index into* the failure, never a replacement for it: `log_path` holds
+  the complete capture and the contract names it on every run.
+
+A wrapper that summarizes a failure down to a status line and drops the detail is a bug.
+
+## Extraction rules for `relevant_error`
+
+- Test harnesses: the first matching decisive line per failing suite — `FAIL:`, `AssertionError`,
+  `Error:`, `ERROR:`, `not ok`, `::error::`, or the runner's own failure line.
+- Local review CLIs: the CLI's own error text — CodeRabbit's NDJSON `type:"error"` record
+  (`errorType: message`), CodeAnt's stderr `API Error` / `[error]` line.
+- Join multiple lines with `\n`; cap at **20 lines / 2000 characters** and mark truncation with a
+  trailing `… (truncated; see log_path)`.
+- `null` when `ok` is `true`.
+
+## Adopters
+
+| Pipeline | Wrapper | Compact mode | Notes |
+|---|---|---|---|
+| Bash test suites | `.github/scripts/run-hook-tests.sh` | `--json` | `failed_tests` = failing suite paths |
+| Python unittest | `.github/scripts/run-python-tests.sh` | `--json` | `failed_tests` = `unittest` test ids |
+| CodeRabbit / CodeAnt local review | `.claude/scripts/local-review.sh` | default (`--format summary` for text) | `failed_tests` always `[]`; adds `tool`/`findings`/`failure_mode`/`verified_run` |
+
+`.github/workflows/hook-scripts.yml` runs both test wrappers in `--json` mode and writes the
+contract to `$GITHUB_STEP_SUMMARY`, so an agent reading the run sees the verdict rather than every
+suite's raw fold.
+
+## Scope — what is deliberately NOT wrapped
+
+- **Scripts that already emit a compact `--json` object** (`ci-status.sh`, `merge-gate.sh`,
+  `escalate-review.sh`, `churn-hotspots.sh`, …). They are already at the target shape; rewriting
+  them into this schema would be churn, not savings.
+- **`gh` calls inside those scripts.** They are already `--jq`-projected at the source.
+- **`pr-state.sh`'s stdout contract.** It already prints only a path. Its *bundle* was made
+  smaller instead — see below — but its interface is unchanged, and it does not adopt this schema
+  (it is a state snapshot, not a pass/fail verdict).
+- **Anything not pass/fail-shaped.** Forcing `ok`/`failed_tests` onto a state dump produces a
+  worse contract than the one it has.
+
+### Related payload reduction: `pr-state.sh` field projection
+
+Not a contract adopter, but the same FU-7 pass. The bundle embedded raw GitHub review/comment
+objects; consumers read `body`, identity, timestamps, URLs, and the two SHA fields, and nothing
+reads `diff_hunk`, `_links`, `reactions`, or the 18-field `user` object. Projecting those away —
+**bodies kept in full** — measured on PR #931's live payload:
+
+| Array | Raw | Projected | Cut |
+|---|---|---|---|
+| `pulls/{n}/comments` (inline) | 215,723 B | 67,014 B | 69% |
+| `pulls/{n}/reviews` | 61,443 B | 25,700 B | 58% |
+| `issues/{n}/comments` | 17,009 B | 6,164 B | 64% |
+| **total** | **294,175 B** | **98,878 B** | **66%** |
+
+`diff_hunk` alone (plus `reactions` and `_links`) accounted for 121,893 B of the inline array.
+The projection is lossless for every field any consumer reads; `path` + `line` + `body` still
+locate and describe each finding. Exact field list: `pr-state.sh` §"Field projection".

--- a/.claude/reference/local-review-cli-failure-modes.md
+++ b/.claude/reference/local-review-cli-failure-modes.md
@@ -172,8 +172,21 @@ with a **clean stderr** and signals the failure as a record in the stdout stream
 ```
 
 A run that produced only `review_context` and `status` records — with no `review`/finding
-records — reviewed nothing, regardless of exit code. Check for a terminal `type: "error"`
-record before treating absence of findings as a clean pass:
+records — reviewed nothing, regardless of exit code. The authoritative verdict is the
+**terminal `type: "complete"` record**, which carries both the outcome and the count:
+
+```json
+{"type":"complete","status":"review_completed","findings":3,"reviewedFiles":["a.sh"]}
+{"type":"complete","status":"review_skipped","findings":0,"message":"No changes detected"}
+```
+
+Its **absence** means the run died mid-flight — never read that as "no findings". And
+`review_skipped` is not a clean pass: it means the CLI saw no changes at all, which is
+usually a wrong-working-directory tell (memory `bash-cwd-resets-between-calls.md`).
+
+`.claude/scripts/local-review.sh --tool coderabbit` checks all three (error record,
+missing terminal record, `review_skipped`) plus the CodeAnt side, and returns the compact
+contract. Hand-rolled equivalent, error record only:
 
 ```bash
 coderabbit review --agent >cr.out 2>cr.err

--- a/.claude/reference/token-efficiency-audit-2026-07.md
+++ b/.claude/reference/token-efficiency-audit-2026-07.md
@@ -83,7 +83,7 @@ Evidence tiers: **A** = Anthropic primary/measured · **B** = community, reprodu
 
 | Pattern | Tier | Call | This-harness note |
 |---|---|---|---|
-| Filter at source (grep/head/jq projections; counts not dumps) | A/B (tool I/O >60% of context; reads 76% of tokens on SWE-bench mini) | **ADOPT (mostly house style)** | Scripts already emit compact summaries; FU-7 audits the noisiest remaining pipelines |
+| Filter at source (grep/head/jq projections; counts not dumps) | A/B (tool I/O >60% of context; reads 76% of tokens on SWE-bench mini) | **ADOPT (mostly house style)** | Scripts already emit compact summaries; FU-7 wrapped the noisiest remainder (#782) |
 | Offload bulky output to disk; pass path + summary | A | **ADOPT (house style)** | Also built-in now: >50K-char tool results auto-spill to disk |
 | Universal lossy tool-output interception (RTK/Headroom-style) | B/C | **SKIP** | Fragile: subagent hook bypass, over-minified errors, blind spots; selective wrappers only |
 | External state as primary memory (session-state.json, handoffs, issues/PR bodies) | A | **ADOPT (already built)** | This harness's strongest asset; keep building on it |
@@ -105,7 +105,7 @@ Evidence tiers: **A** = Anthropic primary/measured · **B** = community, reprodu
 | 6 | Haiku routing for pure poll/classify ticks | Medium ($ more than tokens) | Medium — needs eval; escalation path must stay | **FU-4** |
 | 7 | Rule-corpus kernel shrink + path-scoping audit | High per-turn | Medium-high — literal-following models misfire on botched cuts; #768/#770 own it | **FU-5** |
 | 8 | MCP pruning + `/context`/`ccusage` measurement baseline | High in MCP-heavy sessions | Low | **FU-6** (ties #710) |
-| 9 | Tool-result JSON contracts for remaining noisy pipelines | Medium on long sessions | Low | **FU-7** |
+| 9 | Tool-result JSON contracts for remaining noisy pipelines | Medium on long sessions | Low | **Shipped (#782)** |
 | — | Concise-output styling beyond the shipped contract | Low (4–12% measured) | Medium (retry inflation) | **Rejected** |
 | — | `disable-model-invocation` on operator skills | Medium | High (autocomplete gotcha) | **Blocked** — revisit on harness fix |
 | — | Universal output interception layer | Medium | High | **Rejected** |
@@ -160,7 +160,7 @@ Headline "60–91% savings" figures across the ecosystem come from deliberately 
 - **FU-4:** Poller model-routing eval (Haiku for classify-only ticks) + "set model/effort at spawn, never mid-session" note in `subagent-orchestration.md`.
 - **FU-5:** Rule-corpus kernel/path-scoping audit (with #768/#770).
 - **FU-6:** Measurement baseline: `/context` + `ccusage` per repo, MCP prune list, `permissions.deny` junk-dir blocks (ties #710).
-- **FU-7:** Compact-JSON output contracts for the remaining noisy `gh`/log pipelines.
+- ~~**FU-7:** Compact-JSON output contracts for the remaining noisy `gh`/log pipelines.~~ **Shipped in #782** — the `ok`/`failed_tests`/`relevant_error`/`log_path` contract is defined once in `compact-result-contract.md` and adopted by three selective wrappers: `--json` on both test runners (`run-hook-tests.sh`, `run-python-tests.sh`, surfaced in CI via `summarize-test-run.sh` → step summary + `::error::`) and the new `local-review.sh` around the CodeRabbit/CodeAnt CLIs, which also replaces the capture-and-grep that was copy-pasted across `cr-local-review.md` and four skills. Measured: the Python runner's green output 13,489 B → 165 B (99%); `pr-state.sh`'s comment arrays field-projected 294 KB → 99 KB (66%, bodies kept in full). Deliberately **not** universal — the interception layer stays rejected, and the already-compact `--json` scripts were left alone.
 
 ## AC coverage (#773)
 

--- a/.claude/rules/cr-local-review.md
+++ b/.claude/rules/cr-local-review.md
@@ -13,12 +13,11 @@ Primary review workflow — catches issues before PR noise/quota; does not repla
 
 ### When/how to run
 
-After implementation, before push. Optional mid-development. Run from repo root:
+After implementation, before push. Run from repo root via `.claude/scripts/local-review.sh` — it invokes the CLI, applies every false-clean check below, and returns one line:
 
-- `coderabbit review --agent` — all changes (`--agent` emits structured NDJSON findings, optimized for agent parsing)
-- `codeant review --all --headless` — all changes, committed + uncommitted (`--headless` emits clean JSON for agents)
-- Scoping: CR `--type uncommitted` / `--type committed`; CodeAnt `--uncommitted` / `--committed`
-- If base-branch detection fails (fresh clone, no remote), pass `--base <branch>` — both CLIs support it
+- `.claude/scripts/local-review.sh --tool coderabbit` → `coderabbit review --agent`
+- `.claude/scripts/local-review.sh --tool codeant` → `codeant review --all --headless`
+- Scoping: `--scope uncommitted|committed`. Base branch: `--base <branch>`. Hang bound: `--timeout` (default 120s).
 
 ### Fix loop
 
@@ -30,16 +29,11 @@ After implementation, before push. Optional mid-development. Run from repo root:
 
 ### A "clean" result may be a failed run (NON-NEGOTIABLE)
 
-**Both CLIs exit `0` on total failure**, each hiding the error on a different stream — CodeAnt on **stderr**, CodeRabbit as a stdout NDJSON `type: "error"` record. Capture both streams and check before trusting any "no findings":
+**Both CLIs exit `0` on total failure**, each hiding the error on a different stream — CodeAnt on **stderr**, CodeRabbit as a stdout NDJSON `type: "error"` record. Do not hand-roll the capture-and-grep: `local-review.sh` applies every documented check (stderr error, error record, missing terminal record, nothing-reviewed, 15-file cap, 2-min hang) and emits
 
-```bash
-codeant review --all --headless >ca.json 2>ca.err
-grep -qE 'API Error|\[error\]|40[13]' ca.err && echo "FAILED RUN"
-coderabbit review --agent >cr.out 2>cr.err
-jq -e 'select(.type=="error")' cr.out >/dev/null && echo "FAILED RUN"
-```
+`{"ok":…,"findings":N,"verified_run":…,"failure_mode":…,"relevant_error":…,"log_path":…}`
 
-A hit is a **failed run** (Timeout & fallback below), never a clean pass. An empty result is clean **only** when its error check is clean and, for CodeAnt, `meta.capped` is `false`. Failure shapes, 403 triage, 15-file cap: `.claude/reference/local-review-cli-failure-modes.md`.
+with the raw capture at `log_path`. Exit `0` clean · `1` findings · `3` failed run · `4` timeout · `5` not installed. A CLI counts as covered **only** on `verified_run == true && ok == true`; every other result is a **failed run** (Timeout & fallback below), never a clean pass. Failure shapes, 403 triage, 15-file cap: `.claude/reference/local-review-cli-failure-modes.md`.
 
 > **Never run `codeant logout`/`login` to clear a 403** — the cause is an undocumented daily cap (~10 agent reviews), not auth. On a CodeAnt 403: one retry, then drop for the session and note it in the PR body. The CodeAnt GitHub App is unaffected and satisfies the merge gate alone.
 

--- a/.claude/scripts/README.md
+++ b/.claude/scripts/README.md
@@ -29,6 +29,7 @@ Scripts that manage the CR→BugBot→Greptile reviewer chain, budgets, and roun
 | Script | Purpose |
 |--------|---------|
 | `escalate-review.sh` | Run the CR→BugBot→Greptile escalation gate; emits a single deterministic `STATUS=` verdict — see `--help` |
+| `local-review.sh` | Run a local review CLI (CodeRabbit/CodeAnt) with every false-clean check applied; emits the compact result contract |
 | `cr-review-hourly.sh` | Track CodeRabbit's rolling hourly review cap and per-PR explicit trigger count |
 | `cr-plan.sh` | Detect a substantive CodeRabbit implementation-plan comment on a GitHub issue |
 | `greptile-budget.sh` | Guard the daily Greptile review budget counter in session-state |

--- a/.claude/scripts/local-review.sh
+++ b/.claude/scripts/local-review.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# local-review.sh — Run a local review CLI and emit the compact result contract.
+#
+# One wrapper for the CodeRabbit / CodeAnt local-review invocations that were
+# copy-pasted inline across .claude/rules/cr-local-review.md and several skills,
+# each redirecting streams to ad-hoc files and grepping for errors by hand.
+# Implements the `ok`/`failed_tests`/`relevant_error`/`log_path` shape defined in
+# .claude/reference/compact-result-contract.md (FU-7 of the token-efficiency audit).
+#
+# The point is NOT convenience. Both CLIs exit 0 on total failure and each hides the
+# error on a different stream, so "exit 0 with no findings" is not a clean pass — see
+# .claude/reference/local-review-cli-failure-modes.md. This script applies every
+# documented false-clean check in one place so no call site can forget one.
+#
+# Usage:
+#   local-review.sh --tool coderabbit|codeant [options]
+#   local-review.sh --help
+#
+# Options:
+#   --tool <name>       Required. `coderabbit` or `codeant`.
+#   --scope <scope>     all (default) | uncommitted | committed
+#                       Mapped per CLI: CR `--type <scope>`; CodeAnt `--all`/`--uncommitted`/`--committed`.
+#   --base <branch>     Pass a base branch through (both CLIs support --base).
+#   --timeout <sec>     Hang bound, default 120 (the 2-minute rule in cr-local-review.md).
+#                       CodeAnt v0.5.1 can hang with ZERO output, so silence is never progress.
+#   --log-dir <dir>     Where to persist raw output. Default: $TMPDIR or /tmp.
+#   --format json|summary   Output shape. Default json (the contract).
+#   --print-cmd         Print the exact CLI command to stdout and exit 0. Runs nothing.
+#   --bin <path>        Run this executable instead of discovering the CLI. For a
+#                       non-standard install, and how the offline tests drive stubs.
+#
+# Output (JSON, default) — one line, stdout only:
+#   {"ok":true,"failed_tests":[],"relevant_error":null,
+#    "log_path":"/tmp/local-review-coderabbit-1754107200-a1b2c3.out",
+#    "stderr_path":"/tmp/local-review-coderabbit-1754107200-a1b2c3.err",
+#    "tool":"coderabbit","findings":0,"verified_run":true,"failure_mode":null,"duration_s":37}
+#
+#   ok            true only for a VERIFIED clean run: the CLI actually reviewed the change
+#                 set, emitted no error, and reported zero findings.
+#   verified_run  the run is trustworthy (it really reviewed something and did not error).
+#                 A run with findings is still a verified run — ok is false, verified_run true.
+#   failure_mode  null | stderr_error | error_record | no_review_records | no_changes_reviewed
+#                 | capped | timeout | not_installed   (maps 1:1 onto the failure-modes reference)
+#   failed_tests  always [] — this is not a test pipeline; present for contract uniformity.
+#   relevant_error  the CLI's own decisive error text, capped. Never the whole log.
+#
+# Coverage classification (cr-local-review.md): this CLI counts toward coverage only on
+# `verified_run == true && ok == true`. Anything else is NOT covered for that CLI.
+#
+# --format summary emits one human line instead:
+#   coderabbit: ok=true findings=0 verified=true mode=- log=/tmp/...
+#
+# Exit codes:
+#   0  verified clean pass (no findings, no error)
+#   1  verified run WITH findings (fix them and re-run)
+#   2  usage error
+#   3  failed run — false-clean detected (stderr error, error record, no review records,
+#      nothing reviewed, or a capped partial run). NOT a clean pass, NOT coverage.
+#   4  timed out (exceeded --timeout)
+#   5  CLI binary not installed
+#
+# Notes:
+#   - Raw stdout and stderr are ALWAYS persisted, on every path including timeout, so the
+#     full output survives even though only the verdict reaches an agent's context.
+#   - Never runs `codeant logout`/`login` on a 403 — the cause is an undocumented daily cap,
+#     not auth (issue #643). Retry policy stays with the caller: one retry, then drop.
+set -uo pipefail
+
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" \
+  >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
+
+TOOL=""
+SCOPE="all"
+BASE=""
+TIMEOUT=120
+LOG_DIR="${TMPDIR:-/tmp}"
+FORMAT="json"
+PRINT_CMD=0
+BIN_OVERRIDE=""
+
+usage() { awk 'NR == 1 { next } /^$/ { exit } { print }' "$0"; }
+
+die() { echo "ERROR: $1" >&2; exit 2; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tool)    TOOL="${2:-}"; [[ -z "$TOOL" || "$TOOL" == -* ]] && die "--tool requires a value"; shift 2 ;;
+    --scope)   SCOPE="${2:-}"; [[ -z "$SCOPE" || "$SCOPE" == -* ]] && die "--scope requires a value"; shift 2 ;;
+    --base)    BASE="${2:-}"; [[ -z "$BASE" || "$BASE" == -* ]] && die "--base requires a branch"; shift 2 ;;
+    --timeout) TIMEOUT="${2:-}"; [[ "$TIMEOUT" =~ ^[0-9]+$ ]] || die "--timeout requires an integer (seconds)"; shift 2 ;;
+    --log-dir) LOG_DIR="${2:-}"; [[ -z "$LOG_DIR" || "$LOG_DIR" == -* ]] && die "--log-dir requires a directory"; shift 2 ;;
+    --format)  FORMAT="${2:-}"; [[ "$FORMAT" == "json" || "$FORMAT" == "summary" ]] || die "--format must be json or summary"; shift 2 ;;
+    --bin)     BIN_OVERRIDE="${2:-}"; [[ -z "$BIN_OVERRIDE" || "$BIN_OVERRIDE" == -* ]] && die "--bin requires a path"; shift 2 ;;
+    --print-cmd) PRINT_CMD=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$TOOL" ]] || die "--tool is required (coderabbit or codeant)"
+case "$TOOL" in coderabbit|codeant) ;; *) die "--tool must be coderabbit or codeant (got: $TOOL)" ;; esac
+case "$SCOPE" in all|uncommitted|committed) ;; *) die "--scope must be all, uncommitted, or committed (got: $SCOPE)" ;; esac
+
+# ----------------------------------------------------------------------
+# Build the CLI argv. Scope flags differ between the two CLIs.
+# ----------------------------------------------------------------------
+ARGS=()
+case "$TOOL" in
+  coderabbit)
+    ARGS=(review --agent --type "$SCOPE")
+    [[ -n "$BASE" ]] && ARGS+=(--base "$BASE")
+    ;;
+  codeant)
+    case "$SCOPE" in
+      all)         ARGS=(review --all --headless) ;;
+      uncommitted) ARGS=(review --uncommitted --headless) ;;
+      committed)   ARGS=(review --committed --headless) ;;
+    esac
+    [[ -n "$BASE" ]] && ARGS+=(--base "$BASE")
+    ;;
+esac
+
+if [[ "$PRINT_CMD" -eq 1 ]]; then
+  echo "$TOOL ${ARGS[*]}"
+  exit 0
+fi
+
+# Resolve the binary by absolute path first: the Bash tool's minimal PATH makes a bare
+# `command -v` under-report (safety.md rung 1, and the #819 not-installed failure mode).
+BIN=""
+if [[ -n "$BIN_OVERRIDE" ]]; then
+  [[ -x "$BIN_OVERRIDE" ]] && BIN="$BIN_OVERRIDE"
+else
+  for cand in "/opt/homebrew/bin/$TOOL" "$HOME/.local/bin/$TOOL" "$HOME/bin/$TOOL" "/usr/local/bin/$TOOL"; do
+    [[ -x "$cand" ]] && { BIN="$cand"; break; }
+  done
+  [[ -z "$BIN" ]] && BIN="$(command -v "$TOOL" 2>/dev/null || true)"
+fi
+
+LOG_DIR="${LOG_DIR%/}"   # $TMPDIR usually ends in / — keep log_path free of a doubled slash
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+STAMP="$(date -u +%s)-$$"
+OUT="$LOG_DIR/local-review-$TOOL-$STAMP.out"
+ERR="$LOG_DIR/local-review-$TOOL-$STAMP.err"
+: > "$OUT"
+: > "$ERR"
+
+# ----------------------------------------------------------------------
+# Emitter — every exit path goes through here so the contract shape is
+# identical no matter which failure fired.
+# ----------------------------------------------------------------------
+emit() { # ok verified_run failure_mode findings relevant_error duration exit_code
+  local ok="$1" verified="$2" mode="$3" findings="$4" err_txt="$5" dur="$6" rc="$7"
+  if [[ "$FORMAT" == "summary" ]]; then
+    printf '%s: ok=%s findings=%s verified=%s mode=%s log=%s\n' \
+      "$TOOL" "$ok" "$findings" "$verified" "${mode:--}" "$OUT"
+  else
+    jq -cn \
+      --argjson ok "$ok" \
+      --argjson verified "$verified" \
+      --arg mode "$mode" \
+      --argjson findings "$findings" \
+      --arg err "$err_txt" \
+      --arg log "$OUT" \
+      --arg errlog "$ERR" \
+      --arg tool "$TOOL" \
+      --argjson dur "$dur" \
+      '{ok: $ok, failed_tests: [], relevant_error: (if $err == "" then null else $err end),
+        log_path: $log, stderr_path: $errlog, tool: $tool, findings: $findings,
+        verified_run: $verified, failure_mode: (if $mode == "" then null else $mode end),
+        duration_s: $dur}'
+  fi
+  exit "$rc"
+}
+
+# Cap the decisive error text so it stays an index into the log, never a copy of it
+# (compact-result-contract.md "Extraction rules"). Deduped first: a CodeAnt 403
+# repeats the identical "API Error: Access denied (403)…" line once per file batch,
+# which would spend the whole budget restating one fact.
+cap_error() {
+  awk '!seen[$0]++' \
+    | awk 'NR <= 20 { print } NR == 21 { print "… (truncated; see log_path)"; exit }' \
+    | cut -c1-2000
+}
+
+if [[ -z "$BIN" ]]; then
+  emit false false not_installed 0 "$TOOL: command not found (checked /opt/homebrew/bin, ~/.local/bin, ~/bin, /usr/local/bin, PATH)" 0 5
+fi
+
+# ----------------------------------------------------------------------
+# Run with a hang bound. No `timeout(1)` on stock macOS, so poll the child.
+# ----------------------------------------------------------------------
+START="$(date -u +%s)"
+"$BIN" "${ARGS[@]}" >"$OUT" 2>"$ERR" &
+CLI_PID=$!
+
+TIMED_OUT=0
+ELAPSED=0
+while kill -0 "$CLI_PID" 2>/dev/null; do
+  if (( ELAPSED >= TIMEOUT )); then
+    TIMED_OUT=1
+    kill -TERM "$CLI_PID" 2>/dev/null || true
+    # Give it a moment to flush, then make sure it is gone.
+    sleep 2
+    kill -KILL "$CLI_PID" 2>/dev/null || true
+    break
+  fi
+  sleep 1
+  ELAPSED=$((ELAPSED + 1))
+done
+CLI_RC=0
+wait "$CLI_PID" 2>/dev/null || CLI_RC=$?
+DURATION=$(( $(date -u +%s) - START ))
+
+if [[ "$TIMED_OUT" -eq 1 ]]; then
+  emit false false timeout 0 "$TOOL exceeded --timeout ${TIMEOUT}s and was killed (partial output preserved)" "$DURATION" 4
+fi
+
+# ----------------------------------------------------------------------
+# Verdict. Order matters: an explicit error always outranks an empty result,
+# because an empty result is exactly what a failed run looks like.
+# ----------------------------------------------------------------------
+ERR_TEXT=""
+FINDINGS=0
+
+if [[ "$TOOL" == "codeant" ]]; then
+  # 1. stderr is CodeAnt's ONLY reliable failure signal (issue #642).
+  if grep -qE 'API Error|\[error\]|40[13]' "$ERR" 2>/dev/null; then
+    ERR_TEXT="$(grep -E 'API Error|\[error\]|40[13]' "$ERR" | cap_error)"
+    emit false false stderr_error 0 "$ERR_TEXT" "$DURATION" 3
+  fi
+  # 2. The headless object also carries its own `error` field.
+  CA_ERR="$(jq -r '.error // empty' "$OUT" 2>/dev/null || true)"
+  if [[ -n "$CA_ERR" ]]; then
+    emit false false stderr_error 0 "$(printf '%s' "$CA_ERR" | cap_error)" "$DURATION" 3
+  fi
+  # 3. Unparseable stdout means the run died before printing its result object.
+  if ! jq -e . "$OUT" >/dev/null 2>&1; then
+    ERR_TEXT="$(tail -n 20 "$ERR" | cap_error)"
+    [[ -z "$ERR_TEXT" ]] && ERR_TEXT="codeant produced no parseable JSON on stdout (exit $CLI_RC)"
+    emit false false no_review_records 0 "$ERR_TEXT" "$DURATION" 3
+  fi
+  # 4. noFiles: nothing was reviewed. Often a wrong-directory tell, never a clean pass.
+  if [[ "$(jq -r '.noFiles // false' "$OUT" 2>/dev/null)" == "true" ]]; then
+    emit false false no_changes_reviewed 0 "codeant reviewed 0 files (noFiles=true) — nothing was analysed; check the working directory and diff scope" "$DURATION" 3
+  fi
+  # 5. The 15-file cap: partial coverage is not full coverage.
+  if [[ "$(jq -r '.meta.capped // false' "$OUT" 2>/dev/null)" == "true" ]]; then
+    SKIPPED="$(jq -r '(.meta.skipped // []) | length' "$OUT" 2>/dev/null || echo 0)"
+    FINDINGS="$(jq -r '(.issues // []) | length' "$OUT" 2>/dev/null || echo 0)"
+    emit false false capped "$FINDINGS" "codeant hit the 15-file cap (meta.capped=true, ${SKIPPED} file(s) skipped) — scope the run with --include and re-run" "$DURATION" 3
+  fi
+  FINDINGS="$(jq -r '(.issues // []) | length' "$OUT" 2>/dev/null || echo 0)"
+else
+  # CodeRabbit hides failure as a stdout NDJSON record, with a clean stderr.
+  # 1. Any `type:"error"` record is a failed run regardless of exit code.
+  CR_ERR="$(jq -rs '[.[] | select(.type == "error")]
+                    | map(((.errorType // "error") + ": " + (.message // "")))
+                    | join("\n")' "$OUT" 2>/dev/null || true)"
+  if [[ -n "$CR_ERR" ]]; then
+    emit false false error_record 0 "$(printf '%s' "$CR_ERR" | cap_error)" "$DURATION" 3
+  fi
+  # 2. The terminal `complete` record is the authoritative verdict + finding count.
+  #    Its absence means the run died mid-flight — never read that as "no findings".
+  CR_COMPLETE="$(jq -rs '[.[] | select(.type == "complete" and (.findings != null))] | last // empty' "$OUT" 2>/dev/null || true)"
+  if [[ -z "$CR_COMPLETE" ]]; then
+    ERR_TEXT="$(tail -n 20 "$ERR" | cap_error)"
+    [[ -z "$ERR_TEXT" ]] && ERR_TEXT="coderabbit emitted no terminal complete record (exit $CLI_RC) — the review did not finish"
+    emit false false no_review_records 0 "$ERR_TEXT" "$DURATION" 3
+  fi
+  CR_STATUS="$(printf '%s' "$CR_COMPLETE" | jq -r '.status // ""' 2>/dev/null || true)"
+  if [[ "$CR_STATUS" == "review_skipped" ]]; then
+    emit false false no_changes_reviewed 0 "coderabbit skipped the review (status=review_skipped) — no changes were detected; check the working directory and --scope" "$DURATION" 3
+  fi
+  FINDINGS="$(printf '%s' "$CR_COMPLETE" | jq -r '.findings // 0' 2>/dev/null || echo 0)"
+fi
+
+[[ "$FINDINGS" =~ ^[0-9]+$ ]] || FINDINGS=0
+
+if (( FINDINGS > 0 )); then
+  emit false true "" "$FINDINGS" "" "$DURATION" 1
+fi
+
+emit true true "" 0 "" "$DURATION" 0

--- a/.claude/scripts/local-review.sh
+++ b/.claude/scripts/local-review.sh
@@ -234,8 +234,23 @@ FINDINGS=0
 
 if [[ "$TOOL" == "codeant" ]]; then
   # 1. stderr is CodeAnt's ONLY reliable failure signal (issue #642).
-  if grep -qE 'API Error|\[error\]|40[13]' "$ERR" 2>/dev/null; then
-    ERR_TEXT="$(grep -E 'API Error|\[error\]|40[13]' "$ERR" | cap_error)"
+  #
+  # The status alternative is digit-bounded rather than a bare `40[13]`, which matched
+  # the substring inside any longer number (1403, 4031, an epoch, a byte count) and
+  # would discard an otherwise clean run as a failed one. That direction is safe but
+  # not free: CodeAnt is daily-capped (~10 agent reviews, issue #643), so a spurious
+  # failure burns a review the caller cannot get back.
+  #
+  # Bounded with explicit non-digit context, NOT `\b` — deliberately, per the same
+  # portability rule as the awk patterns in run-python-tests.sh. Tightened only this
+  # far on purpose: requiring a full HTTP status/error record was considered and
+  # declined, because a shape we failed to anticipate would then read as CLEAN, and a
+  # missed failure is the one direction this script must never fail in. Every real
+  # 403 shape still matches — "(403)", "403:", " 401 ", and the "API Error" prefix
+  # CodeAnt's own daily-cap line carries.
+  CA_ERR_RE='API Error|\[error\]|(^|[^0-9])(401|403)([^0-9]|$)'
+  if grep -qE "$CA_ERR_RE" "$ERR" 2>/dev/null; then
+    ERR_TEXT="$(grep -E "$CA_ERR_RE" "$ERR" | cap_error)"
     emit false false stderr_error 0 "$ERR_TEXT" "$DURATION" 3
   fi
   # 2. The headless object also carries its own `error` field.

--- a/.claude/scripts/local-review.sh
+++ b/.claude/scripts/local-review.sh
@@ -61,7 +61,9 @@
 #
 # Notes:
 #   - Raw stdout and stderr are ALWAYS persisted, on every path including timeout, so the
-#     full output survives even though only the verdict reaches an agent's context.
+#     full output survives even though only the verdict reaches an agent's context. That
+#     is enforced, not assumed: an uncreatable or unwritable --log-dir exits 2 before the
+#     CLI is launched, so no verdict ever names a log file that does not exist.
 #   - Never runs `codeant logout`/`login` on a 403 — the cause is an undocumented daily cap,
 #     not auth (issue #643). Retry policy stays with the caller: one retry, then drop.
 set -uo pipefail
@@ -138,12 +140,19 @@ else
 fi
 
 LOG_DIR="${LOG_DIR%/}"   # $TMPDIR usually ends in / — keep log_path free of a doubled slash
-mkdir -p "$LOG_DIR" 2>/dev/null || true
 STAMP="$(date -u +%s)-$$"
 OUT="$LOG_DIR/local-review-$TOOL-$STAMP.out"
 ERR="$LOG_DIR/local-review-$TOOL-$STAMP.err"
-: > "$OUT"
-: > "$ERR"
+
+# The raw capture is a contract, not a convenience: every verdict prints log_path and
+# stderr_path as persisted logs. An unwritable --log-dir would leave both nonexistent
+# while the run continued, so the verdict would still advertise files nobody can read.
+# Verify up front and fail before launching the CLI rather than promise a file that was
+# never created. Both shapes are covered: mkdir -p reports an uncreatable directory, and
+# the truncations catch a directory that exists but is not writable.
+mkdir -p "$LOG_DIR" 2>/dev/null || die "--log-dir cannot be created: $LOG_DIR"
+{ : > "$OUT"; } 2>/dev/null || die "--log-dir is not writable: $LOG_DIR"
+{ : > "$ERR"; } 2>/dev/null || die "--log-dir is not writable: $LOG_DIR"
 
 # ----------------------------------------------------------------------
 # Emitter — every exit path goes through here so the contract shape is

--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -18,6 +18,19 @@
 # Output: writes JSON to /tmp/pr-state-<PR>-<epoch>.json and prints the path on stdout.
 #         (--infer-candidates prints a JSON array to stdout instead — see below.)
 #
+# Field projection (issue #782): the three REST comment arrays are projected before
+#   they enter the bundle — raw GitHub objects carry ~30 fields each and consumers read
+#   nine. Kept: id, node_id, body (FULL — never truncated), state, commit_id,
+#   original_commit_id, created_at, updated_at, submitted_at, url, html_url,
+#   author_association, in_reply_to_id, pull_request_review_id, the inline location
+#   fields (path, line, original_line, start_line, original_start_line, side,
+#   start_side, position, original_position, subject_type), and user reduced to
+#   {login, type, id}. Dropped: diff_hunk, _links, reactions, pull_request_url,
+#   issue_url, performed_via_github_app, body_html, body_text, and the rest of the
+#   user object. Measured 66% smaller on a live payload (294KB -> 99KB). Interface is
+#   unchanged: still "write the bundle to a tempfile, print only the path".
+#   Rationale and the full measurement: .claude/reference/compact-result-contract.md
+#
 # --infer-candidates (shared by /fixpr issue #447 and /wrap issue #448):
 #   Reads ~/.claude/session-state.json and prints a JSON array of the PRs this
 #   session is actively tracking (those with a non-null .phase), newest activity
@@ -479,11 +492,46 @@ BOT_STATUSES=$(echo "$STATUSES" | jq '
 ')
 
 # ----------------------------------------------------------------------
-# 5. REST comment endpoints (paginated)
+# 5. REST comment endpoints (paginated), field-projected
+#
+# Field projection (issue #782, FU-7 of token-efficiency-audit-2026-07.md).
+# These three arrays were the bundle's bulk: raw GitHub objects carry ~30 fields
+# each, of which consumers read nine — .id, .body, .state, .user.login,
+# .commit_id, .original_commit_id, .created_at, .updated_at, .submitted_at.
+# Projecting away the rest, measured on PR #931's live payload:
+#   inline   215,723 B -> 67,014 B (69%)   reviews 61,443 B -> 25,700 B (58%)
+#   convo     17,009 B ->  6,164 B (64%)   total  294,175 B -> 98,878 B (66%)
+# `diff_hunk` + `reactions` + `_links` alone were 121,893 B of the inline array.
+#
+# BODIES ARE KEPT IN FULL — never truncated. Every downstream classifier
+# (pr-state's own classify below, review-substance.sh's substance check,
+# merge-gate.sh's evidence scan) reads body text, and a truncated body is a
+# silent false verdict. This is a payload reduction, not a lossy summary.
+#
+# Dropped, all verified unreferenced across .claude/{scripts,skills,agents}:
+#   reviews: _links, pull_request_url, body_html, body_text
+#   inline:  diff_hunk, _links, reactions, pull_request_url, body_html, body_text
+#   convo:   reactions, performed_via_github_app, issue_url, body_html, body_text
+#   all:     the 18-field `user` object, reduced to {login, type, id}
+# `path` + `line` still locate every inline finding, which is what `diff_hunk`
+# was being carried for. Add a field back here if a consumer ever needs one.
+#
+# The GraphQL thread comments in section 2 are already projected at the query.
 # ----------------------------------------------------------------------
-REVIEWS=$(run_gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" | jq -s 'add // []')
-INLINE=$(run_gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100" | jq -s 'add // []')
-CONVO=$(run_gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100" | jq -s 'add // []')
+PROJECT_USER='(if .user == null then null else {login: .user.login, type: .user.type, id: .user.id} end)'
+
+REVIEWS=$(run_gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
+  | jq -s "add // [] | [.[] | {id, node_id, user: $PROJECT_USER, body, state, commit_id,
+                               submitted_at, html_url, author_association}]")
+INLINE=$(run_gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments?per_page=100" \
+  | jq -s "add // [] | [.[] | {id, node_id, pull_request_review_id, user: $PROJECT_USER, body,
+                               path, line, original_line, start_line, original_start_line,
+                               side, start_side, position, original_position, subject_type,
+                               commit_id, original_commit_id, in_reply_to_id,
+                               created_at, updated_at, url, html_url, author_association}]")
+CONVO=$(run_gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+  | jq -s "add // [] | [.[] | {id, node_id, user: $PROJECT_USER, body,
+                               created_at, updated_at, url, html_url, author_association}]")
 
 # ----------------------------------------------------------------------
 # 6. New-since-baseline classification (only when --since given)

--- a/.claude/scripts/tests/local-review.test.sh
+++ b/.claude/scripts/tests/local-review.test.sh
@@ -58,6 +58,35 @@ field() { printf '%s' "$OUT" | jq -r "$1"; }
 "$SUT" --tool coderabbit --format yaml >/dev/null 2>&1; check_eq 2 "$?" "unknown format exits 2"
 "$SUT" --tool coderabbit --timeout abc >/dev/null 2>&1; check_eq 2 "$?" "non-integer timeout exits 2"
 
+# An unusable --log-dir is a usage error, not a run: the contract promises log_path and
+# stderr_path are real persisted files, so the script must refuse before launching the
+# CLI rather than emit a verdict naming files that were never created. A WORKING stub is
+# used so the only possible cause of a non-zero exit is the log directory itself — with a
+# missing binary the not-installed path (exit 5) could mask the check being absent, and
+# the negative control below proves this same stub exits 0 when the dir is fine.
+LOGDIR_STUB="$(make_stub codeant-logdir '{"issues":[]}' '' 0)"
+run --tool codeant --bin "$LOGDIR_STUB"
+check_eq 0 "$RC" "negative control: this stub + a writable --log-dir is a clean pass"
+
+# Shape 1 — uncreatable: the parent is a regular file, so mkdir -p fails for ANY uid
+# (root included). This case is uid-independent by construction, never a vacuous pass.
+touch "$TMP/not-a-dir"
+"$SUT" --tool codeant --bin "$LOGDIR_STUB" --log-dir "$TMP/not-a-dir/sub" >/dev/null 2>&1
+check_eq 2 "$?" "uncreatable --log-dir exits 2 before running the CLI"
+
+# Shape 2 — exists but read-only. chmod is a no-op for root, so probe real unwritability
+# first and SKIP loudly rather than assert something the environment cannot produce
+# (a guard that passes by not running is not a passing guard).
+RO="$TMP/readonly"; mkdir -p "$RO"; chmod 500 "$RO"
+if { : > "$RO/.probe"; } 2>/dev/null; then
+  rm -f "$RO/.probe"
+  echo "SKIP: read-only --log-dir case (this uid can write to a 0500 dir; likely root)"
+else
+  "$SUT" --tool codeant --bin "$LOGDIR_STUB" --log-dir "$RO" >/dev/null 2>&1
+  check_eq 2 "$?" "unwritable --log-dir exits 2 before running the CLI"
+fi
+chmod 700 "$RO"   # let the EXIT trap clean the sandbox up
+
 # --------------------------------------------------------------------------
 # 2. Command construction — the scope flags differ per CLI.
 # --------------------------------------------------------------------------

--- a/.claude/scripts/tests/local-review.test.sh
+++ b/.claude/scripts/tests/local-review.test.sh
@@ -124,6 +124,25 @@ if printf '%s' "$OUT" | jq -e '.relevant_error | test("403")' >/dev/null; then
   ok "CodeAnt 403 relevant_error carries the decisive line"
 else bad "CodeAnt 403 relevant_error missing the 403 text"; fi
 
+# 4a-bis. The status matcher is digit-bounded: `401`/`403` inside a LONGER number is not
+# an auth failure. A bare `40[13]` matched those, discarding a clean run and burning one
+# of CodeAnt's ~10 daily agent reviews (issue #643) for nothing. Both directions pinned —
+# the benign case must stay clean, and every real 403 shape from
+# local-review-cli-failure-modes.md must still be caught, so tightening cannot have
+# opened a false-clean hole (the one direction this script must never fail in).
+BIN="$(make_stub codeant-bignum "$CA_CLEAN" 'progress: scanned 1403 files in 4031 ms' 0)"
+run --tool codeant --bin "$BIN"
+check_eq 0 "$RC" "digits inside a longer number are not a 401/403 failure"
+check_eq "true" "$(field .ok)" "benign numeric stderr stays a clean pass"
+
+BIN="$(make_stub codeant-403-bare "$CA_CLEAN" 'Access denied (403).' 0)"
+run --tool codeant --bin "$BIN"
+check_eq 3 "$RC" "a real bracketed 403 with no API Error prefix is still caught"
+
+BIN="$(make_stub codeant-401-spaced "$CA_CLEAN" 'request failed with status 401 while reviewing' 0)"
+run --tool codeant --bin "$BIN"
+check_eq 3 "$RC" "a real space-delimited 401 is still caught"
+
 # 4b. noFiles — reviewed nothing. Usually a wrong-directory tell.
 BIN="$(make_stub codeant-nofiles '{"issues": [], "meta": null, "error": null, "noFiles": true}' '' 0)"
 run --tool codeant --bin "$BIN"

--- a/.claude/scripts/tests/local-review.test.sh
+++ b/.claude/scripts/tests/local-review.test.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# local-review.test.sh — Offline unit tests for local-review.sh (issue #782).
+#
+# Fully offline: every CLI is a stub script driven through --bin, so no network, no
+# real coderabbit/codeant invocation, and no dependence on which CLIs are installed
+# on the runner. Stubs never forward through `command -v` (that self-recurses when a
+# stub shadows the real name on PATH — memory: subagent-ops / test-stub recursion).
+#
+# Run from repo root: bash .claude/scripts/tests/local-review.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SUT="$REPO_ROOT/.claude/scripts/local-review.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# The script appends to $HOME/.claude/script-usage.log; point it at the sandbox.
+export HOME="$TMP/home"; mkdir -p "$HOME/.claude"
+LOGS="$TMP/logs"; mkdir -p "$LOGS"
+STUBS="$TMP/stubs"; mkdir -p "$STUBS"
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+check_eq() { # expected actual label
+  if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected: $1, got: $2)"; fi
+}
+
+# make_stub <name> <stdout-heredoc-file-or-empty> <stderr-text> <exit-code>
+make_stub() { # name stdout_payload stderr_payload exit_code
+  local name="$1" out="$2" err="$3" rc="$4"
+  local path="$STUBS/$name"
+  {
+    echo '#!/usr/bin/env bash'
+    printf 'cat <<%s\n%s\n%s\n' "'STUB_STDOUT_EOF'" "$out" "STUB_STDOUT_EOF"
+    printf 'cat >&2 <<%s\n%s\n%s\n' "'STUB_STDERR_EOF'" "$err" "STUB_STDERR_EOF"
+    printf 'exit %s\n' "$rc"
+  } > "$path"
+  chmod +x "$path"
+  echo "$path"
+}
+
+OUT=""
+RC=0
+run() { OUT="$("$SUT" "$@" --log-dir "$LOGS" 2>/dev/null)"; RC=$?; }
+field() { printf '%s' "$OUT" | jq -r "$1"; }
+
+# --------------------------------------------------------------------------
+# 1. Usage errors — exit 2, nothing runs.
+# --------------------------------------------------------------------------
+"$SUT" >/dev/null 2>&1; check_eq 2 "$?" "no --tool exits 2"
+"$SUT" --tool nope >/dev/null 2>&1; check_eq 2 "$?" "unknown tool exits 2"
+"$SUT" --tool coderabbit --scope sideways >/dev/null 2>&1; check_eq 2 "$?" "unknown scope exits 2"
+"$SUT" --tool coderabbit --format yaml >/dev/null 2>&1; check_eq 2 "$?" "unknown format exits 2"
+"$SUT" --tool coderabbit --timeout abc >/dev/null 2>&1; check_eq 2 "$?" "non-integer timeout exits 2"
+
+# --------------------------------------------------------------------------
+# 2. Command construction — the scope flags differ per CLI.
+# --------------------------------------------------------------------------
+check_eq "coderabbit review --agent --type all" \
+  "$("$SUT" --tool coderabbit --print-cmd)" "CR default scope maps to --type all"
+check_eq "coderabbit review --agent --type uncommitted --base develop" \
+  "$("$SUT" --tool coderabbit --scope uncommitted --base develop --print-cmd)" "CR scope + base pass through"
+check_eq "codeant review --all --headless" \
+  "$("$SUT" --tool codeant --print-cmd)" "CodeAnt default scope maps to --all"
+check_eq "codeant review --committed --headless" \
+  "$("$SUT" --tool codeant --scope committed --print-cmd)" "CodeAnt committed scope"
+
+# --------------------------------------------------------------------------
+# 3. Binary absent — the #819 not-installed state.
+# --------------------------------------------------------------------------
+run --tool codeant --bin "$STUBS/definitely-not-here"
+check_eq 5 "$RC" "missing binary exits 5"
+check_eq "not_installed" "$(field .failure_mode)" "missing binary reports not_installed"
+check_eq "false" "$(field .verified_run)" "missing binary is not a verified run"
+
+# --------------------------------------------------------------------------
+# 4. CodeAnt — the false-clean family. Every one of these exits 0 from the CLI
+#    with a clean-looking stdout; none may be read as a clean pass.
+# --------------------------------------------------------------------------
+CA_CLEAN='{"issues": [], "meta": {"capped": false, "skipped": [], "reviewed_files": ["a.sh"]}, "error": null, "noFiles": false}'
+
+# 4a. stderr API error, stdout says {"issues":[]} — the canonical #642 false-clean.
+BIN="$(make_stub codeant-403 "$CA_CLEAN" 'API Error: Access denied (403). Please run `codeant logout`...' 0)"
+run --tool codeant --bin "$BIN"
+check_eq 3 "$RC" "CodeAnt stderr API Error exits 3"
+check_eq "stderr_error" "$(field .failure_mode)" "CodeAnt 403 reports stderr_error"
+check_eq "false" "$(field .ok)" "CodeAnt 403 is not ok"
+check_eq "false" "$(field .verified_run)" "CodeAnt 403 is not a verified run"
+if printf '%s' "$OUT" | jq -e '.relevant_error | test("403")' >/dev/null; then
+  ok "CodeAnt 403 relevant_error carries the decisive line"
+else bad "CodeAnt 403 relevant_error missing the 403 text"; fi
+
+# 4b. noFiles — reviewed nothing. Usually a wrong-directory tell.
+BIN="$(make_stub codeant-nofiles '{"issues": [], "meta": null, "error": null, "noFiles": true}' '' 0)"
+run --tool codeant --bin "$BIN"
+check_eq 3 "$RC" "CodeAnt noFiles exits 3"
+check_eq "no_changes_reviewed" "$(field .failure_mode)" "CodeAnt noFiles reports no_changes_reviewed"
+
+# 4c. 15-file cap — partial coverage is not coverage.
+BIN="$(make_stub codeant-capped \
+  '{"issues": [], "meta": {"capped": true, "skipped": ["x.sh","y.sh"], "max_files": 15}, "error": null, "noFiles": false}' '' 0)"
+run --tool codeant --bin "$BIN"
+check_eq 3 "$RC" "CodeAnt capped run exits 3"
+check_eq "capped" "$(field .failure_mode)" "CodeAnt capped reports capped"
+
+# 4d. The result object's own error field.
+BIN="$(make_stub codeant-errfield '{"issues": [], "meta": null, "error": "socket hang up", "noFiles": false}' '' 0)"
+run --tool codeant --bin "$BIN"
+check_eq 3 "$RC" "CodeAnt error field exits 3"
+check_eq "stderr_error" "$(field .failure_mode)" "CodeAnt error field reports stderr_error"
+
+# 4e. Unparseable stdout — the run died before printing its result object.
+BIN="$(make_stub codeant-garbage 'Segmentation fault' 'boom' 1)"
+run --tool codeant --bin "$BIN"
+check_eq 3 "$RC" "CodeAnt unparseable stdout exits 3"
+check_eq "no_review_records" "$(field .failure_mode)" "CodeAnt unparseable stdout reports no_review_records"
+
+# 4f. Genuinely clean.
+BIN="$(make_stub codeant-clean "$CA_CLEAN" '[files] Reviewing 1 file(s)' 0)"
+run --tool codeant --bin "$BIN"
+check_eq 0 "$RC" "CodeAnt clean run exits 0"
+check_eq "true" "$(field .ok)" "CodeAnt clean run is ok"
+check_eq "true" "$(field .verified_run)" "CodeAnt clean run is verified"
+check_eq "null" "$(field .failure_mode)" "CodeAnt clean run has no failure_mode"
+check_eq "null" "$(field .relevant_error)" "CodeAnt clean run has null relevant_error"
+check_eq "0" "$(field .findings)" "CodeAnt clean run reports 0 findings"
+check_eq "[]" "$(field '.failed_tests | tojson')" "non-test pipeline reports empty failed_tests"
+
+# 4g. Findings present — a verified run, but not a clean pass.
+BIN="$(make_stub codeant-findings \
+  '{"issues": [{"label":"MAJOR"},{"label":"MINOR"}], "meta": {"capped": false, "skipped": []}, "error": null, "noFiles": false}' '' 0)"
+run --tool codeant --bin "$BIN"
+check_eq 1 "$RC" "CodeAnt findings exits 1"
+check_eq "false" "$(field .ok)" "CodeAnt findings is not ok"
+check_eq "true" "$(field .verified_run)" "CodeAnt findings is still a verified run"
+check_eq "2" "$(field .findings)" "CodeAnt findings counts .issues"
+
+# --------------------------------------------------------------------------
+# 5. CodeRabbit — failure hides in the stdout NDJSON stream, stderr stays clean.
+# --------------------------------------------------------------------------
+CR_CTX='{"type":"review_context","reviewType":"all"}'
+CR_DONE='{"type":"complete","status":"review_completed","findings":0,"reviewedFiles":["a.sh"]}'
+
+# 5a. Rate-limit error record with exit 0 and clean stderr.
+BIN="$(make_stub coderabbit-rl "$CR_CTX
+{\"type\":\"error\",\"errorType\":\"rate_limit\",\"message\":\"Rate limit exceeded\"}" '' 0)"
+run --tool coderabbit --bin "$BIN"
+check_eq 3 "$RC" "CR error record exits 3"
+check_eq "error_record" "$(field .failure_mode)" "CR error record reports error_record"
+if printf '%s' "$OUT" | jq -e '.relevant_error | test("rate_limit")' >/dev/null; then
+  ok "CR relevant_error names the errorType"
+else bad "CR relevant_error missing errorType"; fi
+
+# 5b. No terminal complete record — the run died mid-flight. Not "no findings".
+BIN="$(make_stub coderabbit-truncated "$CR_CTX
+{\"type\":\"status\",\"phase\":\"analyzing\",\"status\":\"analyzing_files\"}" '' 0)"
+run --tool coderabbit --bin "$BIN"
+check_eq 3 "$RC" "CR missing complete record exits 3"
+check_eq "no_review_records" "$(field .failure_mode)" "CR missing complete record reports no_review_records"
+
+# 5c. review_skipped — nothing to review. A wrong-directory tell, not a pass.
+BIN="$(make_stub coderabbit-skipped "$CR_CTX
+{\"type\":\"complete\",\"status\":\"review_skipped\",\"findings\":0,\"message\":\"No changes detected\"}" '' 0)"
+run --tool coderabbit --bin "$BIN"
+check_eq 3 "$RC" "CR review_skipped exits 3"
+check_eq "no_changes_reviewed" "$(field .failure_mode)" "CR review_skipped reports no_changes_reviewed"
+
+# 5d. Genuinely clean.
+BIN="$(make_stub coderabbit-clean "$CR_CTX
+$CR_DONE" '' 0)"
+run --tool coderabbit --bin "$BIN"
+check_eq 0 "$RC" "CR clean run exits 0"
+check_eq "true" "$(field .ok)" "CR clean run is ok"
+check_eq "coderabbit" "$(field .tool)" "contract names the tool"
+
+# 5e. Findings.
+BIN="$(make_stub coderabbit-findings "$CR_CTX
+{\"type\":\"complete\",\"status\":\"review_completed\",\"findings\":3,\"reviewedFiles\":[\"a.sh\"]}" '' 0)"
+run --tool coderabbit --bin "$BIN"
+check_eq 1 "$RC" "CR findings exits 1"
+check_eq "3" "$(field .findings)" "CR findings count comes from the complete record"
+check_eq "true" "$(field .verified_run)" "CR findings is a verified run"
+
+# 5f. An error record outranks a later clean complete record — an explicit failure
+#     always beats an empty result, because an empty result IS what failure looks like.
+BIN="$(make_stub coderabbit-err-then-done "$CR_CTX
+{\"type\":\"error\",\"errorType\":\"auth\",\"message\":\"not logged in\"}
+$CR_DONE" '' 0)"
+run --tool coderabbit --bin "$BIN"
+check_eq 3 "$RC" "CR error record wins over a later complete record"
+
+# --------------------------------------------------------------------------
+# 6. Raw output always persists — compaction moves bulk out of context, never
+#    destroys it. log_path and stderr_path must both exist on every path.
+# --------------------------------------------------------------------------
+BIN="$(make_stub codeant-persist "$CA_CLEAN" 'some stderr noise' 0)"
+run --tool codeant --bin "$BIN"
+LOG_PATH="$(field .log_path)"
+ERR_PATH="$(field .stderr_path)"
+[[ -f "$LOG_PATH" ]] && ok "log_path exists on a clean run" || bad "log_path missing: $LOG_PATH"
+[[ -f "$ERR_PATH" ]] && ok "stderr_path exists on a clean run" || bad "stderr_path missing: $ERR_PATH"
+if grep -q 'some stderr noise' "$ERR_PATH" 2>/dev/null; then
+  ok "raw stderr is preserved verbatim at stderr_path"
+else bad "stderr capture did not reach stderr_path"; fi
+case "$LOG_PATH" in *//*) bad "log_path contains a doubled slash: $LOG_PATH" ;; *) ok "log_path has no doubled slash" ;; esac
+
+# --------------------------------------------------------------------------
+# 7. --format summary — one human line, and NOT JSON.
+# --------------------------------------------------------------------------
+BIN="$(make_stub codeant-summary "$CA_CLEAN" '' 0)"
+SUMMARY="$("$SUT" --tool codeant --bin "$BIN" --log-dir "$LOGS" --format summary 2>/dev/null)"
+if printf '%s' "$SUMMARY" | grep -q '^codeant: ok=true findings=0 verified=true'; then
+  ok "--format summary emits the one-line human shape"
+else bad "--format summary shape wrong: $SUMMARY"; fi
+check_eq 1 "$(printf '%s\n' "$SUMMARY" | wc -l | tr -d ' ')" "--format summary is a single line"
+
+# --------------------------------------------------------------------------
+# 8. Timeout — a hung CLI is bounded, never waited on forever (CodeAnt v0.5.1
+#    can hang with ZERO output, so silence is not progress).
+# --------------------------------------------------------------------------
+HANG="$STUBS/codeant-hang"
+{ echo '#!/usr/bin/env bash'; echo 'sleep 60'; } > "$HANG"
+chmod +x "$HANG"
+START="$(date -u +%s)"
+run --tool codeant --bin "$HANG" --timeout 1
+ELAPSED=$(( $(date -u +%s) - START ))
+check_eq 4 "$RC" "hung CLI exits 4"
+check_eq "timeout" "$(field .failure_mode)" "hung CLI reports timeout"
+if (( ELAPSED < 20 )); then ok "hung CLI is killed promptly (${ELAPSED}s)"; else bad "timeout took ${ELAPSED}s"; fi
+
+# --------------------------------------------------------------------------
+# 9. stdout carries ONLY the contract — the whole point of the compact shape is
+#    that `$(local-review.sh ...)` is directly parseable.
+# --------------------------------------------------------------------------
+BIN="$(make_stub codeant-chatty "$CA_CLEAN" 'lots
+of
+stderr
+chatter' 0)"
+RAW="$("$SUT" --tool codeant --bin "$BIN" --log-dir "$LOGS" 2>/dev/null)"
+check_eq 1 "$(printf '%s\n' "$RAW" | wc -l | tr -d ' ')" "json mode emits exactly one line on stdout"
+if printf '%s' "$RAW" | jq -e 'has("ok") and has("failed_tests") and has("relevant_error") and has("log_path")' >/dev/null; then
+  ok "contract carries all four required fields"
+else bad "contract is missing a required field"; fi
+
+# --------------------------------------------------------------------------
+echo "----"
+echo "local-review.test.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.claude/skills/fixpr/SKILL.md
+++ b/.claude/skills/fixpr/SKILL.md
@@ -14,7 +14,7 @@ Bounded-convergence cleanup of the current branch's PR (issue #454 added the pos
 
 CodeRabbit caps **~8 GitHub PR reviews per hour** per account; **each push** consumes one. **Multi-round PRs** exhaust that budget fast if you fix-and-push repeatedly.
 
-**Coalesce locally first:** Before opening `/fixpr` on minor iterations, run the dual-CLI local review (**`coderabbit review --agent`** + **`codeant review --uncommitted --headless`**) per `cr-local-review.md` on uncommitted changes when feasible — catch issues **before** they cost a GitHub review.
+**Coalesce locally first:** Before opening `/fixpr` on minor iterations, run the dual-CLI local review (**`.claude/scripts/local-review.sh --tool coderabbit --scope uncommitted`** + **`--tool codeant --scope uncommitted`**) per `cr-local-review.md` on uncommitted changes when feasible — catch issues **before** they cost a GitHub review. The wrapper returns one compact line per CLI; the raw capture stays at its `log_path`.
 
 **Coalesce inside `/fixpr`:** Steps 1–3 intentionally gather **every** unresolved finding + every failing CI check, then fix **all** actionable items and **`git push` once**. Never push once per finding. One `/fixpr` cycle should produce **at most one** consume-side CR review per completed push (tracked below).
 

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -517,7 +517,7 @@ Fix/implement issue #{N}: {title}
 2. Read the issue body — this is the canonical implementation plan (includes merged CodeRabbit recommendations when available)
 3. Check issue comments only to detect any plan content not yet merged into the body — if found, merge it first
 4. Implement the changes
-5. Run the local dual-CLI review per `cr-local-review.md` (`coderabbit review --agent` + `codeant review --all --headless`) — fix all findings
+5. Run the local dual-CLI review per `cr-local-review.md` (`.claude/scripts/local-review.sh --tool coderabbit` + `--tool codeant`) — fix all findings; read the compact verdict, not the raw log
 6. One clean pass on each available CLI (dropped-CLI and outage fallbacks per `cr-local-review.md`), then commit and push
 7. Create a PR with `Closes #{N}` in the body
 8. Include a Test Plan section with checkboxes for acceptance criteria

--- a/.claude/skills/prompt/SKILL.md
+++ b/.claude/skills/prompt/SKILL.md
@@ -334,7 +334,7 @@ These are mandatory verification points. The executing agent MUST follow these:
 {Include relevant checkpoints based on the task type:}
 
 **If the task involves pushing code and creating a PR:**
-- [ ] After coding: Run `coderabbit review --agent` and `codeant review --all --headless` — one clean pass on each available CLI required before pushing (fallbacks per `cr-local-review.md`)
+- [ ] After coding: Run `.claude/scripts/local-review.sh --tool coderabbit` and `--tool codeant` — one clean pass (`ok:true` + `verified_run:true`) on each available CLI required before pushing (fallbacks per `cr-local-review.md`)
 - [ ] After pushing: Enter GitHub review polling loop immediately — do NOT ask permission
 - [ ] After CR/Greptile posts findings: Fix all valid findings in ONE commit, push once, reply to every thread
 

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -268,7 +268,7 @@ Body:
 1. You are already in a worktree — verify with `git branch --show-current`.
 2. Read the issue body above — this is your implementation plan.
 3. Implement the changes.
-4. Run the local dual-CLI review per `cr-local-review.md`: `coderabbit review --agent` AND `codeant review --all --headless`
+4. Run the local dual-CLI review per `cr-local-review.md`: `.claude/scripts/local-review.sh --tool coderabbit` AND `.claude/scripts/local-review.sh --tool codeant` (each emits `{"ok":…,"findings":N,"verified_run":…,"failure_mode":…,"log_path":…}`; raw output stays at `log_path`)
    - Union the findings; fix all valid findings.
    - Run all available CLIs again. Repeat until each remaining CLI has one clean pass.
    - If a CLI hangs >2 minutes or errors twice, drop it for the session, resolve or explicitly waive its pre-drop findings in the PR body, gate on the remaining one, and note the drop.

--- a/.github/scripts/run-hook-tests.sh
+++ b/.github/scripts/run-hook-tests.sh
@@ -14,12 +14,50 @@
 # positional args needed.
 #
 # Usage (CI or local, runnable from anywhere):
-#   bash .github/scripts/run-hook-tests.sh
+#   bash .github/scripts/run-hook-tests.sh            # human/CI folds (default)
+#   bash .github/scripts/run-hook-tests.sh --json     # compact result contract
+#   bash .github/scripts/run-hook-tests.sh --help
+#
+# --json (issue #782): emits the compact result contract from
+# .claude/reference/compact-result-contract.md as the ONLY thing on stdout:
+#
+#   {"ok":false,"failed_tests":[".claude/scripts/tests/foo.test.sh"],
+#    "relevant_error":"foo.test.sh: FAIL: expects exit 3","log_path":"/tmp/run-hook-tests-....log",
+#    "total":94,"failed":1}
+#
+# Compact mode silences PASSING suites — that is where the savings are. Failing
+# suites still print their captured output IN FULL, on stderr, because a failing
+# test must never be compacted down to a status line (token-efficiency-audit-2026-07.md
+# §"What NOT to change"). The complete capture of every suite, pass or fail, is always
+# written to `log_path` in both modes.
+#
+# Log location: $RUN_TESTS_LOG_DIR, else $RUNNER_TEMP (GitHub Actions), else $TMPDIR, else /tmp.
+#
+# Exit codes:
+#   0  every discovered suite passed
+#   1  one or more suites failed
+#   2  usage error (unknown flag)
+#   3  discovery found no suites — a glob is broken (issue #681); never a silent green
 #
 # Not `set -e`: the loop deliberately runs every suite and aggregates failures
 # so one red test does not hide the rest. The final check is the exit gate.
 set -uo pipefail
 shopt -s nullglob
+
+JSON=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json) JSON=1; shift ;;
+    -h|--help)
+      awk 'NR == 1 { next } /^$/ { exit } { print }' "$0"
+      exit 0
+      ;;
+    *)
+      echo "::error::run-hook-tests.sh: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
 
 # Resolve to the repo root regardless of caller cwd so the globs below resolve.
 cd "$(dirname "${BASH_SOURCE[0]}")/../.." || {
@@ -27,31 +65,103 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.." || {
   exit 1
 }
 
+LOG_DIR="${RUN_TESTS_LOG_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}}"
+LOG_DIR="${LOG_DIR%/}"   # $TMPDIR usually ends in / — keep log_path free of a doubled slash
+mkdir -p "$LOG_DIR" 2>/dev/null || LOG_DIR="/tmp"
+LOG="$LOG_DIR/run-hook-tests-$(date -u +%s)-$$.log"
+: > "$LOG"
+
+# Every human-facing line goes to stderr in --json mode so stdout stays parseable.
+say() { if [ "$JSON" -eq 1 ]; then printf '%s\n' "$1" >&2; else printf '%s\n' "$1"; fi; }
+
+SUITE_OUT="$(mktemp "${TMPDIR:-/tmp}/run-hook-tests-suite-XXXXXX")"
+cleanup() { rm -f "$SUITE_OUT"; }
+trap cleanup EXIT
+
 failed=0
 total=0
+FAILED_LIST=""
+RELEVANT=""
 for t in .claude/hooks/tests/*.test.sh \
          .claude/scripts/tests/*.test.sh \
          .github/scripts/tests/*.test.sh; do
   total=$((total + 1))
-  printf '::group::%s\n' "$t"
-  if bash "$t"; then
-    printf 'PASS: %s\n' "$t"
-    printf '::endgroup::\n'
+  rc=0
+  bash "$t" >"$SUITE_OUT" 2>&1 || rc=$?
+
+  # The full capture always reaches the log, pass or fail, in both modes.
+  {
+    printf '===== %s (rc=%s) =====\n' "$t" "$rc"
+    cat "$SUITE_OUT"
+    printf '\n'
+  } >> "$LOG"
+
+  if [ "$rc" -eq 0 ]; then
+    if [ "$JSON" -eq 0 ]; then
+      printf '::group::%s\n' "$t"
+      cat "$SUITE_OUT"
+      printf 'PASS: %s\n' "$t"
+      printf '::endgroup::\n'
+    fi
   else
-    rc=$?
-    printf '::endgroup::\n'
-    printf '::error::FAIL (rc=%s): %s\n' "$rc" "$t"
+    # Failures print in full in BOTH modes — compaction never hides a red test.
+    if [ "$JSON" -eq 0 ]; then
+      printf '::group::%s\n' "$t"
+      cat "$SUITE_OUT"
+      printf '::endgroup::\n'
+      printf '::error::FAIL (rc=%s): %s\n' "$rc" "$t"
+    else
+      {
+        printf '::group::FAIL %s (rc=%s)\n' "$t" "$rc"
+        cat "$SUITE_OUT"
+        printf '::endgroup::\n'
+      } >&2
+    fi
     failed=$((failed + 1))
+    FAILED_LIST="${FAILED_LIST}${t}"$'\n'
+    # relevant_error: the decisive line(s) from THIS suite's capture only —
+    # anchored so a suite's own "FAIL:" tally lines are picked up but ordinary
+    # prose mentioning "fail" is not. Scanning the aggregate log instead would
+    # attribute another suite's lines to this one.
+    RELEVANT="${RELEVANT}$(awk -v s="$t" '
+        /^(FAIL|ERROR|not ok)/ || /AssertionError/ || /^::error::/ || / line [0-9]+: / {
+          print s ": " $0
+          if (++n >= 3) exit
+        }' "$SUITE_OUT" 2>/dev/null)"$'\n'
   fi
 done
 
-printf '\nDiscovered and ran %s bash test suite(s); %s failed.\n' "$total" "$failed"
+say "$(printf '\nDiscovered and ran %s bash test suite(s); %s failed.\nFull output: %s' "$total" "$failed" "$LOG")"
 
 # Fail loud if discovery found nothing — a silently-empty run must never pass
 # green and masquerade as "all tests passed" (issue #681).
 if [ "$total" -eq 0 ]; then
+  if [ "$JSON" -eq 1 ]; then
+    jq -cn --arg log "$LOG" \
+      '{ok: false, failed_tests: [], relevant_error: "run-hook-tests.sh discovered no test suites — a glob is broken", log_path: $log, total: 0, failed: 0}'
+  fi
   echo "::error::run-hook-tests.sh discovered no test suites — a glob is broken" >&2
-  exit 1
+  exit 3
+fi
+
+if [ "$JSON" -eq 1 ]; then
+  # Cap per the contract — relevant_error indexes the failure, log_path holds it all.
+  RELEVANT="$(printf '%s' "$RELEVANT" | sed '/^$/d' \
+    | awk 'NR <= 20 { print } NR == 21 { print "… (truncated; see log_path)"; exit }' | cut -c1-2000)"
+  # A suite can fail without printing any recognized marker (e.g. a bare non-zero
+  # exit). Naming it is still better than a null error.
+  [ -n "$RELEVANT" ] || RELEVANT="$(printf '%s' "$FAILED_LIST" | sed '/^$/d' | sed 's/^/failed suite: /' | head -n 20)"
+  jq -cn \
+    --argjson ok "$( [ "$failed" -eq 0 ] && echo true || echo false )" \
+    --arg failed_list "$FAILED_LIST" \
+    --arg relevant "$RELEVANT" \
+    --arg log "$LOG" \
+    --argjson total "$total" \
+    --argjson failed "$failed" \
+    '{ok: $ok,
+      failed_tests: ($failed_list | split("\n") | map(select(length > 0))),
+      relevant_error: (if $relevant == "" then null else $relevant end),
+      log_path: $log, total: $total, failed: $failed}'
 fi
 
 [ "$failed" -eq 0 ]

--- a/.github/scripts/run-python-tests.sh
+++ b/.github/scripts/run-python-tests.sh
@@ -13,13 +13,51 @@
 # `python3 -m unittest discover`.
 #
 # Usage (CI or local, runnable from anywhere):
-#   bash .github/scripts/run-python-tests.sh
+#   bash .github/scripts/run-python-tests.sh          # verbose unittest output (default)
+#   bash .github/scripts/run-python-tests.sh --json   # compact result contract
+#   bash .github/scripts/run-python-tests.sh --help
+#
+# --json (issue #782): emits the compact result contract from
+# .claude/reference/compact-result-contract.md as the ONLY thing on stdout:
+#
+#   {"ok":false,"failed_tests":["test_x (tests.test_y.Case)"],
+#    "relevant_error":"AssertionError: 3 != 4","log_path":"/tmp/run-python-tests-....log",
+#    "modules":12}
+#
+# `unittest discover -v` prints one line per test, so a green run is pure noise in an
+# agent's context — compact mode drops it. A FAILING run still prints the full unittest
+# output on stderr: a red test is never compacted to a status line
+# (token-efficiency-audit-2026-07.md §"What NOT to change"). The complete output is
+# always written to `log_path` in both modes.
+#
+# Log location: $RUN_TESTS_LOG_DIR, else $RUNNER_TEMP (GitHub Actions), else $TMPDIR, else /tmp.
+#
+# Exit codes:
+#   0  all discovered tests passed
+#   1  one or more tests failed or errored
+#   2  usage error (unknown flag)
+#   3  discovery found no tests/test_*.py modules — a glob is broken; never a silent green
 #
 # Python version: determined by whatever `python3` is on PATH. The CI workflow
 # handles version pinning via the `setup-python` step before calling this
-# script, so the script itself takes no arguments.
-set -euo pipefail
+# script, so the script itself takes no positional arguments.
+set -uo pipefail
 shopt -s nullglob
+
+JSON=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json) JSON=1; shift ;;
+    -h|--help)
+      awk 'NR == 1 { next } /^$/ { exit } { print }' "$0"
+      exit 0
+      ;;
+    *)
+      echo "::error::run-python-tests.sh: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
 
 # Resolve to the repo root regardless of caller cwd so the glob below resolves.
 cd "$(dirname "${BASH_SOURCE[0]}")/../.." || {
@@ -27,13 +65,72 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.." || {
   exit 1
 }
 
+LOG_DIR="${RUN_TESTS_LOG_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}}"
+LOG_DIR="${LOG_DIR%/}"   # $TMPDIR usually ends in / — keep log_path free of a doubled slash
+mkdir -p "$LOG_DIR" 2>/dev/null || LOG_DIR="/tmp"
+LOG="$LOG_DIR/run-python-tests-$(date -u +%s)-$$.log"
+: > "$LOG"
+
 # Discover tests/test_*.py and fail loud on an empty set — a silent
 # "Ran 0 tests ... OK" must never pass green (issue #681).
 mods=(tests/test_*.py)
 if [ "${#mods[@]}" -eq 0 ]; then
+  if [ "$JSON" -eq 1 ]; then
+    jq -cn --arg log "$LOG" \
+      '{ok: false, failed_tests: [], relevant_error: "No tests/test_*.py modules discovered — a glob is broken or tests/ is empty", log_path: $log, modules: 0}'
+  fi
   echo "::error::No tests/test_*.py modules discovered — a glob is broken or tests/ is empty" >&2
-  exit 1
+  exit 3
 fi
 
-echo "Discovered ${#mods[@]} Python test module(s)."
-python3 -m unittest discover -s tests -p 'test_*.py' -v
+if [ "$JSON" -eq 1 ]; then
+  echo "Discovered ${#mods[@]} Python test module(s)." >&2
+else
+  echo "Discovered ${#mods[@]} Python test module(s)."
+fi
+
+rc=0
+if [ "$JSON" -eq 1 ]; then
+  # unittest writes its report to stderr; capture both streams into the log and
+  # keep stdout clean for the contract.
+  python3 -m unittest discover -s tests -p 'test_*.py' -v >"$LOG" 2>&1 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    # A red run prints in full — see the header note.
+    {
+      printf '::group::Python unittest output (rc=%s)\n' "$rc"
+      cat "$LOG"
+      printf '::endgroup::\n'
+    } >&2
+  fi
+
+  # unittest marks each failure as `FAIL: test_x (mod.Case)` / `ERROR: test_x (mod.Case)`.
+  FAILED_LIST="$(awk '/^(FAIL|ERROR): / { sub(/^(FAIL|ERROR): /, ""); print }' "$LOG" 2>/dev/null | sort -u)"
+  # The decisive line of each traceback, not the traceback itself. No `\b` here:
+  # macOS ships one-true-awk, where `\b` is a backspace character, not a word
+  # boundary, so an anchored `...Error\b` silently matches nothing.
+  RELEVANT="$(awk '/^[A-Za-z_.]*(Error|Exception)(:|$)/ || /^(FAIL|ERROR): / { print; if (++n >= 20) exit }' "$LOG" 2>/dev/null \
+    | awk 'NR <= 20 { print } NR == 21 { print "… (truncated; see log_path)"; exit }' | cut -c1-2000)"
+  if [ "$rc" -ne 0 ] && [ -z "$RELEVANT" ]; then
+    RELEVANT="$(tail -n 5 "$LOG" | cut -c1-2000)"
+  fi
+  [ "$rc" -eq 0 ] && RELEVANT=""
+
+  jq -cn \
+    --argjson ok "$( [ "$rc" -eq 0 ] && echo true || echo false )" \
+    --arg failed_list "$FAILED_LIST" \
+    --arg relevant "$RELEVANT" \
+    --arg log "$LOG" \
+    --argjson modules "${#mods[@]}" \
+    '{ok: $ok,
+      failed_tests: ($failed_list | split("\n") | map(select(length > 0))),
+      relevant_error: (if $relevant == "" then null else $relevant end),
+      log_path: $log, modules: $modules}'
+else
+  # Default mode is unchanged: stream verbose output, and also persist it so
+  # `log_path` means the same thing in both modes.
+  python3 -m unittest discover -s tests -p 'test_*.py' -v 2>&1 | tee "$LOG"
+  rc="${PIPESTATUS[0]}"
+  echo "Full output: $LOG"
+fi
+
+exit "$rc"

--- a/.github/scripts/summarize-test-run.sh
+++ b/.github/scripts/summarize-test-run.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Run a compact-contract test runner and surface its verdict in CI (issue #782).
+#
+# Wraps run-hook-tests.sh / run-python-tests.sh in --json mode so a CI job log carries
+# the one-line result contract instead of every passing suite's raw fold, then mirrors
+# that contract into $GITHUB_STEP_SUMMARY and turns a red run into an ::error::
+# annotation carrying `relevant_error` + `log_path`.
+#
+# It lives here rather than inline in .github/workflows/hook-scripts.yml for the same
+# reason test discovery does (issue #681): that file's shared step tail is a
+# merge-conflict hotspot, and inline `run:` blocks cannot be unit-tested.
+#
+# Contract consumed: .claude/reference/compact-result-contract.md
+#   {"ok":bool,"failed_tests":[...],"relevant_error":str|null,"log_path":str, ...}
+#
+# Usage:
+#   summarize-test-run.sh <label> <runner-script> [extra runner args...]
+#   summarize-test-run.sh --help
+#
+#   <label>          Heading used in the step summary (e.g. "Bash test suites").
+#   <runner-script>  Path to a runner that supports --json. `--json` is appended
+#                    automatically; extra args are passed through before it.
+#
+# The runner's own stderr is NOT captured — it passes straight through, so a failing
+# suite's full output still reaches the job log. Only stdout (the contract) is read.
+#
+# Exit codes:
+#   0  runner reported ok
+#   2  usage error
+#   4  runner emitted no parseable contract on stdout (a wrapper bug — fails loud
+#      rather than passing green on a guard that did not run)
+#   *  otherwise the runner's own exit code, propagated unchanged
+set -uo pipefail
+
+usage() { awk 'NR == 1 { next } /^$/ { exit } { print }' "$0"; }
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+if [ "$#" -lt 2 ]; then
+  echo "::error::summarize-test-run.sh: usage: summarize-test-run.sh <label> <runner-script> [args...]" >&2
+  exit 2
+fi
+
+LABEL="$1"
+RUNNER="$2"
+shift 2
+
+if [ ! -f "$RUNNER" ]; then
+  echo "::error::summarize-test-run.sh: runner not found: $RUNNER" >&2
+  exit 2
+fi
+
+RC=0
+CONTRACT="$(bash "$RUNNER" "$@" --json)" || RC=$?
+
+if ! printf '%s' "$CONTRACT" | jq -e 'has("ok") and has("log_path")' >/dev/null 2>&1; then
+  echo "::error::summarize-test-run.sh: $RUNNER emitted no parseable result contract on stdout" >&2
+  printf 'raw stdout was:\n%s\n' "$CONTRACT" >&2
+  [ "$RC" -ne 0 ] && exit "$RC"
+  exit 4
+fi
+
+# `printf '%s'` not `echo` — echo mangles JSON into jq on some shells
+# (memory: zsh-echo-jq-json-corruption).
+OK="$(printf '%s' "$CONTRACT" | jq -r '.ok')"
+LOG_PATH="$(printf '%s' "$CONTRACT" | jq -r '.log_path // ""')"
+FAILED_COUNT="$(printf '%s' "$CONTRACT" | jq -r '(.failed_tests // []) | length')"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    printf '### %s — %s\n\n' "$LABEL" "$( [ "$OK" = "true" ] && echo 'passed' || echo 'FAILED' )"
+    if [ "$FAILED_COUNT" -gt 0 ]; then
+      printf 'Failing (%s):\n\n' "$FAILED_COUNT"
+      printf '%s' "$CONTRACT" | jq -r '(.failed_tests // [])[] | "- `" + . + "`"'
+      printf '\n'
+    fi
+    printf '```json\n%s\n```\n\n' "$CONTRACT"
+    printf 'Full output on the runner: `%s`\n\n' "$LOG_PATH"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ "$OK" != "true" ]; then
+  # Annotations are single-line; take the first line and point at the full log.
+  FIRST_LINE="$(printf '%s' "$CONTRACT" | jq -r '.relevant_error // ""' | head -n 1)"
+  [ -n "$FIRST_LINE" ] || FIRST_LINE="$LABEL failed"
+  echo "::error::${LABEL}: ${FIRST_LINE} (full output: ${LOG_PATH})" >&2
+fi
+
+exit "$RC"

--- a/.github/scripts/tests/run-tests-json.test.sh
+++ b/.github/scripts/tests/run-tests-json.test.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# run-tests-json.test.sh — Offline tests for the --json compact mode added to
+# run-hook-tests.sh and run-python-tests.sh (issue #782).
+#
+# HERMETIC: the runners are copied into a throwaway fixture repo under mktemp -d and
+# exercised against fixture suites there. They resolve the repo root as
+# `dirname($0)/../..`, so a copy at $FIX/.github/scripts/ discovers only $FIX's tests.
+# Running the real runner against the real repo would recurse (it would discover and
+# re-run this very suite) and would depend on the repo's live test set.
+#
+# Run from repo root: bash .github/scripts/tests/run-tests-json.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BASH_RUNNER_SRC="$REPO_ROOT/.github/scripts/run-hook-tests.sh"
+PY_RUNNER_SRC="$REPO_ROOT/.github/scripts/run-python-tests.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+export HOME="$TMP/home"; mkdir -p "$HOME/.claude"
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+check_eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected: $1, got: $2)"; fi; }
+
+# new_fixture <name> -> prints the fixture repo root, runner already installed.
+new_fixture() {
+  local fix="$TMP/$1"
+  mkdir -p "$fix/.github/scripts" "$fix/.claude/hooks/tests" "$fix/.claude/scripts/tests" \
+           "$fix/.github/scripts/tests" "$fix/tests" "$fix/logs"
+  cp "$BASH_RUNNER_SRC" "$fix/.github/scripts/run-hook-tests.sh"
+  cp "$PY_RUNNER_SRC" "$fix/.github/scripts/run-python-tests.sh"
+  echo "$fix"
+}
+
+add_suite() { # fixture relpath body exit_code
+  { echo '#!/usr/bin/env bash'; printf '%s\n' "$3"; printf 'exit %s\n' "$4"; } > "$1/$2"
+}
+
+# ==========================================================================
+# run-hook-tests.sh
+# ==========================================================================
+
+# --- 1. All green -------------------------------------------------------
+FIX="$(new_fixture green)"
+add_suite "$FIX" .claude/scripts/tests/a.test.sh 'echo "PASS: alpha assertion"' 0
+add_suite "$FIX" .claude/hooks/tests/b.test.sh 'echo "PASS: beta assertion"' 0
+
+OUT="$(RUN_TESTS_LOG_DIR="$FIX/logs" bash "$FIX/.github/scripts/run-hook-tests.sh" --json 2>"$FIX/err.txt")"
+RC=$?
+check_eq 0 "$RC" "bash runner: all-green exits 0"
+check_eq 1 "$(printf '%s\n' "$OUT" | wc -l | tr -d ' ')" "bash runner: --json stdout is exactly one line"
+check_eq "true" "$(printf '%s' "$OUT" | jq -r '.ok')" "bash runner: all-green reports ok"
+check_eq "[]" "$(printf '%s' "$OUT" | jq -c '.failed_tests')" "bash runner: all-green has empty failed_tests"
+check_eq "null" "$(printf '%s' "$OUT" | jq -r '.relevant_error')" "bash runner: all-green has null relevant_error"
+check_eq 2 "$(printf '%s' "$OUT" | jq -r '.total')" "bash runner: total counts every discovered suite"
+
+# The savings claim: a passing suite's own output must not reach stdout OR stderr.
+if grep -q 'alpha assertion' <<<"$OUT" || grep -q 'alpha assertion' "$FIX/err.txt"; then
+  bad "bash runner: passing suite output leaked into --json output"
+else
+  ok "bash runner: passing suite output is silenced in --json mode"
+fi
+
+# ...but it is never destroyed — log_path holds the full capture.
+LOG="$(printf '%s' "$OUT" | jq -r '.log_path')"
+if grep -q 'alpha assertion' "$LOG" 2>/dev/null && grep -q 'beta assertion' "$LOG" 2>/dev/null; then
+  ok "bash runner: full capture of every suite is persisted at log_path"
+else
+  bad "bash runner: log_path is missing suite output"
+fi
+case "$LOG" in *//*) bad "bash runner: log_path has a doubled slash" ;; *) ok "bash runner: log_path has no doubled slash" ;; esac
+
+# --- 2. A red suite -----------------------------------------------------
+FIX="$(new_fixture red)"
+add_suite "$FIX" .claude/scripts/tests/a.test.sh 'echo "PASS: alpha assertion"' 0
+add_suite "$FIX" .claude/scripts/tests/bad.test.sh 'echo "FAIL: expects exit 3, got 0"; echo "  context line that only matters in the log"' 1
+
+OUT="$(RUN_TESTS_LOG_DIR="$FIX/logs" bash "$FIX/.github/scripts/run-hook-tests.sh" --json 2>"$FIX/err.txt")"
+RC=$?
+check_eq 1 "$RC" "bash runner: a failing suite exits 1"
+check_eq "false" "$(printf '%s' "$OUT" | jq -r '.ok')" "bash runner: failing run is not ok"
+check_eq ".claude/scripts/tests/bad.test.sh" \
+  "$(printf '%s' "$OUT" | jq -r '.failed_tests[0]')" "bash runner: failed_tests names the failing suite"
+check_eq 1 "$(printf '%s' "$OUT" | jq -r '.failed_tests | length')" "bash runner: passing suite is not in failed_tests"
+if printf '%s' "$OUT" | jq -e '.relevant_error | test("expects exit 3")' >/dev/null; then
+  ok "bash runner: relevant_error carries the decisive FAIL line"
+else
+  bad "bash runner: relevant_error missing the FAIL line"
+fi
+# relevant_error is an index into the failure, not a copy of it.
+if printf '%s' "$OUT" | jq -e '.relevant_error | test("context line")' >/dev/null; then
+  bad "bash runner: relevant_error copied non-decisive log lines"
+else
+  ok "bash runner: relevant_error stays decisive-lines-only"
+fi
+# NON-NEGOTIABLE: a red suite still prints in full, on stderr.
+if grep -q 'context line that only matters in the log' "$FIX/err.txt"; then
+  ok "bash runner: failing suite output still prints in full (stderr)"
+else
+  bad "bash runner: failing suite output was compacted away — hard-stop detail must never be hidden"
+fi
+check_eq 1 "$(printf '%s\n' "$OUT" | wc -l | tr -d ' ')" "bash runner: stdout stays one line even with a failure"
+
+# --- 3. A suite that fails with no recognizable marker ------------------
+FIX="$(new_fixture bare)"
+add_suite "$FIX" .claude/scripts/tests/quiet.test.sh 'true' 7
+OUT="$(RUN_TESTS_LOG_DIR="$FIX/logs" bash "$FIX/.github/scripts/run-hook-tests.sh" --json 2>/dev/null)"
+if printf '%s' "$OUT" | jq -e '.relevant_error | test("quiet.test.sh")' >/dev/null; then
+  ok "bash runner: a marker-less failure still names the suite in relevant_error"
+else
+  bad "bash runner: marker-less failure produced an unhelpful relevant_error"
+fi
+
+# --- 4. Empty discovery must never pass green (issue #681) --------------
+FIX="$(new_fixture empty)"
+OUT="$(RUN_TESTS_LOG_DIR="$FIX/logs" bash "$FIX/.github/scripts/run-hook-tests.sh" --json 2>/dev/null)"
+RC=$?
+check_eq 3 "$RC" "bash runner: empty discovery exits 3"
+check_eq "false" "$(printf '%s' "$OUT" | jq -r '.ok')" "bash runner: empty discovery is not ok"
+if printf '%s' "$OUT" | jq -e '.relevant_error | test("glob is broken")' >/dev/null; then
+  ok "bash runner: empty discovery explains itself in relevant_error"
+else
+  bad "bash runner: empty discovery gave no explanation"
+fi
+
+# --- 5. Default mode is unchanged ---------------------------------------
+FIX="$(new_fixture default)"
+add_suite "$FIX" .claude/scripts/tests/a.test.sh 'echo "PASS: alpha assertion"' 0
+OUT="$(RUN_TESTS_LOG_DIR="$FIX/logs" bash "$FIX/.github/scripts/run-hook-tests.sh" 2>&1)"
+RC=$?
+check_eq 0 "$RC" "bash runner: default mode still exits 0 when green"
+grep -q '::group::.claude/scripts/tests/a.test.sh' <<<"$OUT" \
+  && ok "bash runner: default mode still emits ::group:: folds" \
+  || bad "bash runner: default mode lost its ::group:: folds"
+grep -q 'alpha assertion' <<<"$OUT" \
+  && ok "bash runner: default mode still streams suite output" \
+  || bad "bash runner: default mode stopped streaming suite output"
+grep -q 'PASS: .claude/scripts/tests/a.test.sh' <<<"$OUT" \
+  && ok "bash runner: default mode still emits per-suite PASS lines" \
+  || bad "bash runner: default mode lost its PASS lines"
+grep -q 'Discovered and ran 1 bash test suite' <<<"$OUT" \
+  && ok "bash runner: default mode still prints the tally" \
+  || bad "bash runner: default mode lost its tally"
+# Default mode must not emit the contract — that would break existing log scrapers.
+grep -q '"ok":' <<<"$OUT" \
+  && bad "bash runner: default mode leaked the JSON contract" \
+  || ok "bash runner: default mode does not emit the contract"
+
+# --- 6. Argument handling -----------------------------------------------
+FIX="$(new_fixture args)"
+add_suite "$FIX" .claude/scripts/tests/a.test.sh 'true' 0
+bash "$FIX/.github/scripts/run-hook-tests.sh" --bogus >/dev/null 2>&1
+check_eq 2 "$?" "bash runner: unknown flag exits 2"
+HELP="$(bash "$FIX/.github/scripts/run-hook-tests.sh" --help 2>&1)"
+check_eq 0 "$?" "bash runner: --help exits 0"
+grep -q 'compact result contract' <<<"$HELP" \
+  && ok "bash runner: --help documents the compact contract" \
+  || bad "bash runner: --help does not mention the contract"
+
+# ==========================================================================
+# run-python-tests.sh
+# ==========================================================================
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "SKIP: python3 not available — python runner cases skipped"
+else
+  # --- 7. Green python run ---------------------------------------------
+  FIX="$(new_fixture pygreen)"
+  cat > "$FIX/tests/test_ok.py" <<'PY'
+import unittest
+
+
+class OkCase(unittest.TestCase):
+    def test_adds(self):
+        self.assertEqual(1 + 1, 2)
+PY
+  OUT="$(cd "$FIX" && RUN_TESTS_LOG_DIR="$FIX/logs" bash "$FIX/.github/scripts/run-python-tests.sh" --json 2>"$FIX/err.txt")"
+  RC=$?
+  check_eq 0 "$RC" "python runner: green run exits 0"
+  check_eq 1 "$(printf '%s\n' "$OUT" | wc -l | tr -d ' ')" "python runner: --json stdout is exactly one line"
+  check_eq "true" "$(printf '%s' "$OUT" | jq -r '.ok')" "python runner: green run reports ok"
+  check_eq "[]" "$(printf '%s' "$OUT" | jq -c '.failed_tests')" "python runner: green run has empty failed_tests"
+  check_eq "null" "$(printf '%s' "$OUT" | jq -r '.relevant_error')" "python runner: green run has null relevant_error"
+  # The verbose per-test lines are the noise this mode exists to remove.
+  if grep -q 'test_adds' <<<"$OUT" || grep -q 'test_adds' "$FIX/err.txt"; then
+    bad "python runner: verbose per-test output leaked into --json output"
+  else
+    ok "python runner: verbose per-test output is silenced in --json mode"
+  fi
+  LOG="$(printf '%s' "$OUT" | jq -r '.log_path')"
+  grep -q 'test_adds' "$LOG" 2>/dev/null \
+    && ok "python runner: full unittest output is persisted at log_path" \
+    || bad "python runner: log_path is missing the unittest output"
+
+  # --- 8. Red python run ------------------------------------------------
+  FIX="$(new_fixture pyred)"
+  cat > "$FIX/tests/test_bad.py" <<'PY'
+import unittest
+
+
+class BadCase(unittest.TestCase):
+    def test_wrong(self):
+        self.assertEqual(3, 4)
+PY
+  OUT="$(cd "$FIX" && RUN_TESTS_LOG_DIR="$FIX/logs" bash "$FIX/.github/scripts/run-python-tests.sh" --json 2>"$FIX/err.txt")"
+  RC=$?
+  check_eq 1 "$RC" "python runner: failing run exits 1"
+  check_eq "false" "$(printf '%s' "$OUT" | jq -r '.ok')" "python runner: failing run is not ok"
+  if printf '%s' "$OUT" | jq -e '.failed_tests[0] | test("test_wrong")' >/dev/null; then
+    ok "python runner: failed_tests names the failing test id"
+  else
+    bad "python runner: failed_tests did not name the failing test"
+  fi
+  if printf '%s' "$OUT" | jq -e '.relevant_error | test("AssertionError")' >/dev/null; then
+    ok "python runner: relevant_error carries the assertion"
+  else
+    bad "python runner: relevant_error missing the assertion"
+  fi
+  if grep -q 'AssertionError' "$FIX/err.txt"; then
+    ok "python runner: failing run still prints in full (stderr)"
+  else
+    bad "python runner: failing run output was compacted away"
+  fi
+
+  # --- 9. Empty discovery ----------------------------------------------
+  FIX="$(new_fixture pyempty)"
+  OUT="$(cd "$FIX" && RUN_TESTS_LOG_DIR="$FIX/logs" bash "$FIX/.github/scripts/run-python-tests.sh" --json 2>/dev/null)"
+  RC=$?
+  check_eq 3 "$RC" "python runner: empty discovery exits 3"
+  check_eq "false" "$(printf '%s' "$OUT" | jq -r '.ok')" "python runner: empty discovery is not ok"
+
+  # --- 10. Default mode unchanged ---------------------------------------
+  FIX="$(new_fixture pydefault)"
+  cat > "$FIX/tests/test_ok.py" <<'PY'
+import unittest
+
+
+class OkCase(unittest.TestCase):
+    def test_adds(self):
+        self.assertEqual(1 + 1, 2)
+PY
+  OUT="$(cd "$FIX" && RUN_TESTS_LOG_DIR="$FIX/logs" bash "$FIX/.github/scripts/run-python-tests.sh" 2>&1)"
+  RC=$?
+  check_eq 0 "$RC" "python runner: default mode exits 0 when green"
+  grep -q 'test_adds' <<<"$OUT" \
+    && ok "python runner: default mode still streams verbose output" \
+    || bad "python runner: default mode stopped streaming verbose output"
+  grep -q 'Discovered 1 Python test module' <<<"$OUT" \
+    && ok "python runner: default mode still prints the discovery line" \
+    || bad "python runner: default mode lost its discovery line"
+  grep -q '"ok":' <<<"$OUT" \
+    && bad "python runner: default mode leaked the JSON contract" \
+    || ok "python runner: default mode does not emit the contract"
+
+  # A red default run must still exit non-zero through the tee pipeline
+  # (PIPESTATUS, not $? — a pipe would otherwise report tee's success).
+  FIX="$(new_fixture pydefaultred)"
+  cat > "$FIX/tests/test_bad.py" <<'PY'
+import unittest
+
+
+class BadCase(unittest.TestCase):
+    def test_wrong(self):
+        self.assertEqual(3, 4)
+PY
+  (cd "$FIX" && RUN_TESTS_LOG_DIR="$FIX/logs" bash "$FIX/.github/scripts/run-python-tests.sh" >/dev/null 2>&1)
+  check_eq 1 "$?" "python runner: default mode propagates failure through the tee pipeline"
+
+  bash "$FIX/.github/scripts/run-python-tests.sh" --bogus >/dev/null 2>&1
+  check_eq 2 "$?" "python runner: unknown flag exits 2"
+fi
+
+echo "----"
+echo "run-tests-json.test.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.github/scripts/tests/summarize-test-run.test.sh
+++ b/.github/scripts/tests/summarize-test-run.test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# summarize-test-run.test.sh — Offline tests for summarize-test-run.sh (issue #782).
+#
+# The runners it wraps are stubs here, so these assert the CI surfacing behaviour
+# (step summary, ::error:: annotation, exit propagation, and the fail-loud path when
+# a runner emits no contract) without running a real test suite.
+#
+# Run from repo root: bash .github/scripts/tests/summarize-test-run.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SUT="$REPO_ROOT/.github/scripts/summarize-test-run.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+export HOME="$TMP/home"; mkdir -p "$HOME/.claude"
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+check_eq() { if [[ "$1" == "$2" ]]; then ok "$3"; else bad "$3 (expected: $1, got: $2)"; fi; }
+
+# make_runner <name> <stdout> <exit-code> — a stub standing in for a --json runner.
+# It records the argv it was handed so the "--json is appended" contract is testable.
+make_runner() {
+  local path="$TMP/$1"
+  {
+    echo '#!/usr/bin/env bash'
+    printf 'printf "%%s\\n" "$*" > "%s.argv"\n' "$path"
+    printf 'cat <<%s\n%s\n%s\n' "'RUNNER_EOF'" "$2" "RUNNER_EOF"
+    printf 'exit %s\n' "$3"
+  } > "$path"
+  chmod +x "$path"
+  echo "$path"
+}
+
+GREEN='{"ok":true,"failed_tests":[],"relevant_error":null,"log_path":"/tmp/green.log","total":3,"failed":0}'
+RED='{"ok":false,"failed_tests":["a.test.sh","b.test.sh"],"relevant_error":"a.test.sh: FAIL: boom\nsecond line of detail","log_path":"/tmp/red.log","total":3,"failed":2}'
+
+# --------------------------------------------------------------------------
+# 1. Usage.
+# --------------------------------------------------------------------------
+"$SUT" >/dev/null 2>&1; check_eq 2 "$?" "no args exits 2"
+"$SUT" "Label only" >/dev/null 2>&1; check_eq 2 "$?" "missing runner exits 2"
+"$SUT" "Label" "$TMP/does-not-exist.sh" >/dev/null 2>&1; check_eq 2 "$?" "nonexistent runner exits 2"
+"$SUT" --help >/dev/null 2>&1; check_eq 0 "$?" "--help exits 0"
+
+# --------------------------------------------------------------------------
+# 2. Green run — exit 0, summary written, no annotation.
+# --------------------------------------------------------------------------
+R="$(make_runner green.sh "$GREEN" 0)"
+SUMMARY_FILE="$TMP/summary-green.md"
+: > "$SUMMARY_FILE"
+ERRF="$TMP/green.err"
+GITHUB_STEP_SUMMARY="$SUMMARY_FILE" "$SUT" "Bash test suites" "$R" >/dev/null 2>"$ERRF"
+check_eq 0 "$?" "green run exits 0"
+grep -q -- '--json' "$R.argv" \
+  && ok "runner is invoked with --json" \
+  || bad "runner was not given --json (argv: $(cat "$R.argv" 2>/dev/null))"
+grep -q 'Bash test suites — passed' "$SUMMARY_FILE" \
+  && ok "green run writes a passed heading to the step summary" \
+  || bad "green run did not write the passed heading"
+grep -q '"ok":true' "$SUMMARY_FILE" \
+  && ok "step summary embeds the raw contract" \
+  || bad "step summary is missing the contract"
+grep -q '/tmp/green.log' "$SUMMARY_FILE" \
+  && ok "step summary names log_path so the raw output stays reachable" \
+  || bad "step summary omits log_path"
+grep -q '::error::' "$ERRF" \
+  && bad "green run emitted an ::error:: annotation" \
+  || ok "green run emits no ::error:: annotation"
+
+# --------------------------------------------------------------------------
+# 3. Red run — exit propagates, annotation carries the decisive line + log path.
+# --------------------------------------------------------------------------
+R="$(make_runner red.sh "$RED" 1)"
+SUMMARY_FILE="$TMP/summary-red.md"
+: > "$SUMMARY_FILE"
+ERRF="$TMP/red.err"
+GITHUB_STEP_SUMMARY="$SUMMARY_FILE" "$SUT" "Bash test suites" "$R" >/dev/null 2>"$ERRF"
+check_eq 1 "$?" "red run propagates the runner's exit code"
+grep -q 'Bash test suites — FAILED' "$SUMMARY_FILE" \
+  && ok "red run writes a FAILED heading" \
+  || bad "red run did not write the FAILED heading"
+grep -q 'a.test.sh' "$SUMMARY_FILE" \
+  && ok "red run lists the failing suites in the summary" \
+  || bad "red run did not list the failing suites"
+grep -q 'Failing (2)' "$SUMMARY_FILE" \
+  && ok "red run reports the failing count" \
+  || bad "red run did not report the failing count"
+grep -q '::error::Bash test suites: a.test.sh: FAIL: boom' "$ERRF" \
+  && ok "red run annotation carries the decisive line" \
+  || bad "red run annotation is wrong: $(cat "$ERRF")"
+grep -q '/tmp/red.log' "$ERRF" \
+  && ok "red run annotation points at the full log" \
+  || bad "red run annotation omits the log path"
+# A GitHub annotation is single-line; a multi-line relevant_error must be trimmed.
+check_eq 1 "$(grep -c '::error::' "$ERRF")" "annotation is a single line"
+grep -q 'second line of detail' "$ERRF" \
+  && bad "annotation leaked a second line (breaks the annotation)" \
+  || ok "annotation drops trailing detail lines"
+
+# --------------------------------------------------------------------------
+# 4. A runner that emits no contract must fail LOUD, never pass green
+#    (memory: guards that pass by not running).
+# --------------------------------------------------------------------------
+R="$(make_runner garbage.sh 'Traceback (most recent call last): everything is on fire' 0)"
+ERRF="$TMP/garbage.err"
+"$SUT" "Bash test suites" "$R" >/dev/null 2>"$ERRF"
+check_eq 4 "$?" "unparseable contract with a 0 exit still fails (exit 4)"
+grep -q 'no parseable result contract' "$ERRF" \
+  && ok "unparseable contract says so on stderr" \
+  || bad "unparseable contract produced no explanation"
+grep -q 'everything is on fire' "$ERRF" \
+  && ok "unparseable contract echoes the raw stdout for diagnosis" \
+  || bad "unparseable contract swallowed the raw stdout"
+
+# When the runner ALSO failed, its own code wins over the wrapper's 4.
+R="$(make_runner garbage-red.sh 'not json' 3)"
+"$SUT" "Bash test suites" "$R" >/dev/null 2>&1
+check_eq 3 "$?" "unparseable contract propagates the runner's own failure code"
+
+# A partial object (no log_path) is not a contract either.
+R="$(make_runner partial.sh '{"ok":true}' 0)"
+"$SUT" "Bash test suites" "$R" >/dev/null 2>&1
+check_eq 4 "$?" "contract missing log_path is rejected"
+
+# --------------------------------------------------------------------------
+# 5. No GITHUB_STEP_SUMMARY (local run) — must not crash.
+# --------------------------------------------------------------------------
+R="$(make_runner nosummary.sh "$GREEN" 0)"
+( unset GITHUB_STEP_SUMMARY; "$SUT" "Local" "$R" >/dev/null 2>&1 )
+check_eq 0 "$?" "runs cleanly with no GITHUB_STEP_SUMMARY set"
+
+echo "----"
+echo "summarize-test-run.test.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.github/workflows/hook-scripts.yml
+++ b/.github/workflows/hook-scripts.yml
@@ -14,6 +14,12 @@ permissions:
 # Bash discovery: .github/scripts/run-hook-tests.sh
 # Python discovery: .github/scripts/run-python-tests.sh (issue #771)
 # See CONTRIBUTING.md "Adding a Test".
+#
+# Both runners are invoked with --json (issue #782) so the job log carries the compact
+# result contract instead of every passing suite's raw fold — `gh run view` consumers
+# read a verdict, not thousands of lines. Failing suites still print in full on stderr,
+# and the complete capture lives at the contract's `log_path` on the runner.
+# Contract: .claude/reference/compact-result-contract.md
 jobs:
   hook-tests:
     runs-on: ubuntu-latest
@@ -29,10 +35,10 @@ jobs:
           git config --global user.name "CI"
 
       - name: Run bash hook + script test suites (auto-discovered)
-        run: bash .github/scripts/run-hook-tests.sh
+        run: bash .github/scripts/summarize-test-run.sh "Bash test suites" .github/scripts/run-hook-tests.sh
 
       - name: Run Python hook unit tests (auto-discovered)
-        run: bash .github/scripts/run-python-tests.sh
+        run: bash .github/scripts/summarize-test-run.sh "Python unit tests" .github/scripts/run-python-tests.sh
 
   # macOS system python3 is 3.9.6 (Xcode CLT) while ubuntu-latest ships 3.10+,
   # so a hook that crashes on 3.9 (e.g. eagerly-evaluated PEP 604 unions,
@@ -53,7 +59,7 @@ jobs:
           python-version: '3.9'
 
       - name: Python hook unit tests (3.9, auto-discovered)
-        run: bash .github/scripts/run-python-tests.sh
+        run: bash .github/scripts/summarize-test-run.sh "Python unit tests (3.9)" .github/scripts/run-python-tests.sh
 
       - name: Hooks import smoke (3.9)
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,20 @@ bash .github/scripts/run-hook-tests.sh        # all bash suites
 bash .github/scripts/run-python-tests.sh      # all Python suites
 ```
 
+**Compact mode (`--json`)** — both runners also emit the one-line result contract from
+[`compact-result-contract.md`](.claude/reference/compact-result-contract.md) instead of every
+suite's raw output, which is what CI uses and what an agent should read:
+
+```bash
+bash .github/scripts/run-hook-tests.sh --json
+# {"ok":true,"failed_tests":[],"relevant_error":null,"log_path":"/tmp/run-hook-tests-...log","total":94,"failed":0}
+```
+
+A green run drops from thousands of lines to one; the full capture is always at `log_path`, and
+**failing** suites still print in full (on stderr) in both modes. In CI both runners go through
+[`summarize-test-run.sh`](.github/scripts/summarize-test-run.sh), which mirrors the contract into
+the job's step summary and raises an `::error::` annotation on a red run.
+
 ## Git Pre-commit Hook (Worktree Enforcement)
 
 `setup.sh` installs `.claude/git-hooks/pre-commit` into the shared git hooks directory on first run (and reuses it on later runs when unchanged). When this hook is installed and not bypassed, it rejects commits made on `main` in the root checkout, enforcing the "never work on main" rule at the git level for any committer — human, Claude, Cursor, Codex, or a random terminal session.


### PR DESCRIPTION
## **User description**
## Summary

Ships **FU-7** of `token-efficiency-audit-2026-07.md`: the noisiest remaining pipelines now return a compact `ok` / `failed_tests` / `relevant_error` / `log_path` verdict instead of folding raw output into context. Three **selective, opt-in wrappers** — never a universal interception layer, which the same audit evaluated and rejected.

**Contract** — `.claude/reference/compact-result-contract.md` defines the schema, the emission conventions (single-line `jq -cn`, stdout = contract / stderr = detail, documented exit codes, raw output always persisted), the adopters, and — explicitly — what is left unwrapped and why.

**What got wrapped, and what it saved (measured, not estimated):**

| Pipeline | Before | After | Cut |
|---|---|---|---|
| `run-hook-tests.sh --json` (65 suites, green) | 158,484 B | 173 B | 99.9% |
| `run-python-tests.sh --json` (green) | 13,489 B | 165 B | 98.8% |
| `pr-state.sh` comment arrays (live PR #931) | 294,175 B | 98,878 B | 66% |

**Failures are compacted, never hidden.** The audit's own §"What NOT to change" requires failing CI to print in full. Compact mode silences *passing* suites — that is where every byte above comes from — while a red suite still prints its complete captured output on stderr, and `log_path` holds the full capture of every run in both modes. There are dedicated tests for this in both directions.

**`local-review.sh`** replaces the CodeRabbit/CodeAnt capture-and-grep that was copy-pasted across `cr-local-review.md` and four skills, each checking a different subset. One place now applies *every* documented false-clean check from `local-review-cli-failure-modes.md`: CodeAnt stderr `API Error`/403, its `error` field, unparseable stdout, `noFiles`, the 15-file cap; CodeRabbit's NDJSON `type:"error"` record, a **missing terminal `complete` record**, and `review_skipped`. The last two are new detections — the authoritative CR verdict is its terminal `{"type":"complete","status":…,"findings":N}` record, so its absence means the run died mid-flight and `review_skipped` means the CLI saw no changes at all (usually a wrong-working-directory tell). A 2-minute hang bound covers the CodeAnt-hangs-with-zero-output mode.

**`pr-state.sh`** is a payload reduction only — the "write the bundle to a tempfile, print only the path" interface is unchanged, and it does **not** adopt the contract (it is a state snapshot, not a pass/fail verdict). **Bodies are kept in full**; every field any consumer reads across `.claude/{scripts,skills,agents}` was enumerated first (nine: `id`, `body`, `state`, `user.login`, `commit_id`, `original_commit_id`, `created_at`, `updated_at`, `submitted_at`) and the projection is a strict superset. `diff_hunk` + `reactions` + `_links` alone were 121,893 B of the inline array.

**Deliberately not wrapped:** the ~40 scripts that already emit a compact `--json` object, the `gh` calls already `--jq`-projected at source, and anything not pass/fail-shaped. Documented in the contract's §Scope so the next pass does not re-litigate it.

Closes #782

## Local review coverage

**Local review coverage:** `none` — both CLIs down, self-review only.

Both were run through the new wrapper and both failed, twice (one retry each, per `cr-local-review.md`):

- **CodeRabbit** — `{"ok":false,"failure_mode":"error_record","relevant_error":"rate_limit: Rate limit exceeded"}`, `waitTime: 28 minutes`. Exit 3.
- **CodeAnt** — `{"ok":false,"failure_mode":"stderr_error","relevant_error":"API Error: Access denied (403)…"}`. The persistent account-wide daily cap (issue #643); no `logout`/`login` was run, per the rule.

Neither produced findings to resolve or waive — both failed *before* reviewing anything, which is precisely the false-clean this PR's wrapper exists to catch, so the outage doubles as an end-to-end proof of the new detection. A self-review of the full diff was done instead: `shellcheck -S style` is clean on all four production scripts (the two remaining `SC2016` notes are backticks inside Markdown fences, matching existing precedent in `portable-handoff-lint.sh`), and `shellcheck -S warning` on `pr-state.sh` produces the identical single pre-existing `SC1112` code as `origin/main`. Self-review never satisfies the GitHub merge gate — CodeRabbit/CodeAnt/BugBot on this PR still do.

**Review round 2 (Phase B).** CodeAnt raised one Major finding on `local-review.sh`: `mkdir -p` and both output-file truncations ignored failure, so an unusable `--log-dir` left `OUT`/`ERR` nonexistent while the run continued and every verdict still advertised those paths as persisted logs. Verified and valid — the fail-safe direction was already correct (the run reported `no_review_records`, exit 3, never a false clean), but the raw-output contract and the error text were both wrong. Fixed by validating the log directory up front and failing with exit 2 before the CLI is launched, plus three regression assertions (uid-independent uncreatable case, read-only case with a root probe that SKIPs loudly rather than passing vacuously, and a negative control proving the same stub exits 0 when the directory is fine). Both CLIs remain dropped for the session per `cr-local-review.md` (one retry each already spent), so this delta carries self-review plus `shellcheck -S style` clean on `local-review.sh`.

## Test plan

- [x] A documented `ok`/`failed_tests`/`relevant_error`/`log_path` contract exists under `.claude/reference/` with field semantics and emission conventions
- [x] Wrappers are **selective and opt-in** — no universal interception layer; the already-compact scripts are excluded and the exclusion is written down
- [x] Every payload-reduction claim has a **measured** before/after, not an estimate (the three rows above; `local-review.sh` is a correctness consolidation, not a payload claim)
- [x] `run-hook-tests.sh --json` emits the contract on stdout and nothing else; default fold behaviour (`::group::`, `PASS:` lines, tally) is unchanged
- [x] `run-python-tests.sh --json` emits the contract; default verbose behaviour is unchanged and still propagates failure through the `tee` pipeline
- [x] A **failing** suite still prints its full output in compact mode (stderr), and `relevant_error` stays decisive-lines-only
- [x] Raw output persists at `log_path` on every path, in both modes, pass or fail
- [x] Empty test discovery still fails loud rather than passing green (issue #681 invariant preserved)
- [x] CI surfaces the contract via `$GITHUB_STEP_SUMMARY` + an `::error::` annotation carrying `relevant_error` + `log_path`; a runner that emits no parseable contract fails loud rather than passing green
- [x] `local-review.sh` detects every documented false-clean mode: CodeAnt stderr error / `error` field / unparseable stdout / `noFiles` / 15-file cap, CodeRabbit `type:"error"` / missing terminal record / `review_skipped`, plus binary-absent and hang
- [x] `local-review.sh` refuses an uncreatable or unwritable `--log-dir` (exit 2) *before* launching the CLI, so no verdict ever names a `log_path`/`stderr_path` that does not exist
- [x] `cr-local-review.md` and the four skills that repeated the inline pattern (`fixpr`, `pm`, `subagent`, `prompt`) point at the wrapper
- [x] `pr-state.sh` bundle is smaller with **bodies intact** and the path-only stdout contract unchanged; verified against a live PR
- [x] Catalog rows added and accurate — `reference-catalog-lint.sh` and `skill-catalog-lint.sh` both green
- [x] Offline tests cover the new wrapper and both runners' compact modes on pass *and* fail paths; full bash + Python suites green
- [x] FU-7 marked shipped in `token-efficiency-audit-2026-07.md`
- [x] Rule corpus stays within budget (`rule-lint.sh` green; this PR is net **−14** words)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Compact test and local-review results while preserving full failure details

### What Changed
- Bash and Python test runners now support an opt-in JSON result with pass status, failing tests, key errors, and a path to the complete log; passing output is reduced to one line while failures remain visible in full.
- CI now surfaces these results in step summaries and error annotations, and rejects missing or invalid result contracts.
- Added a shared local-review wrapper for CodeRabbit and CodeAnt that detects hidden errors, incomplete reviews, skipped changes, file caps, missing tools, and hangs instead of treating them as clean results.
- Local-review output preserves raw stdout and stderr in log files and provides clear exit statuses for clean runs, findings, failed runs, timeouts, and missing CLIs.
- PR comment and review payloads now omit unused metadata while retaining full comment bodies and fields needed by downstream checks.
- Added offline coverage for compact test output, failure handling, log persistence, local-review failure modes, timeouts, and CI result reporting.

### Impact
`✅ One-line results for passing CI suites`
`✅ Full failure output remains available in logs and CI`
`✅ Fewer false-clean local reviews`
`✅ Smaller PR state payloads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

