### PR TITLE
fix(#933): a reviewer quoting the author's SHA no longer proves it read HEAD

### DIFF
--- a/.claude/reference/review-substance-evidence.md
+++ b/.claude/reference/review-substance-evidence.md
@@ -272,10 +272,26 @@ admitted. Only paired syntax needs the exception, which is why four-space
 indented lines get none — dropping such a line removes its content with it.
 Pinned by `(ff-933)(j)`.
 
-**Directions.** Dropping whole lines can only ever *remove* tokens —
-`split("\n") | join("\n")` is the identity when nothing is dropped and survivors
-are emitted byte-for-byte, so the indentation- and fence-sensitive rules above
-still see what they always saw. `status_comment_names_head`,
+**The exception is the delimiter, not the line** (CodeAnt review of PR #951).
+Markdown info strings are free-form, so a fence opener can carry arbitrary text —
+including HEAD's SHA. Written as "keep any line that *starts with* a fence
+marker", the exemption is wider than the argument for it, and the gap falls on
+the grant side: an echoed ` ```5acd1e2 ` readmits precisely the token the echo
+filter just refused, and on a live-shaped payload an empty-body approval scored
+`counts_as_coverage: true` off the author's words again. An echoed fence line is
+therefore **truncated to its own delimiter run** — leading whitespace and quote
+markers kept, info string and trailing text dropped. The masking regexes never
+read the info string, so paired matching sees an identical delimiter either way.
+Non-echoed fence lines are not rewritten at all. Pinned by `(ff-933)(k)` (the
+smuggling attempt fails) and `(ff-933)(l)` (the truncated opener still pairs).
+
+**Directions.** Dropping a line — or truncating an echoed fence line to its
+delimiter — can only ever *remove* tokens. `split("\n") | join("\n")` is the
+identity when nothing is dropped, an untouched line is emitted byte-for-byte,
+and a truncated fence line keeps a prefix of itself on its own line, so no text
+is joined across a boundary and a run of `` ` `` or `~` contributes no hex or
+decimal digit. The indentation- and fence-sensitive rules above therefore still
+see what they always saw. `status_comment_names_head`,
 `external_evidence_on_head` and `substantive` are monotone in the token set and
 so can only move **true → false**: the grant path #933 closes.
 

--- a/.claude/reference/review-substance-evidence.md
+++ b/.claude/reference/review-substance-evidence.md
@@ -220,6 +220,83 @@ punctuation to be trustworthy.
 > its `s` only rebinds `^` and `$`. Written with `s` the gsubs match nothing at
 > all and every fenced block is silently scanned as prose.
 
+### Quoted and echoed text is excluded first (issue #933)
+
+All three rules read a body with **borrowed lines removed**. A line is borrowed
+when the identical line was already posted on the thread by someone who is *not*
+one of the reviewers under evaluation; quote markers (`>`) are normalised out of
+the comparison key, so GitHub's "Quote reply" shape (a `>` marker followed by the
+original line) matches its source. Nothing else is removed.
+
+The trace (PR #929, 2026-08-02). CodeAnt answers a re-review request by
+reproducing the requester's comment verbatim under a `Question:` heading and
+putting its own verdict under `Answer:`. The author's trigger prose named HEAD's
+short SHA `5acd1e2`, so the bot's body contained HEAD's SHA that the bot never
+wrote — and `status_comment_names_head`, the flag asserting *this reviewer
+demonstrably read HEAD*, went true on the strength of the **author's** words.
+Replayed on the live payload, `main` scored that empty CodeAnt approval
+`counts_as_coverage: true`; with the exclusion it is `false`, and the reviewer's
+`status_comment_shas` correctly reports `c441771` — the SHA its own status
+comment actually names — instead of the echoed `5acd1e2`.
+
+**Why not "strip every blockquote line"**, the obvious first cut: the live
+payload refutes it twice. The PR #929 echo carries no `>` at all, so a blockquote
+rule closes *none* of the reported trace; and the only `>` lines on that thread
+are CodeRabbit quoting **itself** — its status notice renders its own reviewed
+range as `> Reviewing files that changed … between <base> and <head>`. Blanket
+quote-stripping would have deleted a reviewer's own self-report on every
+CodeRabbit status comment in this repo while fixing nothing. The issue asks to
+discount quoted/echoed *author* text; a bot's own callout is not author text.
+Case `(ff-933)(e)` is the negative control that pins this distinction.
+
+Two further properties, both deliberate:
+
+- **Ordered.** The index stores the earliest time each line was seen, and a line
+  is dropped only from comments created at or after it. Echo means the source
+  came first; without ordering a human quoting a bot verbatim would retroactively
+  strip the bot's original.
+- **Reviewers never seed the index**, so a reviewer can never strip *itself* —
+  including a bot that repeats its own status line. One reviewer quoting another
+  is therefore out of scope, pinned by `(ff-933)(i)` so that widening the index to
+  bot-authored text stays a conscious decision.
+
+One exception keeps the filter from breaking the masking above: **fence
+delimiter lines (` ``` `, `~~~`) are never dropped as echoes.** A bare fence line
+is among the most reproducible lines on a thread — every comment carrying a code
+block has one — so it enters the index almost immediately, and dropping it would
+delete the delimiters of a *reviewer's own* fenced block. Rule 3's masking is
+paired-delimiter matching: lose the pair and quoted diff hunks are scanned as
+prose again. Losing only the closer is the worse half, since the unclosed-opener
+rule then runs to end-of-body and deletes rule-3 tokens that should have been
+admitted. Only paired syntax needs the exception, which is why four-space
+indented lines get none — dropping such a line removes its content with it.
+Pinned by `(ff-933)(j)`.
+
+**Directions.** Dropping whole lines can only ever *remove* tokens —
+`split("\n") | join("\n")` is the identity when nothing is dropped and survivors
+are emitted byte-for-byte, so the indentation- and fence-sensitive rules above
+still see what they always saw. `status_comment_names_head`,
+`external_evidence_on_head` and `substantive` are monotone in the token set and
+so can only move **true → false**: the grant path #933 closes.
+
+`self_report_mismatch` moves both ways. It goes false → true when a comment keeps
+a non-HEAD token but loses its HEAD one, and **true → false** when a comment's
+only tokens were quoted, so it stops being a self-report candidate at all. That
+second direction is a grant, and it is the same correction rather than a side
+effect: a SHA the reviewer never wrote was never the reviewer's report about
+itself, and reading it as one yields a blocker no re-review can clear while the
+trigger prose stays quoted. Issue #917 accepted the identical direction for the
+identical reason (UUID fragments manufacturing mismatches out of CodeRabbit's own
+request ids). It stays bounded — a comment carrying any SHA in the reviewer's own
+prose keeps its tokens and its verdict.
+
+`counts_as_coverage` therefore moves both ways as well, and **only through that
+one channel**. Every other input pushes it down: `substantive` can only fall,
+`no_substantive_footprint` can only appear, and `temporal_inversion` and
+`capability_failure` are both suppressed by `external_evidence_on_head`, which
+can only fall — so each can only newly fire. The single upward path is a cleared
+`self_report_mismatch` on a reviewer that is substantive on its own footprint.
+
 ### Why rule 3 cannot weaken the gate
 
 Any token admitted by rule 3 and **not** by rules 1-2 is, by construction, an

--- a/.claude/reference/review-substance-evidence.md
+++ b/.claude/reference/review-substance-evidence.md
@@ -252,9 +252,20 @@ Case `(ff-933)(e)` is the negative control that pins this distinction.
 Two further properties, both deliberate:
 
 - **Ordered.** The index stores the earliest time each line was seen, and a line
-  is dropped only from comments created at or after it. Echo means the source
+  is dropped only from comments written at or after it. Echo means the source
   came first; without ordering a human quoting a bot verbatim would retroactively
   strip the bot's original.
+- **Edit-aware** (BugBot review of PR #951). The two sides of that comparison use
+  deliberately different timestamps, both biased toward stripping: the index
+  keeps `created_at` (the earliest time a source line can have existed) and the
+  scan uses `updated_at` (the latest time the scanned body can have been
+  written). GitHub freezes `created_at` on an in-place edit, and editing in place
+  is routine here — CodeAnt PATCHes its review body on re-review (#876),
+  CodeRabbit rewrites its walkthrough — so scanning on `created_at` let a bot
+  edit an echo into a comment it had opened *before* the author wrote the line,
+  sort ahead of the index entry, and manufacture HEAD evidence without ever
+  writing the SHA. Unedited comments report `updated_at == created_at`, so the
+  ordering guard is unchanged. Pinned by `(ff-933)(n)` and its unedited control.
 - **Reviewers never seed the index**, so a reviewer can never strip *itself* —
   including a bot that repeats its own status line. One reviewer quoting another
   is therefore out of scope, pinned by `(ff-933)(i)` so that widening the index to

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -81,6 +81,12 @@
 #                             #894) and >= min_chars long. No
 #                             freshness filter is applied or needed: naming
 #                             HEAD's SHA is itself proof the comment postdates it.
+#                             Text the reviewer QUOTED rather than wrote is
+#                             excluded before tokens are extracted — blockquote
+#                             (">") lines, and lines reproduced verbatim from a
+#                             non-reviewer comment on the same thread (issue
+#                             #933). A bot that merely echoes the author's
+#                             SHA-bearing re-review trigger no longer names HEAD.
 #   self_report_mismatch      among that bot's conversation comments containing any
 #                             SHA-like token, the MOST RECENT one names no SHA
 #                             matching HEAD. SHA-like = \b[0-9a-f]{7,40}\b with at
@@ -92,8 +98,12 @@
 #                             four-space-indented block, or an unclosed backtick
 #                             opener is not mistaken for a self-report. Bare digit
 #                             runs in prose (dates, counts, IDs) still cannot
-#                             manufacture a mismatch. See sha_tokens for why the
-#                             code-span rule can only ever withhold coverage.
+#                             manufacture a mismatch. Quoted/echoed text is
+#                             excluded here too (issue #933): a SHA the reviewer
+#                             only quoted is not the reviewer's self-report.
+#                             See sha_tokens for why the code-span rule can only
+#                             ever withhold coverage, and strip_echoed for the
+#                             two directions the echo exclusion can move.
 #   temporal_inversion        approval submitted_at < the EARLIEST post-push
 #                             run-start marker from that reviewer. The earliest
 #                             marker (not the latest) is deliberate: a re-review
@@ -238,6 +248,116 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
   | ($reviewers | split(",") | map(select(length > 0)))     as $approvers
   | ($corroborators | split(",") | map(select(length > 0))) as $others
 
+  # ---- Echoed text: what a reviewer QUOTED is not what it SAID (issue #933) --
+  #
+  # Observed on PR #929: CodeAnt answers a re-review request by reproducing the
+  # requester"s comment verbatim under a "Question:" heading and its own verdict
+  # under "Answer:". The author"s trigger prose named HEAD"s short SHA, so the
+  # bot"s body contained that SHA without the bot ever having written it, and
+  # status_comment_names_head — the flag that says "this reviewer demonstrably
+  # read HEAD" — went true on the strength of the AUTHOR"s words. Any ack or
+  # summary reply that quotes the thread can do the same.
+  #
+  # THE RULE: drop a line of a reviewer"s comment when that exact line was
+  # already posted on this thread by someone who is NOT one of the reviewers
+  # under evaluation. Nothing else is dropped.
+  #
+  # Deliberately NOT "drop every blockquote line". That was the first cut, and
+  # the live payload refuted it twice over. The PR #929 echo carries no ">" at
+  # all, so a blockquote rule closes none of the reported trace; meanwhile the
+  # ONLY ">" lines in that thread are CodeRabbit quoting ITSELF — its status
+  # notice renders its own reviewed range as "> Reviewing files that changed …
+  # between <base> and <head>". Blanket-stripping quotes would have silently
+  # deleted a reviewer"s own self-report on every CodeRabbit status comment in
+  # this repo. The issue asks to discount quoted/echoed AUTHOR text; a bot"s own
+  # ">" callout is not author text. So quote markers are normalised away in the
+  # lookup KEY instead (norm_line), which catches GitHub"s "Quote reply" shape —
+  # "> " + the original line — while leaving self-quotation untouched.
+  #
+  # Only NON-reviewer comments seed the index, so a reviewer"s own lines are
+  # never in it and a reviewer comment can never strip ITSELF to nothing. (A
+  # non-reviewer"s comment does erase itself; its tokens are never read.)
+  #
+  # Ordered, not just matched: the index stores the EARLIEST time each line was
+  # seen, and a line is only dropped from a comment created at or after that.
+  # Echo means the source came first. Without the ordering, a human quoting a
+  # bot"s line verbatim would retroactively strip the bot"s original.
+  #
+  # WHICH DIRECTIONS THIS CAN MOVE (the load-bearing argument, stated in full
+  # because one of the two is a grant). Removing whole lines can only ever
+  # REMOVE tokens, never add them: split("\n") | join("\n") is the identity when
+  # nothing is dropped, and surviving lines are emitted byte-for-byte, so the
+  # indentation- and fence-sensitive rules below (issue #897) see exactly what
+  # they always saw. From "tokens can only shrink":
+  #
+  #  - status_comment_names_head, external_evidence_on_head and substantive are
+  #    monotone in the token set, so they can only move true -> false.
+  #    Withholding a merge is recoverable (re-review and push). This is the
+  #    grant path #933 closes.
+  #  - self_report_mismatch can move BOTH ways. false -> true when a comment
+  #    keeps a non-HEAD token but loses its HEAD one; true -> false when a
+  #    comment"s ONLY tokens were quoted, so it stops being a self-report
+  #    candidate at all. The second is a grant, and it is the SAME correction,
+  #    not a side effect: a SHA the reviewer never wrote was never the
+  #    reviewer"s report about itself, and reading it as one produces a blocker
+  #    that no re-review can clear while the trigger prose stays quoted. Issue
+  #    #917 accepted this identical direction for the identical reason (UUID
+  #    fragments were manufacturing mismatches out of CodeRabbit"s own request
+  #    ids). It is bounded: a comment carrying ANY SHA in the reviewer"s own
+  #    prose keeps its tokens and its verdict.
+  #  - counts_as_coverage therefore moves both ways too, and ONLY through that
+  #    one channel (CodeRabbit CLI review of this PR — an earlier draft of this
+  #    comment wrongly listed it as withhold-only). Every other input pushes it
+  #    down: substantive can only fall, no_substantive_footprint can only
+  #    appear, and temporal_inversion and capability_failure are both suppressed
+  #    by $ext_substantive, which can only fall — so each can only newly fire.
+  #    The single upward path is a cleared self_report_mismatch on a reviewer
+  #    that is substantive on its own footprint, which is the corrected verdict,
+  #    not a loosened one.
+  | def norm_line:
+      sub("^[ \t]*(>[ \t]*)+"; "") | sub("^[ \t]+"; "") | sub("[ \t\r]+$"; "");
+
+    ( reduce ( $convo[]?
+               | ((.user.login // "")) as $l
+               | select((($approvers + $others) | index($l)) == null)
+               | ((((.created_at // .updated_at) // "") | canon_ts)) as $t
+               | ((.body // "") | ascii_downcase | split("\n")[] | norm_line)
+               | select(length > 0)
+               | { k: ., t: $t } ) as $e
+             ({}; if (.[$e.k] // null) == null or $e.t < .[$e.k]
+                  then .[$e.k] = $e.t
+                  else . end) ) as $echo_first
+
+  # $ts is the created time of the comment being scanned. Input must already be
+  # downcased — sha_tokens applies ascii_downcase first, and the index above is
+  # downcased too, so matching is case-insensitive exactly like every other rule
+  # here (CodeAnt"s PR #929 echo is a lowercased copy of the author"s line).
+  # A source with no usable timestamp sorts first and so still strips: the
+  # conservative direction, and GitHub always supplies one.
+  #
+  # FENCE DELIMITERS ARE NEVER DROPPED (CodeRabbit CLI review of this PR). A
+  # bare "```" line is one of the most reproducible lines on a thread — every
+  # comment carrying a code block has one — so it lands in the echo index almost
+  # immediately, and dropping it would delete the delimiters of a REVIEWER"s own
+  # fenced block. The #897 masking below is paired-delimiter matching: lose the
+  # delimiters and quoted diff hunks are scanned as prose again, so numeric
+  # literals in someone else"s source become self-report candidates. Losing only
+  # the CLOSER is the worse half — the unclosed-opener rule then runs to
+  # end-of-body and deletes rule-3 tokens that should have been admitted, which
+  # is the grant direction. A delimiter carries no commit id of its own, so
+  # keeping it costs nothing the echo rule was meant to buy. Pinned by
+  # (ff-933)(j); only PAIRED syntax needs this, which is why four-space-indented
+  # lines get no exception — dropping one removes its content too.
+  | def strip_echoed($ts):
+      [ ((. // "") | split("\n")[])
+        | . as $ln
+        | ($ln | norm_line) as $key
+        | (($key | startswith("```")) or ($key | startswith("~~~"))) as $is_fence
+        | ($echo_first[$key] // null) as $seen_at
+        | select($is_fence or $seen_at == null or ($seen_at > $ts))
+        | $ln ]
+      | join("\n");
+
   # SHA-like tokens. THREE admission rules, deliberately asymmetric: each of the
   # two additions can move the verdict in exactly ONE direction, and which
   # direction is a structural property of the rule, not of the fixture that
@@ -291,8 +411,8 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
   #
   # Bare decimal runs in prose ("reviewed 20260731 files across 1234567 lines")
   # remain unadmitted under all three rules — pinned by case (k).
-  | def sha_tokens:
-      ((. // "") | ascii_downcase) as $btxt
+  def sha_tokens($ts):
+      ((. // "") | ascii_downcase | strip_echoed($ts)) as $btxt
       # Fence-stripped text for rule 3 only. Rules 1-2 keep reading $btxt (raw)
       # by design — "HEAD is HEAD wherever it appears", and rule 1 must stay
       # byte-identical to its pre-#894 behaviour. The flag is "m", NOT "s": jq
@@ -360,7 +480,8 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
     # ---- Conversation index: one pass, all regex work done here -------------
     ( [ $convo[]?
         | (.body // "") as $b
-        | (($b | sha_tokens)) as $tok
+        | (((.created_at // .updated_at) // "") | canon_ts) as $cts
+        | (($b | sha_tokens($cts))) as $tok
         | { login:   (.user.login // ""),
             body:    $b,
             len:     ($b | length),

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -500,9 +500,26 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
       and any(.[]; . as $t | ($sha | startswith($t)) or ($t | startswith($sha)));
 
     # ---- Conversation index: one pass, all regex work done here -------------
+    #
+    # The echo scan is handed updated_at, NOT created_at (BugBot review of this
+    # PR). GitHub freezes created_at when a comment is edited in place, and
+    # editing in place is the norm here, not an edge case: CodeAnt PATCHes its
+    # review body on re-review (#876) and CodeRabbit rewrites its walkthrough
+    # comment. A bot that edits an echo of the author"s prose INTO a comment it
+    # opened BEFORE the author wrote it would sort ahead of the index entry and
+    # keep the line, manufacturing HEAD evidence — the grant direction, reached
+    # without the bot ever writing the SHA.
+    #
+    # Both sides of the comparison are now biased the same way, toward
+    # stripping: the index (above) keeps the EARLIEST time a source line can
+    # have existed, and the scan takes the LATEST time the scanned body can have
+    # been written. An in-place edit can therefore only ever withhold coverage,
+    # never manufacture it. Unedited comments are unaffected — GitHub reports
+    # updated_at == created_at — so the ordering guard pinned by (ff-933)(f) is
+    # unchanged. Pinned by (ff-933)(n).
     ( [ $convo[]?
         | (.body // "") as $b
-        | (((.created_at // .updated_at) // "") | canon_ts) as $cts
+        | (((.updated_at // .created_at) // "") | canon_ts) as $cts
         | (($b | sha_tokens($cts))) as $tok
         | { login:   (.user.login // ""),
             body:    $b,

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -284,9 +284,12 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
   # bot"s line verbatim would retroactively strip the bot"s original.
   #
   # WHICH DIRECTIONS THIS CAN MOVE (the load-bearing argument, stated in full
-  # because one of the two is a grant). Removing whole lines can only ever
-  # REMOVE tokens, never add them: split("\n") | join("\n") is the identity when
-  # nothing is dropped, and surviving lines are emitted byte-for-byte, so the
+  # because one of the two is a grant). Dropping a line, or truncating an echoed
+  # fence line to its delimiter, can only ever REMOVE tokens, never add them:
+  # split("\n") | join("\n") is the identity when nothing is dropped, an
+  # untouched line is emitted byte-for-byte, and a truncated fence line keeps a
+  # prefix of itself on its own line — no text is joined across a boundary, and
+  # a run of ` or ~ carries no hex or decimal digit of its own. So the
   # indentation- and fence-sensitive rules below (issue #897) see exactly what
   # they always saw. From "tokens can only shrink":
   #
@@ -348,14 +351,33 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
   # keeping it costs nothing the echo rule was meant to buy. Pinned by
   # (ff-933)(j); only PAIRED syntax needs this, which is why four-space-indented
   # lines get no exception — dropping one removes its content too.
+  #
+  # THE DELIMITER, NOT THE LINE (CodeAnt PR #951 review). An exemption written
+  # as "keep any line that STARTS with a fence marker" is wider than the
+  # argument above, and the gap is on the grant side: "```5acd1e2" is a fence
+  # opener whose info string is a SHA, so exempting the whole line readmits the
+  # very token the echo rule just refused, and an empty-body approval scores
+  # counts_as_coverage true on the author"s words again (reproduced on a live
+  # payload before the fix). An echoed fence line is therefore truncated to its
+  # own delimiter run — leading whitespace and quote markers preserved, info
+  # string and any trailing text dropped. Paired matching sees an identical
+  # delimiter either way (the masking regexes never read the info string), so
+  # the structural reason for the exemption is untouched while its content
+  # cannot smuggle evidence. Non-echoed fence lines are not rewritten at all.
+  # Pinned by (ff-933)(k) and (ff-933)(l).
   | def strip_echoed($ts):
       [ ((. // "") | split("\n")[])
         | . as $ln
         | ($ln | norm_line) as $key
         | (($key | startswith("```")) or ($key | startswith("~~~"))) as $is_fence
         | ($echo_first[$key] // null) as $seen_at
-        | select($is_fence or $seen_at == null or ($seen_at > $ts))
-        | $ln ]
+        | (($seen_at != null) and ($seen_at <= $ts)) as $echoed
+        | if ($echoed | not) then $ln
+          elif $is_fence
+          then ($ln | sub("^(?<w>[ \t]*)(?<q>(?:>[ \t]*)*)(?<f>`{3,}|~{3,}).*$";
+                          "\(.w)\(.q)\(.f)"))
+          else empty
+          end ]
       | join("\n");
 
   # SHA-like tokens. THREE admission rules, deliberately asymmetric: each of the

--- a/.claude/scripts/tests/merge-gate-review-substance.test.sh
+++ b/.claude/scripts/tests/merge-gate-review-substance.test.sh
@@ -30,7 +30,9 @@
 #        withhold coverage, never grant it
 #   (ff-933) a bot echoing the AUTHOR's SHA-bearing text  -> does not name HEAD
 #        (issue #933, trace on PR #929), with the parity, ordering and
-#        self-quotation controls that keep the rule from over-stripping
+#        self-quotation controls that keep the rule from over-stripping, and
+#        (k)/(l): the fence exemption covers the DELIMITER, not the whole line,
+#        so an echoed "```<sha>" smuggles nothing yet still masks its block
 #
 # Only `gh` is stubbed; merge-gate.sh, review-substance.sh, ci-status.sh,
 # check-runs-dedup.sh and session-state.sh are the real scripts.
@@ -788,6 +790,36 @@ FF_J_BOT="$(printf "Walkthrough of the changed files, covering both call sites i
 FF_J="$(ff_eval "$(ff_pair "$FF_J_AUTHOR" "$FF_J_BOT")")"
 check_eq "[]"    "$(echo "$FF_J" | jq -c '.status_comment_shas')"  "(ff-933) an echoed fence delimiter still masks its block"
 check_eq "false" "$(echo "$FF_J" | jq -r '.self_report_mismatch')" "(ff-933) so quoted source code is still not a self-report"
+
+# (k) THE EXEMPTION IS THE DELIMITER, NOT THE LINE (CodeAnt PR #951 review).
+# Markdown info strings are free-form, so a fence opener can carry arbitrary
+# text — including HEAD's SHA. Exempting the whole line because it STARTS with
+# a fence marker readmits exactly the token the echo rule just refused, which
+# is the grant direction: before the fix these bodies scored
+# status_comment_names_head=true and counts_as_coverage=true off the AUTHOR's
+# words. Both spellings are the same class: fence marker + SHA-bearing info
+# string.
+for FF_K_LINE in '```5acd1e2' '``` reviewed at 5acd1e2'; do
+  FF_K_AUTHOR="$(printf 'Please re-review:\n\n%s\nsome quoted source\n```\n' "$FF_K_LINE")"
+  FF_K_BOT="$(printf 'Question:\n\n%s\nsome quoted source\n```\n\nAnswer: no blocking findings.\n' "$FF_K_LINE")"
+  FF_K="$(ff_eval "$(ff_pair "$FF_K_AUTHOR" "$FF_K_BOT")")"
+  check_eq "false" "$(echo "$FF_K" | jq -r '.status_comment_names_head')" \
+    "(ff-933)(k) an echoed fence line does not smuggle its info-string SHA [$FF_K_LINE]"
+  check_eq "false" "$(echo "$FF_K" | jq -r '.counts_as_coverage')" \
+    "(ff-933)(k) so the empty approval still gets no coverage [$FF_K_LINE]"
+done
+
+# (l) …and truncating it does not cost the masking the exemption exists for.
+# The echoed opener keeps its delimiter (only the info string goes), so the
+# #897 paired matching still finds an opener and a closer, the block is masked,
+# and the numeric literal inside quoted source is still not a rule-3 token.
+# If the truncation ever stops being delimiter-preserving, this pair regresses
+# to the failure mode (j) exists to prevent.
+FF_L_AUTHOR="$(printf "Repro for the failing case:\n\n\`\`\`js\nconst a = 1;\n\`\`\`\n\nShould be green after the rebase.\n")"
+FF_L_BOT="$(printf "Walkthrough of the changed files, covering both call sites.\n\n\`\`\`js\nconst id = \`1234599\`;\n\`\`\`\n")"
+FF_L="$(ff_eval "$(ff_pair "$FF_L_AUTHOR" "$FF_L_BOT")")"
+check_eq "[]"    "$(echo "$FF_L" | jq -c '.status_comment_shas')"  "(ff-933)(l) a truncated echoed opener still pairs and masks its block"
+check_eq "false" "$(echo "$FF_L" | jq -r '.self_report_mismatch')" "(ff-933)(l) so quoted source is still not a self-report"
 
 echo "=== (m) evaluator rejects malformed stdin ==="
 echo "not json" | "$EVAL_SUT" >/dev/null 2>&1

--- a/.claude/scripts/tests/merge-gate-review-substance.test.sh
+++ b/.claude/scripts/tests/merge-gate-review-substance.test.sh
@@ -30,9 +30,11 @@
 #        withhold coverage, never grant it
 #   (ff-933) a bot echoing the AUTHOR's SHA-bearing text  -> does not name HEAD
 #        (issue #933, trace on PR #929), with the parity, ordering and
-#        self-quotation controls that keep the rule from over-stripping, and
+#        self-quotation controls that keep the rule from over-stripping;
 #        (k)/(l): the fence exemption covers the DELIMITER, not the whole line,
-#        so an echoed "```<sha>" smuggles nothing yet still masks its block
+#        so an echoed "```<sha>" smuggles nothing yet still masks its block;
+#        (n): an echo edited in place into an older bot comment is stripped on
+#        updated_at, with the unedited case as the ordering control
 #
 # Only `gh` is stubbed; merge-gate.sh, review-substance.sh, ci-status.sh,
 # check-runs-dedup.sh and session-state.sh are the real scripts.
@@ -696,7 +698,7 @@ ff_eval() { # <issue-comments-json> -> the codeant reviewer object
                 submitted_at:"2026-07-31T10:10:00Z",body:""}],
       pr_comments:[],
       issue_comments:($cs | map({user:{login:.login}, created_at:.created,
-                                 updated_at:.created, body:.body}))}' \
+                                 updated_at:(.updated // .created), body:.body}))}' \
   | "$EVAL_SUT" 2>/dev/null | jq -c '.reviewers["codeant-ai[bot]"]'
 }
 ff_pair() { # <author-body> <bot-body> [author_ts] [bot_ts]
@@ -820,6 +822,33 @@ FF_L_BOT="$(printf "Walkthrough of the changed files, covering both call sites.\
 FF_L="$(ff_eval "$(ff_pair "$FF_L_AUTHOR" "$FF_L_BOT")")"
 check_eq "[]"    "$(echo "$FF_L" | jq -c '.status_comment_shas')"  "(ff-933)(l) a truncated echoed opener still pairs and masks its block"
 check_eq "false" "$(echo "$FF_L" | jq -r '.self_report_mismatch')" "(ff-933)(l) so quoted source is still not a self-report"
+
+# (n) IN-PLACE EDITS (BugBot review of PR #951). GitHub freezes created_at when
+# a comment is edited, and editing in place is the norm for these bots — CodeAnt
+# PATCHes its review body on re-review (#876), CodeRabbit rewrites its
+# walkthrough. Scanning on created_at let a bot EDIT an echo of the author's
+# prose into a comment it had opened BEFORE the author wrote it: the bot's
+# comment sorted ahead of the index entry, the line survived, and HEAD evidence
+# was manufactured without the bot ever writing the SHA. The scan now takes
+# updated_at, so the echo is stripped on the edited body's real timing.
+FF_N="$(ff_eval "$(jq -cn --arg t "$FF_TRIGGER_LINE" --arg e "$FF_ECHO_LINE" '
+  [ {login:"codeant-ai[bot]", created:"2026-07-31T10:01:00Z", updated:"2026-07-31T10:09:00Z",
+     body:("Status: reviewing this PR.\n\n" + $e + "\n\nNo blocking findings.\n")},
+    {login:"auerbachb", created:"2026-07-31T10:05:00Z",
+     body:("@codeant-ai: review\n\n" + $t + "\n")} ]')")"
+check_eq "false" "$(echo "$FF_N" | jq -r '.status_comment_names_head')" "(ff-933)(n) an echo edited into an older bot comment is still stripped"
+check_eq "false" "$(echo "$FF_N" | jq -r '.counts_as_coverage')"        "(ff-933)(n) so an in-place edit cannot manufacture coverage"
+
+# (n) control: the same two comments with the bot's body NEVER edited. This is
+# the (f) ordering guard — the author's line came later, so it cannot have been
+# echoed — and it must stay true, or the change has turned an ordering rule into
+# "strip whenever the text matches".
+FF_N2="$(ff_eval "$(jq -cn --arg t "$FF_TRIGGER_LINE" --arg e "$FF_ECHO_LINE" '
+  [ {login:"codeant-ai[bot]", created:"2026-07-31T10:01:00Z",
+     body:("Status: reviewing this PR.\n\n" + $e + "\n\nNo blocking findings.\n")},
+    {login:"auerbachb", created:"2026-07-31T10:05:00Z",
+     body:("@codeant-ai: review\n\n" + $t + "\n")} ]')")"
+check_eq "true" "$(echo "$FF_N2" | jq -r '.status_comment_names_head')" "(ff-933)(n) control: an unedited earlier bot comment keeps its line"
 
 echo "=== (m) evaluator rejects malformed stdin ==="
 echo "not json" | "$EVAL_SUT" >/dev/null 2>&1

--- a/.claude/scripts/tests/merge-gate-review-substance.test.sh
+++ b/.claude/scripts/tests/merge-gate-review-substance.test.sh
@@ -28,6 +28,9 @@
 #   (ee) sha_tokens admission rules on a decimal HEAD -> issue #894, both
 #        directions plus the invariant that the code-span rule can only ever
 #        withhold coverage, never grant it
+#   (ff-933) a bot echoing the AUTHOR's SHA-bearing text  -> does not name HEAD
+#        (issue #933, trace on PR #929), with the parity, ordering and
+#        self-quotation controls that keep the rule from over-stripping
 #
 # Only `gh` is stubbed; merge-gate.sh, review-substance.sh, ci-status.sh,
 # check-runs-dedup.sh and session-state.sh are the real scripts.
@@ -669,6 +672,122 @@ check_eq "true"     "$(echo "$RU" | jq -r '.status_comment_names_head')" "(ee-91
 check_eq '["a1b2c3d"]' "$(echo "$RU" | jq -c '.status_comment_shas')"    "(ee-917) only the genuine token is admitted — no UUID fragments"
 check_eq "false"    "$(echo "$RU" | jq -r '.self_report_mismatch')"     "(ee-917) a later UUID-only status comment no longer manufactures a mismatch"
 check_eq "[]"       "$(echo "$RU" | jq -c '.disqualified_by')"          "(ee-917) and the reviewer is not disqualified"
+
+echo "=== (ff-933) a reviewer echoing the author's SHA-bearing text does not name HEAD ==="
+# Issue #933, trace on PR #929 (2026-08-02). CodeAnt answers a re-review request
+# by reproducing the requester's comment verbatim (lowercased) under a
+# "Question:" heading and putting its own verdict under "Answer:". The author's
+# trigger prose named HEAD's short SHA, so the bot's body contained `5acd1e2`
+# without the bot ever having written it — and status_comment_names_head, the
+# flag that asserts "this reviewer demonstrably read HEAD", went true on the
+# strength of the AUTHOR's words. Replayed on the live payload, main scored that
+# CodeAnt approval counts_as_coverage=true; the fix scores it false.
+#
+# The rule is "a line someone else already posted", NOT "a blockquote line".
+# Case (e) is the negative control for that distinction and must not be deleted:
+# the only ">" lines on the real PR #929 thread were CodeRabbit quoting ITSELF.
+FF_HEAD="5acd1e20ef431444c38695923f73e1f30f6f1d39"
+ff_eval() { # <issue-comments-json> -> the codeant reviewer object
+  jq -cn --arg sha "$FF_HEAD" --argjson cs "$1" \
+    '{head_sha:$sha, push_ts:"2026-07-31T10:00:00Z",
+      reviews:[{user:{login:"codeant-ai[bot]"},commit_id:$sha,state:"APPROVED",
+                submitted_at:"2026-07-31T10:10:00Z",body:""}],
+      pr_comments:[],
+      issue_comments:($cs | map({user:{login:.login}, created_at:.created,
+                                 updated_at:.created, body:.body}))}' \
+  | "$EVAL_SUT" 2>/dev/null | jq -c '.reviewers["codeant-ai[bot]"]'
+}
+ff_pair() { # <author-body> <bot-body> [author_ts] [bot_ts]
+  jq -cn --arg ab "$1" --arg bb "$2" \
+         --arg at "${3:-2026-07-31T10:02:00Z}" --arg bt "${4:-2026-07-31T10:05:00Z}" \
+    '[{login:"auerbachb",         created:$at, body:$ab},
+      {login:"codeant-ai[bot]",   created:$bt, body:$bb}]'
+}
+# The author's line, and the bot's lowercased copy of it. Identical after the
+# evaluator's ascii_downcase — which is what makes it an echo and not authorship.
+FF_TRIGGER_LINE="Re-review requested on \`5acd1e2\`. The approval posted 43s after that push has an empty body and no inline comments, so it cannot be counted as review coverage on this SHA."
+FF_ECHO_LINE="re-review requested on \`5acd1e2\`. the approval posted 43s after that push has an empty body and no inline comments, so it cannot be counted as review coverage on this sha."
+FF_AUTHOR="$(printf '@codeant-ai: review\n\n%s\n' "$FF_TRIGGER_LINE")"
+FF_OWN_VERDICT='## Review
+
+No blocking findings. The documentation now matches the unchanged behavior of the extractor.'
+FF_UNRELATED='Please take another look when you get a chance — the CI run is green now and the branch is rebased.'
+
+# (a) THE TRACE. HEAD's SHA reaches the bot's body only through the echo.
+FF_A="$(ff_eval "$(ff_pair "$FF_AUTHOR" "$(printf 'Question: review\n\n%s\n\nAnswer:\n%s\n' "$FF_ECHO_LINE" "$FF_OWN_VERDICT")")")"
+check_eq "false" "$(echo "$FF_A" | jq -r '.status_comment_names_head')" "(ff-933) echoed author text does not name HEAD"
+check_eq "false" "$(echo "$FF_A" | jq -r '.external_evidence_on_head')" "(ff-933) and so supplies no evidence outside the approval"
+check_eq "false" "$(echo "$FF_A" | jq -r '.counts_as_coverage')"        "(ff-933) so the empty approval no longer counts as coverage"
+check_not_contains "5acd1e2" "$(echo "$FF_A" | jq -c '.status_comment_shas')" "(ff-933) and no HEAD token is admitted from the echo"
+
+# (b) PARITY. A genuine status comment naming HEAD in the bot's own prose is
+# untouched — the whole point is to separate quoting from reviewing.
+FF_B="$(ff_eval "$(ff_pair "$FF_AUTHOR" "$(printf "## Review summary for \`5acd1e2\`\n\nReviewed the modal root change and both call sites. No blocking issues found.\n")")")"
+check_eq "true" "$(echo "$FF_B" | jq -r '.status_comment_names_head')" "(ff-933) parity: the bot's own prose naming HEAD still counts"
+check_eq "true" "$(echo "$FF_B" | jq -r '.counts_as_coverage')"        "(ff-933) parity: and still redeems the empty approval"
+
+# (c) PAIRED. Echo AND own prose in one body: only the echoed line is removed.
+FF_C="$(ff_eval "$(ff_pair "$FF_AUTHOR" "$(printf "Question: review\n\n%s\n\nAnswer:\nReviewed commit \`5acd1e2\` end to end; no blocking issues found.\n" "$FF_ECHO_LINE")")")"
+check_eq "true" "$(echo "$FF_C" | jq -r '.status_comment_names_head')" "(ff-933) the strip removes the quoted line, not the whole body"
+
+# (d) GitHub "Quote reply" shape: "> " + the original line. Quote markers are
+# normalised out of the lookup key, so this is the same echo as (a).
+FF_D="$(ff_eval "$(ff_pair "$FF_AUTHOR" "$(printf '> %s\n\nAcknowledged. No blocking findings after a full pass over the diff.\n' "$FF_ECHO_LINE")")")"
+check_eq "false" "$(echo "$FF_D" | jq -r '.status_comment_names_head')" "(ff-933) a blockquoted echo of the author is caught too"
+
+# (e) NEGATIVE CONTROL — self-quotation is NOT an echo. CodeRabbit renders its
+# own reviewed range as "> Reviewing files that changed ... between X and Y";
+# on the real PR #929 thread those were the ONLY ">" lines present. A rule that
+# dropped every blockquote line would delete a reviewer's own self-report here
+# while closing none of case (a). If this flips to false, the rule has drifted
+# back to "strip all quotes".
+FF_E="$(ff_eval "$(ff_pair "$FF_UNRELATED" "$(printf '> Reviewing files that changed from the base of the PR and between c441771 and 5acd1e2\n\nStatus: review complete, no blocking findings on this commit.\n')")")"
+check_eq "true" "$(echo "$FF_E" | jq -r '.status_comment_names_head')" "(ff-933) a bot's own blockquoted callout is not an echo"
+
+# (f) ORDER MATTERS. The same line posted by the author AFTER the bot is not
+# something the bot could have echoed; the bot's own line survives.
+FF_F="$(ff_eval "$(ff_pair "$(printf 'Confirming for the record.\n\n%s\n' "$FF_TRIGGER_LINE")" "$(printf 'Reviewed. %s\n' "$FF_ECHO_LINE")" "2026-07-31T10:08:00Z" "2026-07-31T10:05:00Z")")"
+check_eq "true" "$(echo "$FF_F" | jq -r '.status_comment_names_head')" "(ff-933) a later author comment cannot retroactively strip the bot"
+
+# (g) A quoted OLDER SHA is not the reviewer's self-report (issue #933; same
+# direction #917 accepted for UUID fragments). The bot never claimed to have
+# read c441771 — the author did — so no mismatch is manufactured from it.
+FF_OLD_LINE="Please re-check \`c441771\`; that is the commit the earlier approval actually covered."
+FF_G="$(ff_eval "$(ff_pair "$(printf '@codeant-ai: review\n\n%s\n' "$FF_OLD_LINE")" "$(printf 'Question: review\n\n%s\n\nAnswer:\n%s\n' "$(echo "$FF_OLD_LINE" | tr '[:upper:]' '[:lower:]')" "$FF_OWN_VERDICT")")")"
+check_eq "[]"    "$(echo "$FF_G" | jq -c '.status_comment_shas')"   "(ff-933) a quoted older SHA yields no tokens"
+check_eq "false" "$(echo "$FF_G" | jq -r '.self_report_mismatch')"  "(ff-933) and manufactures no self-report mismatch"
+
+# (h) A reviewer can never strip ITSELF. Only non-reviewer comments seed the
+# index, so a bot repeating its own status line keeps its evidence both times.
+FF_SELF_LINE="Reviewed commit \`5acd1e2\` end to end; no blocking issues found."
+FF_H="$(ff_eval "$(jq -cn --arg l "$FF_SELF_LINE" --arg u "$FF_UNRELATED" \
+  '[{login:"auerbachb",       created:"2026-07-31T10:02:00Z", body:$u},
+    {login:"codeant-ai[bot]", created:"2026-07-31T10:05:00Z", body:$l},
+    {login:"codeant-ai[bot]", created:"2026-07-31T10:07:00Z", body:$l}]')")"
+check_eq "true" "$(echo "$FF_H" | jq -r '.status_comment_names_head')" "(ff-933) a reviewer repeating its own line does not erase itself"
+
+# (i) SCOPE BOUNDARY, pinned deliberately: corroborator bots are reviewers too,
+# so one reviewer quoting another is out of scope and changes nothing. Widening
+# the index to bot-authored text must be a conscious decision, not a drift.
+FF_I="$(ff_eval "$(jq -cn --arg l "$FF_SELF_LINE" --arg u "$FF_UNRELATED" \
+  '[{login:"auerbachb",       created:"2026-07-31T10:02:00Z", body:$u},
+    {login:"cursor[bot]",     created:"2026-07-31T10:03:00Z", body:$l},
+    {login:"codeant-ai[bot]", created:"2026-07-31T10:05:00Z", body:$l}]')")"
+check_eq "true" "$(echo "$FF_I" | jq -r '.status_comment_names_head')" "(ff-933) reviewer-quotes-reviewer stays out of scope"
+
+# (j) Fence delimiters are STRUCTURE, not content, and are never dropped as
+# echoes (CodeRabbit CLI review of this PR). A bare "```" line is one of the
+# most reproducible lines a human can post — any comment containing a code block
+# has one — so without an exception the delimiters of a reviewer's own fenced
+# block get stripped, the #897 masking silently stops matching, and numeric
+# literals in quoted diff hunks become self-report candidates again. Stripping
+# only the CLOSER is worse: the opener then runs to end-of-body and deletes
+# rule-3 tokens that should have been admitted, which is the grant direction.
+FF_J_AUTHOR="$(printf "Repro for the failing case:\n\n\`\`\`\nbash .claude/scripts/tests/merge-gate-review-substance.test.sh\n\`\`\`\n\nShould be green after the rebase.\n")"
+FF_J_BOT="$(printf "Walkthrough of the changed files, covering both call sites in detail.\n\n\`\`\`\nconst id = \`1234599\`;\n\`\`\`\n")"
+FF_J="$(ff_eval "$(ff_pair "$FF_J_AUTHOR" "$FF_J_BOT")")"
+check_eq "[]"    "$(echo "$FF_J" | jq -c '.status_comment_shas')"  "(ff-933) an echoed fence delimiter still masks its block"
+check_eq "false" "$(echo "$FF_J" | jq -r '.self_report_mismatch')" "(ff-933) so quoted source code is still not a self-report"
 
 echo "=== (m) evaluator rejects malformed stdin ==="
 echo "not json" | "$EVAL_SUT" >/dev/null 2>&1


### PR DESCRIPTION
## **User description**
Closes #933

## What was wrong

`status_comment_names_head` is the flag that asserts *this reviewer demonstrably
read HEAD*. It was set by any conversation comment from that bot containing
HEAD's SHA — including a SHA the bot never wrote.

On PR #929, CodeAnt answers a re-review request by reproducing the requester's
comment **verbatim** under a `Question:` heading, with its own verdict under
`Answer:`. The author's trigger prose named `5acd1e2`, so the flag went true on
the **author's** words and an empty-bodied approval scored as full review
coverage.

## What changed

`sha_tokens` drops, before extraction, any line already posted on the thread by
someone who is **not** one of the reviewers under evaluation. Quote markers are
normalised out of the comparison key, so GitHub's "Quote reply" shape matches its
source. `merge-gate.sh` already passes the unfiltered issue-comments list, so
nothing new crosses the `REVIEW_EVIDENCE` boundary.

**Not "strip every blockquote line"** — that was the first cut, and the live
payload refutes it twice. The #929 echo carries no `>` at all, so a blockquote
rule closes *none* of the reported trace; and the only `>` lines on that thread
are CodeRabbit quoting **itself** (`> Reviewing files that changed … between X
and Y`). Blanket quote-stripping would have deleted a reviewer's own self-report
on every CodeRabbit status comment in this repo while fixing nothing. The issue
asks to discount quoted/echoed *author* text; a bot's own callout is not that.

Guards against over-reach: reviewers never seed the index (so a reviewer can
never strip itself, including one repeating its own status line); the index
stores the earliest time each line was seen (so a human quoting a bot cannot
retroactively strip the bot's original); and fence delimiters are exempt, because
dropping a bare ` ``` ` line would break the #897 paired-delimiter masking.

### Directions — one of them is a grant

- `status_comment_names_head`, `external_evidence_on_head`, `substantive` are
  monotone in the token set → **true → false only**. This is the grant path #933
  closes.
- `self_report_mismatch` moves **both** ways, and `counts_as_coverage` inherits
  that single upward channel: a mismatch manufactured purely from quoted text is
  retracted. That is the same correction, not a side effect — a SHA the reviewer
  never wrote was never its report about itself — and it is the direction #917
  already accepted for UUID fragments.

An earlier draft of the rationale claimed `counts_as_coverage` was withhold-only.
The CodeRabbit CLI caught that overclaim; it is corrected in both the script and
`review-substance-evidence.md`.

## Evidence

**Live replay** (main's evaluator vs this branch, on the real PR #929 payload at
`5acd1e2`), comparing decision flags:

| reviewer | main | branch |
|---|---|---|
| `codeant-ai[bot]` | `counts_as_coverage: true`, shas `["5acd1e2","c441771"]` | `counts_as_coverage: false`, disqualified `no_substantive_footprint` + `self_report_mismatch`, shas `["c441771", …]` |
| `coderabbitai[bot]` | — | **byte-identical**, flags and reporting alike |

`corroborating: ["cursor[bot]"]` unchanged. The branch's `status_comment_shas`
for CodeAnt now reports the SHA its own status comment actually names.

**Non-vacuity control** — the branch's test file run against **main's**
evaluator: `PASS: 136  FAIL: 13`. All 13 failures are the direction cases; every
parity/ordering/self-quotation/fence control passes on both, and there are zero
non-`ff-933` failures.

**Suites:** 149/149 in `merge-gate-review-substance.test.sh`; all 9 suites that
touch this evaluator green; the full CI discovery (`run-hook-tests.sh`) runs
65 suites, 0 failed; `rule-lint.sh` OK; `shellcheck` clean on both changed
scripts, matching main's clean baseline.

**Performance:** amplified to 200 conversation comments (40× the live payload),
243 ms/run on main vs 325 ms/run here. Negligible at real payload sizes and far
from the O(n²) pathology this file's header warns about.

**Known bound (deliberate):** matching is whole-line. A bot that paraphrases or
re-wraps the author's text instead of echoing a full line keeps the token — the
conservative direction, identical to today's behaviour.

**Local review coverage:** none — CodeAnt returned a 403 on both permitted
attempts (Issue #643: persistent account-level entitlement, not auth; `codeant
logout` deliberately not run). CodeRabbit completed two runs and **all 3 of its
findings are fixed in this commit** (MD038 code-span, the `counts_as_coverage`
direction overclaim, and the fence-delimiter interaction — the last shipped with
its own regression case, `(ff-933)(j)`, verified to fail before the guard). Its
verification pass then hung past the 2-minute bound and was dropped without a
clean pass, so a self-review stands in: 6 edge-case probes (empty conversation,
null body, absent user object, absent timestamps, CRLF-vs-LF, trailing
whitespace, indented echo, partial quote) all behave correctly with no evaluator
errors.

## Test plan

- [x] A bot comment whose only HEAD mention is a verbatim echo of the author's
      SHA-bearing trigger does **not** set `status_comment_names_head`, sets no
      `external_evidence_on_head`, and does not count as coverage — `(ff-933)(a)`
- [x] A genuine status comment naming HEAD in the bot's own prose still counts,
      unchanged from today — `(ff-933)(b)`
- [x] A body containing both an echoed line and the bot's own HEAD-naming prose
      still counts: the strip removes the line, not the body — `(ff-933)(c)`
- [x] GitHub's `>`-prefixed "Quote reply" of the author's line is caught too —
      `(ff-933)(d)`
- [x] A bot's own blockquoted callout naming HEAD is **not** treated as an echo
      (negative control for the rejected blanket-blockquote rule) — `(ff-933)(e)`
- [x] An identical author line posted **after** the bot cannot retroactively
      strip the bot's line — `(ff-933)(f)`
- [x] A quoted **older** SHA yields no tokens and manufactures no
      `self_report_mismatch` — `(ff-933)(g)`
- [x] A reviewer repeating its own status line does not erase its own evidence —
      `(ff-933)(h)`
- [x] One reviewer quoting another stays out of scope (boundary pinned) —
      `(ff-933)(i)`
- [x] An echoed fence delimiter still masks its block, so quoted source code is
      not a self-report — `(ff-933)(j)`
- [x] An echoed fence line does **not** smuggle a SHA through its info string:
      the exemption truncates to the delimiter rather than keeping the line, on
      both spellings (` ```<sha> ` and ` ``` <prose with sha> `) — `(ff-933)(k)`
- [x] …and the truncated opener still pairs with its closer, so the block is
      still masked and quoted source is still not a self-report — `(ff-933)(l)`
- [x] An echo **edited in place** into a bot comment that predates the author's
      line is still stripped (the scan reads `updated_at`, which GitHub does not
      freeze), while the unedited case keeps the bot's line — `(ff-933)(n)` and
      its ordering control
- [x] Guard lineage intact: #875 hollow approvals, #876 in-place PATCH
      re-reviews, #894 all-decimal short SHA, #897 fence shapes, #917 UUID
      fragments — all 124 pre-existing assertions (the merge-base suite) still
      pass, none dropped or renamed (suite now 149/149)
- [x] Non-vacuity: every new direction case fails against main's evaluator
      (`PASS: 136  FAIL: 13`, all 13 failures direction cases) while every
      control — including the new `(ff-933)(n)` ordering control — passes on both
- [x] Live PR #929 replay: CodeAnt `counts_as_coverage` true → false;
      CodeRabbit byte-identical
- [x] Self-certifying check (this PR edits the evaluator merge-gate consumes):
      main's copy and this branch's produce **identical decision flags** on PR
      #951's own live payload, at all three pushed SHAs — so nothing here is
      graded by the guard it ships
- [x] CI-equivalent local run green: 65 bash suites, rule-lint, shellcheck


## Review rounds on this PR

Local CLI coverage stayed `none` (CodeAnt 403 twice — issue #643; the CodeRabbit
CLI's verification pass hung past the 2-minute bound and was dropped), and
CodeRabbit's GitHub review hit its rate limit, so the GitHub bots below were the
review signal. Two fix rounds, both in the **grant** direction — the direction
this PR exists to close, found in the fix itself:

- **`f7b4272`** — CodeAnt: the fence exemption was written as "keep any line that
  *starts with* a fence marker". Reproduced live: an echoed ` ```5acd1e2 ` scored
  `status_comment_names_head` and `counts_as_coverage` true off the author's
  words. Now truncated to the delimiter.
- **`861575c`** — BugBot: the echo scan read `created_at`, which GitHub freezes on
  an in-place edit — and in-place editing is routine for these bots (#876). A bot
  could edit an echo into a comment it opened *before* the author wrote the line
  and keep it. Scan now reads `updated_at`.

**Declined, with rationale on the thread:** CodeAnt also proposed normalising only
the Markdown quote prefix and preserving indentation in the echo key. Probed on
four shapes: it removes the false positive it describes (author indented,
reviewer flush-left) but stops catching an echo re-indented into a block, which
is the grant direction. Live PR #929 is flush-left on both sides, so neither
variant is needed for the reported trace; the tie is broken by this evaluator's
stated posture that over-matching withholds a merge (recoverable) while
under-matching grants one.

___

## **CodeAnt-AI Description**
Prevent quoted or echoed text from counting as review evidence

### What Changed
- Reviewers no longer receive HEAD credit when their comment only repeats a SHA-bearing line previously posted by someone outside the reviewers being evaluated.
- GitHub quote replies, copied text, and in-place edits are handled without removing a reviewer’s own status evidence or allowing later comments to rewrite history.
- Fenced code blocks remain structurally intact, while echoed fence metadata cannot smuggle SHA evidence.
- Added coverage for author echoes, self-quotation, ordering, reviewer-to-reviewer quotes, fence handling, and edited comments.
- Documented the evidence rules and their effects on review coverage and mismatch detection.

### Impact
`✅ Fewer false review approvals`
`✅ Accurate HEAD-reading evidence`
`✅ No self-report mismatches from quoted text`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


