### PR TITLE
fix(#967): prefer invoking checkout scope

### DIFF
--- a/.claude/reference/state-file-contracts.md
+++ b/.claude/reference/state-file-contracts.md
@@ -16,6 +16,35 @@ Session state lives at `.repos["<owner>/<name>"].prs["<N>"]` rather than a flat 
 
 Entries that predate scoping and cannot be attributed land under `_unknown`. Account-level fields (Greptile daily budget, CodeRabbit hourly consumption) stay global — they are per-account quotas, not per-repo state.
 
+### Polling-gate protection against inherited scope leakage (issue #967)
+
+`polling-state-gate.sh` resolves the invoking checkout before applying that
+general helper precedence. Without an explicit `--repo`, a checkout whose
+`origin` yields a real `owner/repo` replaces any inherited
+`$CLAUDE_SESSION_REPO`, then re-exports the resolved identity so
+`session-state.sh`, `poll-watermarks.sh`, and later child helpers all agree. An
+inherited value is retained only as a supply-only fallback for an origin-less
+checkout (or another checkout that cannot identify itself). An explicit
+`--repo` remains a declaration and is refused when it contradicts the invoking
+checkout. `statusline.sh` established the earlier instance of defending reads
+from stale inherited repo scope; the gate keeps the fallback because it also
+supports origin-less checkout operation.
+
+This prevents new writes from landing in the wrong scope; it does not migrate
+old entries. `session-state-audit.sh --apply --reattribute` remains the
+downstream housekeeping command for entries that can be identified under
+`_unknown`; `--apply --prune` handles old closed entries once they meet its
+retention and notes safeguards. Neither operation moves an active entry out of
+an already named but incorrect scope, so that case still requires targeted
+correction rather than being part of this gate fix.
+
+Issue #655 addressed a distinct, earlier occurrence of the "resolve by PR
+number before scoping" anti-pattern by moving handoffs into per-repo
+directories. No handoff change is required for issue #967. This repository,
+`auerbachb/claude-code-config`, is the source of the gate scripts, so the fix
+belongs here even though the faulty behavior was first observed from another
+repository.
+
 ## Scope-key case normalization (issue #704)
 
 The `.repos["<owner>/<name>"]` key is **always lowercase**, and handoff directories `~/.claude/handoffs/{owner}/{repo}/` follow the same contract.

--- a/.claude/scripts/polling-state-gate.sh
+++ b/.claude/scripts/polling-state-gate.sh
@@ -34,6 +34,13 @@
 # registered here; --ensure-session is the remedy, and other repos' entries are
 # named in that message as diagnostics only.
 #
+# An inherited $CLAUDE_SESSION_REPO is supply-only (issue #967). When --repo is
+# absent, a self-identifying invoking checkout (from --root-repo or the live cwd)
+# overrides that ambient value before any state helper runs. The inherited value
+# is retained only when the checkout cannot identify itself, such as an
+# origin-less checkout. An explicit --repo remains authoritative as a declaration
+# and still refuses when it contradicts the checkout being operated on.
+#
 # Scoping is validated per PR, by repo *identity* (normalized `origin` remote,
 # falling back to the shared git common dir so sibling worktrees of one repo
 # agree) rather than by checkout path:
@@ -75,13 +82,13 @@
 #                            …) agrees. Precedence, resolved by
 #                            `session-state.sh --repo-key`:
 #                              --repo -> $CLAUDE_SESSION_REPO -> cwd `origin`.
-#                            Needed only when the checkout cannot speak for itself
-#                            (no `origin` remote, or not a git checkout at all) —
-#                            with a normal checkout the origin remote already
-#                            gives the right answer.
-#                            A declared key may SUPPLY an identity the checkout
-#                            lacks; it may never OVERRIDE one the checkout
-#                            states. `--repo` and `--root-repo` answer different
+#                            For this gate, a self-identifying invoking checkout
+#                            replaces an inherited environment value before that
+#                            precedence is evaluated. The environment is only a
+#                            supply fallback when the checkout has no `origin`.
+#                            An explicit --repo may SUPPLY an identity the checkout
+#                            lacks; it may never OVERRIDE one the checkout states.
+#                            `--repo` and `--root-repo` answer different
 #                            questions, so when both resolve to a real owner/repo
 #                            and disagree the invocation is refused rather than
 #                            validating against one repo while acting on another.
@@ -125,6 +132,7 @@ PR_NUMBER=""
 MODE="cycle"
 ROOT_REPO_ARG=""
 REPO_ARG=""
+REPO_ARG_PASSED=0
 # Authorship guard (issue #733): enrolling a PR in polling is a "touch", so
 # --ensure-session refuses PRs the authenticated user did not author. A skill
 # passes --allow-nonauthor only under an explicit per-PR user override.
@@ -166,6 +174,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --repo)
+      REPO_ARG_PASSED=1
       REPO_ARG="${2:-}"
       if [[ -z "$REPO_ARG" ]]; then
         echo "polling-state-gate.sh: --repo requires an <owner>/<name> value" >&2
@@ -207,25 +216,6 @@ fi
 # Directory whose repo identity scopes every session-state read below (issue
 # #638). Defaults to the active checkout; --root-repo overrides it.
 STATE_READ_DIR="${STATE_READ_DIR:-$PWD}"
-
-# --repo is implemented by exporting $CLAUDE_SESSION_REPO rather than by threading
-# a flag through every helper invocation (issue #854). session-state.sh already
-# resolves `--repo -> $CLAUDE_SESSION_REPO -> cwd origin`, so one export makes the
-# gate, poll-watermarks.sh, and every other child agree on a single scope key —
-# and it is what makes a pre-set $CLAUDE_SESSION_REPO work here too, since we
-# simply leave it in place when --repo is absent.
-# Was the repo key DECLARED by the caller, or merely derived from the checkout?
-# Only a declared key can contradict the checkout, so only a declared key is
-# subject to the contradiction guard in validate_root_match(). Captured before
-# the export below, which would otherwise make every --repo run look like it
-# also had the environment variable set.
-REPO_KEY_DECLARED=0
-if [[ -n "$REPO_ARG" || -n "${CLAUDE_SESSION_REPO:-}" ]]; then
-  REPO_KEY_DECLARED=1
-fi
-if [[ -n "$REPO_ARG" ]]; then
-  export CLAUDE_SESSION_REPO="$REPO_ARG"
-fi
 
 # Which repo scope holds this PR (issue #638). Resolved once, then reused by
 # state_pr_field() so every read below comes from one consistent entry.
@@ -362,6 +352,55 @@ repo_identity() {
     printf 'path:%s\n' "$path"
   fi
 }
+
+# --repo is implemented by exporting $CLAUDE_SESSION_REPO rather than by
+# threading a flag through every helper invocation (issue #854). Resolve the
+# invoking checkout first (issue #967), so a stale value inherited from a
+# persistent parent shell cannot outrank a checkout that names itself.
+#
+# REPO_KEY_DECLARED retains the contradiction-guard meaning for an explicit
+# --repo. An inherited value counts as declared only on the supply-only path,
+# where the invoking checkout cannot provide an owner/repo identity itself.
+REPO_KEY_DECLARED=0
+INVOKING_CHECKOUT_PATH=""
+INVOKING_CHECKOUT_ID=""
+if [[ -n "$ROOT_REPO_ARG" ]]; then
+  INVOKING_CHECKOUT_PATH="$ROOT_REPO_ARG"
+else
+  INVOKING_CHECKOUT_PATH="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [[ -n "$INVOKING_CHECKOUT_PATH" ]]; then
+  INVOKING_CHECKOUT_ID="$(repo_identity "$INVOKING_CHECKOUT_PATH")"
+fi
+
+is_owner_repo_identity() {
+  case "$1" in
+    ""|_unknown|gitdir:*|path:*) return 1 ;;
+    */*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ "$REPO_ARG_PASSED" -eq 1 ]]; then
+  REPO_KEY_DECLARED=1
+  export CLAUDE_SESSION_REPO="$REPO_ARG"
+
+  # Preserve the explicit mismatch refusal even when no --root-repo was passed:
+  # the live cwd is the invoking checkout and must not be silently redirected by
+  # a stored root from the declared scope.
+  if is_owner_repo_identity "$INVOKING_CHECKOUT_ID"; then
+    declared_arg="$(normalize_repo_key "$REPO_ARG")"
+    if [[ "$declared_arg" != "$INVOKING_CHECKOUT_ID" ]]; then
+      echo "polling-state-gate.sh: repo key '$declared_arg' (from --repo) contradicts the checkout being operated on, which is '$INVOKING_CHECKOUT_ID' ($INVOKING_CHECKOUT_PATH) — refuse to validate against one repo while acting on another. Drop the override, or point --root-repo at a '$declared_arg' checkout." >&2
+      exit 4
+    fi
+    unset declared_arg
+  fi
+elif is_owner_repo_identity "$INVOKING_CHECKOUT_ID"; then
+  export CLAUDE_SESSION_REPO="$INVOKING_CHECKOUT_ID"
+elif [[ -n "${CLAUDE_SESSION_REPO:-}" ]]; then
+  REPO_KEY_DECLARED=1
+fi
 
 ACTIVE_REPO_KEY="$(cd "$STATE_READ_DIR" 2>/dev/null && "$STATE_HELPER" --repo-key 2>/dev/null || true)"
 

--- a/.claude/scripts/tests/polling-state-gate-multirepo.test.sh
+++ b/.claude/scripts/tests/polling-state-gate-multirepo.test.sh
@@ -25,6 +25,11 @@
 # collision case, --repo / $CLAUDE_SESSION_REPO scope selection, and the
 # invariant that no refusal ever exits 0.
 #
+# Issue #967 covers the residual ambient-scope leak: a stale inherited
+# $CLAUDE_SESSION_REPO used to outrank the live checkout origin. The invoking
+# checkout now wins when it can identify itself; the environment remains a
+# supply-only fallback for origin-less checkouts.
+#
 # Uses --verify-state, the offline mode (no gh, no merge-gate), so the test is
 # hermetic. Temporary HOME; never touches the real ~/.claude/. Requires git+jq.
 set -uo pipefail
@@ -137,8 +142,8 @@ cat > "$STUB_BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 set -uo pipefail
 case "${1:-}" in
-  pr)   echo '{"headRefOid":"ccc3333","state":"OPEN","number":84,"headRefName":"feature","url":"https://github.com/org/c/pull/84","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","reviewDecision":""}' ;;
-  repo) echo 'org/c' ;;
+  pr)   printf '{"headRefOid":"%s","state":"OPEN","number":84,"headRefName":"feature","url":"https://github.com/%s/pull/84","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","reviewDecision":""}\n' "${STUB_HEAD_SHA:-ccc3333}" "${STUB_OWNER_REPO:-org/c}" ;;
+  repo) printf '%s\n' "${STUB_OWNER_REPO:-org/c}" ;;
   api)
     shift
     [[ "${1:-}" == "--paginate" ]] && shift
@@ -172,6 +177,25 @@ RC=0; OUT="$( cd "$REPO_C" && bash "$GATE" 84 --verify-state 2>&1 )" || RC=$?
 check_eq "a later tick from repo C validates against C's own state" "0" "$RC"
 
 echo
+echo "== A self-identifying checkout overrides a stale inherited scope (issue #967) =="
+# Reproduce the reported persistent-shell leak with the same PR number present
+# in both repos. The gate is invoked from repo A without --repo while the
+# environment still names repo B. Both registration and verification must use A,
+# and B's existing entry must remain byte-identical.
+B_BEFORE_STALE_ENV="$(jq -Sc '.repos["org/b"].prs["84"]' "$HOME/.claude/session-state.json")"
+write_handoff 84 aaa1111
+RC=0; OUT="$( cd "$REPO_A" && CLAUDE_SESSION_REPO=org/b STUB_HEAD_SHA=aaa1111 STUB_OWNER_REPO=org/a PATH="$STUB_BIN:$PATH" bash "$GATE" 84 --ensure-session 2>&1 )" || RC=$?
+check_eq "stale inherited scope does not block --ensure-session" "0" "$RC"
+check_eq "--ensure-session remains scoped to the invoking repo" "org/a" \
+  "$(jq -r '.repos["org/a"].prs["84"].owner_repo // ""' "$HOME/.claude/session-state.json")"
+check_eq "stale inherited scope does not mutate repo B" "$B_BEFORE_STALE_ENV" \
+  "$(jq -Sc '.repos["org/b"].prs["84"]' "$HOME/.claude/session-state.json")"
+RC=0; OUT="$( cd "$REPO_A" && CLAUDE_SESSION_REPO=org/b bash "$GATE" 84 --verify-state 2>&1 )" || RC=$?
+check_eq "stale inherited scope does not block --verify-state" "0" "$RC"
+check_eq "stale inherited scope emits no contradiction refusal" "0" \
+  "$(grep -c 'contradicts the checkout being operated on' <<<"$OUT")"
+
+echo
 echo "== --repo / \$CLAUDE_SESSION_REPO select the scope (issue #854) =="
 # A checkout with no `origin` remote cannot name itself, so before #854 there was
 # no way to tell the gate which repo it was standing in. Both mechanisms must
@@ -185,6 +209,12 @@ RC=0; OUT="$( cd "$NOREMOTE" && bash "$GATE" 84 --verify-state --repo org/a 2>&1
 check_eq "--repo selects the named scope from an origin-less checkout" "0" "$RC"
 RC=0; OUT="$( cd "$NOREMOTE" && CLAUDE_SESSION_REPO=org/a bash "$GATE" 84 --verify-state 2>&1 )" || RC=$?
 check_eq "\$CLAUDE_SESSION_REPO selects the named scope too" "0" "$RC"
+# Pin the origin-less checkout itself: the inherited value must remain available
+# as identity supply rather than being discarded or replaced with gitdir:/path:.
+RC=0; OUT="$( cd "$NOREMOTE" && CLAUDE_SESSION_REPO=org/a bash "$GATE" 84 --verify-state --root-repo "$NOREMOTE" 2>&1 )" || RC=$?
+check_eq "inherited scope supplies identity for a pinned origin-less checkout" "0" "$RC"
+check_eq "origin-less supply emits no contradiction refusal" "0" \
+  "$(grep -c 'contradicts the checkout being operated on' <<<"$OUT")"
 # --repo outranks the environment variable.
 RC=0; OUT="$( cd "$NOREMOTE" && CLAUDE_SESSION_REPO=org/b bash "$GATE" 84 --verify-state --repo org/a 2>&1 )" || RC=$?
 check_eq "--repo outranks \$CLAUDE_SESSION_REPO" "0" "$RC"
@@ -213,18 +243,24 @@ RC=0; OUT="$( cd "$REPO_B" && bash "$GATE" 84 --verify-state --repo org/a --root
 check_eq "--repo contradicting --root-repo is refused" "4" "$RC"
 check_eq "…and the refusal names both sides" "1" "$(grep -c "contradicts the checkout being operated on" <<<"$OUT")"
 check_eq "…and it did not operate on the declared repo" "0" "$(grep -c 'gate met' <<<"$OUT")"
-# Same hazard via the environment variable, which has identical mechanics.
+# An inherited environment value is ambient rather than explicit. A
+# self-identifying checkout replaces it before scope resolution, whether or not
+# --root-repo pins that checkout.
+write_handoff 84 bbb2222
 RC=0; OUT="$( cd "$REPO_B" && CLAUDE_SESSION_REPO=org/a bash "$GATE" 84 --verify-state --root-repo "$REPO_B" 2>&1 )" || RC=$?
-check_eq "\$CLAUDE_SESSION_REPO contradicting the checkout is refused" "4" "$RC"
-check_eq "…env-var refusal names both sides too" "1" "$(grep -c "contradicts the checkout being operated on" <<<"$OUT")"
-# Declaring org/a from inside repo B with NO --root-repo is NOT the hazard: the
-# per-PR root_repo redirects the checkout to repo A as well, so the scope read
-# and the checkout acted on are both org/a — coherent, and allowed. The bug was
-# state and actions DIVERGING, which the pinned-checkout cases above cover.
+check_eq "stale environment value yields to explicit checkout identity" "0" "$RC"
 RC=0; OUT="$( cd "$REPO_B" && CLAUDE_SESSION_REPO=org/a bash "$GATE" 84 --verify-state 2>&1 )" || RC=$?
-check_eq "declared key redirecting to its own checkout stays coherent" "0" "$RC"
+check_eq "stale environment value yields to live cwd identity" "0" "$RC"
+# Explicit --repo remains a per-invocation declaration even without
+# --root-repo; a stored root must not silently redirect away from the invoking
+# checkout and hide the mismatch.
+RC=0; OUT="$( cd "$REPO_A" && bash "$GATE" 84 --verify-state --repo org/b 2>&1 )" || RC=$?
+check_eq "explicit --repo contradicting live cwd is refused" "4" "$RC"
+check_eq "…and the explicit mismatch keeps the contradiction message" "1" \
+  "$(grep -c "contradicts the checkout being operated on" <<<"$OUT")"
 # A key merely DERIVED from the checkout can never contradict it, so the ordinary
 # no-override path must stay clean — this is the regression guard for the fix.
+write_handoff 84 aaa1111
 RC=0; OUT="$( cd "$REPO_A" && bash "$GATE" 84 --verify-state 2>&1 )" || RC=$?
 check_eq "no declared key: ordinary poll is unaffected" "0" "$RC"
 check_eq "…and emits no contradiction message" "0" "$(grep -c 'contradicts the checkout' <<<"$OUT")"


### PR DESCRIPTION
## Summary

- let a self-identifying invoking checkout replace stale inherited `CLAUDE_SESSION_REPO` scope before polling helpers run
- preserve explicit `--repo` mismatch refusal and inherited identity supply for origin-less checkouts
- add multi-repo regression coverage and document precedence plus stale-state remediation

Closes #967

## Test plan

- [x] Stale inherited repo scope does not block `--ensure-session` or `--verify-state` from a self-identifying checkout, and the foreign repo entry remains unchanged.
- [x] Explicit `--repo` mismatch still refuses with exit 4 and the established contradiction message.
- [x] An origin-less checkout still accepts inherited repo identity as a supply-only fallback.
- [x] Focused multi-repo suite passes (49 assertions).
- [x] Existing polling-state-gate, session-state, and poll-watermarks suites pass (30, 112, and 14 assertions).
- [x] Full auto-discovered Bash suite passes (71 suites, 0 failures), plus rule-lint and ShellCheck warning/error levels.

## Local review coverage

Coverage: `none` (self-review fallback completed). CodeRabbit timed out once and returned a rate-limit error on its single retry. CodeAnt returned `noFiles=true` on both allowed attempts because it analyzed zero files. No findings were emitted; both failed-run states are treated as unavailable rather than clean passes.