### PR TITLE
refactor(#971): extract polling state scope resolver

### DIFF
--- a/.claude/reference/state-file-contracts.md
+++ b/.claude/reference/state-file-contracts.md
@@ -16,6 +16,30 @@ Session state lives at `.repos["<owner>/<name>"].prs["<N>"]` rather than a flat 
 
 Entries that predate scoping and cannot be attributed land under `_unknown`. Account-level fields (Greptile daily budget, CodeRabbit hourly consumption) stay global — they are per-account quotas, not per-repo state.
 
+### Polling-gate scope resolver boundary (issue #971)
+
+`.claude/scripts/lib/pr-scope-resolver.sh` is the single home for the repo-identity
+and per-PR scope-resolution seam used by `polling-state-gate.sh`. The entry point
+still owns argument parsing, mode dispatch, and the `--repo` / `--root-repo` /
+inherited `$CLAUDE_SESSION_REPO` precedence override; it hard-fails if the library
+cannot be sourced so the correctness-sensitive logic cannot drift into a fallback
+copy.
+
+The library preserves two mechanisms because they answer different questions:
+
+- `resolve_pr_scope()` decides **which state lane to read**: the active repo's
+  `.repos["<owner>/<name>"]` lane, then legacy `_unknown`, never another named
+  repo that happens to hold the same PR number (issue #638).
+- `repo_identity()` and `validate_root_match()` decide **whether the invoking
+  checkout may act on that lane** by comparing normalized repo identity and the
+  per-PR `owner_repo` / `root_repo` fields (issue #647).
+
+All state reads in this library go through `session-state.sh`; it never opens or
+writes `session-state.json` or handoff JSON directly. State mutation remains with
+`session-state.sh`, handoff mutation with `handoff-state.sh`, and polling watermark
+mutation with `poll-watermarks.sh`, preserving each helper's lock and path
+contract.
+
 ### Polling-gate protection against inherited scope leakage (issue #967)
 
 `polling-state-gate.sh` resolves the invoking checkout before applying that
@@ -52,7 +76,7 @@ The `.repos["<owner>/<name>"]` key is **always lowercase**, and handoff director
 Three independent code paths derive this key:
 
 - `session-state.sh` — `repo_key_from_remote_url()` and `resolve_repo_key()`
-- `polling-state-gate.sh` — `repo_identity()`
+- `polling-state-gate.sh` via `lib/pr-scope-resolver.sh` — `repo_identity()`
 - `handoff-state.sh` — the path resolver
 
 Before #704 each normalized differently, so a mixed-case remote URL (`AuerbachB/Skingod`) and its lowercase form (`auerbachb/skingod`) mapped to two different scopes — the same PR appeared to be two PRs depending on which script wrote last. All three now share one normalizer, `lib/repo-normalizer.sh`.

--- a/.claude/scripts/lib/pr-scope-resolver.sh
+++ b/.claude/scripts/lib/pr-scope-resolver.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# lib/pr-scope-resolver.sh — Repo identity and per-PR scope resolution for
+# polling-state-gate.sh (issue #971).
+#
+# Source this file (do NOT execute it directly) from polling-state-gate.sh.
+#
+# PROBLEM SOLVED
+#   The polling gate's repo-scoping seam accumulated five correctness fixes in
+#   two weeks: per-repo state lanes, legacy `_unknown` fallback, normalized repo
+#   identities, same-number PR isolation, and stale inherited-scope precedence.
+#   Keeping that seam inline made an 881-line entry point the only place to
+#   understand or change two related decisions: which repo scope owns a PR, and
+#   whether the invoking checkout may act on it.
+#
+# CONTRACT
+#   This library preserves those as distinct mechanisms:
+#     * resolve_pr_scope() chooses the active repo's lane, then `_unknown`, and
+#       never selects another named repo merely because it has the same PR number.
+#     * validate_root_match() compares the chosen lane's per-PR identity with the
+#       checkout being operated on and refuses genuine contradictions.
+#   Every session-state read is delegated to STATE_HELPER (`session-state.sh`).
+#   This library never reads or writes session-state.json or handoff JSON
+#   directly, and it performs no state mutation.
+#
+# USAGE
+#   polling-state-gate.sh must define these caller-owned values before sourcing:
+#     STATE_HELPER STATE_FILE STATE_READ_DIR PR_NUMBER
+#     ACTIVE_REPO_KEY PR_SCOPE PR_SCOPE_RESOLVED
+#   Before validate_root_match() runs it must also define REPO_KEY_DECLARED.
+#   normalize_repo_key() must already be available from lib/repo-normalizer.sh.
+#
+#   source "$SCRIPT_DIR/lib/pr-scope-resolver.sh"
+#   scope="$(resolve_pr_scope)"
+#   validate_root_match "$resolved_root"
+
+# Guard against direct execution. Running a definition-only library would
+# otherwise report success while doing nothing.
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+  echo "pr-scope-resolver.sh: source this file, do not execute it directly" >&2
+  exit 2
+fi
+
+# Every named scope holding this PR number, newline-separated. `--raw-path`
+# addresses the document root, so this sees all scopes while preserving
+# session-state.sh's migration and locking boundary.
+_pr_holders() {
+  ( cd "$STATE_READ_DIR" 2>/dev/null && "$STATE_HELPER" --raw-path --get \
+    "[(.repos // {}) | to_entries[] | select(.value.prs[\"$PR_NUMBER\"] != null) | .key] | join(\"\n\")" \
+    2>/dev/null || true )
+}
+
+active_scope_key() {
+  local active="$ACTIVE_REPO_KEY"
+  if [[ -z "$active" ]]; then
+    active="$(cd "$STATE_READ_DIR" 2>/dev/null && "$STATE_HELPER" --repo-key 2>/dev/null || true)"
+  fi
+  printf '%s' "$active"
+}
+
+resolve_pr_scope() {
+  if [[ "$PR_SCOPE_RESOLVED" -eq 1 ]]; then
+    printf '%s' "$PR_SCOPE"
+    return 0
+  fi
+  PR_SCOPE_RESOLVED=1
+  PR_SCOPE=""
+  [[ -f "$STATE_FILE" ]] || { printf '%s' ""; return 0; }
+  local active holder
+  active="$(active_scope_key)"
+  while IFS= read -r holder; do
+    [[ -n "$holder" && "$holder" != "null" ]] || continue
+    if [[ -n "$active" && "$holder" == "$active" ]]; then
+      PR_SCOPE="$holder"
+      break
+    fi
+    # Remember `_unknown`, but keep looking because the active scope wins.
+    [[ "$holder" == "_unknown" && -z "$PR_SCOPE" ]] && PR_SCOPE="_unknown"
+  done < <(_pr_holders)
+  printf '%s' "$PR_SCOPE"
+}
+
+# Named scopes other than the active one and `_unknown` that hold the same PR
+# number. Diagnostics only; these values are never candidates for reading.
+foreign_pr_scopes() {
+  [[ -f "$STATE_FILE" ]] || return 0
+  local active holder
+  active="$(active_scope_key)"
+  while IFS= read -r holder; do
+    [[ -n "$holder" && "$holder" != "null" ]] || continue
+    [[ "$holder" == "_unknown" ]] && continue
+    [[ -n "$active" && "$holder" == "$active" ]] && continue
+    printf '%s\n' "$holder"
+  done < <(_pr_holders)
+}
+
+# Read a per-PR field from the resolved scope so a same-numbered PR in another
+# repo can never answer for this one.
+state_pr_field() {
+  local field="$1" scope out=""
+  scope="$(resolve_pr_scope)"
+  [[ -n "$scope" ]] || { printf '%s' ""; return 0; }
+  out="$(cd "$STATE_READ_DIR" 2>/dev/null && "$STATE_HELPER" --raw-path --get \
+    ".repos[\"$scope\"].prs[\"$PR_NUMBER\"].$field" 2>/dev/null || true)"
+  [[ "$out" == "null" ]] && out=""
+  printf '%s' "$out"
+}
+
+# repo_identity <path> — stable identity for the repo a checkout belongs to.
+# Prefer normalized `origin` owner/repo so worktrees and clones compare equal.
+# Fall back to the shared git common dir, then the raw path.
+repo_identity() {
+  local path="$1"
+  [[ -n "$path" && -d "$path" ]] || { printf 'path:%s\n' "$path"; return 0; }
+  local url id owner repo
+  url="$(git -C "$path" remote get-url origin 2>/dev/null || true)"
+  if [[ -n "$url" ]]; then
+    id="${url%.git}"
+    id="${id%/}"
+    id="${id#*://}"
+    id="${id#*@}"
+    id="${id/:/\/}"
+    if [[ "$id" == */* ]]; then
+      repo="${id##*/}"
+      id="${id%/*}"
+      owner="${id##*/}"
+      if [[ -n "$owner" && -n "$repo" ]]; then
+        printf '%s\n' "$(normalize_repo_key "${owner}/${repo}")"
+        return 0
+      fi
+    fi
+  fi
+  local common=""
+  common="$(cd "$path" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null || true)"
+  if [[ -n "$common" ]]; then
+    common="$(cd "$path" && cd "$common" 2>/dev/null && pwd -P || true)"
+  fi
+  if [[ -n "$common" ]]; then
+    printf 'gitdir:%s\n' "$common"
+  else
+    printf 'path:%s\n' "$path"
+  fi
+}
+
+is_owner_repo_identity() {
+  case "$1" in
+    ""|_unknown|gitdir:*|path:*) return 1 ;;
+    */*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+resolve_root_repo() {
+  local from_arg="$1"
+  local from_state_pr=""
+  local from_state_top=""
+  if [[ -f "$STATE_FILE" ]]; then
+    from_state_pr="$(state_pr_field root_repo)"
+    from_state_top="$(cd "$STATE_READ_DIR" 2>/dev/null && "$STATE_HELPER" --get '.root_repo' 2>/dev/null || true)"
+    [[ "$from_state_top" == "null" ]] && from_state_top=""
+  fi
+  local chosen=""
+  local live=""
+  live="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  # Explicit arg -> per-PR scoping -> live checkout -> scoped remembered root.
+  # The remembered path stays last because removed worktrees make it stale.
+  if [[ -n "$from_arg" ]]; then
+    chosen="$from_arg"
+  elif [[ -n "$from_state_pr" && "$from_state_pr" != "null" && -d "$from_state_pr" ]]; then
+    chosen="$from_state_pr"
+  elif [[ -n "$live" ]]; then
+    chosen="$live"
+  elif [[ -n "$from_state_top" && "$from_state_top" != "null" ]]; then
+    chosen="$from_state_top"
+  fi
+  if [[ -z "$chosen" || ! -d "$chosen" ]]; then
+    echo "polling-state-gate.sh: could not resolve root repo path (set --root-repo or .root_repo in session-state)" >&2
+    return 1
+  fi
+  local canon
+  canon="$(cd "$chosen" && git rev-parse --show-toplevel 2>/dev/null || echo "$chosen")"
+  echo "$canon"
+}
+
+# validate_root_match <resolved_root> — refuse only genuine cross-repo
+# mismatches. The scope-level `.root_repo` is never authoritative; only per-PR
+# owner_repo/root_repo fields participate in the decision.
+validate_root_match() {
+  local resolved="$1"
+  local stored_owner=""
+  local stored_root=""
+  if [[ -f "$STATE_FILE" ]]; then
+    stored_owner="$(state_pr_field owner_repo)"
+    stored_root="$(state_pr_field root_repo)"
+  fi
+  if [[ "$stored_owner" == "null" ]]; then stored_owner=""; fi
+  if [[ "$stored_root" == "null" ]]; then stored_root=""; fi
+
+  local canon active_id
+  canon="$(cd "$resolved" && git rev-parse --show-toplevel 2>/dev/null || echo "$resolved")"
+  local checkout_id
+  checkout_id="$(repo_identity "$canon")"
+
+  # An explicitly declared repo key may supply an identity an origin-less
+  # checkout lacks, but may never override a checkout that identifies itself.
+  local declared=""
+  if [[ "$REPO_KEY_DECLARED" -eq 1 && -n "$ACTIVE_REPO_KEY" && "$ACTIVE_REPO_KEY" == */* \
+        && "$ACTIVE_REPO_KEY" != "_unknown" \
+        && "$ACTIVE_REPO_KEY" != gitdir:* && "$ACTIVE_REPO_KEY" != path:* ]]; then
+    declared="$(normalize_repo_key "$ACTIVE_REPO_KEY")"
+  fi
+  if [[ -n "$declared" && "$checkout_id" == */* \
+        && "$checkout_id" != gitdir:* && "$checkout_id" != path:* \
+        && "$declared" != "$checkout_id" ]]; then
+    echo "polling-state-gate.sh: repo key '$declared' (from --repo or \$CLAUDE_SESSION_REPO) contradicts the checkout being operated on, which is '$checkout_id' ($canon) — refuse to validate against one repo while acting on another. Drop the override, or point --root-repo at a '$declared' checkout." >&2
+    return 1
+  fi
+  if [[ -n "$declared" ]]; then
+    active_id="$declared"
+  else
+    active_id="$checkout_id"
+  fi
+
+  # Prefer owner/repo identity when both sides have one.
+  if [[ -n "$stored_owner" && "$active_id" == */* && "$active_id" != gitdir:* && "$active_id" != path:* ]]; then
+    local stored_owner_lc
+    stored_owner_lc="$(normalize_repo_key "$stored_owner")"
+    if [[ "$stored_owner_lc" != "$active_id" ]]; then
+      echo "polling-state-gate.sh: PR #$PR_NUMBER is scoped to repo '$stored_owner' but the active checkout is '$active_id' ($canon) — refuse to poll from the wrong repo" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  # Fall back to the per-PR checkout path, compared by repo identity so sibling
+  # worktrees of the same clone agree. A stale path carries no signal.
+  if [[ -n "$stored_root" && -d "$stored_root" ]]; then
+    local stored_id
+    stored_id="$(repo_identity "$stored_root")"
+    if [[ "$stored_id" != "$active_id" ]]; then
+      echo "polling-state-gate.sh: PR #$PR_NUMBER is scoped to repo '$stored_id' ($stored_root) but the active checkout is '$active_id' ($canon) — refuse to poll from the wrong repo" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  # Scoping is recorded but cannot be compared. Fail closed except during
+  # --ensure-session, which is about to refresh the recorded scoping.
+  if [[ -n "$stored_owner" && "${2:-}" != "quiet" ]]; then
+    echo "polling-state-gate.sh: PR #$PR_NUMBER is scoped to repo '$stored_owner' but the active checkout ($canon) has no comparable repo identity ('$active_id') — refuse to poll; re-run from a checkout with an 'origin' remote, or: polling-state-gate.sh $PR_NUMBER --ensure-session" >&2
+    return 1
+  fi
+
+  # Legacy state without per-PR scoping remains a notice, not a refusal.
+  if [[ "${2:-}" != "quiet" ]]; then
+    echo "polling-state-gate.sh: no per-PR repo scoping recorded for PR #$PR_NUMBER — proceeding with the active checkout ($canon); run: polling-state-gate.sh $PR_NUMBER --ensure-session" >&2
+  fi
+  return 0
+}

--- a/.claude/scripts/lib/pr-scope-resolver.sh
+++ b/.claude/scripts/lib/pr-scope-resolver.sh
@@ -31,7 +31,8 @@
 #
 #   source "$SCRIPT_DIR/lib/pr-scope-resolver.sh"
 #   scope="$(resolve_pr_scope)"
-#   validate_root_match "$resolved_root"
+#   validate_root_match "$resolved_root"          # ordinary validation
+#   validate_root_match "$resolved_root" quiet    # --ensure-session only
 
 # Guard against direct execution. Running a definition-only library would
 # otherwise report success while doing nothing.
@@ -181,9 +182,11 @@ resolve_root_repo() {
   echo "$canon"
 }
 
-# validate_root_match <resolved_root> — refuse only genuine cross-repo
+# validate_root_match <resolved_root> [quiet] — refuse only genuine cross-repo
 # mismatches. The scope-level `.root_repo` is never authoritative; only per-PR
-# owner_repo/root_repo fields participate in the decision.
+# owner_repo/root_repo fields participate in the decision. The optional `quiet`
+# mode suppresses legacy notices and the scoped-but-incomparable refusal only
+# for --ensure-session, which is about to refresh the recorded scoping.
 validate_root_match() {
   local resolved="$1"
   local stored_owner=""
@@ -206,7 +209,10 @@ validate_root_match() {
   if [[ "$REPO_KEY_DECLARED" -eq 1 && -n "$ACTIVE_REPO_KEY" && "$ACTIVE_REPO_KEY" == */* \
         && "$ACTIVE_REPO_KEY" != "_unknown" \
         && "$ACTIVE_REPO_KEY" != gitdir:* && "$ACTIVE_REPO_KEY" != path:* ]]; then
-    declared="$(normalize_repo_key "$ACTIVE_REPO_KEY")"
+    if ! declared="$(normalize_repo_key "$ACTIVE_REPO_KEY")" || [[ -z "$declared" ]]; then
+      echo "polling-state-gate.sh: could not normalize repo key '$ACTIVE_REPO_KEY' (from --repo or \$CLAUDE_SESSION_REPO) — refuse to validate against an unusable repo identity" >&2
+      return 1
+    fi
   fi
   if [[ -n "$declared" && "$checkout_id" == */* \
         && "$checkout_id" != gitdir:* && "$checkout_id" != path:* \

--- a/.claude/scripts/polling-state-gate.sh
+++ b/.claude/scripts/polling-state-gate.sh
@@ -243,115 +243,21 @@ ACTIVE_REPO_KEY=""
 PR_SCOPE=""
 PR_SCOPE_RESOLVED=0
 
-# Every named scope holding this PR number, newline-separated, as a jq array
-# expression's output. Resolved once and reused by both readers below.
-_pr_holders() {
-  # `--raw-path` addresses the document root, so this sees every scope at once
-  # (the helper still migrates a legacy flat file in memory first).
-  ( cd "$STATE_READ_DIR" 2>/dev/null && "$STATE_HELPER" --raw-path --get \
-    "[(.repos // {}) | to_entries[] | select(.value.prs[\"$PR_NUMBER\"] != null) | .key] | join(\"\n\")" \
-    2>/dev/null || true )
-}
-
-active_scope_key() {
-  local active="$ACTIVE_REPO_KEY"
-  if [[ -z "$active" ]]; then
-    active="$(cd "$STATE_READ_DIR" 2>/dev/null && "$STATE_HELPER" --repo-key 2>/dev/null || true)"
-  fi
-  printf '%s' "$active"
-}
-
-resolve_pr_scope() {
-  if [[ "$PR_SCOPE_RESOLVED" -eq 1 ]]; then
-    printf '%s' "$PR_SCOPE"
-    return 0
-  fi
-  PR_SCOPE_RESOLVED=1
-  PR_SCOPE=""
-  [[ -f "$STATE_FILE" ]] || { printf '%s' ""; return 0; }
-  local active holder
-  active="$(active_scope_key)"
-  while IFS= read -r holder; do
-    [[ -n "$holder" && "$holder" != "null" ]] || continue
-    if [[ -n "$active" && "$holder" == "$active" ]]; then
-      PR_SCOPE="$holder"
-      break
-    fi
-    # Remember "_unknown" but keep looking: the active scope always wins.
-    [[ "$holder" == "_unknown" && -z "$PR_SCOPE" ]] && PR_SCOPE="_unknown"
-  done < <(_pr_holders)
-  printf '%s' "$PR_SCOPE"
-}
-
-# Named scopes OTHER than the active one (and other than "_unknown") that also
-# hold this PR number. Diagnostics only — this is never a read scope. It exists
-# so a "not registered here" error can explain the collision instead of leaving
-# the caller staring at a PR they can see in the state file.
-foreign_pr_scopes() {
-  [[ -f "$STATE_FILE" ]] || return 0
-  local active holder
-  active="$(active_scope_key)"
-  while IFS= read -r holder; do
-    [[ -n "$holder" && "$holder" != "null" ]] || continue
-    [[ "$holder" == "_unknown" ]] && continue
-    [[ -n "$active" && "$holder" == "$active" ]] && continue
-    printf '%s\n' "$holder"
-  done < <(_pr_holders)
-}
-
-# Read a per-PR field from the scope resolved above, so a same-numbered PR in
-# another repo can never answer for this one.
-state_pr_field() {
-  local field="$1" scope out=""
-  scope="$(resolve_pr_scope)"
-  [[ -n "$scope" ]] || { printf '%s' ""; return 0; }
-  out="$(cd "$STATE_READ_DIR" 2>/dev/null && "$STATE_HELPER" --raw-path --get \
-    ".repos[\"$scope\"].prs[\"$PR_NUMBER\"].$field" 2>/dev/null || true)"
-  [[ "$out" == "null" ]] && out=""
-  printf '%s' "$out"
-}
-
-# repo_identity <path> — stable identity for the repo a checkout belongs to.
-# Prefers the normalized `origin` remote ("owner/repo", lowercased) so any worktree
-# or clone of the same repo compares equal. Falls back to the absolute git common
-# dir ("gitdir:<path>", shared by all worktrees of one clone), then to the raw path
-# ("path:<path>") when the argument is not a git checkout at all.
-repo_identity() {
-  local path="$1"
-  [[ -n "$path" && -d "$path" ]] || { printf 'path:%s\n' "$path"; return 0; }
-  local url id owner repo
-  url="$(git -C "$path" remote get-url origin 2>/dev/null || true)"
-  if [[ -n "$url" ]]; then
-    id="${url%.git}"
-    id="${id%/}"
-    id="${id#*://}"   # drop scheme (https://, ssh://, git://)
-    id="${id#*@}"     # drop user@ (git@github.com:owner/repo)
-    id="${id/:/\/}"   # scp-style host:owner/repo -> host/owner/repo
-    # Last two segments are owner/repo; a URL with no separator carries no identity.
-    if [[ "$id" == */* ]]; then
-      repo="${id##*/}"
-      id="${id%/*}"
-      owner="${id##*/}"
-      if [[ -n "$owner" && -n "$repo" ]]; then
-        # normalize_repo_key() from lib/repo-normalizer.sh (issue #704) so
-        # repo_identity() and session-state.sh's repo_key_from_remote_url()
-        # always agree on the same lowercase key.
-        printf '%s\n' "$(normalize_repo_key "${owner}/${repo}")"
-        return 0
-      fi
-    fi
-  fi
-  local common=""
-  common="$(cd "$path" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null || true)"
-  if [[ -n "$common" ]]; then
-    common="$(cd "$path" && cd "$common" 2>/dev/null && pwd -P || true)"
-  fi
-  if [[ -n "$common" ]]; then
-    printf 'gitdir:%s\n' "$common"
-  else
-    printf 'path:%s\n' "$path"
-  fi
-}
+# The repo-identity and per-PR scope-resolution seam is correctness-sensitive
+# and has one implementation home (issue #971). Missing it must fail loudly;
+# silently falling back to an inline copy would recreate the drift this boundary
+# exists to prevent.
+_SCOPE_RESOLVER_LIB="${SCRIPT_DIR}/lib/pr-scope-resolver.sh"
+if [[ ! -r "$_SCOPE_RESOLVER_LIB" ]]; then
+  echo "polling-state-gate.sh: required scope resolver not found: $_SCOPE_RESOLVER_LIB" >&2
+  exit 4
+fi
+# shellcheck source=./lib/pr-scope-resolver.sh
+if ! source "$_SCOPE_RESOLVER_LIB"; then
+  echo "polling-state-gate.sh: failed to source required scope resolver: $_SCOPE_RESOLVER_LIB" >&2
+  exit 4
+fi
+unset _SCOPE_RESOLVER_LIB
 
 # --repo is implemented by exporting $CLAUDE_SESSION_REPO rather than by
 # threading a flag through every helper invocation (issue #854). Resolve the
@@ -372,14 +278,6 @@ fi
 if [[ -n "$INVOKING_CHECKOUT_PATH" ]]; then
   INVOKING_CHECKOUT_ID="$(repo_identity "$INVOKING_CHECKOUT_PATH")"
 fi
-
-is_owner_repo_identity() {
-  case "$1" in
-    ""|_unknown|gitdir:*|path:*) return 1 ;;
-    */*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
 
 if [[ "$REPO_ARG_PASSED" -eq 1 ]]; then
   REPO_KEY_DECLARED=1
@@ -403,151 +301,6 @@ elif [[ -n "${CLAUDE_SESSION_REPO:-}" ]]; then
 fi
 
 ACTIVE_REPO_KEY="$(cd "$STATE_READ_DIR" 2>/dev/null && "$STATE_HELPER" --repo-key 2>/dev/null || true)"
-
-resolve_root_repo() {
-  local from_arg="$1"
-  local from_state_pr=""
-  local from_state_top=""
-  if [[ -f "$STATE_FILE" ]]; then
-    from_state_pr="$(state_pr_field root_repo)"
-    from_state_top="$(cd "$STATE_READ_DIR" 2>/dev/null && "$STATE_HELPER" --get '.root_repo' 2>/dev/null || true)"
-    [[ "$from_state_top" == "null" ]] && from_state_top=""
-  fi
-  local chosen=""
-  local live=""
-  live="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-  # Precedence: explicit arg -> per-PR scoping -> live checkout -> scope .root_repo.
-  # Since issue #638 the last of those is this repo's OWN recorded checkout rather
-  # than a cross-session global, but it stays last on purpose: it is a remembered
-  # path that may name a worktree since removed, so it must never outrank the
-  # checkout the caller is actually standing in.
-  if [[ -n "$from_arg" ]]; then
-    chosen="$from_arg"
-  elif [[ -n "$from_state_pr" && "$from_state_pr" != "null" && -d "$from_state_pr" ]]; then
-    chosen="$from_state_pr"
-  elif [[ -n "$live" ]]; then
-    chosen="$live"
-  elif [[ -n "$from_state_top" && "$from_state_top" != "null" ]]; then
-    chosen="$from_state_top"
-  fi
-  if [[ -z "$chosen" || ! -d "$chosen" ]]; then
-    echo "polling-state-gate.sh: could not resolve root repo path (set --root-repo or .root_repo in session-state)" >&2
-    return 1
-  fi
-  local canon
-  canon="$(cd "$chosen" && git rev-parse --show-toplevel 2>/dev/null || echo "$chosen")"
-  echo "$canon"
-}
-
-# validate_root_match <resolved_root> — refuse only on a genuine cross-repo mismatch.
-# Compares repo identity against PER-PR scoping; the scope-level .root_repo is
-# never consulted here (issue #647) — only the per-PR fields carry authority.
-validate_root_match() {
-  local resolved="$1"
-  # There is deliberately no cross-scope short-circuit here any more (issue
-  # #854). resolve_pr_scope() can only return the active scope, "_unknown", or
-  # empty, so "the PR lives under a different named repo" is no longer a state
-  # this function can observe — and it was never a reason to refuse in the first
-  # place, since PR numbers are per-repo. What remains below is the guard that
-  # does carry authority: per-PR scoping recorded INSIDE the scope we read, which
-  # still refuses a genuine mismatch. A PR simply absent from our scope is
-  # handled by require_handoff_and_state()'s not-registered check, not here.
-  local stored_owner=""
-  local stored_root=""
-  if [[ -f "$STATE_FILE" ]]; then
-    stored_owner="$(state_pr_field owner_repo)"
-    stored_root="$(state_pr_field root_repo)"
-  fi
-  if [[ "$stored_owner" == "null" ]]; then stored_owner=""; fi
-  if [[ "$stored_root" == "null" ]]; then stored_root=""; fi
-
-  local canon active_id
-  canon=$(cd "$resolved" && git rev-parse --show-toplevel 2>/dev/null || echo "$resolved")
-  # Identity of the checkout the caller is standing in.
-  #
-  # A DECLARED key (--repo / $CLAUDE_SESSION_REPO, surfacing here as
-  # ACTIVE_REPO_KEY) may SUPPLY an identity the checkout lacks; it may never
-  # OVERRIDE one the checkout states. Without that rule
-  # `--repo org/a --root-repo /repo-b` validated every per-PR field against
-  # org/a while gh, merge-gate.sh, and the session-state writes all ran against
-  # repo B — a poll evaluating the wrong repo's PR, and --ensure-session
-  # recording B's head_sha in A's lane (CodeAnt + BugBot, PR #856). The two
-  # flags answer different questions (--root-repo = which checkout, --repo =
-  # which scope key), so when both resolve to a real owner/repo and disagree,
-  # that is a contradiction in the invocation, not something to silently pick a
-  # winner for. Refuse, and say which is which. Not suppressed by "quiet": a
-  # contradictory invocation is never something --ensure-session should paper
-  # over by (re)recording scoping.
-  local checkout_id
-  checkout_id="$(repo_identity "$canon")"
-  # Only a key the caller DECLARED counts here. An ACTIVE_REPO_KEY merely derived
-  # from the checkout cannot "contradict" that same checkout, and treating it as
-  # declared would mislabel a corrupt same-scope root_repo (caught by (a)/(b)
-  # below) as an override the caller never passed.
-  local declared=""
-  if [[ "$REPO_KEY_DECLARED" -eq 1 && -n "$ACTIVE_REPO_KEY" && "$ACTIVE_REPO_KEY" == */* \
-        && "$ACTIVE_REPO_KEY" != "_unknown" \
-        && "$ACTIVE_REPO_KEY" != gitdir:* && "$ACTIVE_REPO_KEY" != path:* ]]; then
-    declared="$(normalize_repo_key "$ACTIVE_REPO_KEY")"
-  fi
-  if [[ -n "$declared" && "$checkout_id" == */* \
-        && "$checkout_id" != gitdir:* && "$checkout_id" != path:* \
-        && "$declared" != "$checkout_id" ]]; then
-    echo "polling-state-gate.sh: repo key '$declared' (from --repo or \$CLAUDE_SESSION_REPO) contradicts the checkout being operated on, which is '$checkout_id' ($canon) — refuse to validate against one repo while acting on another. Drop the override, or point --root-repo at a '$declared' checkout." >&2
-    return 1
-  fi
-  # "_unknown" is NOT an identity: session-state.sh returns it whenever repo
-  # context cannot be resolved, so treating it as a repo name would refuse valid
-  # sessions. When the checkout cannot name itself, the declared key is what
-  # makes it comparable at all; otherwise fall back to repo_identity(), whose
-  # git-common-dir fallback can still compare such checkouts and which fails
-  # closed on its own terms in (c) when they genuinely cannot be compared.
-  if [[ -n "$declared" ]]; then
-    active_id="$declared"
-  else
-    active_id="$checkout_id"
-  fi
-
-  # (a) owner/repo scoping — usable only when the active checkout also resolves to
-  #     an owner/repo identity (i.e. it has an `origin` remote to compare against).
-  if [[ -n "$stored_owner" && "$active_id" == */* && "$active_id" != gitdir:* && "$active_id" != path:* ]]; then
-    local stored_owner_lc
-    stored_owner_lc="$(normalize_repo_key "$stored_owner")"
-    if [[ "$stored_owner_lc" != "$active_id" ]]; then
-      echo "polling-state-gate.sh: PR #$PR_NUMBER is scoped to repo '$stored_owner' but the active checkout is '$active_id' ($canon) — refuse to poll from the wrong repo" >&2
-      return 1
-    fi
-    return 0
-  fi
-
-  # (b) fall back to per-PR checkout path, compared by identity so sibling worktrees
-  #     of the same repo agree. A stale/absent path carries no signal.
-  if [[ -n "$stored_root" && -d "$stored_root" ]]; then
-    local stored_id
-    stored_id="$(repo_identity "$stored_root")"
-    if [[ "$stored_id" != "$active_id" ]]; then
-      echo "polling-state-gate.sh: PR #$PR_NUMBER is scoped to repo '$stored_id' ($stored_root) but the active checkout is '$active_id' ($canon) — refuse to poll from the wrong repo" >&2
-      return 1
-    fi
-    return 0
-  fi
-
-  # (c) scoping IS recorded but nothing above could compare it — the active checkout
-  #     has no usable `origin` identity and the recorded path is stale/absent. Fail
-  #     closed: this is not legacy state, so silently proceeding would validate
-  #     nothing. (--ensure-session is exempt; it is about to (re)record the scoping.)
-  if [[ -n "$stored_owner" && "${2:-}" != "quiet" ]]; then
-    echo "polling-state-gate.sh: PR #$PR_NUMBER is scoped to repo '$stored_owner' but the active checkout ($canon) has no comparable repo identity ('$active_id') — refuse to poll; re-run from a checkout with an 'origin' remote, or: polling-state-gate.sh $PR_NUMBER --ensure-session" >&2
-    return 1
-  fi
-
-  # (d) state written before per-PR scoping existed: degrade gracefully, never refuse
-  #     on the scope-level .root_repo alone.
-  if [[ "${2:-}" != "quiet" ]]; then
-    echo "polling-state-gate.sh: no per-PR repo scoping recorded for PR #$PR_NUMBER — proceeding with the active checkout ($canon); run: polling-state-gate.sh $PR_NUMBER --ensure-session" >&2
-  fi
-  return 0
-}
 
 write_checkpoint_handoff() {
   local head_sha="$1"

--- a/.claude/scripts/tests/polling-state-gate.test.sh
+++ b/.claude/scripts/tests/polling-state-gate.test.sh
@@ -66,10 +66,10 @@ for scope_function in "${SCOPE_FUNCTIONS[@]}"; do
   check_eq "scope resolver exports $scope_function" "function" \
     "$(type -t "$scope_function" 2>/dev/null || true)"
   check_eq "polling gate does not re-inline $scope_function" "0" \
-    "$(grep -Ec "^${scope_function}\\(\\)" "$SCRIPT" || true)"
+    "$(grep -Ec "^[[:space:]]*(function[[:space:]]+)?${scope_function}[[:space:]]*\\(\\)" "$SCRIPT" || true)"
 done
 check_eq "polling gate sources the resolver exactly once" "1" \
-  "$(grep -Ec '^[[:space:]]*if ! source \"\$_SCOPE_RESOLVER_LIB\"; then$' "$SCRIPT" || true)"
+  "$(grep -Ec '^[[:space:]]*(if[[:space:]]+!)?[[:space:]]*(source|\.)[[:space:]]+(\"?\$\{?_SCOPE_RESOLVER_LIB\}?\"?|\"?[^[:space:]]*pr-scope-resolver\.sh\"?)' "$SCRIPT" || true)"
 check_eq "polling gate hard-fails when the resolver is missing" "1" \
   "$(grep -Ec 'required scope resolver not found' "$SCRIPT" || true)"
 
@@ -134,6 +134,21 @@ REPO_A="$TMP/repo-a"
 REPO_B="$TMP/repo-b"
 mk_repo "$REPO_A" "git@github.com:org/a.git"
 mk_repo "$REPO_B" "https://github.com/org/b.git"
+
+# A declared identity is a safety boundary. If its normalizer fails, validation
+# must refuse rather than silently replacing the declaration with checkout_id.
+NORMALIZER_DEF="$(declare -f normalize_repo_key)"
+normalize_repo_key() { return 1; }
+STATE_FILE="$TMP/no-state"
+STATE_READ_DIR="$REPO_A"
+REPO_KEY_DECLARED=1
+ACTIVE_REPO_KEY="org/a"
+PR_NUMBER="99647"
+out="$(validate_root_match "$REPO_A" quiet 2>&1)"; rc=$?
+check_eq "declared repo-key normalization failure refuses validation" "1" "$rc"
+check_contains "normalization refusal explains the unusable identity" \
+  "could not normalize repo key 'org/a'" "$out"
+eval "$NORMALIZER_DEF"
 
 # Sibling worktree of repo A — same repo, different path.
 WT_A="$TMP/wt-a"

--- a/.claude/scripts/tests/polling-state-gate.test.sh
+++ b/.claude/scripts/tests/polling-state-gate.test.sh
@@ -72,7 +72,11 @@ for scope_function in "${SCOPE_FUNCTIONS[@]}"; do
   check_eq "polling gate does not re-inline $scope_function" "0" \
     "$(grep -Ec "$scope_function_re" "$SCRIPT" || true)"
 done
-SCOPE_SOURCE_OP_RE='(source|\.)[[:space:]]+("?\$\{?_SCOPE_RESOLVER_LIB\}?"?|"?[^"[:space:]]*pr-scope-resolver\.sh"?)'
+# Match source operations only at a command boundary. A bare `(source|\.)`
+# search also matches non-operations such as `resource "$var"` or
+# `echo source "$var"`; one such occurrence could mask a removed real source
+# while leaving the expected count at one.
+SCOPE_SOURCE_OP_RE='(^|[;&|()][[:space:]]*|(^|[[:space:]])(if|elif|then|else|do)[[:space:]]+)!?[[:space:]]*(source|\.)[[:space:]]+("?\$\{?_SCOPE_RESOLVER_LIB\}?"?|"?[^"[:space:]]*pr-scope-resolver\.sh"?)'
 check_eq "polling gate sources the resolver exactly once" "1" \
   "$(grep -Ev '^[[:space:]]*#' "$SCRIPT" | grep -Eo "$SCOPE_SOURCE_OP_RE" | wc -l | tr -d '[:space:]')"
 check_eq "polling gate hard-fails when the resolver is missing" "1" \
@@ -86,6 +90,10 @@ check_eq "anti-reinline matcher catches declarations with a next-line brace" "1"
   "$(printf '%s\n' '  resolve_pr_scope ()' '{' | grep -Ec "${SCOPE_FUNCTION_DECL_RE//__NAME__/resolve_pr_scope}" || true)"
 check_eq "source-site matcher counts two operations on one line" "2" \
   "$(printf 'source "%s"; . "%s"\n' '$_SCOPE_RESOLVER_LIB' '$_SCOPE_RESOLVER_LIB' | grep -Eo "$SCOPE_SOURCE_OP_RE" | wc -l | tr -d '[:space:]')"
+check_eq "source-site matcher ignores command names ending in source" "0" \
+  "$(printf '%s\n' 'resource "$_SCOPE_RESOLVER_LIB"' | grep -Ec "$SCOPE_SOURCE_OP_RE" || true)"
+check_eq "source-site matcher ignores source mentioned as an argument" "0" \
+  "$(printf '%s\n' 'echo source "$_SCOPE_RESOLVER_LIB"' | grep -Ec "$SCOPE_SOURCE_OP_RE" || true)"
 
 # Shared gh stub for --ensure-session tests. poll-watermarks.sh (issue #741) calls
 # pr-state.sh during --ensure-session, so the stub must satisfy pr-state's gh

--- a/.claude/scripts/tests/polling-state-gate.test.sh
+++ b/.claude/scripts/tests/polling-state-gate.test.sh
@@ -62,16 +62,26 @@ SCOPE_FUNCTIONS=(
   _pr_holders active_scope_key resolve_pr_scope foreign_pr_scopes state_pr_field
   repo_identity is_owner_repo_identity resolve_root_repo validate_root_match
 )
+SCOPE_FUNCTION_DECL_RE='^[[:space:]]*(__NAME__[[:space:]]*\(\)|function[[:space:]]+__NAME__([[:space:]]*\(\))?)[[:space:]]*\{'
 for scope_function in "${SCOPE_FUNCTIONS[@]}"; do
   check_eq "scope resolver exports $scope_function" "function" \
     "$(type -t "$scope_function" 2>/dev/null || true)"
+  scope_function_re="${SCOPE_FUNCTION_DECL_RE//__NAME__/$scope_function}"
   check_eq "polling gate does not re-inline $scope_function" "0" \
-    "$(grep -Ec "^[[:space:]]*(function[[:space:]]+)?${scope_function}[[:space:]]*\\(\\)" "$SCRIPT" || true)"
+    "$(grep -Ec "$scope_function_re" "$SCRIPT" || true)"
 done
+SCOPE_SOURCE_OP_RE='(source|\.)[[:space:]]+("?\$\{?_SCOPE_RESOLVER_LIB\}?"?|"?[^"[:space:]]*pr-scope-resolver\.sh"?)'
 check_eq "polling gate sources the resolver exactly once" "1" \
-  "$(grep -Ec '^[[:space:]]*(if[[:space:]]+!)?[[:space:]]*(source|\.)[[:space:]]+(\"?\$\{?_SCOPE_RESOLVER_LIB\}?\"?|\"?[^[:space:]]*pr-scope-resolver\.sh\"?)' "$SCRIPT" || true)"
+  "$(grep -Ev '^[[:space:]]*#' "$SCRIPT" | grep -Eo "$SCOPE_SOURCE_OP_RE" | wc -l | tr -d '[:space:]')"
 check_eq "polling gate hard-fails when the resolver is missing" "1" \
   "$(grep -Ec 'required scope resolver not found' "$SCRIPT" || true)"
+
+# Keep the structural matchers honest for both Bash function syntaxes and for
+# multiple source operations sharing one line.
+check_eq "anti-reinline matcher catches function declarations without parentheses" "1" \
+  "$(printf '%s\n' '  function resolve_pr_scope {' | grep -Ec "${SCOPE_FUNCTION_DECL_RE//__NAME__/resolve_pr_scope}" || true)"
+check_eq "source-site matcher counts two operations on one line" "2" \
+  "$(printf 'source "%s"; . "%s"\n' '$_SCOPE_RESOLVER_LIB' '$_SCOPE_RESOLVER_LIB' | grep -Eo "$SCOPE_SOURCE_OP_RE" | wc -l | tr -d '[:space:]')"
 
 # Shared gh stub for --ensure-session tests. poll-watermarks.sh (issue #741) calls
 # pr-state.sh during --ensure-session, so the stub must satisfy pr-state's gh
@@ -147,6 +157,11 @@ PR_NUMBER="99647"
 out="$(validate_root_match "$REPO_A" quiet 2>&1)"; rc=$?
 check_eq "declared repo-key normalization failure refuses validation" "1" "$rc"
 check_contains "normalization refusal explains the unusable identity" \
+  "could not normalize repo key 'org/a'" "$out"
+normalize_repo_key() { printf ''; return 0; }
+out="$(validate_root_match "$REPO_A" quiet 2>&1)"; rc=$?
+check_eq "empty normalized declared repo key refuses validation" "1" "$rc"
+check_contains "empty normalization refusal explains the unusable identity" \
   "could not normalize repo key 'org/a'" "$out"
 eval "$NORMALIZER_DEF"
 

--- a/.claude/scripts/tests/polling-state-gate.test.sh
+++ b/.claude/scripts/tests/polling-state-gate.test.sh
@@ -17,6 +17,7 @@ set -uo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 SCRIPT="$REPO_ROOT/.claude/scripts/polling-state-gate.sh"
 HANDOFF_HELPER="$REPO_ROOT/.claude/scripts/handoff-state.sh"
+SCOPE_LIB="$REPO_ROOT/.claude/scripts/lib/pr-scope-resolver.sh"
 
 TMP="$(mktemp -d)"
 TMP_HOME="$(mktemp -d)"
@@ -43,6 +44,34 @@ check_contains() {
     FAIL=$((FAIL + 1)); echo "FAIL — $desc (missing '$needle' in: $haystack)"
   fi
 }
+
+# ---- 0. extracted scope-resolver boundary (issue #971) ---------------------
+LIB_OUT=""
+LIB_RC=0
+LIB_OUT="$(bash "$SCOPE_LIB" 2>&1)" || LIB_RC=$?
+check_eq "scope resolver refuses direct execution" "2" "$LIB_RC"
+check_contains "direct-execution refusal explains the source-only contract" \
+  "source this file, do not execute it directly" "$LIB_OUT"
+
+SOURCE_RC=0
+# shellcheck source=../lib/pr-scope-resolver.sh
+source "$SCOPE_LIB" || SOURCE_RC=$?
+check_eq "scope resolver can be sourced" "0" "$SOURCE_RC"
+
+SCOPE_FUNCTIONS=(
+  _pr_holders active_scope_key resolve_pr_scope foreign_pr_scopes state_pr_field
+  repo_identity is_owner_repo_identity resolve_root_repo validate_root_match
+)
+for scope_function in "${SCOPE_FUNCTIONS[@]}"; do
+  check_eq "scope resolver exports $scope_function" "function" \
+    "$(type -t "$scope_function" 2>/dev/null || true)"
+  check_eq "polling gate does not re-inline $scope_function" "0" \
+    "$(grep -Ec "^${scope_function}\\(\\)" "$SCRIPT" || true)"
+done
+check_eq "polling gate sources the resolver exactly once" "1" \
+  "$(grep -Ec '^[[:space:]]*if ! source \"\$_SCOPE_RESOLVER_LIB\"; then$' "$SCRIPT" || true)"
+check_eq "polling gate hard-fails when the resolver is missing" "1" \
+  "$(grep -Ec 'required scope resolver not found' "$SCRIPT" || true)"
 
 # Shared gh stub for --ensure-session tests. poll-watermarks.sh (issue #741) calls
 # pr-state.sh during --ensure-session, so the stub must satisfy pr-state's gh

--- a/.claude/scripts/tests/polling-state-gate.test.sh
+++ b/.claude/scripts/tests/polling-state-gate.test.sh
@@ -62,7 +62,9 @@ SCOPE_FUNCTIONS=(
   _pr_holders active_scope_key resolve_pr_scope foreign_pr_scopes state_pr_field
   repo_identity is_owner_repo_identity resolve_root_repo validate_root_match
 )
-SCOPE_FUNCTION_DECL_RE='^[[:space:]]*(__NAME__[[:space:]]*\(\)|function[[:space:]]+__NAME__([[:space:]]*\(\))?)[[:space:]]*\{'
+# Match the declaration itself rather than requiring its opening brace on the
+# same line; both `name() {` and `name()\n{` are legal Bash definitions.
+SCOPE_FUNCTION_DECL_RE='^[[:space:]]*(__NAME__[[:space:]]*\(\)|function[[:space:]]+__NAME__([[:space:]]*\(\))?)([[:space:]]*\{)?[[:space:]]*(#.*)?$'
 for scope_function in "${SCOPE_FUNCTIONS[@]}"; do
   check_eq "scope resolver exports $scope_function" "function" \
     "$(type -t "$scope_function" 2>/dev/null || true)"
@@ -80,6 +82,8 @@ check_eq "polling gate hard-fails when the resolver is missing" "1" \
 # multiple source operations sharing one line.
 check_eq "anti-reinline matcher catches function declarations without parentheses" "1" \
   "$(printf '%s\n' '  function resolve_pr_scope {' | grep -Ec "${SCOPE_FUNCTION_DECL_RE//__NAME__/resolve_pr_scope}" || true)"
+check_eq "anti-reinline matcher catches declarations with a next-line brace" "1" \
+  "$(printf '%s\n' '  resolve_pr_scope ()' '{' | grep -Ec "${SCOPE_FUNCTION_DECL_RE//__NAME__/resolve_pr_scope}" || true)"
 check_eq "source-site matcher counts two operations on one line" "2" \
   "$(printf 'source "%s"; . "%s"\n' '$_SCOPE_RESOLVER_LIB' '$_SCOPE_RESOLVER_LIB' | grep -Eo "$SCOPE_SOURCE_OP_RE" | wc -l | tr -d '[:space:]')"
 

--- a/.claude/scripts/tests/polling-state-gate.test.sh
+++ b/.claude/scripts/tests/polling-state-gate.test.sh
@@ -62,9 +62,9 @@ SCOPE_FUNCTIONS=(
   _pr_holders active_scope_key resolve_pr_scope foreign_pr_scopes state_pr_field
   repo_identity is_owner_repo_identity resolve_root_repo validate_root_match
 )
-# Match the declaration itself rather than requiring its opening brace on the
-# same line; both `name() {` and `name()\n{` are legal Bash definitions.
-SCOPE_FUNCTION_DECL_RE='^[[:space:]]*(__NAME__[[:space:]]*\(\)|function[[:space:]]+__NAME__([[:space:]]*\(\))?)([[:space:]]*\{)?[[:space:]]*(#.*)?$'
+# Match the declaration prefix rather than requiring a particular body layout;
+# `name() {`, `name()\n{`, and `name() { :; }` are all legal Bash definitions.
+SCOPE_FUNCTION_DECL_RE='^[[:space:]]*(__NAME__[[:space:]]*\(\)|function[[:space:]]+__NAME__([[:space:]]*\(\))?)[[:space:]]*(\{|(#.*)?$)'
 for scope_function in "${SCOPE_FUNCTIONS[@]}"; do
   check_eq "scope resolver exports $scope_function" "function" \
     "$(type -t "$scope_function" 2>/dev/null || true)"
@@ -72,15 +72,37 @@ for scope_function in "${SCOPE_FUNCTIONS[@]}"; do
   check_eq "polling gate does not re-inline $scope_function" "0" \
     "$(grep -Ec "$scope_function_re" "$SCRIPT" || true)"
 done
-# Match source operations only at a command boundary. A bare `(source|\.)`
-# search also matches non-operations such as `resource "$var"` or
+# Match source operations only at a command boundary. Include legal grouped,
+# conditional, assignment-prefixed, and builtin/command-prefixed forms. A bare
+# `(source|\.)` search also matches non-operations such as `resource "$var"` or
 # `echo source "$var"`; one such occurrence could mask a removed real source
 # while leaving the expected count at one.
-SCOPE_SOURCE_OP_RE='(^|[;&|()][[:space:]]*|(^|[[:space:]])(if|elif|then|else|do)[[:space:]]+)!?[[:space:]]*(source|\.)[[:space:]]+("?\$\{?_SCOPE_RESOLVER_LIB\}?"?|"?[^"[:space:]]*pr-scope-resolver\.sh"?)'
+SCOPE_SOURCE_BOUNDARY_RE='(^|[;&|(){}])[[:space:]]*((if|elif|then|else|do|while|until|time|coproc)[[:space:]]+)?'
+SCOPE_SOURCE_PREFIX_RE="!?[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=([^[:space:];&|(){}\"']+|\"[^\"]*\"|'[^']*')+[[:space:]]+)*(command[[:space:]]+|builtin[[:space:]]+)?"
+SCOPE_SOURCE_TARGET_RE='(source|\.)[[:space:]]+("?\$\{?_SCOPE_RESOLVER_LIB\}?"?|"?[^"[:space:]]*pr-scope-resolver\.sh"?)'
+SCOPE_SOURCE_OP_RE="${SCOPE_SOURCE_BOUNDARY_RE}${SCOPE_SOURCE_PREFIX_RE}${SCOPE_SOURCE_TARGET_RE}"
 check_eq "polling gate sources the resolver exactly once" "1" \
   "$(grep -Ev '^[[:space:]]*#' "$SCRIPT" | grep -Eo "$SCOPE_SOURCE_OP_RE" | wc -l | tr -d '[:space:]')"
-check_eq "polling gate hard-fails when the resolver is missing" "1" \
-  "$(grep -Ec 'required scope resolver not found' "$SCRIPT" || true)"
+
+# Exercise both load-failure branches instead of merely grepping for their
+# diagnostics. These copies stop at the resolver boundary, before any other
+# helper from SCRIPT_DIR is needed.
+MISSING_LIB_DIR="$TMP/missing-resolver"
+mkdir -p "$MISSING_LIB_DIR"
+cp "$SCRIPT" "$MISSING_LIB_DIR/polling-state-gate.sh"
+missing_out="$(HOME="$TMP_HOME" bash "$MISSING_LIB_DIR/polling-state-gate.sh" 1 2>&1)"; missing_rc=$?
+check_eq "polling gate exits 4 when the resolver is missing" "4" "$missing_rc"
+check_contains "missing-resolver failure names the required dependency" \
+  "required scope resolver not found" "$missing_out"
+
+BROKEN_LIB_DIR="$TMP/broken-resolver"
+mkdir -p "$BROKEN_LIB_DIR/lib"
+cp "$SCRIPT" "$BROKEN_LIB_DIR/polling-state-gate.sh"
+printf '%s\n' 'return 7' > "$BROKEN_LIB_DIR/lib/pr-scope-resolver.sh"
+broken_out="$(HOME="$TMP_HOME" bash "$BROKEN_LIB_DIR/polling-state-gate.sh" 1 2>&1)"; broken_rc=$?
+check_eq "polling gate exits 4 when resolver sourcing fails" "4" "$broken_rc"
+check_contains "source-failure diagnostic names the resolver" \
+  "failed to source required scope resolver" "$broken_out"
 
 # Keep the structural matchers honest for both Bash function syntaxes and for
 # multiple source operations sharing one line.
@@ -88,12 +110,24 @@ check_eq "anti-reinline matcher catches function declarations without parenthese
   "$(printf '%s\n' '  function resolve_pr_scope {' | grep -Ec "${SCOPE_FUNCTION_DECL_RE//__NAME__/resolve_pr_scope}" || true)"
 check_eq "anti-reinline matcher catches declarations with a next-line brace" "1" \
   "$(printf '%s\n' '  resolve_pr_scope ()' '{' | grep -Ec "${SCOPE_FUNCTION_DECL_RE//__NAME__/resolve_pr_scope}" || true)"
+check_eq "anti-reinline matcher catches declarations with an inline body" "1" \
+  "$(printf '%s\n' 'resolve_pr_scope() { :; }' | grep -Ec "${SCOPE_FUNCTION_DECL_RE//__NAME__/resolve_pr_scope}" || true)"
 check_eq "source-site matcher counts two operations on one line" "2" \
   "$(printf 'source "%s"; . "%s"\n' '$_SCOPE_RESOLVER_LIB' '$_SCOPE_RESOLVER_LIB' | grep -Eo "$SCOPE_SOURCE_OP_RE" | wc -l | tr -d '[:space:]')"
+check_eq "source-site matcher catches grouped source operations" "1" \
+  "$(printf '%s\n' '{ source "$_SCOPE_RESOLVER_LIB"; }' | grep -Eoc "$SCOPE_SOURCE_OP_RE" || true)"
+check_eq "source-site matcher catches assignment-prefixed source operations" "1" \
+  "$(printf '%s\n' 'TRACE=1 source "$_SCOPE_RESOLVER_LIB"' | grep -Eoc "$SCOPE_SOURCE_OP_RE" || true)"
+check_eq "source-site matcher catches quoted assignment-prefixed source operations" "1" \
+  "$(printf '%s\n' 'TRACE="two words" source "$_SCOPE_RESOLVER_LIB"' | grep -Eoc "$SCOPE_SOURCE_OP_RE" || true)"
+check_eq "source-site matcher catches conditional source operations" "1" \
+  "$(printf '%s\n' 'while command source "$_SCOPE_RESOLVER_LIB"; do :; done' | grep -Eoc "$SCOPE_SOURCE_OP_RE" || true)"
 check_eq "source-site matcher ignores command names ending in source" "0" \
   "$(printf '%s\n' 'resource "$_SCOPE_RESOLVER_LIB"' | grep -Ec "$SCOPE_SOURCE_OP_RE" || true)"
 check_eq "source-site matcher ignores source mentioned as an argument" "0" \
   "$(printf '%s\n' 'echo source "$_SCOPE_RESOLVER_LIB"' | grep -Ec "$SCOPE_SOURCE_OP_RE" || true)"
+check_eq "source-site matcher ignores source text inside an argument" "0" \
+  "$(printf '%s\n' 'echo '\''x then source "$_SCOPE_RESOLVER_LIB"'\''' | grep -Ec "$SCOPE_SOURCE_OP_RE" || true)"
 
 # Shared gh stub for --ensure-session tests. poll-watermarks.sh (issue #741) calls
 # pr-state.sh during --ensure-session, so the stub must satisfy pr-state's gh


### PR DESCRIPTION
## Summary

- extract the repo-identity and per-PR scope-resolution seam from the 881-line polling gate into a source-only library
- keep argument parsing, scope-precedence setup, handoff/state writes, watermark initialization, mode dispatch, and merge-gate behavior in the entry point
- document the ownership boundary and add structural anti-drift coverage without rewriting unrelated test fixtures

## Decision evidence

Five of the ten recent edits to `polling-state-gate.sh` evolved one ~300-line correctness seam (repo scope/identity/root validation); the other five changed independent concerns. This PR extracts only the recurring seam. CodeRabbit's broader proposal to consolidate all three test fixtures was intentionally excluded because the suites' scenario setup differs and that rewrite would not reduce production-file churn.

## Local review coverage

`none` (degraded, visibility only): the latest Phase B CodeRabbit review exceeded its 120-second bound, and CodeAnt returned its documented 403 daily-cap signal on the initial attempt and one retry. A clean self-review was completed after the full test/lint run.

## Test plan

- [x] Scope logic lives only in `lib/pr-scope-resolver.sh`; the entry point hard-fails when it cannot source the library.
- [x] `--ensure-session`, `--verify-state`, and default-cycle behavior retain their existing interfaces and dispatch paths.
- [x] Multi-repo collisions, sibling worktrees, stale inherited scope, explicit contradictions, legacy `_unknown` state, flat handoffs, and authorship behavior remain covered and passing.
- [x] State/handoff/watermark mutation remains delegated to the existing helpers; the library performs no direct state-file or handoff-file I/O.
- [x] Structural tests cover source-only execution, expected exported functions, one source site, and no inline redefinitions.
- [x] State-file contracts document the extracted boundary and the distinct scope-selection versus checkout-authorization decisions.
- [x] Focused polling tests: 53 primary assertions, 49 multi-repo assertions, compaction recovery all pass.
- [x] Full Bash discovery: 75 suites, 0 failures.
- [x] Python discovery: 142 tests, 0 failures.
- [x] Rule lint and reference catalog lint pass.

Closes #971


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented repository scope selection, checkout validation, state access, and mutation ownership.
  * Updated case-normalization guidance for the polling workflow.

* **Bug Fixes**
  * Improved validation of repository identity and pull request scope.
  * Added clear failure handling when required scope-resolution support is unavailable.

* **Tests**
  * Added coverage for scope resolution, sourcing behavior, duplicate implementations, and missing support detection.
  * Added validation for invalid or unverifiable repository identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->