### PR TITLE
fix(#950): give reference-catalog-lint a CI caller and a test suite

### DIFF
--- a/.claude/scripts/tests/reference-catalog-lint.test.sh
+++ b/.claude/scripts/tests/reference-catalog-lint.test.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Unit tests for .claude/scripts/reference-catalog-lint.sh (issue #950)
+#
+# This lint shipped (PR #909) with no CI caller and no test, so it had never
+# been observed either passing or failing under anything but a hand-typed
+# invocation. The suite therefore does two jobs:
+#
+#   1. Prove the lint FAILS on every drift class it claims to catch — the
+#      deliberate drift named in the issue (a .claude/reference/*.md file with
+#      no ## Contents row) plus the phantom-entry and duplicate-row classes.
+#      A guard asserted only on well-formed input would pass without proving
+#      it catches anything.
+#   2. Prove the lint is WIRED into the required rule-lint job, and that a lint
+#      which cannot run reads as a failure rather than a silent green. Both
+#      wiring assertions carry a negative control, because a wiring check that
+#      quietly matches nothing would itself be a guard that passes by not
+#      running.
+#
+# The lint resolves repo-root-relative paths, so each drift case builds a
+# throwaway repo-shaped fixture and runs the script with that tree as cwd.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LINT="${REPO_ROOT}/.claude/scripts/reference-catalog-lint.sh"
+WORKFLOW="${REPO_ROOT}/.github/workflows/rule-lint.yml"
+# The exact command the workflow step must run. CI invokes the script via
+# `bash`, so the executable bit is deliberately not part of the contract.
+WIRED_COMMAND="bash .claude/scripts/reference-catalog-lint.sh"
+
+TMP_ROOT=$(mktemp -d -t reference-catalog-lint.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+case_num=0
+
+pass() { echo "ok   — $1"; }
+fail() { echo "FAIL — $1"; failures=$((failures + 1)); }
+
+# Well-formed fixture: 2 indexed files, 2 matching rows, plus a nested
+# diagrams/ file the lint is documented to ignore (maxdepth 1).
+make_fixture() {
+  local dir="$1"
+  mkdir -p "$dir/.claude/reference/diagrams"
+  echo "alpha" > "$dir/.claude/reference/alpha.md"
+  echo "{}"    > "$dir/.claude/reference/beta.json"
+  echo "nested" > "$dir/.claude/reference/diagrams/nested.md"
+  cat > "$dir/.claude/reference/README.md" <<'EOF'
+# Fixture reference catalog
+
+Prose above the index. A bullet up here is not a registration.
+
+## Contents
+
+- `alpha.md` — first fixture doc
+- `beta.json` — second fixture doc
+EOF
+}
+
+# expect <name> <expected-exit> <expected-output-regex> <mutator...>
+# Builds a fresh fixture, applies one mutator, then asserts BOTH the exit
+# status and that the output matches the regex. Asserting the message too is
+# what stops a case from passing on an unrelated error — a typo or a syntax
+# break also exits non-zero, and would otherwise look like a caught drift.
+expect() {
+  local name="$1" want="$2" want_re="$3"; shift 3
+  case_num=$((case_num + 1))
+  local dir="${TMP_ROOT}/case${case_num}"
+  make_fixture "$dir"
+
+  if ! ( cd "$dir" && "$@" ); then
+    fail "${name}: fixture mutator failed, case never ran"
+    return
+  fi
+
+  local out got
+  out=$(cd "$dir" && bash "$LINT" 2>&1) && got=0 || got=$?
+
+  if (( got != want )); then
+    fail "${name}: expected exit ${want}, got ${got}"
+    echo "$out" | sed 's/^/       /'
+    return
+  fi
+
+  if ! grep -qE "$want_re" <<< "$out"; then
+    fail "${name}: exit ${got} as expected, but output did not match /${want_re}/"
+    echo "$out" | sed 's/^/       /'
+    return
+  fi
+
+  pass "$name"
+}
+
+noop() { :; }
+
+# Puts a catalog-shaped bullet ABOVE the '## Contents' header, simulating a
+# filename mentioned in the README preamble. Counting it would make the run
+# report a phantom entry, so exit 0 is what proves the section scoping works.
+insert_bullet_above_contents() {
+  local tmp
+  tmp=$(mktemp)
+  awk '
+    /^## Contents/ && !seen {
+      print "- `decoy-above.md` — mentioned before the index"
+      print ""
+      seen = 1
+    }
+    { print }
+  ' .claude/reference/README.md > "$tmp"
+  mv "$tmp" .claude/reference/README.md
+}
+
+# Same idea below the index: the awk in the lint stops at the next '## '.
+append_section_below_contents() {
+  {
+    printf '\n%s\n\n' "## Appendix"
+    printf '%s\n' "- \`decoy-below.md\` — listed outside the index"
+  } >> .claude/reference/README.md
+}
+
+# --- passing case ---------------------------------------------------------
+# The file count in the marker is load-bearing: it proves the run actually
+# scanned the fixture rather than passing vacuously over an empty set.
+expect "well-formed catalog passes" 0 \
+  'reference-catalog-lint: OK \(2 files indexed\)' \
+  noop
+
+# --- drift failures -------------------------------------------------------
+# This is the acceptance criterion: a deliberately-introduced catalog drift
+# (a .claude/reference/*.md file with no README row) must fail the check.
+expect "undocumented reference file fails" 1 \
+  "File 'gamma.md' exists in .* but has no entry in the ## Contents index" \
+  bash -c 'echo gamma > .claude/reference/gamma.md'
+
+expect "undocumented .json file fails" 1 \
+  "File 'gamma.json' exists in .* but has no entry in the ## Contents index" \
+  bash -c 'echo "{}" > .claude/reference/gamma.json'
+
+expect "Contents row with no file on disk fails" 1 \
+  "README indexes 'delta.md' but no such file exists" \
+  bash -c 'printf "%s\n" "- \`delta.md\` — phantom entry" >> .claude/reference/README.md'
+
+expect "duplicate Contents row fails" 1 \
+  "'alpha.md' appears more than once in the ## Contents index" \
+  bash -c 'printf "%s\n" "- \`alpha.md\` — duplicate row" >> .claude/reference/README.md'
+
+# --- fast-path failure ----------------------------------------------------
+# Missing README is the reachable half of the two fast-path guards: the
+# REFERENCE_DIR check below it cannot fire on its own, since the README can
+# only exist when the directory does.
+expect "missing README fails" 1 \
+  'README\.md not found' \
+  rm .claude/reference/README.md
+
+# --- scoping / false-positive guards --------------------------------------
+expect "bullet above the Contents section is ignored" 0 \
+  'reference-catalog-lint: OK \(2 files indexed\)' \
+  insert_bullet_above_contents
+
+expect "bullet in a later section is ignored" 0 \
+  'reference-catalog-lint: OK \(2 files indexed\)' \
+  append_section_below_contents
+
+expect "path-qualified cross-reference is not a registration" 0 \
+  'reference-catalog-lint: OK \(2 files indexed\)' \
+  bash -c 'printf "%s\n" "- \`.claude/rules/safety.md\` — cross reference" >> .claude/reference/README.md'
+
+expect "nested diagrams/ file needs no index row" 0 \
+  'reference-catalog-lint: OK \(2 files indexed\)' \
+  bash -c 'echo more > .claude/reference/diagrams/extra.md'
+
+# --- CLI contract ---------------------------------------------------------
+case_num=$((case_num + 1))
+cli_dir="${TMP_ROOT}/case${case_num}"
+make_fixture "$cli_dir"
+
+if (cd "$cli_dir" && bash "$LINT" --help >/dev/null 2>&1); then
+  pass "--help exits 0"
+else
+  fail "--help should exit 0"
+fi
+
+got=0
+(cd "$cli_dir" && bash "$LINT" --bogus >/dev/null 2>&1) || got=$?
+if (( got == 2 )); then
+  pass "unknown arg exits 2"
+else
+  fail "unknown arg: expected exit 2, got ${got}"
+fi
+
+# --- CI wiring (issue #950) -----------------------------------------------
+# Prints the run command of the step named 'Run reference-catalog-lint' inside
+# the rule-lint job — the job id that is the required status check on main.
+# Prints nothing when the step is absent, sits in another job, or carries no
+# run command; each of those is exercised as a negative control below.
+wired_step_command() {
+  awk '
+    /^  [A-Za-z0-9_-]+:/ { in_job = ($0 ~ /^  rule-lint:/) }
+    !in_job { next }
+    /^[[:space:]]*- name:[[:space:]]*Run reference-catalog-lint[[:space:]]*$/ { want = 1; next }
+    want && /^[[:space:]]*- / { want = 0; next }
+    want && /^[[:space:]]*run:[[:space:]]*/ {
+      sub(/^[[:space:]]*run:[[:space:]]*/, "")
+      print
+      exit
+    }
+  ' "$1"
+}
+
+wired="$(wired_step_command "$WORKFLOW")"
+if [[ "$wired" == "$WIRED_COMMAND" ]]; then
+  pass "rule-lint job runs the lint as a named step"
+else
+  fail "rule-lint job does not run '${WIRED_COMMAND}' under a 'Run reference-catalog-lint' step (found: '${wired}')"
+fi
+
+# Negative controls for the wiring check itself.
+neg_dir="${TMP_ROOT}/wiring"
+mkdir -p "$neg_dir"
+
+cat > "${neg_dir}/absent.yml" <<'EOF'
+jobs:
+  rule-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run rule-lint
+        run: bash .github/scripts/rule-lint.sh
+EOF
+
+cat > "${neg_dir}/other-job.yml" <<'EOF'
+jobs:
+  rule-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run rule-lint
+        run: bash .github/scripts/rule-lint.sh
+
+  unrelated-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run reference-catalog-lint
+        run: bash .claude/scripts/reference-catalog-lint.sh
+EOF
+
+cat > "${neg_dir}/no-run.yml" <<'EOF'
+jobs:
+  rule-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run reference-catalog-lint
+        uses: actions/checkout@v5
+EOF
+
+for control in absent other-job no-run; do
+  if [[ -z "$(wired_step_command "${neg_dir}/${control}.yml")" ]]; then
+    pass "wiring check reports not-wired for the ${control} control"
+  else
+    fail "wiring check matched the ${control} control — it would pass on an unwired repo"
+  fi
+done
+
+# The step names the script by path, so the two must not drift apart.
+target="${WIRED_COMMAND#bash }"
+if [[ -f "${REPO_ROOT}/${target}" ]]; then
+  pass "wired path ${target} exists"
+else
+  fail "wired path ${target} does not exist — the CI step would exit non-zero"
+fi
+
+# A lint that cannot run must read as failure, never as a silent pass.
+got=0
+(cd "$REPO_ROOT" && bash .claude/scripts/reference-catalog-lint-does-not-exist.sh) >/dev/null 2>&1 || got=$?
+if (( got != 0 )); then
+  pass "a missing lint script exits non-zero (CI step fails, not skips)"
+else
+  fail "a missing lint script exited 0 — a deleted lint would pass CI green"
+fi
+
+# --- real repo ------------------------------------------------------------
+if (cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1); then
+  pass "real repo catalog is in sync"
+else
+  fail "lint does not pass against the real repo"
+  (cd "$REPO_ROOT" && bash "$LINT" 2>&1 | sed 's/^/       /') || true
+fi
+
+if (( failures > 0 )); then
+  echo "reference-catalog-lint.test: ${failures} failure(s)"
+  exit 1
+fi
+
+echo "OK: reference-catalog-lint tests passed (${case_num} fixtures)"

--- a/.github/workflows/rule-lint.yml
+++ b/.github/workflows/rule-lint.yml
@@ -27,3 +27,7 @@ jobs:
 
       - name: Run verbatim-block-lint
         run: bash .github/scripts/verbatim-block-lint.sh
+
+      # Unlike its siblings above, this lint lives under .claude/scripts/.
+      - name: Run reference-catalog-lint
+        run: bash .claude/scripts/reference-catalog-lint.sh


### PR DESCRIPTION
## **User description**
Closes #950

`.claude/scripts/reference-catalog-lint.sh` shipped in PR #909 wired to nothing — no workflow invoked it and no test exercised it, so it only ran when a human or agent remembered to type it. Its two siblings (`skill-catalog-lint.sh`, `verbatim-block-lint.sh`) are named steps in the required `rule-lint` job; this one was not. PR #946's Test Plan asserted it green, which is what surfaced the gap.

## What changed

**Wiring — `.github/workflows/rule-lint.yml`.** One step, `Run reference-catalog-lint`, appended after `Run verbatim-block-lint` inside the existing `rule-lint` job. The job id is the required status check on `main`, so the lint joins that gate with no branch-protection change and no new check name. Path is `.claude/scripts/`, not `.github/scripts/` — this script lives in a different tree from its siblings. No existing step, the job id, the checkout, or the workflow name is touched.

**Test suite — `.claude/scripts/tests/reference-catalog-lint.test.sh`.** Lands in one of `run-hook-tests.sh`'s three auto-discovered directories (issue #681), so it needs no `hook-scripts.yml` edit. 19 assertions over 11 throwaway repo-shaped fixtures:

- Each drift class asserts **both** the exit code and the specific message — undocumented `.md`, undocumented `.json`, phantom row, duplicate row, missing README fast path. A lint that exits non-zero for an unrelated reason (typo, syntax break) cannot read as a caught drift.
- The happy path asserts `OK (2 files indexed)`, not just exit 0, so a run over an empty set cannot pass vacuously.
- False-positive guards: bullet above the `## Contents` header, bullet in a later section, path-qualified cross-reference, nested `diagrams/` file.
- CLI contract: `--help` exits 0, unknown flag exits 2.
- **Wiring assertions**, since the whole failure being fixed is a guard nobody calls: the `rule-lint` job must run exactly `bash .claude/scripts/reference-catalog-lint.sh` under a step of that name; the path it names must exist; and a missing lint script must exit non-zero (a deleted lint fails CI red, it does not skip green).
- **Three negative controls for the wiring check itself** — step absent, step present in a different job, step named but carrying no `run` — so the wiring assertion cannot become a second guard that passes by not running.

## Verification performed

- New suite: 19/19 pass, exit 0.
- **Non-vacuity controls.** Re-ran the suite against two stub lints. Against an always-exit-0 stub, 6 assertions fail (all five drift cases plus the unknown-flag case). Against an always-exit-1 stub with an unrelated message, 13 fail — including all five drift cases failing on the *message* regex despite the exit code matching. The assertions are real, not decorative.
- **Real-repo drift probe.** Added an unindexed `.claude/reference/*.md` file: lint exited 1 with `File '…' exists in .claude/reference/ but has no entry in the ## Contents index`. Removed it: back to `OK (71 files indexed)`.
- Full auto-discovered bash run: `run-hook-tests.sh --json` → `{"ok":true,…,"total":69,"failed":0}` (68 before this PR).
- All four `rule-lint` job steps run green locally: `rule-lint.sh`, `skill-catalog-lint.sh`, `verbatim-block-lint.sh`, `reference-catalog-lint.sh`.
- `rule-lint.yml` parses; `yaml.safe_load` reports one job (`rule-lint`) and steps `Checkout, Run rule-lint, Run skill-catalog-lint, Run verbatim-block-lint, Run reference-catalog-lint` — the first four byte-identical to `main`.

**Local review coverage:** cr-only — CodeRabbit CLI returned a verified-successful clean run (0 findings, `verified_run: true`). CodeAnt returned `403 Access denied` on the initial run and on its one allowed retry (the persistent account-level entitlement pattern, Issue #643 — no `codeant logout`/`login` attempted per `cr-local-review.md`), so it is dropped for this session. It emitted no findings before failing, so nothing is being waived. The CodeAnt GitHub App is unaffected and still gates the merge.

## Note on acceptance criterion 3

"The step name is stable so it can be added to branch protection's required checks" — branch protection keys on the **job** name, not the step name. Putting the step inside the existing `rule-lint` job is what satisfies the intent: the lint is covered by the required check that already exists, so no protection edit is needed. The step name `Run reference-catalog-lint` is stable and matches the sibling naming convention, and the test suite asserts it verbatim.

## Test plan

- [x] `reference-catalog-lint.sh` runs as a named step in CI on every PR — `Run reference-catalog-lint` in the `rule-lint` job of `.github/workflows/rule-lint.yml`, which triggers on `pull_request`
- [x] A deliberately-introduced catalog drift (a `.claude/reference/*.md` file with no README row) fails that check — covered by the `undocumented reference file fails` case and confirmed by the real-repo probe above
- [x] The step is covered by a stable required check — it sits in the `rule-lint` job, the existing required status check; the job id, `name:`-less job block, and workflow trigger are unchanged
- [x] Existing `rule-lint.yml` steps are unchanged — `git diff` on the file is +4 lines (one comment, one step), no deletions or edits to prior steps
- [x] The lint now has a test suite that runs in CI without a workflow edit — `.claude/scripts/tests/reference-catalog-lint.test.sh` is auto-discovered by `run-hook-tests.sh`
- [x] The test suite is non-vacuous — every drift case asserts the specific error message, and both stub controls above prove the assertions fail when the lint stops working
- [x] A lint that cannot run reads as failure, not as a pass — asserted directly, plus three negative controls proving the wiring check itself can fail
- [x] The full auto-discovered bash suite stays green — 69/69


___

## **CodeAnt-AI Description**
Run reference catalog checks in CI and verify catalog drift detection

### What Changed
- CI now runs the reference catalog lint as part of the required rule-lint check
- Added tests covering undocumented files, missing files, duplicate entries, missing README files, invalid CLI options, and catalog parsing edge cases
- Added checks confirming the CI step is present in the correct job and fails when the lint cannot run

### Impact
`✅ Reference catalog drift is blocked in CI`
`✅ Clear failures for missing or duplicate catalog entries`
`✅ Fewer false positives from unrelated README content`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
