### PR TITLE
fix(#956): a check NAME is not a publisher — scope the Cursor Bugbot match to the Cursor app

### DIFF
--- a/.claude/scripts/escalate-review.sh
+++ b/.claude/scripts/escalate-review.sh
@@ -377,7 +377,28 @@ fi
 # conclusion is ambiguous (completed/neutral, non-blocking, non-failure title)
 # the LATEST cursor[bot] comment (by timestamp, not "any historical match")
 # disambiguates a usage-limit failure from a genuine clean pass/findings.
+#
+# Both check-run selectors in this file — the $run classifier below and
+# BUGBOT_CHECK_PRESENT after it — match the PUBLISHING APP as well as the name
+# (issue #956). GitHub lets any app publish a check-run under any name, so a
+# name-only match let a foreign app's `Cursor Bugbot` run stand in for BugBot's
+# footprint on this commit. That is not a harmless misread: it shuts the
+# never-invited branch below, suppressing the FREE `@cursor review` this script
+# would otherwise route to, and spends a PAID Greptile review instead. The
+# identity comes from pr-state.sh's bundle, which carries `app: {slug, id}` on
+# every check-run entry; check-runs-dedup.sh one step earlier has grouped by
+# [.app.slug, .app.id, .name] since issue #675 for the same reason.
+#
+# Slug `cursor` is the publisher confirmed live on this repo (app id 1210556, app
+# name "Cursor"). pr-preflight.sh keeps a wider defensive slug set per reviewer;
+# that is deliberately NOT mirrored here because the cost asymmetry runs the
+# other way. There an unmatched slug costs one extra trigger; here an over-broad
+# match costs paid budget. A missing or foreign slug therefore fails toward "not
+# a BugBot footprint": classification falls back to cursor[bot]'s own comments,
+# and the worst case is one duplicate `@cursor review`, which bugbot.md calls
+# harmless.
 read -r BUGBOT_FAILED BUGBOT_GENUINE < <(jq -r '
+  def is_cursor_bugbot_check: (.name // "") == "Cursor Bugbot" and (.app.slug // "") == "cursor";
   def is_failure_text: test("couldn.t run|could not run|usage limit|usage or spend limit"; "i");
   def is_blocking_conclusion: . == "failure" or . == "timed_out" or . == "action_required" or . == "startup_failure" or . == "stale";
   def cursor_comments: [.comments.reviews[], .comments.inline[], .comments.conversation[]
@@ -385,7 +406,7 @@ read -r BUGBOT_FAILED BUGBOT_GENUINE < <(jq -r '
   def comment_ts: (.submitted_at // .created_at // "");
 
   (cursor_comments | sort_by(comment_ts) | last) as $latest_comment
-  | ([.check_runs.all[] | select((.name // "") == "Cursor Bugbot")] | last) as $run
+  | ([.check_runs.all[] | select(is_cursor_bugbot_check)] | last) as $run
   | ($latest_comment != null and (($latest_comment.body // "") | is_failure_text)) as $latest_comment_failed
   | ($run != null and ((($run.conclusion // "") | is_blocking_conclusion) or (($run.title // "") | is_failure_text))) as $run_definitive_failure
   | ($run != null and ($run.status // "") == "completed" and ($run_definitive_failure | not)) as $run_completed_ambiguous
@@ -404,8 +425,11 @@ read -r BUGBOT_FAILED BUGBOT_GENUINE < <(jq -r '
   exit 4
 }
 
+# Same app-scoped predicate as the classifier above (issue #956) — a same-named
+# check-run from any other app is not a BugBot footprint on this commit.
 BUGBOT_CHECK_PRESENT="$(jq -r '
-  [.check_runs.all[] | select((.name // "") == "Cursor Bugbot")] | length > 0
+  def is_cursor_bugbot_check: (.name // "") == "Cursor Bugbot" and (.app.slug // "") == "cursor";
+  [.check_runs.all[] | select(is_cursor_bugbot_check)] | length > 0
 ' "$STATE_PATH")"
 
 # Was BugBot ever INVITED on this HEAD? (issue #935.) BugBot does not auto-review
@@ -521,7 +545,9 @@ fi
 # carries the availability signal for the grace window above; it just no longer
 # answers a per-SHA question. Swapping in the live term rather than dropping one
 # also keeps the branch faithful to the first paragraph: an in-flight
-# `Cursor Bugbot` run on this commit is a footprint, so it still falls through.
+# `Cursor Bugbot` run on this commit is a footprint, so it still falls through —
+# provided Cursor published it (issue #956); a same-named run from another app
+# leaves this branch open and routes to the free `@cursor review` instead.
 if [[ "$BUGBOT_FAILED" != "true" && "$BUGBOT_GENUINE" != "true" \
       && "$BUGBOT_CHECK_PRESENT" != "true" && "$BUGBOT_TRIGGER_PRESENT" != "true" ]]; then
   emit "switch_bugbot"

--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -31,6 +31,13 @@
 #   unchanged: still "write the bundle to a tempfile, print only the path".
 #   Rationale and the full measurement: .claude/reference/compact-result-contract.md
 #
+# Check-run projection (issue #956): entries in check_runs.all, .failing_runs and
+#   .in_progress_runs each carry `app: {slug, id}` — the GitHub App that published
+#   the run. A check NAME identifies nothing on its own (any app may publish a
+#   check-run under any name), so a consumer asking "did THIS reviewer run here?"
+#   has to match the publisher too. Additive: every field these three arrays
+#   already carried is unchanged. Absent app data projects as {slug: null, id: null}.
+#
 # --infer-candidates (shared by /fixpr issue #447 and /wrap issue #448):
 #   Reads ~/.claude/session-state.json and prints a JSON array of the PRs this
 #   session is actively tracking (those with a non-null .phase), newest activity
@@ -465,14 +472,23 @@ CHECK_RUNS=$(run_gh api --paginate "repos/$OWNER/$REPO/commits/$HEAD_SHA/check-r
 CR_SPLIT=$(echo "$CHECK_RUNS" | jq '
   def is_blocking: . == "failure" or . == "timed_out" or . == "action_required" or . == "startup_failure" or . == "stale";
   def is_passing: . == "success" or . == "neutral" or . == "skipped" or . == "cancelled";
+  # Publishing GitHub App, retained on every projected entry (issue #956). The
+  # dedup step above already groups by [.app.slug, .app.id, .name] precisely
+  # because a name is not a publisher — any app may publish a check-run under any
+  # name — and the projection used to drop that identity one line later, leaving
+  # downstream reviewer routing to match `Cursor Bugbot` on the name alone.
+  # Carried on all three arrays so an entry has the same shape whichever view a
+  # consumer reads it from; absent app data projects as {slug: null, id: null}
+  # and the consumer decides whether that fails open or closed.
+  def app_identity: {slug: (.app.slug // null), id: (.app.id // null)};
   {
     total: length,
     passing: ([.[] | select(.conclusion | is_passing)] | length),
     failing: ([.[] | select(.conclusion | is_blocking)] | length),
     in_progress: ([.[] | select(.status != "completed")] | length),
-    failing_runs: [.[] | select(.conclusion | is_blocking) | {id, name, conclusion, title: .output.title, details_url, html_url}],
-    in_progress_runs: [.[] | select(.status != "completed") | {id, name, status}],
-    all: [.[] | {id, name, status, conclusion, title: .output.title}]
+    failing_runs: [.[] | select(.conclusion | is_blocking) | {id, name, conclusion, title: .output.title, details_url, html_url, app: app_identity}],
+    in_progress_runs: [.[] | select(.status != "completed") | {id, name, status, app: app_identity}],
+    all: [.[] | {id, name, status, conclusion, title: .output.title, app: app_identity}]
   }
 ')
 

--- a/.claude/scripts/tests/escalate-review.test.sh
+++ b/.claude/scripts/tests/escalate-review.test.sh
@@ -174,18 +174,44 @@ run_script() {
   ( cd "$REPO_ROOT" && bash "$STUB_DIR/escalate-review.sh" "$PR_NUM" )
 }
 
-BUGBOT_CHECK_RUN_OK='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "neutral", "title": ""}'
-BUGBOT_CHECK_RUN_FAILED_TITLE='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "neutral", "title": "Bugbot couldn'"'"'t run - usage limit reached"}'
-BUGBOT_CHECK_RUN_TIMED_OUT='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "timed_out", "title": ""}'
+# Every canonical BugBot check-run below carries the PUBLISHING APP the real one
+# does (issue #956) — pr-state.sh projects `app: {slug, id}` onto each check-run
+# entry, and escalate-review.sh now requires slug `cursor` alongside the name.
+# Values confirmed against live data on this repo (app slug `cursor`, app id
+# 1210556, app name "Cursor"), reproducible with:
+#   gh api repos/auerbachb/claude-code-config/commits/<sha>/check-runs?per_page=100 \
+#     --jq '.check_runs[] | select(.name=="Cursor Bugbot") | {slug: .app.slug, id: .app.id}'
+CURSOR_APP='"app": {"slug": "cursor", "id": 1210556}'
+# A DIFFERENT app publishing a check-run under the very same name — the spoof
+# shape the app scope exists to reject. github-actions is the other publisher
+# actually seen on this repo's commits, so this is a realistic collision rather
+# than an invented slug.
+FOREIGN_APP='"app": {"slug": "github-actions", "id": 15368}'
+
+BUGBOT_CHECK_RUN_OK='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "neutral", "title": "", '"$CURSOR_APP"'}'
+BUGBOT_CHECK_RUN_FAILED_TITLE='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "neutral", "title": "Bugbot couldn'"'"'t run - usage limit reached", '"$CURSOR_APP"'}'
+BUGBOT_CHECK_RUN_TIMED_OUT='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "timed_out", "title": "", '"$CURSOR_APP"'}'
 # Silent-pass shape (issue #844): conclusion:success — BugBot found no issues.
 # merge-gate.sh now accepts this as a clean BugBot pass, but escalate-review.sh
 # still emits switch_bugbot so the caller persists sticky ownership before polling.
-BUGBOT_CHECK_RUN_SUCCESS='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "success", "title": ""}'
+BUGBOT_CHECK_RUN_SUCCESS='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "success", "title": "", '"$CURSOR_APP"'}'
 # A run that exists on this HEAD but has NOT finished (issue #948). Both
 # content-aware flags are false for it — BUGBOT_FAILED needs a definitive
 # failure, BUGBOT_GENUINE needs status=completed — so it is the one shape where
 # the never-invited branch's footprint term is the only thing that sees it.
-BUGBOT_CHECK_RUN_IN_PROGRESS='{"id": 2, "name": "Cursor Bugbot", "status": "in_progress", "conclusion": null, "title": ""}'
+BUGBOT_CHECK_RUN_IN_PROGRESS='{"id": 2, "name": "Cursor Bugbot", "status": "in_progress", "conclusion": null, "title": "", '"$CURSOR_APP"'}'
+
+# --- issue #956 fixtures: same check NAME, wrong or absent publisher ----------
+# Each is a byte-for-byte twin of a canonical fixture above with only the `app`
+# object changed, so any verdict difference is attributable to the app scope and
+# nothing else. The NO_APP pair is a bundle written before pr-state.sh carried
+# app identity — the missing-slug fallback, which must land on the cheap error
+# (a duplicate `@cursor review`) rather than on paid Greptile budget.
+BUGBOT_RUN_FOREIGN_IN_PROGRESS='{"id": 2, "name": "Cursor Bugbot", "status": "in_progress", "conclusion": null, "title": "", '"$FOREIGN_APP"'}'
+BUGBOT_RUN_NO_APP_IN_PROGRESS='{"id": 2, "name": "Cursor Bugbot", "status": "in_progress", "conclusion": null, "title": ""}'
+BUGBOT_RUN_FOREIGN_OK='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "neutral", "title": "", '"$FOREIGN_APP"'}'
+BUGBOT_RUN_NO_APP_OK='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "neutral", "title": ""}'
+BUGBOT_RUN_FOREIGN_FAILED_TITLE='{"id": 2, "name": "Cursor Bugbot", "status": "completed", "conclusion": "neutral", "title": "Bugbot couldn'"'"'t run - usage limit reached", '"$FOREIGN_APP"'}'
 
 # Comments carry explicit created_at timestamps so "latest event wins" ordering
 # (issue #552 CodeRabbit finding) is genuinely exercised, not an accident of
@@ -700,6 +726,127 @@ write_state "[$BUGBOT_CHECK_RUN_IN_PROGRESS]" "[]" "[]" "[]"
 OUT=$(run_script); RC=$?
 check_eq "exit 0" 0 "$RC"
 check_eq "STATUS=trigger_greptile" "STATUS=trigger_greptile" "$OUT"
+
+############################################################################
+# Same check NAME, different publishing app (issue #956)
+#
+# `Cursor Bugbot` used to be matched on the name alone, in both places this
+# script reads check-runs: the $run content classifier and BUGBOT_CHECK_PRESENT.
+# Any GitHub App may publish a check-run under any name, so a same-named run from
+# a foreign app read as BugBot's footprint on this commit — which shuts the
+# never-invited branch and spends a PAID Greptile review instead of the FREE
+# `@cursor review` that arm posts.
+#
+# o1/o4/o7 are the three behavioural deltas, one per term the old name-only match
+# fed (footprint / genuine / failed). Against the pre-fix script all three return
+# the opposite verdict. o2/o5 are the parity controls: the SAME fixtures
+# published by the real Cursor app must keep their pre-fix verdicts, so the scope
+# cannot be satisfied by refusing every check-run. o3/o6 pin the missing-slug
+# fallback on both paths.
+############################################################################
+echo
+echo "== Scenario (o1): foreign app publishes a same-named in-flight run, zero real footprint -> switch_bugbot (issue #956) =="
+# (n1) with a spoofed footprint bolted on. Pre-fix this is trigger_greptile: the
+# foreign run satisfies BUGBOT_CHECK_PRESENT and the never-invited branch shuts.
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+write_state "[$BUGBOT_RUN_FOREIGN_IN_PROGRESS]" "[]" "[]" "[]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=switch_bugbot" "STATUS=switch_bugbot" "$OUT"
+
+############################################################################
+echo "== Scenario (o2): identical fixture published by the REAL Cursor app -> trigger_greptile (parity control for o1) =="
+# Differs from (o1) by the app slug and nothing else. This is (n7) without the
+# cache seed: a live Cursor run on HEAD is a genuine footprint, so the
+# never-invited branch must stay shut and escalation is unchanged from pre-fix.
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+write_state "[$BUGBOT_CHECK_RUN_IN_PROGRESS]" "[]" "[]" "[]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=trigger_greptile" "STATUS=trigger_greptile" "$OUT"
+
+############################################################################
+echo "== Scenario (o3): same-named in-flight run with NO app identity -> switch_bugbot (missing-slug fallback) =="
+# A bundle written before pr-state.sh carried `app`. Unverifiable identity fails
+# toward "not a footprint", so the cost is one duplicate `@cursor review`
+# (harmless per bugbot.md) rather than a paid Greptile review on an unverified run.
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+write_state "[$BUGBOT_RUN_NO_APP_IN_PROGRESS]" "[]" "[]" "[]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=switch_bugbot" "STATUS=switch_bugbot" "$OUT"
+
+############################################################################
+echo "== Scenario (o4): foreign app's completed run must not read as a genuine BugBot pass -> trigger_greptile =="
+# The $run classifier path, isolated from the footprint path by a fresh
+# `@cursor review` invite: BugBot WAS asked on this HEAD and never answered, so
+# the never-invited branch is closed either way and only BUGBOT_GENUINE decides.
+# Pre-fix the foreign completed/neutral run makes BUGBOT_GENUINE true and this
+# returns switch_bugbot — i.e. a foreign app got to certify BugBot as responsive.
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+TRIGGER_COMMENT_O4="$(trigger_comment "$(ts_seconds_ago 3000)")"
+write_state "[$BUGBOT_RUN_FOREIGN_OK]" "[]" "[]" "[$TRIGGER_COMMENT_O4]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=trigger_greptile" "STATUS=trigger_greptile" "$OUT"
+
+############################################################################
+echo "== Scenario (o5): identical fixture published by the REAL Cursor app -> switch_bugbot (parity control for o4) =="
+# Cursor's own completed/neutral run on HEAD is still a genuine response, invite
+# or no invite. Without this control the o4 assertion could be satisfied by the
+# classifier having stopped recognising check-runs at all.
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+TRIGGER_COMMENT_O5="$(trigger_comment "$(ts_seconds_ago 3000)")"
+write_state "[$BUGBOT_CHECK_RUN_OK]" "[]" "[]" "[$TRIGGER_COMMENT_O5]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=switch_bugbot" "STATUS=switch_bugbot" "$OUT"
+
+############################################################################
+echo "== Scenario (o6): completed run with NO app identity, invited on HEAD -> trigger_greptile (missing-slug fallback, classifier path) =="
+# (o4)'s fallback twin. The invite postdates the push and nothing verifiable
+# answered it, which is exactly (n3)'s invited-but-silent state — escalation,
+# not another invite, is the non-looping answer here.
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+TRIGGER_COMMENT_O6="$(trigger_comment "$(ts_seconds_ago 3000)")"
+write_state "[$BUGBOT_RUN_NO_APP_OK]" "[]" "[]" "[$TRIGGER_COMMENT_O6]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=trigger_greptile" "STATUS=trigger_greptile" "$OUT"
+
+############################################################################
+echo "== Scenario (o7): foreign app cannot forge a BugBot FAILURE either -> switch_bugbot =="
+# The third term the name-only match fed. Pre-fix the foreign run's usage-limit
+# title sets BUGBOT_FAILED, which both skips the grace window and shuts the
+# never-invited branch, so a stranger's check title alone sent the PR to paid
+# Greptile. (a2) pins the same title as a real failure when Cursor publishes it.
+reset_state
+write_commits "$(ts_seconds_ago 7200)"
+write_state "[$BUGBOT_RUN_FOREIGN_FAILED_TITLE]" "[]" "[]" "[]"
+OUT=$(run_script); RC=$?
+check_eq "exit 0" 0 "$RC"
+check_eq "STATUS=switch_bugbot" "STATUS=switch_bugbot" "$OUT"
+
+############################################################################
+echo
+echo "== Scenario (o8): the app scope is not removable one selector at a time (issue #956) =="
+# Structural guard. The behavioural scenarios above cover both selectors today,
+# but they check verdicts, not that BOTH matches stayed scoped — a future edit
+# could re-widen one of them in a shape no current fixture distinguishes. The
+# predicate is a single-line jq def in each of the two programs, so every
+# occurrence of the quoted check name must share its line with the app.slug term.
+NAME_LINES="$(grep -c '"Cursor Bugbot"' "$ESCALATE_SRC" || true)"
+SCOPED_LINES="$(grep '"Cursor Bugbot"' "$ESCALATE_SRC" | grep -c 'app\.slug' || true)"
+# Positive control first: without it the equality below passes vacuously if the
+# selectors are deleted outright (0 == 0). Two programs read check-runs, so two.
+check_eq "both Cursor Bugbot selectors present and app-scoped" "2" "$SCOPED_LINES"
+check_eq "no unscoped Cursor Bugbot selector remains" "$NAME_LINES" "$SCOPED_LINES"
 
 echo
 echo "== summary: $PASS passed, $FAIL failed =="

--- a/.claude/scripts/tests/pr-state-check-runs.test.sh
+++ b/.claude/scripts/tests/pr-state-check-runs.test.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Unit test for the `CR_SPLIT` check-run projection inside `pr-state.sh`
+# (issue #956).
+#
+# What it pins:
+#   1. Publishing-app identity survives the projection on ALL THREE arrays
+#      (`check_runs.all`, `.failing_runs`, `.in_progress_runs`). The raw
+#      check-run objects carry `.app.slug`/`.app.id`, and check-runs-dedup.sh one
+#      step earlier already groups by [.app.slug, .app.id, .name] — the identity
+#      was fetched, used, then dropped by this projection, leaving reviewer
+#      routing to match check NAMES that any GitHub App may publish.
+#   2. Two runs sharing a name but published by different apps stay
+#      distinguishable after projection — the motivating case.
+#   3. Absent app data projects as {slug: null, id: null} rather than vanishing,
+#      so a consumer can tell "no identity" from "identity says not me".
+#   4. Backward compatibility: every field the pre-#956 projection emitted is
+#      still emitted, unrenamed and unchanged. Asserted as exact key sets plus
+#      per-field values, so a dropped or renamed field fails here rather than in
+#      a downstream consumer.
+#
+# Strategy (same as pr-state-classify.test.sh): extract the real jq block from
+# pr-state.sh with sed and exercise it in isolation, so the test cannot drift
+# from the production code it claims to cover.
+#
+# Requires: jq, bash 3.2+ (macOS-compatible). Offline: no gh, git, or network.
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$TEST_DIR/../pr-state.sh"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+check_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    PASS=$((PASS + 1)); echo "ok   — $desc"
+  else
+    FAIL=$((FAIL + 1)); echo "FAIL — $desc (expected '$expected', got '$actual')"
+  fi
+}
+
+# ---- extract the production projection ------------------------------------
+# From the `CR_SPLIT=$(echo ... | jq '` opener through the closing `')`, then
+# strip those two wrapper lines to leave the jq program itself.
+CR_SPLIT_JQ="$(sed -n "/^CR_SPLIT=/,/^')\$/p" "$SCRIPT" | sed '1d;$d')"
+
+# Assert the EXTRACTION ran before trusting anything it produced: a sed pattern
+# that silently stops matching (renamed variable, reflowed quoting) would hand
+# every assertion below an empty program, and jq would happily evaluate the bare
+# filter that remains. Check for all three projected arrays by name.
+EXTRACT_OK="yes"
+[[ -n "$CR_SPLIT_JQ" ]] || EXTRACT_OK="empty"
+for needle in 'failing_runs:' 'in_progress_runs:' 'all:'; do
+  case "$CR_SPLIT_JQ" in
+    *"$needle"*) ;;
+    *) EXTRACT_OK="missing $needle" ;;
+  esac
+done
+check_eq "CR_SPLIT projection extracted from pr-state.sh" "yes" "$EXTRACT_OK"
+if [[ "$EXTRACT_OK" != "yes" ]]; then
+  echo "== summary: $PASS passed, $FAIL failed ==" >&2
+  exit 1
+fi
+
+# Run the real projection over a raw check-run array, then apply a filter to the
+# result. The program goes through a file rather than an inline argument so its
+# comments, backticks and quoting reach jq untouched.
+project() {
+  # $1 = raw check-runs JSON array, $2 = jq filter over the projection output
+  local prog="$TMP/prog.jq"
+  {
+    printf '%s\n' "$CR_SPLIT_JQ"
+    printf '| (%s)\n' "$2"
+  } > "$prog"
+  jq -c -f "$prog" <<<"$1"
+}
+
+# ---- fixtures ---------------------------------------------------------------
+# Shaped like real GitHub check-run objects post-dedup. Two entries deliberately
+# share the name "Cursor Bugbot": one from Cursor (app slug `cursor`, app id
+# 1210556 — confirmed live on this repo), one from another app publishing under
+# the identical name. That pair is the whole point of issue #956.
+RUNS='[
+  {"id": 11, "name": "Cursor Bugbot", "status": "completed", "conclusion": "success",
+   "output": {"title": "No issues"}, "details_url": "https://example/1", "html_url": "https://example/h1",
+   "app": {"slug": "cursor", "id": 1210556, "name": "Cursor"}},
+  {"id": 12, "name": "Cursor Bugbot", "status": "completed", "conclusion": "success",
+   "output": {"title": "impostor"}, "details_url": "https://example/2", "html_url": "https://example/h2",
+   "app": {"slug": "github-actions", "id": 15368, "name": "GitHub Actions"}},
+  {"id": 13, "name": "rule-lint", "status": "completed", "conclusion": "failure",
+   "output": {"title": "budget exceeded"}, "details_url": "https://example/3", "html_url": "https://example/h3",
+   "app": {"slug": "github-actions", "id": 15368, "name": "GitHub Actions"}},
+  {"id": 14, "name": "CodeRabbit", "status": "in_progress", "conclusion": null,
+   "output": {"title": null}, "details_url": "https://example/4", "html_url": "https://example/h4",
+   "app": {"slug": "coderabbitai", "id": 173846, "name": "CodeRabbit"}}
+]'
+
+# The same four runs with the app object stripped entirely — a bundle produced
+# before the projection carried identity, or an API response missing it.
+RUNS_NO_APP="$(jq -c 'map(del(.app))' <<<"$RUNS")"
+
+############################################################################
+echo "== app identity survives the projection on all three arrays =="
+check_eq "all[] carry app slugs in input order" \
+  '["cursor","github-actions","github-actions","coderabbitai"]' \
+  "$(project "$RUNS" '[.all[].app.slug]')"
+check_eq "all[] carry numeric app ids" \
+  '[1210556,15368,15368,173846]' \
+  "$(project "$RUNS" '[.all[].app.id]')"
+check_eq "failing_runs[] carry the publishing app" \
+  '[{"name":"rule-lint","slug":"github-actions","id":15368}]' \
+  "$(project "$RUNS" '[.failing_runs[] | {name, slug: .app.slug, id: .app.id}]')"
+check_eq "in_progress_runs[] carry the publishing app" \
+  '[{"name":"CodeRabbit","slug":"coderabbitai","id":173846}]' \
+  "$(project "$RUNS" '[.in_progress_runs[] | {name, slug: .app.slug, id: .app.id}]')"
+
+############################################################################
+echo
+echo "== two apps publishing the SAME check name stay distinguishable (issue #956) =="
+# Pre-#956 both entries projected to an identical {id, name, status, conclusion,
+# title} shape modulo id, and every consumer matching on `.name` counted the
+# impostor as Cursor. A consumer can now filter on the publisher.
+check_eq "only the Cursor-published run matches name + slug" \
+  '[11]' \
+  "$(project "$RUNS" '[.all[] | select(.name == "Cursor Bugbot" and .app.slug == "cursor") | .id]')"
+check_eq "the same-named foreign run is still present, just attributable" \
+  '[12]' \
+  "$(project "$RUNS" '[.all[] | select(.name == "Cursor Bugbot" and .app.slug != "cursor") | .id]')"
+
+############################################################################
+echo
+echo "== absent app data projects as {slug: null, id: null} =="
+# Not dropped and not an error: consumers get a readable "identity unknown" and
+# decide for themselves whether that fails open or closed.
+check_eq "all[] app is a null-valued object, not a missing key" \
+  '[{"slug":null,"id":null},{"slug":null,"id":null},{"slug":null,"id":null},{"slug":null,"id":null}]' \
+  "$(project "$RUNS_NO_APP" '[.all[].app]')"
+check_eq "failing_runs[] app is a null-valued object" \
+  '[{"slug":null,"id":null}]' \
+  "$(project "$RUNS_NO_APP" '[.failing_runs[].app]')"
+check_eq "in_progress_runs[] app is a null-valued object" \
+  '[{"slug":null,"id":null}]' \
+  "$(project "$RUNS_NO_APP" '[.in_progress_runs[].app]')"
+check_eq "app key is present even when identity is unknown" \
+  'true' \
+  "$(project "$RUNS_NO_APP" '.all | all(has("app"))')"
+
+############################################################################
+echo
+echo "== backward compatibility: the change is purely additive =="
+# Exact key sets (jq `keys` sorts), so a dropped or renamed pre-#956 field fails
+# here instead of surfacing as a downstream consumer reading null.
+check_eq "all[] key set = pre-#956 keys + app" \
+  '["app","conclusion","id","name","status","title"]' \
+  "$(project "$RUNS" '.all[0] | keys')"
+check_eq "failing_runs[] key set = pre-#956 keys + app" \
+  '["app","conclusion","details_url","html_url","id","name","title"]' \
+  "$(project "$RUNS" '.failing_runs[0] | keys')"
+check_eq "in_progress_runs[] key set = pre-#956 keys + app" \
+  '["app","id","name","status"]' \
+  "$(project "$RUNS" '.in_progress_runs[0] | keys')"
+check_eq "all[] pre-existing field values unchanged" \
+  '{"id":11,"name":"Cursor Bugbot","status":"completed","conclusion":"success","title":"No issues"}' \
+  "$(project "$RUNS" '.all[0] | del(.app)')"
+check_eq "failing_runs[] pre-existing field values unchanged" \
+  '{"id":13,"name":"rule-lint","conclusion":"failure","title":"budget exceeded","details_url":"https://example/3","html_url":"https://example/h3"}' \
+  "$(project "$RUNS" '.failing_runs[0] | del(.app)')"
+check_eq "in_progress_runs[] pre-existing field values unchanged" \
+  '{"id":14,"name":"CodeRabbit","status":"in_progress"}' \
+  "$(project "$RUNS" '.in_progress_runs[0] | del(.app)')"
+check_eq "counts unchanged (total/passing/failing/in_progress)" \
+  '{"total":4,"passing":2,"failing":1,"in_progress":1}' \
+  "$(project "$RUNS" '{total, passing, failing, in_progress}')"
+check_eq "top-level bundle key set unchanged" \
+  '["all","failing","failing_runs","in_progress","in_progress_runs","passing","total"]' \
+  "$(project "$RUNS" 'keys')"
+
+echo
+echo "== summary: $PASS passed, $FAIL failed =="
+[[ "$FAIL" -eq 0 ]] || exit 1
+echo "OK: pr-state.sh check-run projection tests passed"


### PR DESCRIPTION
## **User description**
Closes #956

`pr-state.sh` fetched check-run app identity, handed it to `check-runs-dedup.sh`
(which groups by `[.app.slug, .app.id, .name]`, issue #675), then **dropped it one
line later** — the `check_runs` projection was `{id, name, status, conclusion,
title}`. So every consumer asking "did Cursor's BugBot run here?" could only match
the check **name**, and any GitHub App may publish a check-run under any name.

In `escalate-review.sh` that name-only match fed three terms: the `$run` content
classifier, `BUGBOT_CHECK_PRESENT`, and transitively `BUGBOT_INSTALLED`. A
same-named run from a foreign app read as a BugBot footprint on HEAD, which shuts
the never-invited branch — the PR skipped the **free** `@cursor review` that arm
posts and spent a **paid** Greptile review instead. The same run could also certify
BugBot as responsive (completed/neutral) or as failed (a usage-limit title), all on
a stranger's check-run.

## What changed

- **`pr-state.sh`** — `check_runs.all`, `.failing_runs` and `.in_progress_runs`
  entries each carry `app: {slug, id}`. Purely additive; absent app data projects as
  `{slug: null, id: null}` so a consumer can tell "no identity" from "identity says
  not me".
- **`escalate-review.sh`** — both check-run selectors now require `app.slug ==
  "cursor"` alongside the name, via a one-line `is_cursor_bugbot_check` jq def in
  each of the two programs.
- **Missing-slug fallback (deliberate, and opposite to the gate path):** an
  unverifiable run is **not** a BugBot footprint. Classification falls back to
  `cursor[bot]`'s own comments and the worst case is one duplicate `@cursor review`,
  which `bugbot.md` calls harmless. Failing the other way would spend paid budget.
- **`pr-preflight.sh`'s wider defensive slug set is deliberately not mirrored.** There
  an unmatched slug costs one extra trigger; here an over-broad match costs paid
  budget, so the asymmetry runs the other way.

## Publisher identity — confirmed live, not guessed

```
gh api "repos/auerbachb/claude-code-config/commits/<sha>/check-runs?per_page=100" \
  --jq '.check_runs[] | select(.name=="Cursor Bugbot") | {app_slug: .app.slug, app_id: .app.id, app_name: .app.name}'
```

`{"app_slug":"cursor","app_id":1210556,"app_name":"Cursor"}` — identical on two HEAD
SHAs (`a4f2866` / PR #954, `bd44058` / PR #960). The only other publisher on those
commits is `github-actions` (id 15368), which is what the foreign-app fixtures use, so
the collision modelled here is realistic rather than invented.

## Scope carve-out — `merge-gate.sh` is issue #962

Issue #956's AC also named `merge-gate.sh`'s BugBot silent-pass path, where a false
positive is worse (it is **gate-satisfying**, so it must fail **closed** on absent
identity). Phase A file ownership for this PR was `pr-state.sh` +
`escalate-review.sh` + their tests, so that half is filed as **Issue #962**. The
carve-out is verified, not assumed: `merge-gate.sh` builds its own `CHECK_RUNS_JSON`
from the raw check-runs response (line 357) rather than reading this bundle, so
`.app.slug` is already in the data it holds and there is no dependency or ordering
constraint between the two PRs.

## Verification

**Main-vs-branch replay of the new escalate-review scenarios** (branch tests run
against `main`'s script): 7 failures, all intended — the three behavioural deltas
(`o1` footprint, `o4` genuine, `o7` failed) plus the structural guard `o8`. The two
parity controls `o2`/`o5` — the *same* fixtures published by the real Cursor app —
**pass on both sides**, so the app scope cannot be satisfied by refusing every
check-run. Every pre-existing scenario (a–n) passes on both sides.

**Live field diff** on open PR #944: the branch's `check_runs` block is
byte-identical to `main`'s once `app` is stripped (`diff` exit 0). Cost: 978 B vs
732 B on that block, +246 B on an 82 KB bundle.

**Shellcheck:** identical code multiset to `main` (`SC2016`, `SC1112` — both
pre-existing in `pr-state.sh`, line numbers shifted by added comments). No new
findings; the two test files are clean.

**Full discovered bash suite:** 70 suites, 0 failed, including the new
`pr-state-check-runs.test.sh` (auto-discovered, rc=0).

**Local review coverage:** none — CodeRabbit CLI rate-limited (`rate_limit`, two
attempts) and CodeAnt CLI 403 (issue #643, persistent account-wide entitlement; no
re-auth attempted per `cr-local-review.md`). Self-review plus the replays and diff
above stood in. This does not satisfy the GitHub merge gate.

## Test plan

- [x] **`pr-state.sh` `check_runs.all` entries carry the publishing app's identity.**
      `pr-state-check-runs.test.sh` asserts app slug + id on `all`, `failing_runs`
      and `in_progress_runs`; confirmed on live PR #944 (`cursor`/1210556 and
      `github-actions`/15368).
- [x] **`escalate-review.sh` treats a `Cursor Bugbot` check-run as a BugBot footprint
      only when Cursor published it.** Scenarios `o1` (foreign app, in-flight run →
      `switch_bugbot`, was `trigger_greptile`), `o4` (foreign app, completed run must
      not read as a genuine pass → `trigger_greptile`, was `switch_bugbot`) and `o7`
      (foreign app cannot forge a *failure* → `switch_bugbot`, was
      `trigger_greptile`).
- [x] **A genuine Cursor-published check-run is unaffected.** Parity controls `o2`
      and `o5` are byte-twins of `o1`/`o4` differing only in `app.slug`, and both
      return the pre-fix verdict. All pre-existing `escalate-review.test.sh`
      scenarios still pass (83 checks, 0 failed) with the canonical fixtures updated
      to carry the real Cursor app block.
- [x] **Missing app identity is covered on both paths.** Scenarios `o3` (footprint
      path) and `o6` (classifier path) pin the fallback, and the projection suite
      asserts `{slug: null, id: null}` rather than a dropped key.
- [x] **The projection change is backward-compatible.** Three controls pass against
      `main` as well as the branch — per-field values for all three arrays, the four
      counts, and the top-level key set. The exact key-set assertions
      (`pre-#956 keys + app`) pin the change as purely additive and are branch-only
      by construction, so they are not part of that parity set. Plus a
      byte-identical live `diff` on PR #944 once `app` is stripped.
- [x] **The app scope is not removable one selector at a time.** Structural guard
      `o8`: every `"Cursor Bugbot"` occurrence in the source must share its line with
      the `app.slug` term, with a positive control (exactly 2 scoped selectors) so it
      cannot pass by the selectors having been deleted.


___

## **CodeAnt-AI Description**
Ensure foreign check runs cannot be mistaken for Cursor Bugbot activity

### What Changed
- Check-run data now preserves the publishing app identity, including when the identity is unavailable.
- BugBot detection and review routing require both the `Cursor Bugbot` name and Cursor as the publishing app.
- Same-named checks from other apps, or checks without verified publisher data, no longer suppress the free `@cursor review` path or trigger paid escalation based on a false BugBot result.
- Added coverage for foreign, missing-identity, and genuine Cursor check runs while preserving existing check-run fields and behavior.

### Impact
`✅ Fewer unnecessary paid Greptile reviews`
`✅ Fewer false BugBot failures and passes`
`✅ Correct routing for same-named checks from different apps`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

