### PR TITLE
docs(#940): record cr-merge-gate rule hotspot decision; targeted dedup

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -88,6 +88,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `phase-c-merger-hotspot-decision.md` — evidence-based diagnosis of `phase-c-merger.md` churn (9 merged PRs in the Issue #976 window); verdict: KEEP single file + dedup non-decision detail toward canonical owners
 - `start-issue-hotspot-decision.md` — diagnosis of `start-issue/SKILL.md` churn (9 merged PRs in the Issue #981 window); verdict: KEEP the seven-step skill + no operative change
 - `merge-gate-hotspot-decision.md` — diagnosis and extract-not-split decision for `merge-gate.sh` churn (16 PRs in the Issue #936 window); verdict: KEEP single file + extract CR/CodeAnt approval state machine into `_fetch_bot_approvals` local function
+- `cr-merge-gate-rule-hotspot-decision.md` — diagnosis and keep + targeted-dedup decision for `cr-merge-gate.md` rule churn (15 PRs in the Issue #940 window); verdict: KEEP single canonical policy file + compress two downstream restatements + clarify policy-vs-runtime authority split
 - `scheduling-reliability-hotspot-decision.md` — diagnosis and dedup decision for `scheduling-reliability.md` churn (12 merged PRs in the #959 hotspot window, re-measured after #982); verdict: KEEP single rule file + remove downstream formula/enforcement restatements
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `harness-model-audit-2026-06.md` — harness components vs current model fleet (#49)

--- a/.claude/reference/cr-merge-gate-rule-hotspot-decision.md
+++ b/.claude/reference/cr-merge-gate-rule-hotspot-decision.md
@@ -65,7 +65,7 @@ corpus. Future compressions will continue to touch it when it drifts above budge
 
 ## 3. Concrete remedy
 
-Two targeted deduplication changes and one authority clarification. Zero behavior change.
+Two targeted deduplication changes and one authority clarification. Zero behavior change from this PR's structural remedy — the zero-P0 Greptile round reuse described in §3.2 is pre-existing policy established by PR #1001 (see §5); this PR removes its duplicate inline statement and points to the reference that already holds the full conditions.
 
 ### 3.1 BugBot §Merge Gate in `bugbot.md`
 

--- a/.claude/reference/cr-merge-gate-rule-hotspot-decision.md
+++ b/.claude/reference/cr-merge-gate-rule-hotspot-decision.md
@@ -1,0 +1,116 @@
+# cr-merge-gate Rule Hotspot Decision
+
+Reference for Issue #940 (`.claude/rules/cr-merge-gate.md` churn hotspot). Not auto-loaded.
+
+Companion to `merge-gate-hotspot-decision.md` (Issue #936, PR #1010), which covers the same
+gate enforced as a script (`merge-gate.sh`). This file covers the rule document itself.
+
+## Executive summary
+
+### Verdict: **KEEP** the single rule file; **targeted deduplication only**
+
+Keep `.claude/rules/cr-merge-gate.md` as the single canonical policy definition of the pre-merge
+gate. Do not split it into per-reviewer-path rule files. The churn is largely by design: the file
+is the authoritative policy document that every flow-changing PR must touch by convention.
+
+Two concrete duplication drivers are removed to reduce avoidable synchronized edits:
+(1) the brief BugBot "two accepted shapes" restatement in `bugbot.md` §Merge Gate (already covered
+in full by `.claude/reference/merge-gate-reviewer-paths.md` §BugBot path), and (2) the expanded
+Greptile merge-ready conditions in `cr-merge-gate.md` Step 1 §Greptile path (covered by the same
+reference). A clarifying clause is added to `merge-gate-reviewer-paths.md` to make the
+policy-vs-runtime authority split explicit and non-circular.
+
+## 1. Trigger and measured evidence
+
+Issue #940 was filed after 12 merged PRs touched the rule file since 2026-07-18. By close, 15 PRs
+had accumulated: PRs #650, #658, #660, #686, #719, #737, #742, #761, #787, #804, #849, #883,
+#919, #968, #1001.
+
+At diagnosis time (`main` `7e386a7`), the file is 1,175 words — below the 2,000-word per-file
+warning. The touch history falls into four groups:
+
+| Churn class | PRs | What changed |
+|-------------|-----|--------------|
+| Reviewer-path policy changes | PRs #686, #849, #883, #1001 | Check-run dedup, BugBot silent-pass shape, hollow-approval guard, zero-P0 Greptile reuse |
+| Merge mechanics (BEHIND / admin-merge / Step 1d) | PRs #658, #719, #737, #761, #968 | BEHIND admin-merge, churn threshold, auto-wrap trigger, no-protection auto-plain, BEHIND auto-plain |
+| Corpus compression | PRs #660, #742, #804, #919 | Broad corpus compression passes (not targeted at this file) |
+| Other / incidental | PRs #650, #787 | Local-CLI failure handling, rm of untracked files |
+
+## 2. Decision: keep, targeted deduplication
+
+**Splitting is rejected.** The file declares itself the single authoritative definition of the
+merge gate; all other rule files reference it rather than duplicating it. Every caller
+(`merge.sh`, `wrap/SKILL.md`, `phase-c-merger.md`, `go-on`) depends on that single-contract
+structure. Splitting into per-path rule files would scatter the gate into multiple authoritative
+sources and force callers to reconcile partial reads — exactly the failure mode the canonical
+structure prevents.
+
+This follows the same extract-not-split precedent as:
+- `fixpr/SKILL.md` hotspot (Issue #788, PR #789)
+- `merge-gate.sh` hotspot (Issue #936, PR #1010) — the companion script
+
+**Another compression pass is not needed.** The file was already 308 words below the ratchet cap
+at diagnosis time (`11,749 − 11,441 = 308`); the targeted deduplication in §3 reduces the
+corpus to 11,377 (−64 words), preserving 372 words of headroom. Broad per-file compression was
+already applied by PRs #660, #742, #804, and #919.
+
+**Churn by design (dominant driver).** Four of the fifteen PRs changed actual reviewer-path
+policy, and five changed merge-mechanics prose. These must touch the canonical policy file by
+convention — the same pattern that `churn-hotspots.md` §churn-by-design documents for canonical
+junction files. No structural remedy reduces this driver.
+
+**Corpus compression passes (four PRs) are cross-file and inherently touch the largest files.**
+These are not a structural problem; they reflect that the file is the largest rule file in the
+corpus. Future compressions will continue to touch it when it drifts above budget thresholds.
+
+## 3. Concrete remedy
+
+Two targeted deduplication changes and one authority clarification. Zero behavior change.
+
+### 3.1 BugBot §Merge Gate in `bugbot.md`
+
+`bugbot.md` §Merge Gate summarized the "two accepted shapes" that are documented in full in
+`.claude/reference/merge-gate-reviewer-paths.md` §BugBot path. Any BugBot shape change (like
+PR #849) required synchronized edits in both files. Compressed to a single assertion line
+plus a pointer to the reference, following the pointer-only pattern already established for
+the Greptile path in `greptile.md` §Sticky Assignment.
+
+No detail removed from `.claude/reference/merge-gate-reviewer-paths.md` — it remains the full
+source.
+
+### 3.2 Greptile path in `cr-merge-gate.md` Step 1
+
+The Greptile path paragraph in `cr-merge-gate.md` expanded the three merge-ready conditions and
+the 3-review cap in detail that is also present in `.claude/reference/merge-gate-reviewer-paths.md`
+§Greptile path. Any Greptile gate change (like PR #1001) required synchronized edits in both
+files. Compressed to a one-line summary of the outward merge-ready criteria plus a pointer to
+the reference for full conditions.
+
+The "Never switch back to CR/BugBot; ignore their late reviews" behavioral directive is retained
+in the rule because it governs agent behavior in the polling turn without a reference lookup.
+
+### 3.3 Authority clarity in `merge-gate-reviewer-paths.md`
+
+`cr-merge-gate.md` declares itself "the single authoritative definition of the merge gate";
+`merge-gate-reviewer-paths.md` said "`merge-gate.sh` is authoritative — re-read its JSON when
+in doubt." These nominated different authoritative sources without clarifying the split. Added a
+qualifying clause to the reference file header: `merge-gate.sh` is authoritative for **runtime
+behavior and enforced JSON output** (what the script does when run); the rule file is
+authoritative for **gate policy and intent** (what should happen and why). The reference holds
+expanded per-path prose. No gate semantics changed.
+
+## 4. Re-open trigger
+
+Per `.claude/reference/churn-hotspots.md`, `/wrap` must re-file this hotspot only when
+`conflict_rounds > 0` — i.e. when churn starts costing measurable conflict rounds. Rising PR count
+alone (the inherent canonical-file convention) is not a re-filing trigger; the closed decision on
+record covers that case explicitly.
+
+## 5. Related
+
+- Issue #936 / PR #1010 — `merge-gate.sh` hotspot, companion script decision
+- Issue #788 / PR #789 — `fixpr/SKILL.md` hotspot, structural precedent
+- Issue #844 — BugBot silent-pass shape (the rule PR #849 added, whose duplication this removes)
+- Issue #1000 / PR #1001 — zero-P0 Greptile reuse (the rule PR #1001 added, whose duplication this removes)
+- `.claude/reference/merge-gate-reviewer-paths.md` — the single detailed source for all reviewer-path semantics
+- `.claude/reference/churn-hotspots.md` — hotspot mechanism, calibration, and re-open trigger logic

--- a/.claude/reference/merge-gate-reviewer-paths.md
+++ b/.claude/reference/merge-gate-reviewer-paths.md
@@ -1,6 +1,6 @@
 # Merge Gate — Reviewer Path Details
 
-Full path-specific rules extracted from `.claude/rules/cr-merge-gate.md` Step 1. The rule file keeps the polling exit criterion and step headers; this file holds per-path semantics. **`merge-gate.sh` is authoritative** — re-read its JSON when in doubt.
+Full path-specific rules extracted from `.claude/rules/cr-merge-gate.md` Step 1 (authoritative for gate policy and intent). The rule file keeps the polling exit criterion and step headers; this file holds expanded per-path semantics. **`merge-gate.sh` is authoritative for runtime behavior and enforced JSON output** — re-read its output when implementation details are in doubt.
 
 ## Check-run dedup — all paths (#675)
 

--- a/.claude/rules/bugbot.md
+++ b/.claude/rules/bugbot.md
@@ -41,7 +41,7 @@ Verify all findings against actual code. Fix all valid findings in one commit, p
 
 ## Merge Gate
 
-**A clean BugBot pass on current HEAD satisfies the merge gate alone** (`cr-merge-gate.md` Step 1). Two accepted shapes: (1) a `cursor[bot]` review object on HEAD with no `CHANGES_REQUESTED` and no inline findings; (2) a `Cursor Bugbot` check-run with `conclusion: "success"`, no post-HEAD failure-phrase comment, and a fresh timestamp (issue #844). Full conditions: `.claude/reference/merge-gate-reviewer-paths.md` §BugBot path.
+**A clean BugBot pass on current HEAD satisfies the merge gate alone** (`cr-merge-gate.md` Step 1). Full conditions and accepted shapes: `.claude/reference/merge-gate-reviewer-paths.md` §BugBot path.
 
 ## Re-Reviews
 

--- a/.claude/rules/cr-merge-gate.md
+++ b/.claude/rules/cr-merge-gate.md
@@ -21,7 +21,7 @@ The merge gate depends on which reviewer owns the PR. Per-path gates below; expa
 
 **BugBot path** (CR failed, BugBot responded — sticky; `bugbot.md`): 1 clean BugBot pass on current HEAD satisfies the gate (review object or silent-pass success check-run — issue #844; see `bugbot.md` §Merge Gate for accepted shapes). Re-review after fixes: `bugbot.md` §Re-Reviews. Never switch back to CR; ignore late CR reviews.
 
-**Greptile path** (sticky; `greptile.md`): merge-ready on **clean review** (👍); **no P0** (fix P1/P2, push, reply with current HEAD, resolve, no re-review — the proven fix-only push may reuse its trigger-delimited zero-P0 round); or **P0 fixed + re-review clean**. A P0 round is never reusable, and no review history never passes. Max 3 reviews per PR; at 3 with persistent P0, self-review and report. Never switch back to CR/BugBot; ignore their late reviews.
+**Greptile path** (sticky; `greptile.md`): severity-gated — merge-ready when clean (👍), no-P0 (reply + resolve, no re-review), or P0-fixed + re-review clean. Full conditions, 3-review cap, zero-P0 round reuse: `.claude/reference/merge-gate-reviewer-paths.md` §Greptile path. Never switch back to CR/BugBot; ignore their late reviews.
 
 **All three down:** self-review for risk reduction only — it never satisfies the gate; report the blocker.
 


### PR DESCRIPTION
## Summary

Closes #940

`cr-merge-gate.md` (the *rule file*) was touched by 15 distinct merged PRs since 2026-07-18. This PR adjudicates the hotspot and makes targeted changes.

**Verdict: KEEP** the single canonical policy document. The churn is largely by design — this is the authoritative policy file every flow-changing PR must touch. No structural split is warranted.

**Targeted deduplication (net −64 words, 11441→11377):**
- `bugbot.md` §Merge Gate: remove "two accepted shapes" brief restatement already covered in full by `.claude/reference/merge-gate-reviewer-paths.md §BugBot path`; keep the gate assertion and pointer only.
- `cr-merge-gate.md` §Greptile path: compress the expanded merge-ready conditions and 3-review cap to a one-line summary + pointer; retain "Never switch back" behavioral directive. Full conditions remain in the reference.

**Authority clarity (reference file only, not word-counted):**
- `merge-gate-reviewer-paths.md`: clarify that `merge-gate.sh` is authoritative for "runtime behavior and enforced JSON output" while `cr-merge-gate.md` is authoritative for "gate policy and intent" — makes the split non-circular and consistent with the companion decision in PR #1010.

**Decision record:** `.claude/reference/cr-merge-gate-rule-hotspot-decision.md`
**Re-open trigger:** `conflict_rounds > 0` per `.claude/reference/churn-hotspots.md`

Companion to `merge-gate-hotspot-decision.md` (Issue #936 / PR #1010), which covers `merge-gate.sh` (the script). This PR covers `cr-merge-gate.md` (the rule).

**Local review coverage:** none — CR CLI rate-limited, CodeAnt 403 daily cap (both failed twice). GitHub-side reviewers gate the merge.

## Test plan

- [x] `rule-lint.sh` passes (corpus 11,377 words, below ratchet cap 11,749)
- [x] `cr-merge-gate.md` Greptile path retains "Never switch back to CR/BugBot" behavioral directive
- [x] `bugbot.md` §Merge Gate retains the gate assertion (`cr-merge-gate.md` Step 1 reference) and full-conditions pointer
- [x] `merge-gate-reviewer-paths.md` §BugBot path and §Greptile path are unchanged (remain the single detailed source)
- [x] Decision record follows house style of `scheduling-reliability-hotspot-decision.md` and `merge-gate-hotspot-decision.md`
- [x] `README.md` index entry added for the new decision record
- [x] Net word change is negative (−64 words), ratchet cap not raised

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance defining the canonical merge-gate policy and clarifying the distinction between policy documentation and runtime behavior.
  * Documented path-specific review semantics and decision criteria for revisiting merge-gate hotspots.
  * Consolidated BugBot acceptance guidance into a shared reference.
* **Policy Updates**
  * Zero-P0 review rounds may now be reused after fix-only pushes.
  * P0 review rounds remain non-reusable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->