### PR TITLE
docs(#964): adjudicate session-state schema hotspot

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -32,6 +32,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `review-substance-evidence.md` — why a bot APPROVED requires a substantive review footprint; hollow APPROVED failure mode and evidence checks in `merge-gate.sh` (#875)
 - `wrap-fixpr-delegation.md` — `/wrap` Step 2.1 → full `/fixpr` recovery handoff contract
 - `state-file-contracts.md` — expanded scoping, write-lock, migration, and field-type mechanics for `session-state.json` + handoffs (`handoff-files.md`; #625, #638, #639, #651, #655, #682, #687, #704)
+- `session-state-schema-hotspot-decision.md` — KEEP + targeted-dedup adjudication for the `session-state-schema.json` churn hotspot; canonical ownership, preserved compatibility, and field-change checklist (#964)
 - `session-state-collector.md` — the single definition of what a handoff *reads*, shared by `/pm-handoff` (Claude-native rendering) and `/pause` (portable rendering); one collector, two renderers (#901)
 - `portable-handoff.md` — the `/pause` artifact: naming, atomic single-writer write, why it is a sibling to the PR-scoped JSON handoffs rather than one of them, and how `portable-handoff-lint.sh` enforces portability (#901)
 - `authorship-guard.md` — `pr-authorship.sh` exit-code semantics, the three shared-script fail-safes, and `--allow-nonauthor` override plumbing (`safety.md` §Authorship; #733)

--- a/.claude/reference/session-state-schema-hotspot-decision.md
+++ b/.claude/reference/session-state-schema-hotspot-decision.md
@@ -1,0 +1,112 @@
+# Session-State Schema Hotspot Decision
+
+Reference for Issue #964 (`.claude/reference/session-state-schema.json` churn hotspot). Not auto-loaded.
+
+## Executive summary
+
+### Verdict: **KEEP** the combined contract and representative document; **deduplicate toward it**
+
+Keep `.claude/reference/session-state-schema.json` intact as the canonical source for both the
+machine-readable `_field_types` maps and the representative session-state document. Remove the
+stale typed-field enumeration from the `session-state.sh` header, correct the ownership statement
+in `state-file-contracts.md`, and document how future fields should update the contract.
+
+The file's churn is contract churn: its recent edits added or corrected state that the workflow
+actually persists. Moving the representative document would transfer those edits to another file,
+create another ownership boundary, and require migrating current tests and named references.
+
+## 1. Trigger and current evidence
+
+Issue #964 recorded 10 merged PRs touching the schema after 2026-07-19. Current `main` adds
+PR #982, producing 11 touches: PRs #654, #659, #690, #728, #747, #765, #820, #825, #828,
+#867, and #982.
+
+Those changes fall into related session-state contract work:
+
+| Churn class | PRs | Contract change |
+|-------------|-----|-----------------|
+| Type and scope contract | PRs #654, #659, #728 | Nested type guards, per-repo state, and lowercase scope identity |
+| PR lifecycle state | PRs #690, #747, #765 | Conflict streaks, poll watermarks, and overlap-aware merge holds |
+| Orchestration posture | PR #828 | Persisted refill pause/scope state |
+| Scheduling lifecycle | PRs #820, #825, #867, #982 | Backoff fields, corrected scheduler durability, reconciliation, and Monitor identity |
+
+The file has two deliberate consumers:
+
+- `session-state.sh` and `session-state-audit.sh` load
+  `._field_types.top_level` and `._field_types.pr_nested` at runtime.
+- `scheduling-primitive-alignment.test.sh` checks representative scheduling values and Monitor
+  identity fields in the example. The example is therefore tested contract documentation, not
+  unused prose. `handoff-files.md` also points agents to `_token_exhaustion_example` by name.
+
+## 2. Decision: keep one canonical artifact
+
+**Splitting is rejected.** A separate example fixture would still change whenever persisted state
+changes, while type-guarded additions would continue to change `_field_types`. It would not reduce
+the underlying churn and would add a second file that callers must discover and keep aligned.
+
+**Extracting the prose is rejected for now.** The `_`-prefixed descriptions sit beside the exact
+shapes they qualify. Moving them would make the representative document less self-explanatory
+without changing the edit frequency caused by new state fields.
+
+**KEEP + targeted deduplication is chosen.** The schema remains byte-for-byte unchanged in the
+Issue #964 remediation. Downstream documentation names it as authoritative instead of mirroring
+its field list.
+
+This differs from CodeRabbit's initial extract-not-split proposal because that plan predates
+PR #982 and did not account for the alignment test's direct consumption of example values. It
+retains the useful parts of that proposal: an explicit adjudication record, removal of the stale
+header mirror, and a contributor checklist.
+
+## 3. Canonical ownership
+
+| Content | Canonical owner | Consumer behavior |
+|---------|-----------------|-------------------|
+| Type-guarded top-level and per-PR fields | `session-state-schema.json` `_field_types` | Scripts load the maps; comments and docs point here rather than listing fields |
+| Representative session-state shapes | `session-state-schema.json` example document | Contract tests assert behaviorally important shapes and lifecycle vocabulary |
+| Scoping, locking, migration, and type rationale | `state-file-contracts.md` | Explain why the contract works without duplicating its full field inventory |
+| Runtime parsing and graceful degradation | `session-state.sh` and `session-state-audit.sh` | Preserve behavior when the schema is missing or cannot be parsed |
+
+## 4. What is preserved
+
+- `schema_version` remains `2`.
+- `._field_types.top_level` and `._field_types.pr_nested` remain the runtime jq paths.
+- Repo-scoped state remains under `.repos["<owner>/<name>"].prs["<N>"]`.
+- Unknown fields remain forward-compatible and unvalidated unless explicitly type-guarded.
+- A missing or invalid schema still warns and disables type checks for that invocation instead of
+  blocking all state reads and writes.
+- The representative example, including `_token_exhaustion_example` and Monitor identity fields,
+  remains in place.
+
+## 5. Targeted remediation
+
+1. Replace the `session-state.sh` header's hand-maintained field enumeration with a direct pointer
+   to the schema's `_field_types` maps. The runtime loader already follows that source.
+2. Update `state-file-contracts.md` so it no longer claims the script header owns the typed-field
+   list. Document the representative example and the field-change checklist there.
+3. Register this decision in the reference catalog.
+
+No runtime code, state migration, schema edit, or compatibility shim is required.
+
+## 6. Future edits and reconsideration
+
+For a new field:
+
+- add it to `_field_types` only when `session-state.sh` must enforce its JSON type;
+- update the representative object when the shape is part of the documented cross-agent contract;
+- update a focused alignment test when lifecycle vocabulary or a coupled field set matters;
+- leave untyped forward-compatible fields out of `_field_types`; and
+- put rationale in `state-file-contracts.md`, not in a second field inventory.
+
+Reconsider this KEEP verdict only if independent consumers need incompatible representative
+documents, the file becomes difficult to validate as one JSON object, or unrelated concerns begin
+changing on separate cadences. Raw touch count alone is not a reason to split a canonical schema.
+
+The traceability marker on Issue #964 is:
+`<!-- churn-hotspot: .claude/reference/session-state-schema.json -->`.
+
+## Related precedent
+
+- `.claude/reference/scheduling-reliability-hotspot-decision.md` — KEEP + targeted deduplication
+  when churn follows one cohesive contract;
+- `.claude/reference/fixpr-hotspot-decision.md` — extract only independently changing machinery;
+- `.claude/reference/churn-hotspots.md` — observational detector semantics and adjudication goal.

--- a/.claude/reference/state-file-contracts.md
+++ b/.claude/reference/state-file-contracts.md
@@ -93,7 +93,30 @@ Repair with `session-state-audit.sh --apply --reattribute`, which moves entries 
 
 The most common way to corrupt a field is passing a raw jq filter as a `--set` value — the string is stored literally instead of being evaluated. Evaluate first, then pass the resulting scalar.
 
-The `session-state.sh` header is the single source of truth for which fields are typed and what each type is.
+The `_field_types.top_level` and `_field_types.pr_nested` maps in
+`session-state-schema.json` are the single source of truth for which fields are typed and what
+each type is. `session-state.sh` and `session-state-audit.sh` load those maps at runtime; their
+headers describe the mechanism without carrying a second field inventory.
+
+The remainder of `session-state-schema.json` is the canonical representative state document. It
+keeps field shapes, compatibility examples, and lifecycle vocabulary next to the type contract.
+Focused tests may assert important values in that representative document—for example, Monitor
+identity and teardown semantics in `scheduling-primitive-alignment.test.sh`. It is intentionally
+not a disposable sample.
+
+### Adding or changing a session-state field
+
+1. Add the field to `_field_types` only when `session-state.sh` must enforce a specific JSON type.
+   Untyped fields need no schema-map edit and remain forward-compatible.
+2. Update the representative document when the field's shape is part of the cross-agent contract.
+3. Add or update a focused alignment test when a lifecycle term, identity pair, or related group
+   of fields must change together.
+4. Document rationale and migration detail here. Do not copy the complete typed-field list into a
+   script header, rule, skill, or another reference file.
+
+Sub-shape documents may explain their own state machines without becoming schema owners.
+`merge-sequencing.md` owns merge-hold behavior, and `/babysit-pr` owns its Monitor lifecycle; the
+JSON field names and enforced types remain authoritative in `session-state-schema.json`.
 
 ## Handoff file migration
 

--- a/.claude/scripts/session-state.sh
+++ b/.claude/scripts/session-state.sh
@@ -177,19 +177,13 @@
 #   `.claude/rules/handoff-files.md`.
 #
 # FIELD-TYPE CONTRACT (issues #625, #640)
-#   A known set of fields always hold a specific JSON type — top-level
-#   fields (arrays: active_agents, polling_jobs, polling_failures,
-#   polling_backoffs; objects: prs, cr_quota, cr_hourly, greptile_daily,
-#   pmm_in_flight, pmm) and per-PR nested fields under `.prs["<N>"]`
-#   (objects: last_cron_action, preflight_triggered, babysit, wrap_sweep;
-#   array: cr_explicit_triggers; number: digest_streak). Fields outside
-#   these lists are unvalidated, preserving forward-compatibility with the
-#   "preserve unknown fields" convention.
+#   Known fields and their required JSON types are loaded at runtime from
+#   .claude/reference/session-state-schema.json's `_field_types.top_level`
+#   and `_field_types.pr_nested` maps. That file is the single source of
+#   truth; fields absent from both maps are unvalidated, preserving the
+#   "preserve unknown fields" forward-compatibility convention.
 #
-#   The contract is loaded at runtime from
-#   .claude/reference/session-state-schema.json's `_field_types` object —
-#   that file is the single source of truth, not a hardcoded list in this
-#   script, so the two can never drift apart. If the schema file can't be
+#   If the schema file can't be
 #   found or parsed (unusual invocation context, e.g. this script copied
 #   somewhere without its .claude/reference/ sibling), the contract is
 #   disabled for this run with a warning on stderr — --get/--set still work,


### PR DESCRIPTION
## Summary

- record a KEEP + targeted-dedup decision for the `session-state-schema.json` churn hotspot
- keep the schema/type contract and representative example byte-for-byte unchanged because runtime scripts, alignment tests, and named rule references consume it
- remove the stale hand-mirrored field inventory from `session-state.sh` and make schema ownership explicit in `state-file-contracts.md`
- add a field-change checklist and register the decision in the reference catalog

## Decision evidence

Current `main` has 11 relevant touches since 2026-07-19. They track cohesive session-state contract evolution: type/scoping, lifecycle state, refill posture, and scheduling identity. CodeRabbit's initial extraction plan was revised after current-main inspection found that `scheduling-primitive-alignment.test.sh` directly validates the representative example and `handoff-files.md` links to `_token_exhaustion_example` by name. Splitting would move—not remove—the edit surface and add a synchronized artifact.

## Local review coverage

`none` — CodeRabbit CLI timed out after 120 seconds; CodeAnt twice reported `noFiles=true` / zero reviewed files for this Markdown-and-shell-comment-only diff. A clean self-review covered the full diff, the unchanged-schema invariant, ownership claims, and consumer references.

## Test plan

- [x] Hotspot decision records the 11-touch evidence, consumers, KEEP verdict, owners, preserved invariants, and reconsideration criteria.
- [x] `.claude/reference/session-state-schema.json` is byte-for-byte unchanged from `main`.
- [x] `session-state.sh` no longer mirrors typed-field names; runtime loading and graceful degradation are unchanged.
- [x] `state-file-contracts.md` names `_field_types` as authoritative and documents the representative-example role plus field-change checklist.
- [x] Reference catalog registers `session-state-schema-hotspot-decision.md`.
- [x] Direct jq checks validate both `_field_types` maps.
- [x] `session-state.test.sh`: 112 passed.
- [x] `session-state-audit.test.sh`: 83 passed.
- [x] `session-state-migration.test.sh`: 37 passed.
- [x] `scheduling-primitive-alignment.test.sh` and `reference-catalog-lint.test.sh` pass.
- [x] Full Bash suite: 75 suites, 0 failed.
- [x] Full Python suite: 142 tests, 0 failed.

Closes #964
