### PR TITLE
fix(#948): answer the never-invited BugBot question per-SHA, not from a sticky cache

### DIFF
--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -153,7 +153,7 @@ If CR remains silent or cannot produce a current-HEAD approval, keep using the R
 
 ## BugBot Review Path (when `reviewer` = `bugbot`)
 
-**Invite BugBot before polling it.** BugBot does NOT auto-review pushes — something has to post `@cursor review`, normally the `cursor-review-pr-comment.yml` CI job, which posts nothing when `CURSOR_REVIEW_PAT` is unprovisioned (issue #905). So `switch_bugbot` now also arrives for a PR BugBot was never invited to (issue #935): if `cursor[bot]` has no review/comment and there is no `Cursor Bugbot` check-run on HEAD, post `gh pr comment {{PR_NUMBER}} --body "@cursor review"` first — duplicates are OK. Then poll for `cursor[bot]` reviews on all 3 endpoints every 60 seconds.
+**Invite BugBot before polling it.** BugBot does NOT auto-review pushes — something has to post `@cursor review`, normally the `cursor-review-pr-comment.yml` CI job, which posts nothing when `CURSOR_REVIEW_PAT` is unprovisioned (issue #905). So `switch_bugbot` now also arrives for a PR BugBot was never invited to (issue #935): if `cursor[bot]` has no review/comment and there is no `Cursor Bugbot` check-run on HEAD, post `gh pr comment {{PR_NUMBER}} --body "@cursor review"` first — duplicates are OK. That verdict is judged per-SHA, so it also arrives for a PR BugBot *did* answer on an earlier SHA once the current HEAD is uninvited and has no footprint (issue #948) — the `bugbot_installed` cache described above no longer suppresses it. Then poll for `cursor[bot]` reviews on all 3 endpoints every 60 seconds.
 
 ### Polling
 

--- a/.claude/scripts/escalate-review.sh
+++ b/.claude/scripts/escalate-review.sh
@@ -509,11 +509,21 @@ fi
 # escalation below exactly as before.
 #
 # BUGBOT_GENUINE is already false here (it emits above); restated so the branch
-# reads as a complete statement of the state it claims. BUGBOT_INSTALLED cached
-# true from an earlier SHA also keeps this branch shut — that PR stays on today's
-# path, adjacent to issue #552 and deliberately out of scope here.
+# reads as a complete statement of the state it claims. Every term is scoped to
+# the CURRENT HEAD, which is the only question this branch asks. The footprint
+# term is BUGBOT_CHECK_PRESENT — read from this commit's check-run bundle — and
+# NOT the sticky `bugbot_installed` cache it used to be (issue #948, follow-up to
+# PR #945). That cache is per-PR and never reset, so once BugBot answered on any
+# earlier SHA it read as "invited here" forever: on a later push where the
+# CI auto-trigger posts nothing (issue #905) the PR had no BugBot footprint at
+# all, yet this branch stayed shut and escalation spent paid Greptile budget
+# instead of posting the free `@cursor review` that resolves it. The cache still
+# carries the availability signal for the grace window above; it just no longer
+# answers a per-SHA question. Swapping in the live term rather than dropping one
+# also keeps the branch faithful to the first paragraph: an in-flight
+# `Cursor Bugbot` run on this commit is a footprint, so it still falls through.
 if [[ "$BUGBOT_FAILED" != "true" && "$BUGBOT_GENUINE" != "true" \
-      && "$BUGBOT_INSTALLED" != "true" && "$BUGBOT_TRIGGER_PRESENT" != "true" ]]; then
+      && "$BUGBOT_CHECK_PRESENT" != "true" && "$BUGBOT_TRIGGER_PRESENT" != "true" ]]; then
   emit "switch_bugbot"
 fi
 

--- a/.claude/scripts/tests/escalate-review.test.sh
+++ b/.claude/scripts/tests/escalate-review.test.sh
@@ -115,6 +115,23 @@ reset_state() {
   rm -f "$HOME/.claude/session-state.json"
 }
 
+# Pre-seed `.prs[<PR>].bugbot_installed` the way an EARLIER cycle of the same PR
+# would have (issue #948). Uses the same real session-state.sh from $STUB_DIR
+# that escalate-review.sh calls, run from the same cwd ($REPO_ROOT), so the
+# per-repo scoping resolves to the identical key the script will read back.
+#
+# Reads the value back and asserts it: a silent seed failure would leave (n6) in
+# the same state as (n1), which expects the same verdict — so (n6) would keep
+# passing while testing nothing. Assert the setup RAN, not just its outcome.
+seed_bugbot_installed() {
+  local want="$1" got
+  ( cd "$REPO_ROOT" && "$STUB_DIR/session-state.sh" \
+      --set ".prs[\"$PR_NUM\"].bugbot_installed=$want" >/dev/null )
+  got="$( cd "$REPO_ROOT" && "$STUB_DIR/session-state.sh" \
+      --get ".prs[\"$PR_NUM\"].bugbot_installed" 2>/dev/null )"
+  check_eq "bugbot_installed pre-seeded to $want" "$want" "$got"
+}
+
 write_commits() {
   local push_ts="$1"
   cat > "$TMP/commits.json" <<EOF
@@ -164,6 +181,11 @@ BUGBOT_CHECK_RUN_TIMED_OUT='{"id": 2, "name": "Cursor Bugbot", "status": "comple
 # merge-gate.sh now accepts this as a clean BugBot pass, but escalate-review.sh
 # still emits switch_bugbot so the caller persists sticky ownership before polling.
 BUGBOT_CHECK_RUN_SUCCESS='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "success", "title": ""}'
+# A run that exists on this HEAD but has NOT finished (issue #948). Both
+# content-aware flags are false for it — BUGBOT_FAILED needs a definitive
+# failure, BUGBOT_GENUINE needs status=completed — so it is the one shape where
+# the never-invited branch's footprint term is the only thing that sees it.
+BUGBOT_CHECK_RUN_IN_PROGRESS='{"id": 2, "name": "Cursor Bugbot", "status": "in_progress", "conclusion": null, "title": ""}'
 
 # Comments carry explicit created_at timestamps so "latest event wins" ordering
 # (issue #552 CodeRabbit finding) is genuinely exercised, not an accident of
@@ -619,6 +641,65 @@ write_state "[]" "[]" "[]" "[]"
 OUT=$(run_script); RC=$?
 check_eq "exit 0" 0 "$RC"
 check_eq "STATUS=polling_cr" "STATUS=polling_cr" "$OUT"
+
+############################################################################
+# Stale `bugbot_installed` cache vs. the never-invited branch (issue #948)
+#
+# PR #945 shipped (n1)-(n5) with the branch gated on BUGBOT_INSTALLED, which is
+# read from a per-PR cache that is written once and never reset. n6-n8 pin the
+# swap to BUGBOT_CHECK_PRESENT — the same question asked of THIS commit's
+# check-run bundle instead of the PR's history.
+#
+# Against the pre-fix script only n6 fails (trigger_greptile), which is the whole
+# behavioural delta: the two terms can only disagree when the cache reads true
+# while this commit has no BugBot footprint. n7 and n8 pass before and after, and
+# are here so the term cannot be DELETED rather than swapped — a bare deletion
+# flips both to switch_bugbot and re-invites a BugBot already running on HEAD.
+############################################################################
+echo
+echo "== Scenario (n6): bugbot_installed cached true from an EARLIER SHA, zero footprint on HEAD, past the grace window -> switch_bugbot (issue #948) =="
+# (n1) with the cache pre-seeded, i.e. BugBot answered earlier in this PR's life
+# and then a later push went uninvited (issue #905). The cache made the branch
+# read "already invited here" forever, so this fell through to a PAID Greptile
+# review instead of the free `@cursor review` that resolves it in seconds.
+reset_state
+seed_bugbot_installed true
+write_commits "$(ts_seconds_ago 7200)"
+write_state "[]" "[]" "[]" "[]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=switch_bugbot" "STATUS=switch_bugbot" "$OUT"
+
+############################################################################
+echo "== Scenario (n7): cache true AND an in-flight Cursor Bugbot run on HEAD -> trigger_greptile (a live footprint still shuts the branch) =="
+# The negative control for (n6): dropping the term outright — rather than
+# swapping the cached proxy for the live one — would emit switch_bugbot here and
+# re-invite a BugBot that is already running on this very commit. Escalation is
+# unchanged from pre-fix behaviour.
+reset_state
+seed_bugbot_installed true
+write_commits "$(ts_seconds_ago 7200)"
+write_state "[$BUGBOT_CHECK_RUN_IN_PROGRESS]" "[]" "[]" "[]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=trigger_greptile" "STATUS=trigger_greptile" "$OUT"
+
+############################################################################
+echo "== Scenario (n8): same in-flight run on HEAD, cache NOT readable-true -> trigger_greptile (the derived path shuts the branch too) =="
+# (n7)'s mirror over the other cache state, so the live-footprint guard is pinned
+# on both paths into BUGBOT_INSTALLED rather than only the cached one.
+# Note the seeded `false` is deliberately never read back: escalate-review.sh
+# reads the cache as `bugbot_installed // ""`, and jq's `//` treats false exactly
+# like null, so a cached false falls through to the derivation below it. That is
+# what makes this the DERIVED-true path (BUGBOT_CHECK_PRESENT sets it) rather
+# than a second cached-value case.
+reset_state
+seed_bugbot_installed false
+write_commits "$(ts_seconds_ago 7200)"
+write_state "[$BUGBOT_CHECK_RUN_IN_PROGRESS]" "[]" "[]" "[]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=trigger_greptile" "STATUS=trigger_greptile" "$OUT"
 
 echo
 echo "== summary: $PASS passed, $FAIL failed =="


### PR DESCRIPTION
## **User description**
Closes #948

## What was wrong

PR #945 (issue #935) taught `escalate-review.sh` to emit `switch_bugbot` instead of escalating to paid Greptile when BugBot was never invited on the current HEAD. It gated that branch on `BUGBOT_INSTALLED`, which is read from a **per-PR cache that is written once and never reset**:

```bash
CACHED_BUGBOT_INSTALLED="$("$SESSION_STATE" --get ".prs[\"$PR_NUMBER\"].bugbot_installed // \"\"" ...)"
```

So once BugBot answered on *any* earlier SHA of a PR, the branch read "already invited here" forever. On a later push where the CI auto-trigger posts nothing (unprovisioned `CURSOR_REVIEW_PAT`, issue #905), the PR had **zero** BugBot footprint on HEAD and still fell through to a paid Greptile review — the original #935 symptom, narrowed to multi-push PRs. PR #945 recorded this as a deliberate scope boundary pointing at issue #552, which is closed.

## Not a duplicate of #552

The issue carried a `Possibly duplicates #552` caveat. Verified against the current script, not the assumption: #552 (closed 2026-07-16) added the content-aware `BUGBOT_FAILED` / `BUGBOT_GENUINE` classifier that tells a BugBot usage-limit failure from a genuine completed review. **Both the `bugbot_installed` cache read and the never-invited branch postdate it** (PR #945, 458b391). Nothing in #552's resolution touches this path, so there was no already-fixed outcome to close #948 with.

## The change

One term in one condition:

```diff
 if [[ "$BUGBOT_FAILED" != "true" && "$BUGBOT_GENUINE" != "true" \
-      && "$BUGBOT_INSTALLED" != "true" && "$BUGBOT_TRIGGER_PRESENT" != "true" ]]; then
+      && "$BUGBOT_CHECK_PRESENT" != "true" && "$BUGBOT_TRIGGER_PRESENT" != "true" ]]; then
```

`BUGBOT_CHECK_PRESENT` is the same question — "is BugBot present here?" — asked of **this commit's** check-run bundle rather than the PR's history. Every term in the branch is now HEAD-scoped, which is the only question it asks. The cache block and the grace-window branch are untouched; the cache still carries the availability signal that lets later cycles skip the 10-minute wait.

### Why swapped, not deleted

The issue's suggested direction and CodeRabbit's plan both proposed *removing* the term outright, on the reasoning that `BUGBOT_FAILED`/`BUGBOT_GENUINE`/`BUGBOT_TRIGGER_PRESENT` already answer the per-SHA question. That is not quite true: a `Cursor Bugbot` run that exists on HEAD but has **not finished** leaves both content-aware flags false (`BUGBOT_FAILED` needs a definitive failure, `BUGBOT_GENUINE` needs `status: completed`). A bare deletion therefore emits `switch_bugbot` and re-invites a BugBot that is already running on that very commit — and contradicts the branch's own comment, which states its precondition as "no `Cursor Bugbot` check-run ever appears". Swapping in the live term keeps that precondition true.

**The swap has no collateral behaviour change.** The two terms can only disagree when the cache reads `true` while this commit has no footprint — exactly the reported bug. In every other state they agree, because a cache miss derives `BUGBOT_INSTALLED` from `BUGBOT_CHECK_PRESENT` in the first place, and a cached `false` is never read back at all (the script reads it as `bugbot_installed // ""`, and jq's `//` treats `false` like `null`).

## Verification — three script variants, one fixture set

| Script under test | n6 | n7 | n8 | Result |
|---|---|---|---|---|
| **Pre-fix** (`HEAD:` before-image) | **FAIL** — `trigger_greptile` | ok | ok | 66 passed, 1 failed |
| **Bare deletion** of the term (the plan as literally written) | ok | **FAIL** — `switch_bugbot` | **FAIL** — `switch_bugbot` | 65 passed, 2 failed |
| **This PR** | ok | ok | ok | **67 passed, 0 failed** |

The pre-fix column reproduces the reported symptom exactly; the deletion column proves n7/n8 are real guards rather than dead weight. Each new scenario also asserts that its cache seed actually landed — without that, a silently-failed seed would leave n6 identical to n1, which expects the same verdict, and n6 would keep passing while testing nothing.

## Local review coverage

**Local review coverage:** none — both CLIs unavailable, self-review only. CodeRabbit CLI returned `rate_limit: Rate limit exceeded` on both attempts (`failure_mode: error_record`); CodeAnt CLI returned `403 Access denied` on both attempts (`failure_mode: stderr_error`) — the persistent account-wide entitlement failure of issue #643, so no re-auth was attempted. Neither produced findings before failing, so nothing is being waived. The self-review is what surfaced the vacuous-seed hole fixed above. This does not satisfy the GitHub merge gate.

## Adjacent defect found, deliberately not fixed here

`escalate-review.sh` reads the cache as `bugbot_installed // ""`. jq's `//` treats `false` exactly like `null`, so **a cached `false` never round-trips** — it falls through to the derivation on every cycle. That silently defeats the documented "repositories without BugBot skip the grace wait on later cycles" optimisation (`phase-b-reviewer.md` line 132) for the not-installed case. It is harmless today and out of scope for this ticket: fixing it would change grace-window behaviour for every not-installed PR, a far wider blast radius than this one-term swap. Worth a follow-up. Scenario n8 is written to stay correct either way.

Now tracked as issue #955.

## Review finding declined here, tracked as issue #956

CodeAnt (Major, `escalate-review.sh` line 526) flagged that `BUGBOT_CHECK_PRESENT` matches the `Cursor Bugbot` check-run by **name only** — `pr-state.sh` projects `check_runs.all` as `{id, name, status, conclusion, title}` and drops the publishing app's identity — so a same-name check from another GitHub App could read as a BugBot footprint. The premise is correct and was verified against the code.

It is declined **on this PR** as pre-existing, not introduced or widened here. `BUGBOT_CHECK_PRESENT` (line 407) is untouched, landed in PR #945, and already seeded `BUGBOT_INSTALLED` at line 457 — so before this change the same collision shut the same branch through the same path. Replaying `main`'s copy of the script against this branch's over one byte-identical live payload confirms it: on a collision fixture both variants return `trigger_greptile` in all three cache states (unset / true / false). The only divergence anywhere in that matrix is the ticket scenario this PR exists to fix, where `main` returns `trigger_greptile` (paid) and this branch returns `switch_bugbot` (free `@cursor review`) — the change moves away from paid escalation, never toward it.

Fixing it properly means changing the shared bundle shape every routing script reads, then updating three consumers across two files including `merge-gate.sh`'s BugBot silent-pass path (issue #844), where a false positive is gate-satisfying and needs a deliberate fail-closed decision. Issue #956 carries the analysis and acceptance criteria.

## Test plan

- [x] A PR with `bugbot_installed=true` cached from an earlier SHA, no BugBot footprint on the current HEAD, and no `@cursor review` postdating the HEAD commit, past the grace window, resolves to `switch_bugbot` rather than silently escalating to Greptile — scenario **n6**; reproduced as a failure against the pre-fix script (`trigger_greptile`) and passing after.
- [x] A regression fixture pins that scenario alongside the existing `(n1)`–`(n5)` cases in `.claude/scripts/tests/escalate-review.test.sh` — **n6**, plus **n7**/**n8** as the negative controls that keep the term from being deleted instead of swapped.
- [x] No change in behaviour for the `(n1)`–`(n5)` scenarios or the pre-existing assertions. *(The issue text says "48 pre-existing assertions"; the actual count on `main` at branch point is **58** — the suite grew after the issue was filed. All 58 pass unchanged; the suite is 67 with the 9 new assertions.)*
- [x] The `bugbot_installed` cache read/write block and the BugBot grace-window `polling_cr` branch are unchanged — the whole-file diff against the merge base is a single hunk at line 509, so the cache's role in the grace window is byte-identical to before. *(Clause corrected at merge time: the cache's documented "skip the grace wait" optimisation is defeated for the not-installed case by the pre-existing `// ""` read — issue #955 — which this PR neither introduces nor changes.)*
- [x] `shellcheck` reports zero findings on both changed shell files (identical to the before-image: zero before, zero after).
- [x] The full auto-discovered CI bash suite passes locally — `{"ok":true,"total":68,"failed":0}`.
- [x] `rule-lint.sh` passes; no `CLAUDE.md` or `.claude/rules/*` file is touched, so the word budget is unaffected.
- [x] `.claude/agents/phase-b-reviewer.md` describes the new per-SHA behaviour, and its existing line 132 description of the cache's grace-window purpose is left untouched and no less accurate than before this PR. *(Clause corrected at merge time: line 132 carries two pre-existing inaccuracies this PR neither introduces nor widens — the window is 600 s in code, not the "5-minute" it names, and its "repositories without BugBot skip the grace wait" optimisation is defeated by the `// ""` read tracked as issue #955.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Decide whether to invite BugBot using the current commit instead of stale PR history

### What Changed
- A later push with no BugBot activity on the current commit now triggers the free `@cursor review` flow instead of paid Greptile escalation.
- An in-progress BugBot run on the current commit still prevents duplicate invitations and continues through the existing escalation path.
- Added coverage for stale cache, active run, and no-cache scenarios.

### Impact
`✅ Fewer unnecessary paid Greptile reviews`
`✅ BugBot invitations reflect the current commit`
`✅ No duplicate invitations for active BugBot runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


