### PR TITLE
docs(#959): record scheduling reliability hotspot decision

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -80,6 +80,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `fixpr-hotspot-decision.md` — diagnosis and extract-not-split decision for `fixpr/SKILL.md` churn (17 PRs in the run-up to #788); verdict: KEEP single file + extract large command forms
 - `escalate-review-test-hotspot-decision.md` — diagnosis and split decision for `escalate-review.test.sh` churn (11 merged PRs in the #966 hotspot window, re-measured after #969); verdict: SPLIT into four concern suites plus one shared fixture helper
 - `monitor-mode-hotspot-decision.md` — diagnosis and dedup decision for `monitor-mode.md` churn (9 merged PRs in the #984 hotspot window); verdict: KEEP single rule file + point PM recovery prose to its canonical owners
+- `scheduling-reliability-hotspot-decision.md` — diagnosis and dedup decision for `scheduling-reliability.md` churn (12 merged PRs in the #959 hotspot window, re-measured after #982); verdict: KEEP single rule file + remove downstream formula/enforcement restatements
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `harness-model-audit-2026-06.md` — harness components vs current model fleet (#49)
 - `script-extraction-audit.md` — deterministic script extraction inventory (#271)

--- a/.claude/reference/scheduling-failure-modes.md
+++ b/.claude/reference/scheduling-failure-modes.md
@@ -57,9 +57,9 @@ problem entirely. Don't optimize cadence inside a flaky chain — fix the chain 
 
 **Root cause.** The scheduler had no stable-state digest or backoff gate, so "nothing changed" was treated like actionable progress forever. In PR #359 on 2026-04-25, cron `e7230e2f` kept a 1-minute cadence while orphan one-shot `4e56074f` also remained alive; ticks #45-#93 repeated the same state for roughly 50 minutes until the user manually stopped it.
 
-**Fix.** Apply `scheduling-reliability.md` "Stable-State Backoff": compute the digest, increment `digest_streak`, widen to `max(15m, 3×base)` at streak 3 (for the default 5m base this is 15m — always strictly greater than the base), and pause at streak 9. If `blocker_kind == "user_input"` or the blocker text says the agent is awaiting the user's direction, pause after the first visible message. On a tier change, stop the prior Monitor task before arming its replacement.
+**Fix.** Apply `.claude/rules/scheduling-reliability.md` `## Stable-State Backoff`, the canonical source for digest inputs, cadence widening, stop/resume thresholds, and user-input handling. On a tier change, stop the prior Monitor task before arming its replacement.
 
-> **Authoritative source decision (issue #794):** the base-relative formula `max(15m, 3×base)` from `babysit-pr/SKILL.md` T5 was made authoritative over the earlier absolute `5m`/`15m` ladder in `scheduling-reliability.md`, because absolute minutes silently no-op at the documented 5m default (widening to 5m from 5m is no change). The base-relative form is correct at every `--cadence` value and was validated live on PR #775.
+> **Authoritative source decision (Issue #794):** the cadence-relative policy was chosen over the earlier absolute-minute ladder because an absolute widening can silently no-op at the documented default. The current formula and thresholds live only in `scheduling-reliability.md`; the policy was validated live on PR #775.
 
 ## Pattern 6 — Background Work With No Armed Observer
 

--- a/.claude/reference/scheduling-reliability-hotspot-decision.md
+++ b/.claude/reference/scheduling-reliability-hotspot-decision.md
@@ -1,0 +1,107 @@
+# Scheduling Reliability Hotspot Decision
+
+Reference for Issue #959 (`.claude/rules/scheduling-reliability.md` churn hotspot). Not auto-loaded.
+
+## Executive summary
+
+### Verdict: **KEEP** the single rule file and **deduplicate toward it**
+
+Keep `.claude/rules/scheduling-reliability.md` intact as the canonical source for scheduling
+primitive selection, PM monitoring boundaries, recurring-scheduler reliability, the polling
+pre-exit checklist, stable-state backoff, and dropped-tick recovery. The file is compact, its
+sections form one liveness contract, and most of its churn followed changes in the underlying
+scheduling primitives rather than unrelated concerns accumulating in one file.
+
+Remove two confirmed downstream restatements: the copied backoff thresholds in
+`.claude/reference/scheduling-failure-modes.md` and the copied Stop-hook enforcement sentence in
+`.claude/rules/subagent-orchestration.md`. Keep `.claude/rules/monitor-mode.md` unchanged because
+the newer Issue #984 decision makes that file the canonical owner of PM recovery and its
+scheduler-ownership boundary.
+
+## 1. Trigger and current evidence
+
+When Issue #959 was filed, the hotspot detector recorded 11 merged PRs touching
+`scheduling-reliability.md` since 2026-07-19. Current `main` adds PR #982, producing 12 touches:
+PRs #660, #717, #774, #787, #804, #807, #820, #825, #867, #919, #922, and #982.
+
+At diagnosis time the rule was 53 lines and 609 words, far below the 2,000-word per-file warning.
+The touch history falls into four groups:
+
+| Churn class | PRs | What changed |
+|-------------|-----|--------------|
+| New liveness mechanisms and posture | PRs #717, #774, #807 | Default babysitting, heartbeat wording, and the background-work ceiling |
+| Scheduling correctness and primitive lifecycle | PRs #820, #825, #867, #922, #982 | Backoff reconciliation, corrected CronCreate durability, session reconciliation, observed scheduler failure, and migration to persistent Monitor tasks |
+| Corpus compression | PRs #660, #804, #919 | Shortened auto-loaded prose without changing the scheduling contract |
+| Incidental corpus hygiene | PR #787 | Removed an unrelated duplicated root-repo safety restriction |
+
+The dominant driver is therefore an unstable or newly understood scheduling substrate. The
+sequence from Issue #808 through Issue #827, Issue #914, and Issue #924 successively corrected
+what recurrence and durability the available primitives could actually provide. Splitting the
+rule cannot remove that driver; it would only spread those corrections across more owners.
+
+## 2. Decision: keep one canonical scheduling rule
+
+**Splitting is rejected.** The current file is small, and its named sections are coupled parts of
+one question: how an agent selects a scheduling primitive and proves that recurring work remains
+observable. A split would add cross-file navigation and caller migrations without isolating an
+independently changing concern.
+
+**Another compression pass is rejected.** The file is already concise. Its remaining mechanism is
+operative policy that agents need in auto-loaded context, while detailed rationale and incident
+history already live in `.claude/reference/`.
+
+**KEEP + targeted deduplication is chosen.** Downstream documents should point to the canonical
+named section instead of copying its exact thresholds or enforcement wording.
+
+## 3. Canonical ownership
+
+| Content | Canonical owner | Non-owner action |
+|---------|-----------------|------------------|
+| Primitive choice, including recurring Monitor selection | `.claude/rules/scheduling-reliability.md` `## Tool Selection Decision Tree` | Point here; do not recreate the selection table |
+| PM's on-demand role and fleet-monitor ownership | `.claude/rules/scheduling-reliability.md` `## PM Monitoring Primitive` | Recovery documents may state their own actions, but do not redefine the primitive boundary |
+| Recurring scheduler failure and session-only limitations | `.claude/rules/scheduling-reliability.md` `### Recurring scheduler contract (authoritative)` | Reference docs retain evidence and rationale, not a second operative contract |
+| Polling turn liveness proof | `.claude/rules/scheduling-reliability.md` `## Mandatory Pre-Exit Checklist for Polling Turns` | Spawn rules keep the required action and point here for enforcement |
+| Digest inputs, widening formula, and stop/resume thresholds | `.claude/rules/scheduling-reliability.md` `## Stable-State Backoff` | Incident docs preserve history and link to this section without copying values |
+| Dropped-tick recovery | `.claude/rules/scheduling-reliability.md` `## Failure Recovery` plus the owning skill lifecycle | Consumers record the failure and invoke the owning recovery path |
+| PM recovery state and scheduler-ownership behavior | `.claude/rules/monitor-mode.md` `## PM Monitoring Recovery` | Preserve the explicit Issue #984 owner decision; do not trim this rule as part of Issue #959 |
+
+## 4. Targeted remediation
+
+1. In `.claude/reference/scheduling-failure-modes.md` Pattern 5, preserve the PR #359 incident and
+   the Issue #794 explanation for choosing a cadence-relative policy, but replace the copied
+   formula and thresholds with a direct pointer to `## Stable-State Backoff`.
+2. In `.claude/rules/subagent-orchestration.md` spawn Step 8, preserve the same-step action,
+   `bgwork-ceiling.sh --arm-command`, persistent `Monitor`, and the pointer to
+   `scheduling-reliability.md`; remove only the duplicated Stop-hook sentence.
+
+These changes reduce lockstep edit risk without changing behavior. The authoritative
+`.claude/rules/scheduling-reliability.md` and the separately owned `.claude/rules/monitor-mode.md`
+remain byte-for-byte unchanged.
+
+## 5. What not to change
+
+- Do not split `scheduling-reliability.md` while it remains a compact, cohesive liveness contract.
+- Do not move the decision tree, scheduler contract, pre-exit checklist, backoff formula, or
+  failure-recovery action out of the auto-loaded rule.
+- Do not duplicate backoff values in incident or skill documentation; cite the named section.
+- Do not weaken the requirement to arm the background-work ceiling in the same step as spawning.
+- Do not edit `monitor-mode.md` under this decision. Issue #984 records why its PM recovery and
+  scheduler-ownership wording belongs there.
+- Do not raise `.claude/rules/.budget-soft-cap` for this remediation; the auto-loaded corpus shrinks.
+
+## 6. Future edits
+
+Scheduling-policy changes should update the canonical named section and leave consumers as
+pointers. Reconsider this KEEP verdict only if the rule crosses the repository's size/adherence
+limits or acquires genuinely independent concerns with disjoint callers—not because another
+underlying scheduling primitive changes.
+
+The traceability marker on Issue #959 is:
+`<!-- churn-hotspot: .claude/rules/scheduling-reliability.md -->`.
+
+## Related precedent
+
+- `.claude/reference/monitor-mode-hotspot-decision.md` — KEEP + dedup, and the controlling decision
+  for PM recovery ownership;
+- `.claude/reference/fixpr-hotspot-decision.md` — KEEP + extract deterministic implementation;
+- `.claude/reference/churn-hotspots.md` — detector scope and observational-ticket rationale.

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -14,7 +14,7 @@ Use `.claude/agents/` definitions; they embed phase rules. Every Agent call must
 5. The verbatim `SAFETY:` block from `safety.md`.
 6. The verbatim `MINDSET:` block from `safety.md` (try CLI/browser before handoff — see "Capability Discovery").
 7. The verbatim `SKILLS:` block from `skill-first.md` — **skip for `phase-c-merger`** (no `Skill` tool).
-8. Same step, but not part of the call: arm the silence ceiling — `bgwork-ceiling.sh --arm-command` → `Monitor` (`persistent: true`). The Stop hook blocks the turn otherwise.
+8. Same step, but not part of the call: arm the silence ceiling — `bgwork-ceiling.sh --arm-command` → `Monitor` (`persistent: true`).
 
 See `.claude/agents/README.md` for the full placeholder reference and spawning examples.
 


### PR DESCRIPTION
## Summary

- record the owner decision to keep `scheduling-reliability.md` as one compact canonical liveness contract
- remove copied backoff thresholds and Stop-hook enforcement prose from two downstream documents
- preserve the newer Issue #984 ownership decision by leaving both `scheduling-reliability.md` and `monitor-mode.md` unchanged
- register the decision so future hotspot analysis can distinguish a reviewed KEEP verdict from an unhandled churn report

Closes #959

## Decision and budget notes

This PR records an owner decision for the scheduling-reliability hotspot. If a later `/wrap` run sees the closed marker again based on PR count alone, it should surface the condition for decision rather than silently re-file it.

The auto-loaded corpus decreases by 7 words (11,374 → 11,367). The ratchet cap remains 11,749 and was not raised.

**Local review coverage:** cr-only — CodeRabbit completed a verified clean pass; CodeAnt returned `no_changes_reviewed` twice and was dropped per the local-review fallback contract.

## Test plan

- [x] A registered scheduling-reliability hotspot decision records the evidence, KEEP verdict, canonical ownership, targeted deduplication, and preserved behavior.
- [x] `.claude/reference/scheduling-failure-modes.md` Pattern 5 preserves its unique incident history and Issue #794 rationale while pointing to `## Stable-State Backoff` instead of restating its formula or thresholds.
- [x] `.claude/rules/subagent-orchestration.md` still requires arming the ceiling in the spawn step with a persistent `Monitor` and points to `scheduling-reliability.md`, but no longer repeats the Stop-hook enforcement sentence.
- [x] `.claude/rules/scheduling-reliability.md` and `.claude/rules/monitor-mode.md` are unchanged from current `main`.
- [x] Rule lint passes, the `CLAUDE.md` rule index remains aligned, and the corpus stays below the ratchet cap without raising it.
- [x] All 75 Bash suites and all 142 Python tests pass.

## Verification

- `bash .github/scripts/rule-lint.sh`
- `bash .github/scripts/run-hook-tests.sh` (75 suites, 0 failed)
- `bash .github/scripts/run-python-tests.sh` (142 tests, 0 failed)
- `.claude/scripts/local-review.sh --tool coderabbit --scope uncommitted --base main --timeout 120` (verified clean)
- `.claude/scripts/local-review.sh --tool codeant --scope uncommitted --base main --timeout 120` (two `no_changes_reviewed` failures; dropped)
