### PR TITLE
fix: allow verified clean-BEHIND auto-plain merges

### DIFF
--- a/.claude/reference/admin-merge-auto-plain.md
+++ b/.claude/reference/admin-merge-auto-plain.md
@@ -30,7 +30,7 @@ A degraded-context agent, or one following an injected instruction, cannot reach
 Everything before the shape gate is the existing `--print` pre-flight, unchanged:
 
 1. Authorship guard (#733) — `pr-authorship.sh`, fail-closed. `--auto-plain` never passes `--allow-nonauthor`.
-2. `merge-gate.sh` hard-blocker filter — steps over exactly two protection-mechanical blockers (the branch-protection `reviewDecision` note, and a `BEHIND` that `clean-behind-check.sh` confirms is clean).
+2. `merge-gate.sh` hard-blocker filter — steps over exactly two protection-mechanical blockers (the branch-protection `reviewDecision` note, and a `BEHIND` whose mechanical safety `clean-behind-check.sh` confirms). A normal helper exit 0 is accepted directly. If the helper exits 1 only because its bundled gate still includes the branch-protection `reviewDecision` note, `admin-merge.sh` accepts the JSON evidence only when the PR is `BEHIND`, mergeable, zero-overlap, all AC boxes are checked, and every residual blocker is that reviewDecision note. Every other helper error or blocker remains a refusal.
 3. Solo-owner heuristic.
 4. Branch-protection read → `BYPASS_MODE`.
 
@@ -39,16 +39,18 @@ Then, `--auto-plain` only:
 5. **Hard shape gate** → exit `8` on anything but `plain`.
 6. **Repeat guard** → exit `8` if a marker already exists.
 7. `cd` into the resolved `REPO_PATH` so `gh pr merge` targets the intended repo from any cwd.
-8. **Mandatory re-validation** — re-run `clean-behind-check.sh`, capturing its JSON. Non-zero → exit `1` ("rebase and re-run instead of bypassing").
+8. **Mandatory re-validation** — re-run `clean-behind-check.sh`, capturing its JSON and applying the same clean-BEHIND evidence test used at pre-flight. Unsafe mechanics, any non-reviewDecision residual, or a helper error → exit `1` ("rebase and re-run instead of bypassing").
 9. Write the repeat-guard marker.
 10. `gh pr merge <N> --squash --admin`, then the 3-attempt `state == MERGED` read-after-write retry.
 11. Evidence report on stdout.
 
 ### Why step 8 cannot be skipped
 
-`CLEAN_BEHIND_OK == true` is a precondition of `BYPASS_MODE == plain`, and it can only be true if `clean-behind-check.sh` was found and exited `0`. So a missing helper can never reach the auto path — but the branch still checks `-z "$CBC"` and refuses rather than assuming.
+`CLEAN_BEHIND_OK == true` is a precondition of `BYPASS_MODE == plain`, and it can only be true if `clean-behind-check.sh` was found and either exited `0` or supplied the narrowly accepted safe-mechanics JSON described above. So a missing helper can never reach the auto path — but the branch still checks `-z "$CBC"` and refuses rather than assuming.
 
 The re-validation exists for TOCTOU: `main` can advance between the pre-flight snapshot and the merge, turning a clean `BEHIND` into one whose base delta now overlaps this PR's lines. Test 22 drives a stub that returns safe on call 1 and unsafe on call 2, and asserts both that the merge is refused and that the helper genuinely ran twice.
+
+Refusals distinguish the routing decision. Any non-BEHIND blocker keeps the general "not merge-ready apart from branch protection" message. When the only blocker is a BEHIND whose mechanical evidence is unsafe, the script says it is "not safe to skip a rebase" and prints the helper's `reasons_not_safe` entries. A verified clean-BEHIND proceeds without listing BEHIND as outstanding.
 
 ## Exit-code contract
 

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -52,7 +52,10 @@ Every thread must be `isResolved: true` via GraphQL `reviewThreads` (REST misses
 **Do not infer “behind base” from `mergeStateStatus: "BLOCKED"` alone.** Read **`mergeStateStatus` and `mergeable`** explicitly (`gh pr view <N> --json mergeStateStatus,mergeable,reviewDecision` — same as `merge-gate.sh`).
 
 - **`CLEAN`** — OK for merge once Steps 1–1c and 1b pass.
-- **`BEHIND`** — Run `.claude/scripts/clean-behind-check.sh <N>`. Exit 0 → do **Step 2 first**, then **auto-merge via `admin-merge.sh <N> --auto-plain --ac-verified`** (no user turn; report evidence block after). Exit 8 (protection change or repeat) → **offer `/admin-merge`**, never auto-run. `churn.advisory` is context only. Otherwise rebase via `/fixpr` (`fixpr/SKILL.md`), **force-push only** after `dirty-main-guard.sh --check`.
+- **`BEHIND`** — Run `.claude/scripts/clean-behind-check.sh <N>`:
+  - Exit 0 → do **Step 2 first**, then **auto-merge via `admin-merge.sh <N> --auto-plain --ac-verified`** (no user turn; report evidence after). The `BEHIND` entry remains in `merge-gate.sh`'s `missing[]`; verified evidence satisfies only that blocker inside `admin-merge.sh`.
+  - Exit 8 from `admin-merge.sh` (protection change or repeat) → **offer `/admin-merge`**, never auto-run.
+  - Any other failure → rebase via `/fixpr` (`fixpr/SKILL.md`), **force-push only** after `dirty-main-guard.sh --check`. `churn.advisory` is context only.
 - **`BLOCKED`** — Use `reviewDecision`, CI, threads — not a substitute for **`BEHIND`**.
 - **`UNSTABLE` / `DIRTY` / `UNKNOWN`** — Not merge-ready; wait, rebase, or resolve per `fixpr` / Step 1b.
 

--- a/.claude/scripts/admin-merge.sh
+++ b/.claude/scripts/admin-merge.sh
@@ -681,8 +681,9 @@ if [[ "$MODE" == "auto-plain" ]]; then
   # delta now overlaps this PR's lines. Capture the JSON this time: the evidence
   # report must describe the state that actually authorized the merge, not the
   # stale pre-flight snapshot. Reaching `plain` at all requires CLEAN_BEHIND_OK,
-  # which requires CBC to have been found and to have exited 0 — so this check
-  # can never be skipped by a missing helper, but verify rather than assume.
+  # which requires CBC to have been found and to have supplied accepted evidence
+  # (exit 0, or the narrowly recovered exit-1 reviewDecision asymmetry) — so this
+  # check can never be skipped by a missing helper, but verify rather than assume.
   if [[ -z "${CBC:-}" ]]; then
     echo "REFUSED: clean-behind-check.sh unavailable — cannot re-validate the clean-BEHIND state before an auto merge." >&2
     exit 1

--- a/.claude/scripts/admin-merge.sh
+++ b/.claude/scripts/admin-merge.sh
@@ -320,10 +320,39 @@ fi
 # hard blocker (rebase first). But when the base delta does NOT touch the PR's
 # files, rebasing is pure churn and an admin squash-merge is safe — `gh pr merge
 # --admin` merges a BEHIND branch regardless of the "require up to date" rule.
-# Step over BEHIND ONLY when clean-behind-check.sh confirms it is safe (gate green
-# except BEHIND, not CONFLICTING, AC verified, no base-delta↔PR-file overlap).
-# Any non-clean BEHIND (overlap, conflicts, other blockers) stays a hard blocker.
+# Step over BEHIND ONLY when clean-behind-check.sh confirms its mechanical axes
+# are safe (not CONFLICTING, AC checked, no base-delta↔PR-file overlap). The
+# helper may still exit 1 when its bundled merge-gate run reports only the branch-
+# protection reviewDecision note that admin-merge is independently allowed to
+# bypass. Keep that note separate from the mechanical clean-BEHIND verdict so the
+# two gate filters cannot make --auto-plain unreachable (issue #947).
+REVIEW_DECISION_BLOCKER_RE='^branch protection reviewDecision is [A-Z_]+, not APPROVED, with (CodeRabbit in CODEOWNERS — if the prior CR approval was dismissed as stale, trigger @coderabbitai full review|Greptile in CODEOWNERS — if the prior Greptile approval was dismissed as stale, trigger @greptileai|CodeAnt in CODEOWNERS — if the prior CodeAnt approval was dismissed as stale, trigger @codeant-ai review)$'
+
+clean_behind_evidence_allows_admin() {
+  local json="$1" rc="$2"
+
+  # Preserve clean-behind-check.sh's primary contract: exit 0 is authoritative.
+  [[ "$rc" -eq 0 ]] && return 0
+  # Exit 1 means "not safe to offer" and carries inspectable JSON. Recover only
+  # the known gate-filter asymmetry; helper errors remain fail-closed.
+  [[ "$rc" -eq 1 ]] || return 1
+
+  printf '%s' "$json" | jq -e --arg review_blocker_re "$REVIEW_DECISION_BLOCKER_RE" '
+    type == "object"
+    and .merge_state == "BEHIND"
+    and .mergeable == "MERGEABLE"
+    and ((.file_overlap.count | type) == "number")
+    and .file_overlap.count == 0
+    and .ac.all_checked == true
+    and ((.residual_blockers | type) == "array")
+    and all(.residual_blockers[];
+      type == "string" and test($review_blocker_re))
+  ' >/dev/null 2>&1
+}
+
 CLEAN_BEHIND_OK=false
+CBC_JSON=""
+CBC_RC=4
 BEHIND_PRESENT=$(echo "$GATE_JSON" | jq -r '[.missing[]? | select(test("BEHIND base"; "i"))] | length')
 if [[ "${BEHIND_PRESENT:-0}" -gt 0 ]]; then
   CBC=""
@@ -336,18 +365,29 @@ if [[ "${BEHIND_PRESENT:-0}" -gt 0 ]]; then
   if [[ -n "$CBC" ]]; then
     CBC_ARGS=("$PR_NUMBER")
     [[ -n "$REVIEWER_OVERRIDE" ]] && CBC_ARGS+=(--reviewer "$REVIEWER_OVERRIDE")
-    # Exit 0 == safe_to_offer; suppress output (we only need the verdict).
-    if "$CBC" "${CBC_ARGS[@]}" >/dev/null 2>&1; then CLEAN_BEHIND_OK=true; fi
+    CBC_JSON="$("$CBC" "${CBC_ARGS[@]}" 2>/dev/null)"
+    CBC_RC=$?
+    if clean_behind_evidence_allows_admin "$CBC_JSON" "$CBC_RC"; then
+      CLEAN_BEHIND_OK=true
+    fi
   fi
 fi
 
 # Hard blockers = every missing reason that is NOT one of the two protection-
 # mechanical blockers the admin bypass is allowed to step over: (1) the branch-
 # protection reviewDecision note, and (2) a *clean* BEHIND (only when CLEAN_BEHIND_OK).
-HARD_BLOCKERS=$(echo "$GATE_JSON" | jq -r --argjson cbo "$CLEAN_BEHIND_OK" '
+HARD_BLOCKERS=$(echo "$GATE_JSON" | jq -r \
+  --argjson cbo "$CLEAN_BEHIND_OK" \
+  --arg review_blocker_re "$REVIEW_DECISION_BLOCKER_RE" '
   [.missing[]?
-    | select(test("branch protection reviewDecision") | not)
+    | select(test($review_blocker_re) | not)
     | select(($cbo | not) or (test("BEHIND base"; "i") | not))]
+  | .[]')
+NON_BEHIND_HARD_BLOCKERS=$(echo "$GATE_JSON" | jq -r \
+  --arg review_blocker_re "$REVIEW_DECISION_BLOCKER_RE" '
+  [.missing[]?
+    | select(test($review_blocker_re) | not)
+    | select(test("BEHIND base"; "i") | not)]
   | .[]')
 HUMAN_CHANGES=$(echo "$GATE_JSON" | jq -r '[.human_changes_requested[]?] | join(", ")')
 
@@ -357,9 +397,22 @@ if [[ -n "$HUMAN_CHANGES" ]]; then
   exit 1
 fi
 if [[ -n "$HARD_BLOCKERS" ]]; then
-  echo "REFUSED: PR #$PR_NUMBER is not merge-ready apart from branch protection. Outstanding blockers:" >&2
-  while IFS= read -r line; do [[ -n "$line" ]] && echo "  - $line" >&2; done <<< "$HARD_BLOCKERS"
-  echo "Fix these (CI / approval / threads / rebase) before using /admin-merge." >&2
+  if [[ -z "$NON_BEHIND_HARD_BLOCKERS" && "${BEHIND_PRESENT:-0}" -gt 0 && "$CLEAN_BEHIND_OK" != true ]]; then
+    echo "REFUSED: PR #$PR_NUMBER is BEHIND and is not safe to skip a rebase." >&2
+    if printf '%s' "$CBC_JSON" | jq -e '.reasons_not_safe | type == "array" and length > 0' >/dev/null 2>&1; then
+      while IFS= read -r line; do [[ -n "$line" ]] && echo "  - $line" >&2; done \
+        < <(printf '%s' "$CBC_JSON" | jq -r '.reasons_not_safe[]')
+    elif [[ -z "${CBC:-}" ]]; then
+      echo "  - clean-behind-check.sh is unavailable; mechanical safety could not be verified" >&2
+    else
+      echo "  - clean-behind-check.sh did not provide usable clean-BEHIND evidence (exit $CBC_RC)" >&2
+    fi
+    echo "Rebase and re-run the normal review flow before using /admin-merge." >&2
+  else
+    echo "REFUSED: PR #$PR_NUMBER is not merge-ready apart from branch protection. Outstanding blockers:" >&2
+    while IFS= read -r line; do [[ -n "$line" ]] && echo "  - $line" >&2; done <<< "$HARD_BLOCKERS"
+    echo "Fix these (CI / approval / threads / rebase) before using /admin-merge." >&2
+  fi
   exit 1
 fi
 
@@ -636,7 +689,7 @@ if [[ "$MODE" == "auto-plain" ]]; then
   fi
   CBC_JSON="$("$CBC" "${CBC_ARGS[@]}" 2>/dev/null)"
   CBC_RC=$?
-  if [[ "$CBC_RC" -ne 0 ]]; then
+  if ! clean_behind_evidence_allows_admin "$CBC_JSON" "$CBC_RC"; then
     echo "REFUSED: the clean-BEHIND state no longer holds (main advanced, or a new blocker appeared) — rebase and re-run instead of bypassing." >&2
     exit 1
   fi
@@ -721,7 +774,9 @@ if [[ "$MODE" == "execute" ]]; then
   # base delta now overlaps the PR's files. Refuse if it no longer holds. (This
   # runs before enforce_admins is disabled, so a refusal leaves protection intact.)
   if [[ "$CLEAN_BEHIND_OK" == true && -n "${CBC:-}" ]]; then
-    if ! "$CBC" "${CBC_ARGS[@]}" >/dev/null 2>&1; then
+    CBC_JSON="$("$CBC" "${CBC_ARGS[@]}" 2>/dev/null)"
+    CBC_RC=$?
+    if ! clean_behind_evidence_allows_admin "$CBC_JSON" "$CBC_RC"; then
       echo "REFUSED: the clean-BEHIND state no longer holds (main advanced, or a new blocker appeared) — rebase and re-run instead of bypassing." >&2
       exit 1
     fi

--- a/.claude/scripts/tests/admin-merge.test.sh
+++ b/.claude/scripts/tests/admin-merge.test.sh
@@ -40,6 +40,9 @@ chmod +x "$SCRIPTS/merge-gate.sh"
 # FAKE_CBC_EXIT_SEQ — space-separated per-call exit codes ("0 1" = safe on the
 #                     pre-flight call, unsafe on the pre-merge re-validation).
 #                     Requires FAKE_CBC_COUNT_FILE to count calls.
+# FAKE_CBC_OVERLAP_COUNT / FAKE_CBC_AC_ALL_CHECKED / FAKE_CBC_RESIDUAL /
+# FAKE_CBC_REASONS / FAKE_CBC_MERGE_STATE / FAKE_CBC_MERGEABLE control the
+# mechanical evidence emitted for each call.
 cat > "$SCRIPTS/clean-behind-check.sh" <<'EOF'
 #!/usr/bin/env bash
 N=1
@@ -56,10 +59,29 @@ if [ -n "${FAKE_CBC_EXIT_SEQ:-}" ]; then
     if [ "$I" -eq "$N" ]; then RC="$code"; fi
   done
 fi
-jq -cn --argjson rc "$RC" '{
+OVERLAP="${FAKE_CBC_OVERLAP_COUNT:-}"
+if [ -z "$OVERLAP" ]; then
+  if [ "$RC" -eq 0 ]; then OVERLAP=0; else OVERLAP=1; fi
+fi
+REASONS="${FAKE_CBC_REASONS:-}"
+if [ -z "$REASONS" ]; then
+  if [ "$RC" -eq 0 ]; then REASONS='[]'; else REASONS='["base delta overlaps PR files (dirty.txt)"]'; fi
+fi
+jq -cn \
+  --argjson rc "$RC" \
+  --arg merge_state "${FAKE_CBC_MERGE_STATE:-BEHIND}" \
+  --arg mergeable "${FAKE_CBC_MERGEABLE:-MERGEABLE}" \
+  --argjson overlap "$OVERLAP" \
+  --argjson ac_all_checked "${FAKE_CBC_AC_ALL_CHECKED:-true}" \
+  --argjson residual "${FAKE_CBC_RESIDUAL:-[]}" \
+  --argjson reasons "$REASONS" '{
   safe_to_offer: ($rc == 0), head_sha: "abc1234def",
-  ac: {checked: 6, total: 6},
-  file_overlap: {count: 0, granularity: "hunk"},
+  reasons_not_safe: $reasons,
+  merge_state: $merge_state,
+  mergeable: $mergeable,
+  residual_blockers: $residual,
+  ac: {checked: (if $ac_all_checked then 6 else 5 end), total: 6, all_checked: $ac_all_checked},
+  file_overlap: {count: $overlap, granularity: "hunk"},
   churn: {base_ahead_by: 2}
 }'
 exit "$RC"
@@ -165,7 +187,7 @@ expect_rc 1 "refuses on hard blocker (exit 1)"
 grep_absent "X DELETE" "no bypass printed on hard blocker"
 
 # 3. Only a code-owner reviewDecision blocker → bypassable, still prints.
-FAKE_GATE_EXIT=1 FAKE_GATE_MISSING='["branch protection reviewDecision is REVIEW_REQUIRED, not APPROVED, with CodeRabbit in CODEOWNERS — trigger @coderabbitai full review"]' \
+FAKE_GATE_EXIT=1 FAKE_GATE_MISSING='["branch protection reviewDecision is REVIEW_REQUIRED, not APPROVED, with CodeRabbit in CODEOWNERS — if the prior CR approval was dismissed as stale, trigger @coderabbitai full review"]' \
   run 1 --print --repo-path "$CLONE" --branch main
 expect_rc 0 "reviewDecision-only blocker is bypassable (exit 0)"
 
@@ -329,9 +351,45 @@ new_log
 FAKE_GATE_EXIT=1 FAKE_CBC_EXIT=1 FAKE_GATE_MISSING="$BEHIND_ONLY" FAKE_PROTECTION="$PLAIN_PROT" \
   run 3 --auto-plain --ac-verified --repo-path "$CLONE" --branch main
 expect_rc 1 "--auto-plain refuses a non-clean BEHIND (exit 1)"
-grep_ok "rebase" "non-clean BEHIND refusal routes to the rebase path"
+grep_ok "not safe to skip a rebase" "non-clean BEHIND gets the distinct unsafe-to-skip refusal"
+grep_ok "base delta overlaps PR files" "non-clean BEHIND refusal surfaces clean-behind reasons"
 log_absent "^pr merge" "non-clean BEHIND: no merge call issued"
 log_absent "protection/enforce_admins" "non-clean BEHIND: no protection API call issued"
+
+# 21b. CBC can exit 1 solely because its bundled gate keeps the branch-protection
+#      reviewDecision residual. Safe mechanical evidence still reaches the merge.
+new_log
+FAKE_GATE_EXIT=1 FAKE_CBC_EXIT=1 FAKE_CBC_OVERLAP_COUNT=0 \
+  FAKE_CBC_RESIDUAL='["branch protection reviewDecision is REVIEW_REQUIRED, not APPROVED, with CodeRabbit in CODEOWNERS — if the prior CR approval was dismissed as stale, trigger @coderabbitai full review"]' \
+  FAKE_CBC_REASONS='["merge gate blocker: branch protection reviewDecision is REVIEW_REQUIRED, not APPROVED, with CodeRabbit in CODEOWNERS"]' \
+  FAKE_GATE_MISSING="$BEHIND_ONLY" FAKE_PROTECTION="$PLAIN_PROT" \
+  run 9 --auto-plain --ac-verified --repo-path "$CLONE" --branch main
+expect_rc 0 "--auto-plain accepts safe mechanics when CBC only retains reviewDecision (exit 0)"
+log_present "^pr merge 9 --squash --admin" "reviewDecision-only CBC asymmetry reaches the merge call"
+log_absent "protection/enforce_admins" "reviewDecision-only CBC asymmetry issues no protection call"
+
+# 21c. A real non-BEHIND blocker wins over the special dirty-BEHIND refusal.
+new_log
+FAKE_GATE_EXIT=1 FAKE_CBC_EXIT=1 \
+  FAKE_GATE_MISSING='["branch is BEHIND base — rebase + force-push before merging","CI incomplete: rule-lint"]' \
+  FAKE_PROTECTION="$PLAIN_PROT" \
+  run 10 --auto-plain --ac-verified --repo-path "$CLONE" --branch main
+expect_rc 1 "--auto-plain refuses dirty BEHIND plus CI blocker (exit 1)"
+grep_ok "not merge-ready apart from branch protection" "non-BEHIND blockers retain the generic refusal"
+grep_ok "CI incomplete" "generic refusal surfaces the non-BEHIND blocker"
+log_absent "^pr merge" "dirty BEHIND plus CI blocker issues no merge call"
+
+# 21d. A residual that merely contains the magic words is not the canonical
+#      branch-protection blocker and must not be bypassed.
+new_log
+FAKE_GATE_EXIT=1 FAKE_CBC_EXIT=1 FAKE_CBC_OVERLAP_COUNT=0 \
+  FAKE_CBC_RESIDUAL='["CI failed while reporting branch protection reviewDecision"]' \
+  FAKE_CBC_REASONS='["merge gate blocker: CI failed"]' \
+  FAKE_GATE_MISSING="$BEHIND_ONLY" FAKE_PROTECTION="$PLAIN_PROT" \
+  run 11 --auto-plain --ac-verified --repo-path "$CLONE" --branch main
+expect_rc 1 "--auto-plain refuses a non-canonical reviewDecision residual (exit 1)"
+grep_ok "not safe to skip a rebase" "non-canonical reviewDecision residual uses the safe refusal"
+log_absent "^pr merge" "non-canonical reviewDecision residual issues no merge call"
 
 # 22. TOCTOU: clean-behind-check safe at pre-flight, UNSAFE at merge time (main
 #     advanced in between) → refuse, no merge. Proves the re-validation is real.


### PR DESCRIPTION
Closes #947

## Summary

- decouple clean-BEHIND mechanical safety from the helper's branch-protection reviewDecision residual
- reuse the same fail-closed evidence check at pre-flight and immediately before merge
- give dirty-BEHIND refusals a distinct message with the helper's reasons, while preserving every other blocker
- reconcile the merge-gate rule and auto-plain reference contract

## Test plan

- [x] Clean-BEHIND with `clean-behind-check.sh` exit 0 reaches the plain admin merge call.
- [x] Safe mechanical evidence with only the canonical branch-protection `reviewDecision` residual reaches the merge call.
- [x] Dirty-BEHIND and non-canonical residual evidence refuse without issuing a merge.
- [x] CI, unresolved-thread, approval, human `CHANGES_REQUESTED`, authorship, and protection-shape guards remain closed.
- [x] Pre-merge TOCTOU revalidation uses the same clean-BEHIND evidence logic.
- [x] `admin-merge.test.sh`, `clean-behind-check.test.sh`, rule/reference lints, and syntax checks pass.

## Local review

Coverage: `none` (self-review fallback). CodeRabbit produced three findings on its first verified run; all were addressed, but the clean re-run timed out at 120s. CodeAnt returned `noFiles=true` on both allowed attempts. The final diff was self-reviewed after both CLIs became unavailable.