### PR TITLE
refactor(#936): extract CR/CodeAnt approval state machine into _fetch_bot_approvals

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -87,6 +87,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `phase-b-reviewer-hotspot-decision.md` — diagnosis and no-runtime-change decision for `phase-b-reviewer.md` churn (14 merged PRs in the Issue #942 window); verdict: KEEP the self-contained Phase B state machine
 - `phase-c-merger-hotspot-decision.md` — evidence-based diagnosis of `phase-c-merger.md` churn (9 merged PRs in the Issue #976 window); verdict: KEEP single file + dedup non-decision detail toward canonical owners
 - `start-issue-hotspot-decision.md` — diagnosis of `start-issue/SKILL.md` churn (9 merged PRs in the Issue #981 window); verdict: KEEP the seven-step skill + no operative change
+- `merge-gate-hotspot-decision.md` — diagnosis and extract-not-split decision for `merge-gate.sh` churn (16 PRs in the Issue #936 window); verdict: KEEP single file + extract CR/CodeAnt approval state machine into `_fetch_bot_approvals` local function
 - `scheduling-reliability-hotspot-decision.md` — diagnosis and dedup decision for `scheduling-reliability.md` churn (12 merged PRs in the #959 hotspot window, re-measured after #982); verdict: KEEP single rule file + remove downstream formula/enforcement restatements
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `harness-model-audit-2026-06.md` — harness components vs current model fleet (#49)

--- a/.claude/reference/merge-gate-hotspot-decision.md
+++ b/.claude/reference/merge-gate-hotspot-decision.md
@@ -1,0 +1,100 @@
+# merge-gate hotspot — diagnosis and extract-not-split decision
+
+Reference for Issue #936 (`.claude/scripts/merge-gate.sh` churn hotspot). Not auto-loaded.
+
+## The problem being read
+
+`merge-gate.sh` was touched by 16 distinct merged PRs (#626, #659, #686, #727, #730, #739, #751,
+#840, #849, #883, #891, #893, #907, #965, #972, #1001) — the highest-churn script file in the
+repo when Issue #936 was filed.
+
+The file is the single authoritative merge gate for all reviewer paths. Every consumer (`merge`,
+`wrap`, `go-on`, `status`, `phase-c-merger`) reads its JSON output contract and must not change
+when the internals are refactored. This junction nature explains some churn, but three additional
+co-located concerns iterate independently and produce edit collisions:
+
+| Concern | Location in merge-gate.sh | Churn driver |
+|---------|---------------------------|--------------|
+| CR/CodeAnt approval state machine | Lines 780–883 (~104 lines) | Reviewer-path changes (new guard, new bot) require editing identical CR and CA blocks separately |
+| emit_json() 16-positional-parameter surface | Lines 245–270, 5 call sites | Each new output field requires updating the function signature and every call site |
+| Freshness-verdict branching | CR/CA staleness block + BugBot freshness block | norm_ts comparison pattern repeated; future reviewer additions copy the pattern again |
+
+## Decision: extract, not split
+
+**Splitting merge-gate.sh into multiple scripts is rejected.**
+
+Every consumer depends on a single `merge-gate.sh <PR>` invocation returning one JSON object.
+A physical split would require consumers to orchestrate multiple script calls, reconcile partial
+JSON, and handle failure modes across multiple processes. The merge gate's correctness is
+audited by black-box tests (`merge-gate-*.test.sh`) that call the script end-to-end; a split
+would require re-architecting all of them.
+
+This follows the same extract-not-split verdict as:
+- `fixpr/SKILL.md` hotspot (#788) — extracted deterministic concerns into `.claude/scripts/*.sh`
+- `pr-state.sh` hotspot (#980) — extracted two pure jq programs, kept the public CLI
+- `subagent-orchestration.md` hotspot (#814) — extracted Phase A/B/C descriptions to canonical owners
+
+## Concrete remedy (Issue #936, implemented in the PR that closes it)
+
+One targeted extraction, zero behavior change:
+
+### 1. CR/CodeAnt approval state machine → `_fetch_bot_approvals` local function
+
+The near-identical CR and CodeAnt approval blocks (jq queries, retraction logic, stale-approval
+guard, substance check) were extracted into one parameterized local function `_fetch_bot_approvals`
+defined inside merge-gate.sh. The function accepts `<PREFIX> <login>` (e.g. `CR "coderabbitai[bot]"`)
+and sets the correct global variables using `eval` for dynamic variable names. bash 3.2 compatible:
+no namerefs, no associative arrays.
+
+The following derivations are **deliberately kept in the calling scope**, not the function:
+
+| Variable | Reason kept in main body |
+|----------|--------------------------|
+| `CR_STALE_REDEEMED` / `CA_STALE_REDEEMED` | `ts-normalizer-parity.test.sh` pins the exact `external_evidence_ok` condition that precedes the `=true` assignment |
+| `CR_APPROVAL_STALE_BLOCKING` / `CA_APPROVAL_STALE_BLOCKING` | Same test pins the condition (`$_APPROVAL_STALE == true && $_STALE_REDEEMED == false`) preceding the `=true` assignment |
+| `CR_APPROVAL_VALID` / `CA_APPROVAL_VALID` / `CR_HOLLOW` / `CA_HOLLOW` | Same test extracts the guard block starting at `CR_APPROVAL_VALID=false` and verifies nesting order of `_STALE_BLOCKING` and `_SUBSTANTIVE` checks |
+
+**Net change**: the duplicated 104-line CR+CA block shrinks to two function calls; the
+parameterized function body is ~60 lines. Future reviewer-path changes (new bot, revised stale
+guard, updated substance check) require editing only the function, not two separate blocks.
+
+### Why emit_json() and freshness branching were not changed
+
+`emit_json()` uses 16 positional parameters across 5 call sites. Replacing positional parameters
+with a named-variable or associative-array approach requires bash 4+ for associative arrays;
+a global-variable-based approach saves few call-site lines and weakens encapsulation. The current
+16-param form is verbose but correct and covers the full JSON contract without risk of field
+ordering or key-name drift. Left unchanged.
+
+The freshness-verdict branching (norm_ts comparisons in the CR/CA and BugBot blocks) was folded
+into `_fetch_bot_approvals` for the CR/CA cases. The BugBot block uses norm_ts in a different
+structural context (the result feeds MISSING[] entries directly, not bot-specific variables) and
+the Greptile block uses an inline jq `def canon_ts` rather than bash norm_ts — these two are not
+unified to avoid false parity. Left as-is.
+
+## What was explicitly preserved
+
+- JSON output contract: `.met`, `.reviewer`, `.path`, `.missing[]`, `.head_sha`, `.ci_status`,
+  `.merge_state`, `.mergeable`, `.review_decision`, `.code_owner_bots`, `.human_changes_requested`,
+  `.stale_bot_changes_requested_count`, `.unresolved_thread_count`, `.primary_review_met`,
+  `.authorship`, `.review_evidence` — byte-identical across all paths
+- All documented variable names reachable in merge-gate.sh source: `CR_APPROVAL_VALID`,
+  `CA_APPROVAL_VALID`, `CR_APPROVAL_STALE_BLOCKING`, `CA_APPROVAL_STALE_BLOCKING`,
+  `CR_STALE_REDEEMED`, `CA_STALE_REDEEMED`, `CR_PATH_APPROVED_ON_HEAD` — unchanged
+- Boolean formulas for the validity block, stale-blocking derivation, and redemption channel:
+  unchanged operand count, operand order, and guard nesting — `ts-normalizer-parity.test.sh`
+  validates all of them and was not modified
+- Zero-initialization block (lines 758–776): unchanged, needed so the cr) MISSING section
+  works correctly when the CR/CA guard does not fire
+- All `if [[ "$REVIEWER" == "cr" || "$REVIEWER" == "bugbot" ]]; then` guard structure: unchanged
+
+## Related
+
+- Issue #836 — stale-approval guard (the primary security invariant preserved by structural tests)
+- Issue #875 — review-substance guard (substance_ok call extracted into function)
+- Issue #876 — stale-approval redemption (external_evidence_ok channel preserved in main scope)
+- Issue #865 — shared CR/CA block for bugbot path
+- Issue #788 — fixpr hotspot, structural precedent for local extraction
+- Issue #980 — pr-state hotspot, precedent for keeping public CLI while extracting internals
+- `.claude/scripts/tests/ts-normalizer-parity.test.sh` — structural test that pins the preserved formulas
+- `.claude/reference/merge-gate-reviewer-paths.md` — authoritative per-path semantics

--- a/.claude/scripts/merge-gate.sh
+++ b/.claude/scripts/merge-gate.sh
@@ -749,6 +749,107 @@ external_evidence_ok() { # <login>
     '.reviewers[$l].external_evidence_on_head // false' >/dev/null 2>&1 && echo true || echo false
 }
 
+# Fetch and compute per-bot approval state. Called once per bot for the shared
+# CR/CodeAnt approval block (issue #865 / Issue #936 hotspot extraction).
+#
+# Sets the following global variables (examples shown for P="CR"):
+#   LATEST_<P>_APPROVED_AT            - newest APPROVED submitted_at on HEAD, or ""
+#   LATEST_<P>_CHANGES_REQUESTED_AT   - newest CHANGES_REQUESTED submitted_at on HEAD, or ""
+#   APPROVED_<P>_ON_HEAD              - count of APPROVED reviews on HEAD SHA
+#   TOTAL_<P>_ON_HEAD                 - count of all reviews on HEAD SHA
+#   <P>_RETRACTED                     - true when fresh CHANGES_REQUESTED beats APPROVED
+#   <P>_APPROVAL_STALE                - true when approval predates HEAD commit (issue #836)
+#   <P>_APPROVAL_FRESHNESS_UNKNOWN    - true when LAST_COMMIT_TS is unavailable
+#   <P>_APPROVAL_SUBMITTED_AT_MISSING - true when APPROVED has no submitted_at
+#   <P>_SUBSTANTIVE                   - true when bot left substantive evidence (issue #875)
+#
+# The following derivations are kept in the calling scope so their exact formulas
+# remain grep-findable for structural tests (ts-normalizer-parity.test.sh):
+#   <P>_STALE_REDEEMED, <P>_APPROVAL_STALE_BLOCKING, <P>_APPROVAL_VALID, <P>_HOLLOW
+#
+# Reads globals: REVIEWS_JSON, HEAD_SHA, LAST_COMMIT_TS, REVIEW_EVIDENCE.
+# Compatible with bash 3.2: uses eval for dynamic variable names, no namerefs.
+_fetch_bot_approvals() { # <PREFIX> <login>
+  local _p="$1" _login="$2"
+  local _approved_at _changes_at _approved_count _total_count
+
+  # Fetch review timestamps and counts on HEAD SHA.
+  _approved_at=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" --arg login "$_login" '
+    [.[]?
+      | select(.user.login == $login and .commit_id == $sha and .state == "APPROVED")
+      | .submitted_at]
+    | sort | last // ""')
+  _changes_at=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" --arg login "$_login" '
+    [.[]?
+      | select(.user.login == $login and .commit_id == $sha and .state == "CHANGES_REQUESTED")
+      | .submitted_at]
+    | sort | last // ""')
+  _approved_count=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" --arg login "$_login" '
+    [.[]? | select(.user.login == $login and .commit_id == $sha and .state == "APPROVED")]
+    | length')
+  _total_count=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" --arg login "$_login" '
+    [.[]? | select(.user.login == $login and .commit_id == $sha)]
+    | length')
+
+  eval "LATEST_${_p}_APPROVED_AT=\$_approved_at"
+  eval "LATEST_${_p}_CHANGES_REQUESTED_AT=\$_changes_at"
+  eval "APPROVED_${_p}_ON_HEAD=\$_approved_count"
+  eval "TOTAL_${_p}_ON_HEAD=\$_total_count"
+
+  # Retraction: later CHANGES_REQUESTED on same SHA invalidates APPROVED (ISO timestamps).
+  # Freshness guard (issue #836): GitHub retargets commit_id on force-push, so a
+  # pre-push CHANGES_REQUESTED can appear on HEAD while predating the commit.
+  # Only treat as retraction if the CHANGES_REQUESTED is itself fresh
+  # (submitted_at >= LAST_COMMIT_TS). When LAST_COMMIT_TS is unknown, skip
+  # retraction — the approval's own freshness check will block via
+  # <P>_APPROVAL_FRESHNESS_UNKNOWN.
+  eval "${_p}_RETRACTED=false"
+  if [[ "$_approved_count" -ge 1 && -n "$_changes_at" && -n "$_approved_at" ]]; then
+    if [[ "$(norm_ts "$_changes_at")" > "$(norm_ts "$_approved_at")" ]]; then
+      if [[ -n "$LAST_COMMIT_TS" && ! "$(norm_ts "$_changes_at")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
+        eval "${_p}_RETRACTED=true"
+      fi
+    fi
+  fi
+
+  # Stale-approval guard (issue #836): GitHub retargets commit_id on force-push
+  # but does NOT update submitted_at. An approval whose submitted_at predates
+  # the HEAD commit's committer date was submitted before the current commit
+  # and must not count even when commit_id matches. Equal timestamps are
+  # accepted (submitted_at >= LAST_COMMIT_TS). Use norm_ts for comparisons
+  # to handle mixed Z/+00:00 UTC suffixes (issue #836, BugBot round 5).
+  #
+  # Fail-closed (issue #836): when LAST_COMMIT_TS is empty (HEAD timestamp API
+  # failure) we CANNOT verify freshness, so qualifying approvals do NOT satisfy
+  # the gate. Callers poll every ~60 s, so a transient API failure self-heals
+  # on the next cycle without wedging a merge indefinitely.
+  eval "${_p}_APPROVAL_STALE=false"
+  eval "${_p}_APPROVAL_FRESHNESS_UNKNOWN=false"
+  # Separate flag for missing submitted_at (distinct from LAST_COMMIT_TS missing):
+  # the approval's timestamp is absent — different cause, different user message.
+  eval "${_p}_APPROVAL_SUBMITTED_AT_MISSING=false"
+  local _p_retracted_var="${_p}_RETRACTED"
+  if [[ "$_approved_count" -ge 1 && "${!_p_retracted_var}" == false ]]; then
+    if [[ -z "$LAST_COMMIT_TS" ]]; then
+      eval "${_p}_APPROVAL_FRESHNESS_UNKNOWN=true"
+    elif [[ -z "$_approved_at" ]]; then
+      # submitted_at is missing from the approval itself (not a transient API
+      # failure) — cannot verify freshness (fail-closed, issue #836).
+      eval "${_p}_APPROVAL_SUBMITTED_AT_MISSING=true"
+    elif [[ "$(norm_ts "$_approved_at")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
+      eval "${_p}_APPROVAL_STALE=true"
+    fi
+  fi
+
+  # Review-substance verdict (issue #875). `counts_as_coverage` folds temporal
+  # inversion, capability failure, self-report SHA mismatch and footprint
+  # substance into one boolean; `disqualified_by` carries the reasons so the
+  # missing[] entry can say WHY rather than "need 1 approval".
+  local _substantive
+  _substantive=$(substance_ok "$_login")
+  eval "${_p}_SUBSTANTIVE=\$_substantive"
+}
+
 # CR-path approval detection — shared by the cr) and bugbot) cases (issue #865).
 # On the cr) path these variables are also consumed by the MISSING-entry section
 # and the supplemental CodeAnt gate below. On the bugbot) path only
@@ -775,119 +876,20 @@ CA_APPROVAL_SUBMITTED_AT_MISSING=false
 CR_APPROVAL_STALE_BLOCKING=false
 CA_APPROVAL_STALE_BLOCKING=false
 if [[ "$REVIEWER" == "cr" || "$REVIEWER" == "bugbot" ]]; then
-  # Require 1 explicit CodeRabbit APPROVED on HEAD (SHA freshness in the jq filter).
-  # Retraction: CHANGES_REQUESTED newer than APPROVED on same SHA invalidates approval.
-  LATEST_CR_APPROVED_AT=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" '
-    [.[]?
-      | select(.user.login == "coderabbitai[bot]" and .commit_id == $sha and .state == "APPROVED")
-      | .submitted_at]
-    | sort | last // ""')
-  LATEST_CR_CHANGES_REQUESTED_AT=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" '
-    [.[]?
-      | select(.user.login == "coderabbitai[bot]" and .commit_id == $sha and .state == "CHANGES_REQUESTED")
-      | .submitted_at]
-    | sort | last // ""')
-  APPROVED_CR_ON_HEAD=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
-    [.[]? | select(.user.login == "coderabbitai[bot]" and .commit_id == $sha and .state == "APPROVED")]
-    | length')
-  TOTAL_CR_ON_HEAD=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
-    [.[]? | select(.user.login == "coderabbitai[bot]" and .commit_id == $sha)]
-    | length')
+  # Fetch review stats, retraction, stale-approval, and substance checks for each
+  # bot (issue #936 extraction). Redemption (<P>_STALE_REDEEMED), blocking
+  # (<P>_APPROVAL_STALE_BLOCKING), and validity (<P>_APPROVAL_VALID/<P>_HOLLOW)
+  # are derived in the main scope so their formulas remain grep-findable for
+  # structural tests (ts-normalizer-parity.test.sh).
+  _fetch_bot_approvals CR "coderabbitai[bot]"
+  _fetch_bot_approvals CA "codeant-ai[bot]"
 
-  LATEST_CA_APPROVED_AT=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" '
-    [.[]?
-      | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha and .state == "APPROVED")
-      | .submitted_at]
-    | sort | last // ""')
-  LATEST_CA_CHANGES_REQUESTED_AT=$(echo "$REVIEWS_JSON" | jq -r --arg sha "$HEAD_SHA" '
-    [.[]?
-      | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha and .state == "CHANGES_REQUESTED")
-      | .submitted_at]
-    | sort | last // ""')
-  APPROVED_CA_ON_HEAD=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
-    [.[]? | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha and .state == "APPROVED")]
-    | length')
-  TOTAL_CA_ON_HEAD=$(echo "$REVIEWS_JSON" | jq --arg sha "$HEAD_SHA" '
-    [.[]? | select(.user.login == "codeant-ai[bot]" and .commit_id == $sha)]
-    | length')
-
-  # Retraction: later CHANGES_REQUESTED on same SHA invalidates APPROVED (ISO timestamps).
-  # Freshness guard (issue #836): GitHub retargets commit_id on force-push, so a
-  # pre-push CHANGES_REQUESTED can appear on HEAD while predating the commit.
-  # Only treat as retraction if the CHANGES_REQUESTED is itself fresh
-  # (submitted_at >= LAST_COMMIT_TS). When LAST_COMMIT_TS is unknown, skip
-  # retraction — the approval's own freshness check will block via
-  # CR/CA_APPROVAL_FRESHNESS_UNKNOWN.
-  CR_RETRACTED=false
-  if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && -n "$LATEST_CR_CHANGES_REQUESTED_AT" && -n "$LATEST_CR_APPROVED_AT" ]]; then
-    if [[ "$(norm_ts "$LATEST_CR_CHANGES_REQUESTED_AT")" > "$(norm_ts "$LATEST_CR_APPROVED_AT")" ]]; then
-      if [[ -n "$LAST_COMMIT_TS" && ! "$(norm_ts "$LATEST_CR_CHANGES_REQUESTED_AT")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
-        CR_RETRACTED=true
-      fi
-    fi
-  fi
-  CA_RETRACTED=false
-  if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && -n "$LATEST_CA_CHANGES_REQUESTED_AT" && -n "$LATEST_CA_APPROVED_AT" ]]; then
-    if [[ "$(norm_ts "$LATEST_CA_CHANGES_REQUESTED_AT")" > "$(norm_ts "$LATEST_CA_APPROVED_AT")" ]]; then
-      if [[ -n "$LAST_COMMIT_TS" && ! "$(norm_ts "$LATEST_CA_CHANGES_REQUESTED_AT")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
-        CA_RETRACTED=true
-      fi
-    fi
-  fi
-
-  # Stale-approval guard (issue #836): GitHub retargets commit_id on force-push
-  # but does NOT update submitted_at. An approval whose submitted_at predates
-  # the HEAD commit's committer date was submitted before the current commit
-  # and must not count even when commit_id matches. Equal timestamps are
-  # accepted (submitted_at >= LAST_COMMIT_TS). Use norm_ts for comparisons
-  # to handle mixed Z/+00:00 UTC suffixes (issue #836, BugBot round 5).
-  #
-  # Fail-closed (issue #836): when LAST_COMMIT_TS is empty (HEAD timestamp API
-  # failure) we CANNOT verify freshness, so qualifying approvals do NOT satisfy
-  # the gate. Callers poll every ~60 s, so a transient API failure self-heals
-  # on the next cycle without wedging a merge indefinitely.
-  CR_APPROVAL_STALE=false
-  CR_APPROVAL_FRESHNESS_UNKNOWN=false
-  # Separate flag for missing submitted_at (distinct from LAST_COMMIT_TS missing):
-  # the approval's timestamp is absent — different cause, different user message.
-  CR_APPROVAL_SUBMITTED_AT_MISSING=false
-  if [[ "$APPROVED_CR_ON_HEAD" -ge 1 && "$CR_RETRACTED" == false ]]; then
-    if [[ -z "$LAST_COMMIT_TS" ]]; then
-      CR_APPROVAL_FRESHNESS_UNKNOWN=true
-    elif [[ -z "$LATEST_CR_APPROVED_AT" ]]; then
-      # submitted_at is missing from the approval itself (not a transient API
-      # failure) — cannot verify freshness (fail-closed, issue #836).
-      CR_APPROVAL_SUBMITTED_AT_MISSING=true
-    elif [[ "$(norm_ts "$LATEST_CR_APPROVED_AT")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
-      CR_APPROVAL_STALE=true
-    fi
-  fi
-  CA_APPROVAL_STALE=false
-  CA_APPROVAL_FRESHNESS_UNKNOWN=false
-  CA_APPROVAL_SUBMITTED_AT_MISSING=false
-  if [[ "$APPROVED_CA_ON_HEAD" -ge 1 && "$CA_RETRACTED" == false ]]; then
-    if [[ -z "$LAST_COMMIT_TS" ]]; then
-      CA_APPROVAL_FRESHNESS_UNKNOWN=true
-    elif [[ -z "$LATEST_CA_APPROVED_AT" ]]; then
-      CA_APPROVAL_SUBMITTED_AT_MISSING=true
-    elif [[ "$(norm_ts "$LATEST_CA_APPROVED_AT")" < "$(norm_ts "$LAST_COMMIT_TS")" ]]; then
-      CA_APPROVAL_STALE=true
-    fi
-  fi
-
-  # Review-substance verdict per bot (issue #875). `counts_as_coverage` folds
-  # temporal inversion, capability failure, self-report SHA mismatch and
-  # footprint substance into one boolean; `disqualified_by` carries the reasons
-  # so the missing[] entry can say WHY rather than "need 1 approval".
-  CR_SUBSTANTIVE=$(substance_ok "coderabbitai[bot]")
-  CA_SUBSTANTIVE=$(substance_ok "codeant-ai[bot]")
-
-  # <P>_APPROVAL_STALE above is the unchanged #836 norm_ts verdict and stays
-  # that way — redemption is a SEPARATE, separately-named term rather than a
-  # loosening of the ordering rule, so the timestamp comparison keeps exactly
-  # one meaning. <P>_APPROVAL_STALE_BLOCKING is what the rest of the path
-  # consumes. Redemption cannot fire unless the approval is stale in the first
-  # place, so the fresh path is byte-for-byte unaffected.
+  # <P>_APPROVAL_STALE (set by _fetch_bot_approvals) is the unchanged #836
+  # norm_ts verdict — redemption is a SEPARATE, separately-named term rather
+  # than a loosening of the ordering rule, so the timestamp comparison keeps
+  # exactly one meaning. <P>_APPROVAL_STALE_BLOCKING is what the rest of the
+  # path consumes. Redemption cannot fire unless the approval is stale in the
+  # first place, so the fresh path is byte-for-byte unaffected.
   CR_STALE_REDEEMED=false
   CA_STALE_REDEEMED=false
   if [[ "$CR_APPROVAL_STALE" == true && "$(external_evidence_ok "coderabbitai[bot]")" == true ]]; then


### PR DESCRIPTION
## Summary

Implements Issue #936 hotspot reduction for `merge-gate.sh`.

The CR and CodeAnt approval blocks (~104 lines) were near-identical duplicates differentiated only by login string and variable prefix. They are extracted into a single parameterized local function `_fetch_bot_approvals <PREFIX> <login>` that:

- Fetches the four review-query jq results per bot
- Computes retraction (issue #836 freshness guard on the CHANGES_REQUESTED side)
- Computes the stale-approval guard (issue #836)
- Calls `substance_ok` for the substance verdict (issue #875)

The security-critical derivations (`*_STALE_REDEEMED`, `*_APPROVAL_STALE_BLOCKING`, `*_APPROVAL_VALID`, `*_HOLLOW`) **remain in the main body** — unchanged formula, unchanged variable names — so `ts-normalizer-parity.test.sh` structural tests pass without modification.

Adds `merge-gate-hotspot-decision.md` recording the diagnosis (16 merged PRs), the verdict (extract not split), what was preserved, and why `emit_json()` and freshness branching were left unchanged.

## Test plan

- [x] `ts-normalizer-parity.test.sh` — 81 passed, 0 failed (unchanged from baseline)
- [x] `merge-gate-stale-approval.test.sh` — 32 passed, 0 failed
- [x] `merge-gate-codeant-inplace-review.test.sh` — 78 passed, 0 failed
- [x] `merge-gate-review-substance.test.sh` — 175 passed, 0 failed
- [x] `merge-gate-authorship.test.sh` — 11 passed, 0 failed
- [x] `merge-gate-ci-dedup.test.sh` — 38 passed, 0 failed
- [x] `merge-gate-greptile-comment.test.sh` — 81 passed, 0 failed
- [x] `merge-gate-sticky-cr-approval.test.sh` — 17 passed, 0 failed
- [x] JSON output contract byte-identical (all field names, all paths verified by tests above)
- [x] Self-review confirms `eval` safety: values are ISO timestamps, counts, or "true"/"false" — no injection risk; `${!var}` indirect expansion is valid bash 3.2

**Local review coverage: none** — CodeRabbit rate-limited (free OSS cap); CodeAnt 403 daily cap reached. Self-review confirmed correctness. GitHub App reviewers (CodeAnt/CR) are independent of CLI caps.

Closes #936