### PR TITLE
docs(#1002): adjudicate merge-gate-reviewer-paths hotspot; KEEP + dedup

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -89,6 +89,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `start-issue-hotspot-decision.md` — diagnosis of `start-issue/SKILL.md` churn (9 merged PRs in the Issue #981 window); verdict: KEEP the seven-step skill + no operative change
 - `merge-gate-hotspot-decision.md` — diagnosis and extract-not-split decision for `merge-gate.sh` churn (16 PRs in the Issue #936 window); verdict: KEEP single file + extract CR/CodeAnt approval state machine into `_fetch_bot_approvals` local function
 - `cr-merge-gate-rule-hotspot-decision.md` — diagnosis and keep + targeted-dedup decision for `cr-merge-gate.md` rule churn (15 PRs in the Issue #940 window); verdict: KEEP single canonical policy file + compress two downstream restatements + clarify policy-vs-runtime authority split
+- `merge-gate-reviewer-paths-hotspot-decision.md` — diagnosis and keep + targeted-dedup decision for `merge-gate-reviewer-paths.md` churn (8 PRs in the Issue #1002 window); verdict: KEEP as designated expansion home for gate prose + add canonical-source markers to shared-mechanism sections
 - `scheduling-reliability-hotspot-decision.md` — diagnosis and dedup decision for `scheduling-reliability.md` churn (12 merged PRs in the #959 hotspot window, re-measured after #982); verdict: KEEP single rule file + remove downstream formula/enforcement restatements
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `harness-model-audit-2026-06.md` — harness components vs current model fleet (#49)

--- a/.claude/reference/merge-gate-reviewer-paths-hotspot-decision.md
+++ b/.claude/reference/merge-gate-reviewer-paths-hotspot-decision.md
@@ -1,0 +1,138 @@
+# Merge Gate Reviewer Paths Hotspot Decision
+
+Reference for Issue #1002 (`.claude/reference/merge-gate-reviewer-paths.md` churn hotspot). Not auto-loaded.
+
+Third leg of the merge-gate seam, companion to `merge-gate-hotspot-decision.md` (Issue #936, PR #1010,
+the script) and `cr-merge-gate-rule-hotspot-decision.md` (Issue #940, PR #1013, the rule). This file
+covers the reference document that holds expanded per-path prose for both.
+
+## Executive summary
+
+### Verdict: **KEEP** the single reference file; **targeted pointer deduplication only**
+
+Keep `.claude/reference/merge-gate-reviewer-paths.md` as the single detailed source for all
+reviewer-path semantics. Do not split it into per-path reference files. The churn is coordinated
+propagation of shared CR-path and dedup mechanisms, not independent per-path drift; the file is
+explicitly designated by `cr-merge-gate-rule-hotspot-decision.md` §3.1 and §3.2 as the expansion
+home for gate prose that the rule files shed for budget reasons. Splitting it would scatter the
+prose that `cr-merge-gate.md`, `bugbot.md`, and `greptile.md` now depend on as a single pointer
+target.
+
+One targeted deduplication: each shared-mechanism section receives a brief canonical-source marker
+pointing to the authoritative script, so future gate changes know where to land first and where to
+reflect the update.
+
+## 1. Trigger and measured evidence
+
+Issue #1002 was filed by `/wrap` churn detection after PR #1001 merged. The issue body recorded
+7 distinct merged PRs since 2026-07-21: PRs #686, #727, #840, #849, #907, #965, #1001. PR #1013
+(merged the same hour as this adjudication) added one more: the evidence comment appended to the
+issue records 8 PRs total: PRs #686, #727, #840, #849, #907, #965, #1001, #1013.
+
+At diagnosis time the file is ~78 lines and ~900 words, well below the 2,000-word per-file warning.
+The touches fall into four groups:
+
+| Churn class | PRs | What changed |
+|-------------|-----|--------------|
+| BugBot hardening | #849, #907, #965 | Silent-pass shapes (issue #844), publisher fail-closed (issue #962), timestamp/commit-id staleness guards |
+| Greptile edge cases | #727, #1001 | Comment-based clean-pass detection (issue #723), zero-P0 round reuse with fix-only push provenance (issue #1000) |
+| Shared-mechanism updates | #686, #840 | Check-run dedup (issue #675), stale-approval guard (issue #836) |
+| Authority clarification | #1013 | Policy-vs-runtime split in the header; `merge-gate.sh` for runtime, `cr-merge-gate.md` for policy |
+
+## 2. Options considered
+
+### Option 1: Split the file per reviewer path
+
+Create separate reference files for CR/CodeAnt, BugBot, Greptile, and shared mechanisms.
+
+**Rejected.** The companion rule decision (PR #1013) explicitly named this file as "the single
+detailed source for all reviewer-path semantics" and restructured `bugbot.md` §Merge Gate and
+`cr-merge-gate.md` §Greptile path to point here rather than restate the content. Splitting now
+would require updating those pointers and re-expanding prose in multiple files — reversing the
+deduplication just completed. The churn classes (BugBot, Greptile, shared) reuse the same CR-path
+and dedup mechanisms via cross-reference, not independent per-path state. Splitting would not
+remove the coordination dependency.
+
+### Option 2: KEEP with no content change
+
+Record a "by design" decision and make no changes to the reference file.
+
+**Rejected.** A targeted pointer deduplication is available: the shared-mechanism sections
+(check-run dedup, stale-approval guard) name the authoritative scripts in prose but do not mark
+them as canonical. Adding brief markers reduces drift risk for future gate changes without removing
+any prose. This is the same targeted-pointer shape applied by the companion rule decision §3.3.
+
+### Option 3: KEEP + targeted pointer deduplication (Chosen)
+
+Retain the file's shape and per-path prose. Add canonical-source markers to the two shared-mechanism
+sections so future gate changes land in the script first and propagate to this reference as a pointer.
+
+**Chosen.** Matches the KEEP + dedup precedent in `monitor-mode-hotspot-decision.md` and
+`cr-merge-gate-rule-hotspot-decision.md`. Preserves the designated expansion-home role while
+reducing the drift surface for shared-mechanism sections.
+
+## 3. Canonical ownership
+
+| Concern | Authoritative script | Reference doc role |
+|---------|---------------------|--------------------|
+| Check-run dedup | `check-runs-dedup.sh` | Prose explaining the grouping algorithm, `filter=latest` limitation, ordering by `check_suite.id`, and polling consequences |
+| Stale-approval guard | `merge-gate.sh` (`LAST_COMMIT_TS` comparison) | Prose explaining the force-push retargeting scenario, what it applies to, and the disable-on-empty fallback |
+| CR/CodeAnt clean approval shapes | `merge-gate.sh` | Prose expanding `cr-merge-gate.md` Step 1 CR path (re-trigger policy, stale bot dismissal, not-approvals list) |
+| Stale bot `CHANGES_REQUESTED` dismissal | `dismiss-stale-bot-changes.sh` | Prose explaining when to dismiss vs. when a human block holds |
+| BugBot silent-pass shapes | `merge-gate.sh` | Prose expanding issue #844 shape details (two accepted shapes, fail-closed conditions) |
+| BugBot publisher fail-closed | `merge-gate.sh` (contrast: `escalate-review.sh` opens; `merge-gate.sh` closes) | Prose explaining the asymmetric identity check and why the contrast is intentional |
+| Greptile detection and zero-P0 reuse | `merge-gate.sh` | Prose expanding the severity-gated merge-ready conditions and fix-only-push provenance chain |
+
+## 4. Remediation applied
+
+- Added a brief "**Authoritative source:** `check-runs-dedup.sh`" marker to the check-run dedup
+  section so future dedup changes know to land in the script first.
+- Added a brief "**Authoritative source:** `merge-gate.sh`" marker to the stale-approval guard
+  section, naming the `LAST_COMMIT_TS` comparison as the canonical implementation.
+- No prose removed; no section headers changed; no issue-number citations altered; no behavioral
+  semantics modified.
+- Registered this decision in `.claude/reference/README.md`.
+
+## 5. Preserved invariants
+
+- The file remains the single detailed source for all reviewer-path semantics: CR/CodeAnt, BugBot,
+  Greptile, and shared mechanisms.
+- All issue-number citations (e.g., #675, #836, #844, #962, #1000) remain in their original positions.
+- All section headers remain unchanged.
+- The authority-clarity header added by PR #1013 (`merge-gate.sh` authoritative for runtime behavior,
+  `cr-merge-gate.md` authoritative for policy) is preserved as the file's canonical framing.
+- The "Stay on BugBot / stay on Greptile" behavioral directives are untouched.
+- The file's role as the pointer target for `bugbot.md` §Merge Gate and `cr-merge-gate.md` §Greptile
+  path (deduplication completed by PR #1013) is preserved.
+
+## 6. Re-open trigger
+
+Per `.claude/reference/churn-hotspots.md`, `/wrap` must re-file this hotspot only when
+`conflict_rounds > 0`. Rising PR count from policy propagation (the inherent role of this
+designated-expansion file) is not a re-filing trigger; the closed decision on record covers that
+case explicitly.
+
+## 7. Future edits
+
+New merge-gate edits must land in the authoritative script first (`merge-gate.sh`,
+`check-runs-dedup.sh`, `dismiss-stale-bot-changes.sh`, `escalate-review.sh`), then propagate to
+this reference as a pointer or prose expansion. The rule file (`cr-merge-gate.md`) carries the
+policy intent; this reference carries the expanded per-path semantics. This file should not be the
+first place a gate change is recorded.
+
+Reconsider the SPLIT verdict only if BugBot or Greptile sections start evolving independently of
+the shared CR-path and check-run-dedup mechanisms — specifically, if a BugBot or Greptile gate
+change arrives that has no shared-mechanism dependency and adds more than 200 words to its section.
+
+## 8. Related
+
+- Issue #936 / PR #1010 — `merge-gate.sh` hotspot, companion script decision (`merge-gate-hotspot-decision.md`)
+- Issue #940 / PR #1013 — `cr-merge-gate.md` hotspot, companion rule decision (`cr-merge-gate-rule-hotspot-decision.md`)
+- Issue #675 — check-run dedup (shared mechanism: `check-runs-dedup.sh`)
+- Issue #836 — stale-approval guard (shared mechanism: `merge-gate.sh` `LAST_COMMIT_TS`)
+- Issue #844 — BugBot silent-pass shapes (BugBot hardening)
+- Issue #962 — BugBot publisher fail-closed (BugBot hardening)
+- Issue #723 / Issue #1000 — Greptile comment-based clean pass, zero-P0 round reuse (Greptile edge cases)
+- `.claude/reference/churn-hotspots.md` — hotspot mechanism, calibration, and re-open trigger logic
+- `.claude/reference/monitor-mode-hotspot-decision.md` — KEEP + dedup precedent (rule hub file)
+- `.claude/reference/fixpr-hotspot-decision.md` — KEEP + extract precedent (contrasting extraction case)

--- a/.claude/reference/merge-gate-reviewer-paths.md
+++ b/.claude/reference/merge-gate-reviewer-paths.md
@@ -4,6 +4,8 @@ Full path-specific rules extracted from `.claude/rules/cr-merge-gate.md` Step 1 
 
 ## Check-run dedup — all paths (#675)
 
+**Authoritative source:** `.claude/scripts/check-runs-dedup.sh` — all grouping and ordering logic lives there; this section is prose explanation only.
+
 Every check-run read goes through `.claude/scripts/check-runs-dedup.sh` before anything classifies it: `ci-status.sh`, `merge-gate.sh`, `pr-state.sh` (and so `escalate-review.sh`), and `pr-preflight.sh`.
 
 GitHub keeps a record for **every** run of a check on a commit, and each re-trigger opens a new check suite — so the `commits/{sha}/check-runs` endpoint returns an old failed run right next to the new passing one. The endpoint's `filter=latest` does not help; it is latest-per-*suite*. GitHub's own PR page resolves each check name to its newest run, and the dedup does the same:
@@ -17,6 +19,8 @@ GitHub keeps a record for **every** run of a check on a commit, and each re-trig
 **Consequence for polling:** a check that failed and was re-run stops blocking the moment the newer run lands — no rebase or new push required. If tooling still reports a failure GitHub's merge box shows as green, suspect the fetch bypassed the helper, not the dedup rule.
 
 ## Stale-approval guard — all review paths (issue #836)
+
+**Authoritative source:** `.claude/scripts/merge-gate.sh` (`LAST_COMMIT_TS` comparison logic) — this section is prose explanation of the mechanism and its scope.
 
 GitHub retargets a review's `commit_id` to the new HEAD SHA after a force-push (when diff context persists), but `submitted_at` is never changed. An approval submitted _before_ the force-push therefore shows `commit_id == HEAD` with a `submitted_at` that predates the HEAD commit's `committer.date`. `merge-gate.sh` rejects such approvals even when `commit_id` matches, using `LAST_COMMIT_TS` (HEAD committer date, already fetched for the Greptile freshness gate). Applies to: CR/CodeAnt `APPROVED` reviews, CodeAnt clean check-run `completed_at`, and BugBot reviews. Guard is disabled when `LAST_COMMIT_TS` is empty (API failure). Distinct `missing[]` reason: "predates the HEAD commit (force-push retargeting) — re-review required".
 


### PR DESCRIPTION
## Summary

Closes #1002

`.claude/reference/merge-gate-reviewer-paths.md` was flagged as a churn hotspot (8 PRs: #686, #727, #840, #849, #907, #965, #1001, #1013). This PR adjudicates it as the third leg of the merge-gate seam, companion to PR #1010 (script) and PR #1013 (rule).

**Verdict: KEEP + targeted dedup.** The file is the designated expansion home for gate prose — PR #1013 explicitly named it as the single detailed source for all reviewer-path semantics, and restructured `bugbot.md` and `cr-merge-gate.md` to point here. Splitting would reverse that deduplication. Churn is coordinated propagation of shared CR-path and dedup mechanisms, not independent per-path drift.

**Deliverables:**
- New decision record: `merge-gate-reviewer-paths-hotspot-decision.md` (full KEEP + dedup template with churn diagnosis, options considered, canonical-ownership table, preserved invariants, and re-open trigger)
- `merge-gate-reviewer-paths.md`: add `Authoritative source:` markers to the check-run dedup section (→ `check-runs-dedup.sh`) and stale-approval guard section (→ `merge-gate.sh` `LAST_COMMIT_TS`). No prose removed; no behavioral change.
- `README.md`: catalog entry under Audits and research

**Re-open trigger:** `conflict_rounds > 0` per `churn-hotspots.md` — rising PR count from policy propagation (the file's inherent role) is not a trigger.

**Local review coverage:** cr-only — CodeRabbit verified clean (0 findings, verified_run:true); CodeAnt 403 daily cap, dropped after 2 failures per `cr-local-review.md`.

## Test plan

- [x] Decision record follows full KEEP + dedup template (options considered section, canonical-ownership table, preserved invariants) — matching `monitor-mode-hotspot-decision.md` precedent
- [x] `merge-gate-reviewer-paths.md` unchanged in prose and section headers; only `Authoritative source:` markers added to two shared-mechanism sections
- [x] `reference-catalog-lint.sh` passes (84 files indexed, up from 83)
- [x] Rule corpus unchanged (reference files only); word count 11,377 — below ratchet cap
- [x] Decision cross-references sibling decisions PR #1010 and PR #1013 without duplicating their diagnoses
- [x] README.md entry uses bare backtick-quoted basename, no path separator, no duplicate