### PR TITLE
docs(#958): correct BugBot grace duration

### DIFF
--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -129,7 +129,7 @@ case "$ESCALATION_STATUS" in
 esac
 ```
 
-The script caches `.prs["{{PR_NUMBER}}"].bugbot_installed` in `~/.claude/session-state.json` on first BugBot detection so repositories without BugBot skip the 5-minute grace wait on later cycles. Do not duplicate the timing logic inline; `cr-github-review.md` owns the numbered gate and STOP conditions.
+The script caches `.prs["{{PR_NUMBER}}"].bugbot_installed` in `~/.claude/session-state.json` on first BugBot detection so repositories without BugBot skip the 10-minute (600 s) grace wait on later cycles. Do not duplicate the timing logic inline; `cr-github-review.md` owns the numbered gate and STOP conditions.
 
 ### Completion Detection
 


### PR DESCRIPTION
## Summary

- correct the Phase B reviewer documentation to name the actual 10-minute (600 s) BugBot grace period
- audit other agent, rule, and reference guidance for stale 5-minute BugBot durations
- leave `.claude/scripts/escalate-review.sh` behavior unchanged

Closes #958

## Test plan

- [x] `.claude/agents/phase-b-reviewer.md` names the 10-minute (600 s) grace period
- [x] agent/rule/reference audit finds no stale 5-minute BugBot grace duration
- [x] `.claude/scripts/escalate-review.sh` has no diff and retains its 600-second thresholds
- [x] focused repository lints pass
- [x] full hook suite passes (71 suites, 0 failed) on the final rebased head

**Local review coverage:** none — CodeRabbit rate-limited twice and CodeAnt returned 403 twice; fallback self-review confirmed a one-line documentation-only diff matching the script threshold with no behavior change.