### PR TITLE
fix(review): recognize descriptive non-SHA evidence

### DIFF
--- a/.claude/reference/merge-gate-stale-approval-redemption.md
+++ b/.claude/reference/merge-gate-stale-approval-redemption.md
@@ -60,6 +60,9 @@ whose timestamp is in doubt** —
 - inline diff comments with `commit_id` **and** `original_commit_id` == HEAD, or
 - a `>= min_chars` conversation comment naming HEAD's SHA that is not a
   capability-failure notice, or
+- a `>= min_chars` descriptive conversation comment tied to a post-push
+  run-start marker that is neither a capability-failure nor a fixed
+  run-start/completion marker, or
 - a substantive non-`APPROVED` review on HEAD with `submitted_at >= push_ts`.
 
 Redemption is announced on stderr and is visible in the emitted

--- a/.claude/reference/review-substance-evidence.md
+++ b/.claude/reference/review-substance-evidence.md
@@ -134,7 +134,8 @@ comment satisfies every condition below:
 - its reviewer-authored body is at least `min_chars` long after the existing
   echoed-author-line filter removes borrowed prose;
 - it is not a capability-failure notice;
-- it is not itself a run-start marker (which proves only that work began);
+- it is not itself a run-start marker or fixed completion marker (which prove
+  only that work began or ended);
 - it is at or after `push_ts`; and
 - the reviewer has an earliest post-push run-start marker, with the comment at
   or after that marker.
@@ -144,6 +145,12 @@ new network input. This is why the alternative changed-file-path rule was not
 chosen: it would require fetching the PR file list, introduce path-spelling
 false negatives, and add evaluator input solely to prove context that the
 existing round markers already establish.
+
+The completion-marker exclusion is semantic, not an accident of the default
+length threshold: the known `CodeAnt AI finished running the review.` notice is
+currently 39 characters, but it remains ineligible even when `min_chars` is
+configured below that. A fixed terminal status cannot certify that the reviewer
+read the diff.
 
 The safety property is one-directional and explicit in the evaluator dataflow.
 `$descriptive_ev` is ORed only into `$ext_substantive`; it never enters

--- a/.claude/reference/review-substance-evidence.md
+++ b/.claude/reference/review-substance-evidence.md
@@ -22,6 +22,7 @@ in its prompt not to trust the gate's verdict.
 | mia#172 | `396ced5` | CodeRabbit `APPROVED`, `bodylen=0` — **but genuine**: its comment named the exact `95febff…396ced5` range, listed all 3 changed files, carried an accurate walkthrough |
 | ccc#867 | `f54effb7` | CodeAnt `APPROVED` at 06:24:44Z; its own "CodeAnt AI is running the review" marker at 06:24:50Z — **six seconds later**; and "User … does not have a PR Review subscription" 11 s *before* the approval. Same inversion on the prior SHA `5a4a9d8d` (approved 06:18:05Z, marker 06:18:22Z) |
 | ccc#883 | 5 SHAs | **This PR, during its own review.** CodeAnt `APPROVED` every SHA with `bodylen=0` — once **four identical approvals in the same second** (`8ef311a`, 07:50:35Z), never once updating the status comment past `a1c03ed`. On `e1cccbb` it approved 6 s after the push at 08:20:54Z and posted "CodeAnt AI is running the review" at 08:22:17Z — **83 s later** — then completed a real review that named no SHA at all. Caught live by this file's own evaluator: `temporal_inversion`, `self_report_mismatch`, `no_substantive_footprint`. Meanwhile GitHub's `reviewDecision` read `APPROVED` throughout |
+| ccc#923 | `d04389e` | CodeAnt posted a substantive Sequence Diagram summary after its current-round run-start marker, accurately describing the UUID-fragment guard, but its simultaneous empty `APPROVED` stayed hollow because the summary did not repeat HEAD's SHA |
 
 ## Why body length alone was rejected
 
@@ -49,8 +50,10 @@ Implemented in `.claude/scripts/review-substance.sh` (pure evaluator; no network
    would read that as an inversion. Requires the HEAD committer date; when that
    is unavailable the check is skipped rather than guessed, so a transient API
    failure cannot invent a blocker.
-   The suppressing term is `external_evidence_on_head` — inline comments on HEAD
-   or a status comment naming HEAD — and it is deliberately **not** time-bounded.
+   The suppressing term is `external_evidence_on_head` — inline comments on HEAD,
+   a status comment naming HEAD, a descriptive current-round comment, or a
+   substantive non-`APPROVED` review — and it is deliberately **not** bounded
+   relative to the approval timestamp.
    Both halves were review findings on PR #883 itself, pulling in opposite
    directions, and both are right:
    - Keying off the approval's *own body* is circular (CodeAnt): the body is the
@@ -100,7 +103,8 @@ Implemented in `.claude/scripts/review-substance.sh` (pure evaluator; no network
    triggered") from masking the walkthrough that carries the self-report.
 4. **Substance across the whole footprint.** Review body ≥ `min_chars` **or**
    inline diff comments anchored to HEAD **or** a same-SHA status comment naming
-   HEAD. Never body length on its own — and never a comment whose content is the
+   HEAD **or** a long descriptive comment tied to the current review round.
+   Never body length on its own — and never a comment whose content is the
    reviewer *declining* to review.
    That last clause closes a loop this file's own live payload demonstrated
    (CodeAnt, PR #883). Capability-failure notices routinely name HEAD and run
@@ -115,6 +119,40 @@ Implemented in `.claude/scripts/review-substance.sh` (pure evaluator; no network
    corroborating only. An 8-second approval is suspicious, not disqualifying.
 
 `counts_as_coverage = approved ∧ substantive ∧ ¬inversion ∧ ¬capability_failure ∧ ¬mismatch`.
+
+### Descriptive evidence without a SHA (issue #927)
+
+The ccc#923 trace showed a genuine review footprint that the original evidence
+model could not admit: after CodeAnt announced that it was running the review,
+it posted a long, accurate Sequence Diagram summary of the UUID-fragment change,
+but did not repeat HEAD's SHA. `status_comment_names_head` was therefore false,
+and the empty approval had no other coverage source.
+
+`descriptive_evidence_on_head` admits that shape when a reviewer's conversation
+comment satisfies every condition below:
+
+- its reviewer-authored body is at least `min_chars` long after the existing
+  echoed-author-line filter removes borrowed prose;
+- it is not a capability-failure notice;
+- it is not itself a run-start marker (which proves only that work began);
+- it is at or after `push_ts`; and
+- the reviewer has an earliest post-push run-start marker, with the comment at
+  or after that marker.
+
+The push and marker bounds tie the prose to the current review round without a
+new network input. This is why the alternative changed-file-path rule was not
+chosen: it would require fetching the PR file list, introduce path-spelling
+false negatives, and add evaluator input solely to prove context that the
+existing round markers already establish.
+
+The safety property is one-directional and explicit in the evaluator dataflow.
+`$descriptive_ev` is ORed only into `$ext_substantive`; it never enters
+`$selfrep` or `$mismatch`. Turning the channel on can remove
+`no_substantive_footprint`, but `self_report_mismatch` is byte-identical with or
+without it. A reviewer whose latest SHA-naming comment identifies an older
+commit therefore remains disqualified even when descriptive evidence is true.
+The channel grants evidence of work; it cannot manufacture a false mismatch or
+launder a wrong-commit self-report.
 
 ### What counts as a run-start marker
 

--- a/.claude/reference/review-substance-evidence.md
+++ b/.claude/reference/review-substance-evidence.md
@@ -132,7 +132,8 @@ and the empty approval had no other coverage source.
 comment satisfies every condition below:
 
 - its reviewer-authored body is at least `min_chars` long after the existing
-  echoed-author-line filter removes borrowed prose;
+  echoed-author-line filter removes borrowed prose and blank or syntax-only
+  remnants are excluded from the length calculation;
 - it is not a capability-failure notice;
 - it is not itself a run-start marker or fixed completion marker (which prove
   only that work began or ended);

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -29,8 +29,9 @@
 #   #836-stale forever. A stale approval is therefore REDEEMED when that same
 #   reviewer left substantive evidence on the current SHA outside the review
 #   object (review-substance.sh `external_evidence_on_head`: HEAD-anchored inline
-#   comments, a status comment naming HEAD, or a substantive non-APPROVED review
-#   on HEAD). Redemption is by EVIDENCE, never by reviewer identity — CodeRabbit
+#   comments, a status comment naming HEAD, a descriptive current-round comment,
+#   or a substantive non-APPROVED review on HEAD). Redemption is by EVIDENCE,
+#   never by reviewer identity — CodeRabbit
 #   is treated identically, and an approval's own body can never redeem its own
 #   timestamp. `<P>_APPROVAL_STALE` keeps the unchanged norm_ts meaning;
 #   `<P>_APPROVAL_STALE_BLOCKING` (stale AND NOT redeemed) is what the path
@@ -735,7 +736,8 @@ override_eligible() { # <login>
 # object whose timestamp is in doubt (review-substance.sh):
 #   - inline diff comments with commit_id AND original_commit_id == HEAD, or
 #   - a >= min_chars conversation comment naming HEAD's SHA that is not a
-#     capability-failure notice, or
+#     capability-failure notice, or a descriptive comment tied to a post-push
+#     run-start marker, or
 #   - a substantive non-APPROVED review on HEAD with submitted_at >= push.
 # Each is anchored to the post-push commit, and the approval's own body is
 # excluded by construction — an approval can never redeem its own timestamp.

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -536,7 +536,16 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
     ( [ $convo[]?
         | (.body // "") as $b
         | (((.updated_at // .created_at) // "") | canon_ts) as $cts
-        | (($b | ascii_downcase | strip_echoed($cts)) | length) as $authored_len
+        # Measure only content-bearing reviewer-authored lines. strip_echoed
+        # deliberately preserves blank separators and fence delimiters so SHA
+        # masking keeps its structure; those remnants are not prose and must
+        # not add up to the descriptive-evidence threshold on their own.
+        | (($b | ascii_downcase | strip_echoed($cts))
+           | [ split("\n")[]
+               | norm_line
+               | select(test("[^[:space:][:punct:]]")) ]
+           | join("\n")
+           | length) as $authored_len
         | (($b | sha_tokens($cts))) as $tok
         | { login:   (.user.login // ""),
             body:    $b,

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -27,9 +27,10 @@
 #   3. self_report_mismatch  — the reviewer's own latest SHA-naming comment names
 #                              a commit other than the one it approved.
 #   4. substantive           — review body OR inline comments on HEAD OR a
-#                              same-SHA status comment naming HEAD. Never body
-#                              length on its own, and never a comment whose
-#                              content is the reviewer declining to review.
+#                              same-SHA status comment naming HEAD OR a long
+#                              descriptive comment in the current review round.
+#                              Never body length on its own, and never a comment
+#                              whose content is the reviewer declining to review.
 #   5. seconds_after_push    — reported only. Timing corroborates, never decides.
 #
 # This is a pure evaluator: no network, no gh calls. Callers pass the review and
@@ -54,7 +55,8 @@
 #     "reviewers": { "<login>": {
 #        "approved_on_head": true, "approval_submitted_at": "…",
 #        "body_len": 0, "inline_comments_on_head": 0,
-#        "status_comment_names_head": true, "status_comment_shas": ["…"],
+#        "status_comment_names_head": true,
+#        "descriptive_evidence_on_head": true, "status_comment_shas": ["…"],
 #        "self_report_mismatch": false,
 #        "temporal_inversion": false, "run_start_marker_at": "…",
 #        "capability_failure": false, "capability_failure_text": "",
@@ -87,6 +89,16 @@
 #                             non-reviewer comment on the same thread (issue
 #                             #933). A bot that merely echoes the author's
 #                             SHA-bearing re-review trigger no longer names HEAD.
+#   descriptive_evidence_on_head
+#                             a non-failure, non-marker conversation comment at
+#                             least min_chars long, posted in the current HEAD
+#                             round at or after that reviewer's earliest
+#                             post-push run-start marker. It need not name HEAD:
+#                             the marker and push bounds tie it to this round.
+#                             This signal enters only $ext_substantive. It never
+#                             enters $selfrep or $mismatch, so it can only grant
+#                             coverage; it cannot manufacture a false mismatch
+#                             or bypass an existing wrong-commit hard block.
 #   self_report_mismatch      among that bot's conversation comments containing any
 #                             SHA-like token, the MOST RECENT one names no SHA
 #                             matching HEAD. SHA-like = \b[0-9a-f]{7,40}\b with at
@@ -119,10 +131,13 @@
 #                             (repo memory coderabbit-rate-limit-is-temporary), and
 #                             that later evidence must win.
 #   substantive               body_len >= min_chars OR inline_comments_on_head > 0
-#                             OR status_comment_names_head
+#                             OR status_comment_names_head OR
+#                             descriptive_evidence_on_head
 #   external_evidence_on_head substantive footprint OTHER than the approval body
-#                             (inline comments, or a status comment naming HEAD);
-#                             what suppresses a temporal_inversion verdict
+#                             (inline comments, a status comment naming HEAD, a
+#                             descriptive current-round comment, or a substantive
+#                             non-APPROVED review); what suppresses a
+#                             temporal_inversion verdict
 #   counts_as_coverage        approved AND substantive AND none of the three
 #                             disqualifiers above
 #
@@ -520,10 +535,12 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
     ( [ $convo[]?
         | (.body // "") as $b
         | (((.updated_at // .created_at) // "") | canon_ts) as $cts
+        | (($b | ascii_downcase | strip_echoed($cts)) | length) as $authored_len
         | (($b | sha_tokens($cts))) as $tok
         | { login:   (.user.login // ""),
             body:    $b,
             len:     ($b | length),
+            authored_len: $authored_len,
             ts:      (((.updated_at // .created_at) // "") | canon_ts),
             created: (((.created_at // .updated_at) // "") | canon_ts),
             tokens:  $tok,
@@ -572,6 +589,25 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
     ( [ $approvers[]
         | . as $login
         | ( [ $cidx[] | select(.login == $login) ] )                       as $mine
+
+        # EARLIEST post-push run-start marker. Earliest, not latest: a re-review
+        # kicked off AFTER a genuine approval would otherwise look inverted.
+        #
+        # ">=", not ">" — the push second is INCLUSIVE, matching fresh_review
+        # below (BugBot review on c90b32a, PR #883). canon_ts has already
+        # stripped fractional seconds, so a marker posted a fraction of a second
+        # after the commit carries the SAME string as $push; under a strict ">"
+        # it was discarded and temporal_inversion could not fire at all — which
+        # is precisely when these bots post, seconds either side of the push.
+        # One evaluator cannot read the push second as inclusive for reviews and
+        # exclusive for markers. Including it is also the conservative direction:
+        # inversion additionally requires the approval to be at or before the
+        # marker, and $ext_substantive still clears any bot that really worked.
+        | ( if $push == "" then null
+            else ( [ $mine[] | select(.created >= $push and .marker) ]
+                   | sort_by(.created) | first )
+            end )                                                          as $marker
+
         | ( [ $ridx[] | select(.login == $login and .state == "APPROVED") ] )
                                                                            as $aps
         | ( $aps | sort_by(.submitted_at) | last )                         as $ap
@@ -611,11 +647,32 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
         | ( [ $mine[]
               | select(.len >= $min_chars and .names_head and (.failure | not)) ] ) as $status_ev
         | (($status_ev | length) > 0)                                      as $names_head
+
+        # A run-start marker cannot serve as its own evidence, even when verbose:
+        # it says work began, not that any diff was read. The length threshold
+        # also uses authored_len, after the existing echoed-author-line filter;
+        # borrowed prose cannot become the bot"s evidence merely by being quoted.
+        # A separate long descriptive comment posted at or after the marker is
+        # evidence that the bot read the current diff even when it does not repeat
+        # HEAD"s SHA. This admission channel is intentionally one-directional: it
+        # feeds only external substance and never $selfrep or $mismatch. An
+        # existing wrong-SHA self-report therefore remains a hard disqualifier
+        # even when this value is true.
+        | ( $marker != null and
+            ([ $mine[]
+               | select(.authored_len >= $min_chars
+                        and (.failure | not)
+                        and (.marker | not)
+                        and .created >= $push
+                        and .created >= $marker.created) ]
+             | length) > 0 )                                               as $descriptive_ev
         # Substance that exists INDEPENDENTLY of the approval object itself:
-        # inline comments anchored to HEAD, a status comment naming HEAD, or a
-        # substantive non-APPROVED review on HEAD. The approval"s own body is
-        # excluded on purpose — see $inversion below.
+        # inline comments anchored to HEAD, a status comment naming HEAD, a
+        # descriptive current-round comment, or a substantive non-APPROVED
+        # review on HEAD. The approval"s own body is excluded on purpose — see
+        # $inversion below.
         | ( (($inl | length) > 0) or $names_head
+            or $descriptive_ev
             or ($other_review_len >= $min_chars) )                         as $ext_substantive
 
         | ( ($body_len >= $min_chars) or $ext_substantive )                as $substantive
@@ -633,24 +690,6 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
         | ( [ $mine[] | select((.tokens | length) > 0) ]
             | sort_by(.created) | last )                                   as $selfrep
         | ( $selfrep != null and ($selfrep.names_head | not) )             as $mismatch
-
-        # EARLIEST post-push run-start marker. Earliest, not latest: a re-review
-        # kicked off AFTER a genuine approval would otherwise look inverted.
-        #
-        # ">=", not ">" — the push second is INCLUSIVE, matching fresh_review
-        # above (BugBot review on c90b32a, PR #883). canon_ts has already
-        # stripped fractional seconds, so a marker posted a fraction of a second
-        # after the commit carries the SAME string as $push; under a strict ">"
-        # it was discarded and temporal_inversion could not fire at all — which
-        # is precisely when these bots post, seconds either side of the push.
-        # One evaluator cannot read the push second as inclusive for reviews and
-        # exclusive for markers. Including it is also the conservative direction:
-        # inversion additionally requires the approval to be at or before the
-        # marker, and $ext_substantive still clears any bot that really worked.
-        | ( if $push == "" then null
-            else ( [ $mine[] | select(.created >= $push and .marker) ]
-                   | sort_by(.created) | first )
-            end )                                                          as $marker
 
         # Capability failure: a post-push notice that this reviewer could not
         # review, and no evidence outside the approval object that it read the
@@ -739,6 +778,7 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
               body_len:                  $body_len,
               inline_comments_on_head:   ($inl | length),
               status_comment_names_head: $names_head,
+              descriptive_evidence_on_head: $descriptive_ev,
               other_review_body_len:     $other_review_len,
               external_evidence_on_head: $ext_substantive,
               status_comment_shas:       (($selfrep.tokens // []) | unique),

--- a/.claude/scripts/review-substance.sh
+++ b/.claude/scripts/review-substance.sh
@@ -30,7 +30,8 @@
 #                              same-SHA status comment naming HEAD OR a long
 #                              descriptive comment in the current review round.
 #                              Never body length on its own, and never a comment
-#                              whose content is the reviewer declining to review.
+#                              whose content is the reviewer declining to review
+#                              or a fixed run-start/completion marker.
 #   5. seconds_after_push    — reported only. Timing corroborates, never decides.
 #
 # This is a pure evaluator: no network, no gh calls. Callers pass the review and
@@ -556,6 +557,11 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
             # marker, and an approval after it stops looking inverted against
             # the bot"s genuine "is running the review" notice later on.
             marker:  ($b | test("is running the review|is reviewing|review in progress|currently processing|started reviewing|started the review|is analyzing"; "i")),
+            # Fixed completion notices prove only that a run ended. Match the
+            # whole authored body so a real summary that happens to say
+            # "review complete" in its prose remains eligible.
+            completion_marker:
+              ($b | test("^[[:space:][:punct:]]*((codeant ai|coderabbit|cursor bugbot|greptile)[[:space:]]+)?(finished running the review|(the )?review (is )?(now )?complete(d)?)[[:space:][:punct:]]*$"; "i")),
             # explicit "I cannot review this" notices
             failure: ($b | test("does not have a pr review subscription|no active subscription|not have an active subscription|rate limit|rate-limit|usage limit|usage or spend limit|quota exceeded|could not run|couldn'"'"'t run|unable to run|unable to review|unable to complete|failed to run|failed to review"; "i")) } ]
       | sort_by(.ts) ) as $cidx
@@ -648,10 +654,12 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
               | select(.len >= $min_chars and .names_head and (.failure | not)) ] ) as $status_ev
         | (($status_ev | length) > 0)                                      as $names_head
 
-        # A run-start marker cannot serve as its own evidence, even when verbose:
-        # it says work began, not that any diff was read. The length threshold
-        # also uses authored_len, after the existing echoed-author-line filter;
-        # borrowed prose cannot become the bot"s evidence merely by being quoted.
+        # A run-start or fixed completion marker cannot serve as its own
+        # evidence, even when it clears a configured length threshold: it says
+        # only that work began or ended, not that any diff was read. The length
+        # threshold also uses authored_len, after the existing
+        # echoed-author-line filter; borrowed prose cannot become the bot"s
+        # evidence merely by being quoted.
         # A separate long descriptive comment posted at or after the marker is
         # evidence that the bot read the current diff even when it does not repeat
         # HEAD"s SHA. This admission channel is intentionally one-directional: it
@@ -663,6 +671,7 @@ OUT=$(printf '%s' "$INPUT" | jq -c \
                | select(.authored_len >= $min_chars
                         and (.failure | not)
                         and (.marker | not)
+                        and (.completion_marker | not)
                         and .created >= $push
                         and .created >= $marker.created) ]
              | length) > 0 )                                               as $descriptive_ev

--- a/.claude/scripts/tests/merge-gate-review-substance.test.sh
+++ b/.claude/scripts/tests/merge-gate-review-substance.test.sh
@@ -906,6 +906,16 @@ OUT="$(run_gate)"
 check_eq "false" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].descriptive_evidence_on_head')" "(gg-927) echoed author prose is not reviewer-authored descriptive evidence"
 check_contains "no_substantive_footprint" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].disqualified_by | join(" | ")')" "(gg-927) an echo-only description stays hollow"
 
+ECHO_SOURCE="$(jq -nr '[range(1; 51) | "Author evidence line \(.)."] | join("\n")')"
+ECHO_WITH_BLANKS="$(printf '%s\n' "$ECHO_SOURCE" | sed 'G')"
+FAKE_ISSUE_COMMENTS="$(convo \
+  "codeant-ai[bot]" "$RUN_START" "2026-07-31T10:01:00Z" \
+  "auerbachb" "$ECHO_SOURCE" "2026-07-31T10:02:00Z" \
+  "codeant-ai[bot]" "$ECHO_WITH_BLANKS" "2026-07-31T10:03:00Z")"
+OUT="$(run_gate)"
+check_eq "false" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].descriptive_evidence_on_head')" "(gg-927) blank separators left after echo stripping are not authored evidence"
+check_contains "no_substantive_footprint" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].disqualified_by | join(" | ")')" "(gg-927) echo-only whitespace remnants stay hollow"
+
 echo "=== (gg-927) pre-marker and pre-push descriptions remain hollow ==="
 FAKE_ISSUE_COMMENTS="$(convo \
   "codeant-ai[bot]" "$DESCRIPTIVE_SUMMARY" "2026-07-31T10:00:30Z" \

--- a/.claude/scripts/tests/merge-gate-review-substance.test.sh
+++ b/.claude/scripts/tests/merge-gate-review-substance.test.sh
@@ -36,8 +36,9 @@
 #        (n): an echo edited in place into an older bot comment is stripped on
 #        updated_at, with the unedited case as the ordering control
 #   (gg-927) a long post-run-start descriptive comment without a SHA grants
-#        external evidence; timing/failure negatives stay hollow, and an
-#        existing wrong-SHA self-report remains disqualifying
+#        external evidence; timing/failure/start-marker/completion-marker
+#        negatives stay hollow, and an existing wrong-SHA self-report remains
+#        disqualifying
 #
 # Only `gh` is stubbed; merge-gate.sh, review-substance.sh, ci-status.sh,
 # check-runs-dedup.sh and session-state.sh are the real scripts.
@@ -884,6 +885,18 @@ FAKE_ISSUE_COMMENTS="$(convo "codeant-ai[bot]" "$LONG_RUN_START" "2026-07-31T10:
 OUT="$(run_gate)"
 check_eq "false" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].descriptive_evidence_on_head')" "(gg-927) a long run-start marker is not its own descriptive evidence"
 check_contains "no_substantive_footprint" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].disqualified_by | join(" | ")')" "(gg-927) a content-free run marker stays hollow"
+
+# The production completion notice is 39 characters, just below the default
+# threshold. Lower the supported threshold to prove the exclusion is semantic,
+# not an accidental consequence of that current spelling's length.
+FAKE_ISSUE_COMMENTS="$(convo \
+  "codeant-ai[bot]" "$RUN_START" "2026-07-31T10:01:00Z" \
+  "codeant-ai[bot]" "CodeAnt AI finished running the review." "2026-07-31T10:03:00Z")"
+export MERGE_GATE_SUBSTANCE_MIN_CHARS=20
+OUT="$(run_gate)"
+unset MERGE_GATE_SUBSTANCE_MIN_CHARS
+check_eq "false" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].descriptive_evidence_on_head')" "(gg-927) a fixed completion marker is not descriptive evidence"
+check_contains "no_substantive_footprint" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].disqualified_by | join(" | ")')" "(gg-927) a content-free completion marker stays hollow"
 
 FAKE_ISSUE_COMMENTS="$(convo \
   "codeant-ai[bot]" "$RUN_START" "2026-07-31T10:01:00Z" \

--- a/.claude/scripts/tests/merge-gate-review-substance.test.sh
+++ b/.claude/scripts/tests/merge-gate-review-substance.test.sh
@@ -35,6 +35,9 @@
 #        so an echoed "```<sha>" smuggles nothing yet still masks its block;
 #        (n): an echo edited in place into an older bot comment is stripped on
 #        updated_at, with the unedited case as the ordering control
+#   (gg-927) a long post-run-start descriptive comment without a SHA grants
+#        external evidence; timing/failure negatives stay hollow, and an
+#        existing wrong-SHA self-report remains disqualifying
 #
 # Only `gh` is stubbed; merge-gate.sh, review-substance.sh, ci-status.sh,
 # check-runs-dedup.sh and session-state.sh are the real scripts.
@@ -849,6 +852,85 @@ FF_N2="$(ff_eval "$(jq -cn --arg t "$FF_TRIGGER_LINE" --arg e "$FF_ECHO_LINE" '
     {login:"auerbachb", created:"2026-07-31T10:05:00Z",
      body:("@codeant-ai: review\n\n" + $t + "\n")} ]')")"
 check_eq "true" "$(echo "$FF_N2" | jq -r '.status_comment_names_head')" "(ff-933)(n) control: an unedited earlier bot comment keeps its line"
+
+echo "=== (gg-927) descriptive current-round comments are external evidence ==="
+RUN_START="CodeAnt AI is running the review."
+DESCRIPTIVE_SUMMARY="## Sequence Diagram
+This change preserves the merge gate while recognizing a detailed reviewer summary tied to the current review round without requiring the summary to repeat a commit SHA."
+
+FAKE_REVIEWS="$(approval "codeant-ai[bot]" "")"
+FAKE_ISSUE_COMMENTS="$(convo \
+  "codeant-ai[bot]" "$RUN_START" "2026-07-31T10:01:00Z" \
+  "codeant-ai[bot]" "$DESCRIPTIVE_SUMMARY" "2026-07-31T10:03:00Z")"
+OUT="$(run_gate)"
+GG_REVIEWER="$(echo "$OUT" | jq -c '.review_evidence.reviewers["codeant-ai[bot]"]')"
+check_eq "true"  "$(echo "$OUT" | jq -r '.met')" "(gg-927) long post-marker description satisfies the gate"
+check_eq "false" "$(echo "$GG_REVIEWER" | jq -r '.status_comment_names_head')" "(gg-927) description does not need to name HEAD"
+check_eq "true"  "$(echo "$GG_REVIEWER" | jq -r '.descriptive_evidence_on_head')" "(gg-927) descriptive evidence is inspectable"
+check_eq "true"  "$(echo "$GG_REVIEWER" | jq -r '.external_evidence_on_head')" "(gg-927) description contributes external evidence"
+check_eq "true"  "$(echo "$GG_REVIEWER" | jq -r '.counts_as_coverage')" "(gg-927) description grants substantive coverage"
+check_not_contains "no_substantive_footprint" "$(echo "$GG_REVIEWER" | jq -r '.disqualified_by | join(" | ")')" "(gg-927) hollow reason is removed"
+
+echo "=== (gg-927) short description remains hollow ==="
+FAKE_ISSUE_COMMENTS="$(convo \
+  "codeant-ai[bot]" "$RUN_START" "2026-07-31T10:01:00Z" \
+  "codeant-ai[bot]" "Reviewed the change." "2026-07-31T10:03:00Z")"
+OUT="$(run_gate)"
+check_eq "false" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].descriptive_evidence_on_head')" "(gg-927) short description is rejected"
+check_contains "no_substantive_footprint" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].disqualified_by | join(" | ")')" "(gg-927) short description stays hollow"
+
+LONG_RUN_START="CodeAnt AI is running the review and will post a separate analysis when the review work has completed."
+FAKE_ISSUE_COMMENTS="$(convo "codeant-ai[bot]" "$LONG_RUN_START" "2026-07-31T10:01:00Z")"
+OUT="$(run_gate)"
+check_eq "false" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].descriptive_evidence_on_head')" "(gg-927) a long run-start marker is not its own descriptive evidence"
+check_contains "no_substantive_footprint" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].disqualified_by | join(" | ")')" "(gg-927) a content-free run marker stays hollow"
+
+FAKE_ISSUE_COMMENTS="$(convo \
+  "codeant-ai[bot]" "$RUN_START" "2026-07-31T10:01:00Z" \
+  "auerbachb" "$DESCRIPTIVE_SUMMARY" "2026-07-31T10:02:00Z" \
+  "codeant-ai[bot]" "$DESCRIPTIVE_SUMMARY" "2026-07-31T10:03:00Z")"
+OUT="$(run_gate)"
+check_eq "false" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].descriptive_evidence_on_head')" "(gg-927) echoed author prose is not reviewer-authored descriptive evidence"
+check_contains "no_substantive_footprint" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].disqualified_by | join(" | ")')" "(gg-927) an echo-only description stays hollow"
+
+echo "=== (gg-927) pre-marker and pre-push descriptions remain hollow ==="
+FAKE_ISSUE_COMMENTS="$(convo \
+  "codeant-ai[bot]" "$DESCRIPTIVE_SUMMARY" "2026-07-31T10:00:30Z" \
+  "codeant-ai[bot]" "$RUN_START" "2026-07-31T10:01:00Z")"
+OUT="$(run_gate)"
+check_eq "false" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].descriptive_evidence_on_head')" "(gg-927) pre-marker description is rejected"
+
+FAKE_ISSUE_COMMENTS="$(convo \
+  "codeant-ai[bot]" "$DESCRIPTIVE_SUMMARY" "2026-07-31T09:59:00Z" \
+  "codeant-ai[bot]" "$RUN_START" "2026-07-31T10:01:00Z")"
+OUT="$(run_gate)"
+check_eq "false" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].descriptive_evidence_on_head')" "(gg-927) pre-push description is rejected"
+
+echo "=== (gg-927) failure notice and missing marker remain hollow ==="
+FAILURE_SUMMARY="CodeAnt could not run the requested review because its usage limit was reached, so no analysis of the current diff was performed."
+FAKE_ISSUE_COMMENTS="$(convo \
+  "codeant-ai[bot]" "$RUN_START" "2026-07-31T10:01:00Z" \
+  "codeant-ai[bot]" "$FAILURE_SUMMARY" "2026-07-31T10:03:00Z")"
+OUT="$(run_gate)"
+check_eq "false" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].descriptive_evidence_on_head')" "(gg-927) capability-failure notice is rejected"
+
+FAKE_ISSUE_COMMENTS="$(convo "codeant-ai[bot]" "$DESCRIPTIVE_SUMMARY" "2026-07-31T10:03:00Z")"
+OUT="$(run_gate)"
+check_eq "false" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].descriptive_evidence_on_head')" "(gg-927) description without a run-start marker is rejected"
+check_contains "no_substantive_footprint" "$(echo "$OUT" | jq -r '.review_evidence.reviewers["codeant-ai[bot]"].disqualified_by | join(" | ")')" "(gg-927) no-marker description stays hollow"
+
+echo "=== (gg-927) descriptive evidence cannot launder a wrong-SHA self-report ==="
+FAKE_ISSUE_COMMENTS="$(convo \
+  "codeant-ai[bot]" "$RUN_START" "2026-07-31T10:01:00Z" \
+  "codeant-ai[bot]" "CodeAnt AI finished reviewing commit 98f0bd0 and found no blocking issues in the changes." "2026-07-31T10:02:00Z" \
+  "codeant-ai[bot]" "$DESCRIPTIVE_SUMMARY" "2026-07-31T10:03:00Z")"
+OUT="$(run_gate)"
+GG_REVIEWER="$(echo "$OUT" | jq -c '.review_evidence.reviewers["codeant-ai[bot]"]')"
+check_eq "true"  "$(echo "$GG_REVIEWER" | jq -r '.descriptive_evidence_on_head')" "(gg-927) descriptive channel is active beside mismatch"
+check_eq "true"  "$(echo "$GG_REVIEWER" | jq -r '.self_report_mismatch')" "(gg-927) wrong-SHA self-report remains a mismatch"
+check_eq "false" "$(echo "$GG_REVIEWER" | jq -r '.counts_as_coverage')" "(gg-927) mismatch still disqualifies the approval"
+check_contains "self_report_mismatch" "$(echo "$GG_REVIEWER" | jq -r '.disqualified_by | join(" | ")')" "(gg-927) mismatch reason remains explicit"
+check_not_contains "no_substantive_footprint" "$(echo "$GG_REVIEWER" | jq -r '.disqualified_by | join(" | ")')" "(gg-927) only the hollow reason is cleared"
 
 echo "=== (m) evaluator rejects malformed stdin ==="
 echo "not json" | "$EVAL_SUT" >/dev/null 2>&1


### PR DESCRIPTION
## **User description**
Closes #927

## Summary

- recognize long reviewer-authored conversation summaries tied to the current post-push review round, even when they do not repeat HEAD
- keep run markers, failure notices, pre-marker/pre-push prose, and echoed author text out of the new evidence channel
- preserve the one-directional wrong-SHA guard and expose the new signal for diagnostics

## Test plan

- [x] A sufficiently long, non-failure conversation comment posted after the current-round run-start marker is recognized as descriptive external evidence even when it does not name HEAD.
- [x] Short, pre-marker, pre-push, capability-failure, no-marker, marker-only, and echo-only comments do not activate descriptive evidence.
- [x] Descriptive evidence can only grant substantive coverage; it never changes self-report mismatch or bypasses the wrong-commit guard.
- [x] The new signal is inspectable in per-reviewer evaluator output and documented with its one-directional proof and the rejected changed-file-path alternative.
- [x] Focused regression tests, adjacent merge-gate suites, syntax checks, ShellCheck, rule-lint, and required CI pass.

## Verification

- `merge-gate-review-substance.test.sh`: 173 passed, 0 failed
- adjacent merge-gate suites: 6 passed
- `bash -n` and ShellCheck: passed
- `rule-lint.sh`: passed
- full hook/script runner was attempted repeatedly but the shared local process was terminated after 30 green suites; GitHub CI will run the complete auto-discovered suite

**Local review coverage:** none — CodeRabbit was rate-limited and CodeAnt was unavailable (noFiles/403) across local review attempts; self-review completed before each push.


___

## **CodeAnt-AI Description**
Recognize valid reviewer summaries without requiring a commit SHA

### What Changed
- Long, reviewer-authored summaries posted after the current review run starts can now count as substantive review evidence even when they do not repeat HEAD's SHA.
- Run-start notices, completion messages, failure notices, pre-run comments, and author-text echoes remain excluded from evidence.
- Existing wrong-commit self-reports still disqualify approvals; descriptive evidence cannot bypass that safeguard.
- Review diagnostics now expose whether descriptive evidence was detected, with regression tests and updated guidance covering the new cases.

### Impact
`✅ Fewer valid reviews incorrectly blocked`
`✅ Wrong-commit approvals remain rejected`
`✅ Clearer review evidence diagnostics`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
