### PR TITLE
refactor: dedup Phase C merger contract

### DIFF
--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -53,11 +53,18 @@ gh pr view {{PR_NUMBER}} --json state,title,mergeStateStatus,commits
 
 > **pr-state.sh first (NON-NEGOTIABLE):** Before calling `gh api .../pulls/{N}/reviews`, `pulls/{N}/comments`, or `issues/{N}/comments` directly, call `pr-state.sh --pr N` first and read the cached JSON bundle. This agent delegates to `merge-gate.sh`, which calls `pr-state.sh` internally — do not add inline `gh api` calls to these three endpoints.
 
-Run the shared merge-gate verifier. It implements the three-path gate from `.claude/rules/cr-merge-gate.md` (CR 1-clean-approval on current HEAD, BugBot 1-clean, Greptile severity-gated), plus these explicit pre-merge gates — each is a hard STOP if not satisfied:
+Run the shared merge-gate verifier. Do not restate the gate from memory:
+`.claude/rules/cr-merge-gate.md` Steps 1 and 1b–1d own the exact-current-HEAD
+review, terminal CI, unresolved-thread, and merge-metadata requirements, and
+`merge-gate.sh` is their executable source of truth.
 
-- **Gate 1a — CI terminal state.** All check-runs `status: "completed"` with no blocking conclusion (`failure`, `timed_out`, `action_required`, `startup_failure`, `stale`). In-progress checks BLOCK — do NOT present the merge prompt; wait and re-poll.
-- **Gate 1b — All review threads resolved.** Every thread `isResolved: true` via GraphQL `reviewThreads(first: 100)` (REST misses cursor/copilot bot threads). Any unresolved thread BLOCKS regardless of author.
-- **Gate 1c — BEHIND / merge metadata.** `merge-gate.sh` enforces merge metadata (see `cr-merge-gate.md` Step 1d). The script JSON field **`merge_state`** mirrors GitHub **`mergeStateStatus`**. If **`GATE_EXIT == 1`** and **`echo "$GATE_JSON" | jq -e '.merge_state == "BEHIND"'`** succeeds, **do not merge** — report `OUTCOME: blocked` and instruct the parent to run **`/fixpr`** (rebase + force-push from a guard-clean worktree) until **`merge_state`** is no longer **`BEHIND`**, then re-run Phase C. For other gate failures, still parse **`missing`** as below — do not infer BEHIND from **`missing`** substring matching.
+Keep one Phase-C-specific branch inline: if **`GATE_EXIT == 1`** and
+**`echo "$GATE_JSON" | jq -e '.merge_state == "BEHIND"'`** succeeds, **do not
+merge**. Report `OUTCOME: blocked` and instruct the parent to run **`/fixpr`**
+(rebase + force-push from a guard-clean worktree) until **`merge_state`** is no
+longer **`BEHIND`**, then re-run Phase C. For other gate failures, parse
+**`missing`** as below — never infer BEHIND from **`missing`** substring
+matching.
 
 ```bash
 # Prefer the handoff's reviewer field; fall back to reviewer-of.sh (session-state
@@ -75,13 +82,8 @@ if [[ -f "$HANDOFF_FILE" ]]; then
   esac
 fi
 if [[ -z "$REVIEWER" ]]; then
-  # Capture stdout + exit code separately. Do NOT swallow stderr or mask the
-  # exit code — exit 5 from reviewer-of.sh means session-state is malformed
-  # (not a JSON object), which is an explicit fail-fast signal per the
-  # script's contract. Falling through to merge-gate.sh on corrupt state
-  # would silently swap the sticky assignment for whatever live-history
-  # inference merge-gate.sh picks, defeating the purpose of storing the
-  # sticky decision in session-state.
+  # Capture stdout + exit code separately; reviewer-of.sh documents exit 5 as
+  # the fail-fast signal for malformed session state.
   RESOLVED=$(.claude/scripts/reviewer-of.sh {{PR_NUMBER}})
   RESOLVED_EXIT=$?
   if [[ "$RESOLVED_EXIT" -eq 5 ]]; then
@@ -108,7 +110,7 @@ If `REVIEWER_ERROR` is set, set `OUTCOME: blocked`, include the error in the out
 
 Only when `REVIEWER_ERROR` is unset, branch on `GATE_EXIT`:
 - Exit `0` → merge gate met (all three paths + CI + merge metadata satisfied). Proceed to Step 2 (AC verification).
-- Exit `1` with **`merge_state == "BEHIND"`** (see Gate 1c) → **`OUTCOME: blocked`** per the BEHIND branch above; do not treat **`missing`** text as the source of truth for this case.
+- Exit `1` with **`merge_state == "BEHIND"`** → **`OUTCOME: blocked`** per the explicit BEHIND branch above; do not treat **`missing`** text as the source of truth for this case.
 - Exit `1` otherwise → gate not met for another reason. Parse the **`missing`** array from the JSON output and include it verbatim in your exit report; set **`OUTCOME: blocked`**.
 - Exit `2`/`3`/`4` → script/usage/gh error. Set `OUTCOME: blocked` and report the stderr/JSON message.
 
@@ -121,17 +123,15 @@ Only when `REVIEWER_ERROR` is unset, branch on `GATE_EXIT`:
    AC_EXIT=$?
    ```
 
-   Exit codes:
-   - `0` → `$ITEMS` is a JSON array of `{index, checked, text}`. Proceed to step 2.
-   - `1` → **either** no Test Plan section **or** the section exists but contains no checkbox items. Both mean "no acceptance criteria to verify" and both are blocking per CLAUDE.md. `OUTCOME: blocked`. Report the specific subcase — `gh pr view {{PR_NUMBER}} --json body --jq '.body'` can tell you which:
-     - No `## Test plan` / `## Test Plan` / `## Acceptance Criteria` heading → "PR body is missing a Test Plan section".
-     - Heading present but zero `- [ ]`/`- [x]` lines → "Test Plan section has no checkbox items".
-   - `3` → PR not found; `OUTCOME: blocked`.
-   - `2`/`4` → script/gh error; `OUTCOME: blocked`.
+   Interpret the helper's output and exit codes exactly as documented by
+   `.claude/scripts/ac-checkboxes.sh --help`. Any nonzero exit blocks Phase C.
+   For exit `1`, inspect the PR body and report whether the Test Plan heading is
+   missing or its section has no checkbox items; both mean there are no
+   acceptance criteria to verify and are blocking per CLAUDE.md.
 
 2. For each item with `checked == false`, read the relevant source file(s) and verify the criterion is met.
 
-3. Tick passing items by zero-based index, or use `--all-pass` if every unchecked item passed. Capture the helper exit code — a failed `gh pr edit --body-file` leaves the PR body unchanged, so Phase C must NOT mark AC as verified on tick failure:
+3. Tick passing items by zero-based index, or use `--all-pass` if every unchecked item passed. Follow `.claude/scripts/ac-checkboxes.sh --help` and capture the helper exit code — any nonzero result leaves AC unverified and blocks Phase C:
 
    ```bash
    # Example: indexes 0, 2, 3 passed
@@ -141,11 +141,6 @@ Only when `REVIEWER_ERROR` is unset, branch on `GATE_EXIT`:
    .claude/scripts/ac-checkboxes.sh {{PR_NUMBER}} --all-pass
    TICK_EXIT=$?
    ```
-
-   Exit codes:
-   - `0` → body updated (or noop — nothing to tick). Proceed.
-   - `4` → `gh pr edit --body-file` failed. `OUTCOME: blocked` — report the stderr with a `[gh-error]` tag.
-   - `2` / other non-zero → internal script error. `OUTCOME: blocked` — report the stderr with a `[script-error]` tag.
 
 4. If any item fails verification: `OUTCOME: blocked` — report which items failed and why. Do NOT tick failing items.
 
@@ -179,11 +174,12 @@ NEXT_PHASE: none
 HANDOFF_FILE: ~/.claude/handoffs/{{OWNER}}/{{REPO}}/pr-{{PR_NUMBER}}-handoff.json
 ```
 
-**Valid OUTCOME values for Phase C:**
-- `merged` — all acceptance criteria verified and checked off, `/wrap` completed the squash merge and follow-up flow.
-- `blocked` — merge blocked. Include details in your output before the exit report: what's blocking (CI failure, unmet AC, merge gate not satisfied, unresolved findings, or `/wrap` stop condition).
+Use `.claude/reference/exit-report-format.md` as the canonical field and
+Phase C `OUTCOME` contract. Include blocker details before the report when the
+outcome is `blocked`.
 
-**Note:** Do NOT delete the handoff file. The parent deletes it only after `OUTCOME: merged` and GitHub confirms the PR is merged.
+**Note:** Do NOT delete the handoff file. Parent-owned deletion timing is
+defined by `.claude/rules/phase-protocols.md` "Phase C Completion Protocol."
 
 ## Skill-First Reflex
 

--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -84,6 +84,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `monitor-mode-hotspot-decision.md` — diagnosis and dedup decision for `monitor-mode.md` churn (9 merged PRs in the #984 hotspot window); verdict: KEEP single rule file + point PM recovery prose to its canonical owners
 - `phase-a-fixer-hotspot-decision.md` — diagnosis and no-runtime-change decision for `phase-a-fixer.md` churn (9 merged PRs in the Issue #975 window); verdict: KEEP the self-contained Phase A agent contract
 - `phase-b-reviewer-hotspot-decision.md` — diagnosis and no-runtime-change decision for `phase-b-reviewer.md` churn (14 merged PRs in the Issue #942 window); verdict: KEEP the self-contained Phase B state machine
+- `phase-c-merger-hotspot-decision.md` — evidence-based diagnosis of `phase-c-merger.md` churn (9 merged PRs in the Issue #976 window); verdict: KEEP single file + dedup non-decision detail toward canonical owners
 - `scheduling-reliability-hotspot-decision.md` — diagnosis and dedup decision for `scheduling-reliability.md` churn (12 merged PRs in the #959 hotspot window, re-measured after #982); verdict: KEEP single rule file + remove downstream formula/enforcement restatements
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `harness-model-audit-2026-06.md` — harness components vs current model fleet (#49)

--- a/.claude/reference/phase-c-merger-hotspot-decision.md
+++ b/.claude/reference/phase-c-merger-hotspot-decision.md
@@ -1,0 +1,100 @@
+# Phase C Merger Hotspot Decision — August 2026
+
+**Issue:** [Issue #976](https://github.com/auerbachb/claude-code-config/issues/976)
+
+**Date:** 2026-08-04
+
+## Decision
+
+**KEEP single file + dedup toward canonical owners, not split.**
+
+`.claude/agents/phase-c-merger.md` remains the standalone definition for the
+independent verification-and-merge phase. The remedy removes selected policy
+restatements while retaining every instruction that makes Phase C operational
+and safe on its own.
+
+## Churn evidence
+
+The hotspot window contained nine merged PRs. The file history shows two kinds
+of change:
+
+| Change class | PRs | Why the agent changed |
+|---|---|---|
+| Shared guardrail propagation | PRs #617, #762, #787, #817, #858, #902, #920 | Skill-first, capability-discovery, browser-boundary, and destructive-command or environment-template safety contracts changed across all spawned agents. |
+| Phase C behavior | PRs #724, #737 | Per-repo handoff paths and standing merge authorization changed the merger's own orchestration. |
+
+Seven of the nine changes were required copies of shared spawn-time guardrails.
+Custom agent definitions need those protections in their own prompts because
+project rule files are not guaranteed to auto-load for the spawned agent. That
+is propagation churn, not evidence of independently evolving Phase C
+subsystems, so extracting or splitting those blocks would weaken the standalone
+contract without removing their update requirement.
+
+The remaining two changes are cohesive Phase C concerns. The file is therefore
+a single state machine with no useful split boundary.
+
+## Options considered
+
+### Split by merge gate, acceptance criteria, and wrap execution
+
+Rejected. These are consecutive gates in one short-lived agent state machine.
+A split would add dispatch and context-transfer boundaries immediately before a
+high-impact merge without making the observed shared-guardrail churn cheaper.
+
+### KEEP with no content change
+
+Rejected. The file still repeated details already owned by executable helpers
+and canonical contracts. Those copies can drift even though they did not drive
+most changes in this measurement window.
+
+### KEEP and deduplicate non-decision detail
+
+Chosen. Phase C retains the branch decisions it must make and points to the
+sources that define the underlying schemas and gates.
+
+## Concrete remedy
+
+- `.claude/rules/cr-merge-gate.md` and `.claude/scripts/merge-gate.sh` own the
+  exact-current-HEAD review, terminal CI, unresolved-thread, and merge-metadata
+  requirements. The agent retains exit-code branching and its explicit BEHIND
+  stop-and-report boundary.
+- `.claude/scripts/ac-checkboxes.sh --help` owns helper modes and exit-code
+  details. The agent retains source-based verification, the missing-criteria
+  stop, update-failure stop, and no-tick-on-failure judgment.
+- `.claude/reference/exit-report-format.md` owns field semantics and valid
+  outcomes. The agent retains the exact Phase C report skeleton because the
+  parent parses it at the phase boundary.
+- `.claude/rules/phase-protocols.md` owns handoff deletion timing. The agent
+  retains scoped path resolution, migration fallback, and handoff-first
+  reviewer precedence.
+
+## What was explicitly preserved
+
+- Phase C remains independent from the implementation and review phases and
+  remains read-only with respect to code fixes.
+- Review approval must match the current HEAD, CI must be terminal and
+  non-blocking, all review threads must be resolved, and merge metadata must be
+  acceptable before `/wrap`.
+- A literal `BEHIND` result blocks Phase C and routes rebase/re-review recovery
+  back to the parent; the merger never self-heals or merges around it.
+- Every unchecked acceptance criterion is verified against relevant source
+  files before it is ticked. Missing criteria, failed verification, and helper
+  or PR-body update errors block the merge.
+- Standing merge authorization remains active: after the gate and acceptance
+  criteria pass, Phase C runs the canonical `/wrap` flow without a permission
+  pause. `/wrap` remains the only merge path and continues to own squash merge,
+  main sync, issue closure, and follow-up detection.
+- The parent still owns post-merge handoff deletion and session-state cleanup.
+- The exact `EXIT_REPORT` block remains in the agent, including the Phase C
+  marker, `OUTCOME: <merged|blocked>`, `NEXT_PHASE: none`, and the repo-scoped
+  handoff path.
+- Safety, capability-discovery, unavailable-browser, tool-restriction, and
+  skill-first guardrails remain inline for the standalone spawned agent.
+
+## Related
+
+- [fixpr hotspot decision](fixpr-hotspot-decision.md)
+- [subagent orchestration churn audit](subagent-orchestration-churn-audit-2026-07.md)
+- [merge gate contract](../rules/cr-merge-gate.md)
+- [structured exit report format](exit-report-format.md)
+- [phase completion protocols](../rules/phase-protocols.md)


### PR DESCRIPTION
## Summary

- record the evidence-based KEEP + dedup decision for the Phase C merger hotspot
- point non-decision gate, checkbox-helper, exit-report, and cleanup detail at canonical owners
- preserve the independent Phase C state machine, exact-current-HEAD/CI/thread/metadata gates, explicit BEHIND stop, source-based AC verification, standing `/wrap` authorization, exact exit-report skeleton, and standalone safety/tool/skill guardrails

Closes #976

## Test Plan

- [x] The audit records an evidence-based KEEP single file + dedup toward canonical owners, not split decision for `.claude/agents/phase-c-merger.md`.
- [x] The agent continues to independently enforce the current-HEAD review gate, terminal/non-blocking CI gate, unresolved-thread gate, merge metadata, and explicit BEHIND block-and-report branch before `/wrap`.
- [x] Acceptance criteria are still extracted, verified against source, checked only after verification, and blocking on missing criteria or helper/update failures.
- [x] Standing merge authorization, `/wrap`-only merging, issue closure/follow-up behavior, parent-owned handoff/session cleanup, and the exact structured Phase C `EXIT_REPORT` contract remain intact.
- [x] The safety, capability-discovery, tool-restriction, and skill-first guardrails remain available in the standalone Phase C agent prompt.
- [x] The decision document is cataloged, all relevant tests/lints pass, and neither the rule corpus nor `.claude/rules/.budget-soft-cap` changes.

## Validation

- `bash .github/scripts/run-hook-tests.sh` — 75/75 Bash suites passed
- `bash .github/scripts/run-python-tests.sh` — 142/142 Python tests passed
- catalog, rule, merge-authority, verbatim-block, environment-template, model-guard, and skill-catalog lints passed
- rule corpus remains 11,367 words; `.claude/rules/.budget-soft-cap` remains 11,749
- local review coverage: `cr-only` — CodeRabbit returned a verified clean run; CodeAnt returned `noFiles=true` twice and was dropped for this session per the fallback contract
