### PR TITLE
docs(#780): FU-4 poller model-routing eval + spawn-time model note

### DIFF
--- a/.claude/reference/token-efficiency-audit-2026-07.md
+++ b/.claude/reference/token-efficiency-audit-2026-07.md
@@ -193,3 +193,42 @@ Headline "60–91% savings" figures across the ecosystem come from deliberately 
 - `.claude/skills/subagent/SKILL.md` Step 6.3: removed the full-corpus `cat ./CLAUDE.md; cat ./.claude/rules/*.md` injection from Phase A/B/C spawn templates — these were the largest double-pay.
 
 **Outcome:** FU-1 resolved. Inheritance confirmed → de-duplication performed. Every future spawn that uses a `subagent_type` from `.claude/agents/` no longer double-pays the rule corpus.
+
+---
+
+## FU-4 Evaluation — Poller Model-Routing (Issue #780, 2026-08-05)
+
+**Origin:** [#780](https://github.com/auerbachb/claude-code-config/issues/780). Evaluates the FU-4 entry in the recommendations table above: routing pure poll/classify ticks to a cheaper tier (Haiku-class) while keeping fix/review/merge phases on current defaults. Companion note shipped to `subagent-orchestration.md` §Model Selection (PR closing #780).
+
+**Scope vs. #776:** Issue #776 targets PM thread economics broadly — biasing work toward inline subagents to reduce chip-spawn overhead. This eval is narrower: per-tick model tier for polling/monitoring surfaces only. The two are complementary, not duplicates.
+
+### Surfaces evaluated
+
+| Surface | How it runs today | Model today |
+|---|---|---|
+| `/babysit-pr` quiet ticks (T0–T7; classification at T3) | Inline in Monitor parent session — Monitor emits `/babysit-pr <PR> --tick`; skill executes in the same session | Parent session model (not configurable per tick) |
+| PMM quiet ticks (Steps 1–3: fleet rediscovery + per-PR classify) | Same — Monitor emits `/pr-monitor-and-manage --tick`; runs inline in parent session | Parent session model |
+| `escalate-review.sh` classify calls | Pure bash — `STATUS=` verdicts computed via `gh` JSON + `jq`; zero model tokens | **None** |
+| `pm-worker` data gathering | Agent spawn via `model: sonnet` frontmatter | `sonnet` |
+
+**Core mechanism constraint:** The Monitor primitive (the only reliable recurring-poll primitive per `scheduling-reliability.md`) has no `model` or `effort` parameter — parallel to the `spawn_task` gap tracked in Issue #735. Quiet babysit/PMM ticks are inline skill invocations inside the parent session; the parent session's tier is fixed at session start, not adjustable per tick. Per-model caches are session-scoped: switching tiers mid-session cold-starts the new tier's cache.
+
+### Option evaluation
+
+| Option | Decision | Reason |
+|---|---|---|
+| Add `model` param to Monitor/scheduling primitives | **Blocked** | The scheduling primitive has no such field; a fix requires upstream harness changes |
+| Spawn a dedicated Haiku subagent per classify tick | **Reject** | Per-tick Agent spawn overhead + cold per-model cache each tick likely negates savings; routing `merge-ready` / `conflicting` dispatch judgment to Haiku carries misclassification risk |
+| Run the entire monitor session on a cheaper tier | **Reject** | Subjects T3/Step 3 dispatch judgment — `hard-blocked`, `merge-ready`, escalation routing — to a weak model; one misrouted hard-blocked PR is false economy |
+| Treat `escalate-review.sh` as a routing target | **N/A** | Pure bash — already zero model tokens |
+| Route `pm-worker` to Haiku | **Defer** | `pm-worker` does planning work (issue creation, bootstrap checks) beyond pure classify; Haiku's planning quality on multi-step repo tasks is unverified for this harness |
+
+**Verdict: Defer/Advisory.** No surface today supports a clearly safe Haiku-tier downgrade. The per-tick routing mechanism does not exist; the options that do exist carry correctness risk on dispatch judgment or add overhead that negates savings.
+
+**Guardrails (non-negotiable, unchanged):** Phase defaults stay — A/B = `opus`, C/`pm-worker` = `sonnet`. The escalation path (CR → BugBot → Greptile → self-review) must remain intact. Misrouting a hard bug or a `merge-ready` dispatch to Haiku is false economy even if a mechanism becomes available.
+
+**Re-check triggers:**
+1. Monitor/scheduling primitives gain a `model` or `effort` parameter (Issue #735 or a harness update)
+2. `ccusage` measurement (FU-6) shows poll-tick model cost exceeds ~15% of total session cost on a representative session
+
+**Lower-risk adjacent lever:** FU-2 (script-side no-change short-circuit in PMM) reduces model involvement on unchanged quiet ticks without any tier-routing risk and without waiting on a harness change. Prioritize FU-2 over FU-4 for near-term classify-cost reduction.

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -35,7 +35,7 @@ Built-in Explore/Plan agents omit the project hierarchy. For any spawn that does
 
 Fleet: **Fable, Opus, Sonnet, Haiku** (Agent `model` takes the lowercase family name). Fable is **never a spawn default** — reserve for interactive step-ups. Alias resolution + rationale: `.claude/agents/README.md`. An explicit `model` overrides frontmatter; escalate to `opus` if a Sonnet-tier agent underperforms.
 
-**Effort is not settable on a spawn** — subagents inherit the parent session's effort level; never write an effort instruction into a subagent prompt.
+**Effort is not settable on a spawn** — subagents inherit the parent session's effort level; never write an effort instruction into a subagent prompt. **Set model at spawn and never change it mid-session** — per-model caches are session-scoped; a mid-session tier switch cold-restarts the new cache and typically costs more than the downgrade saves (FU-4: `token-efficiency-audit-2026-07.md`).
 
 ## Phase Transition Autonomy (Quick Reference)
 


### PR DESCRIPTION
## Summary

Closes #780

FU-4 from `.claude/reference/token-efficiency-audit-2026-07.md` — poller model-routing eval (Haiku for classify-only ticks) plus the "set model/effort at spawn, never mid-session" note.

### What was evaluated

Four surfaces were audited for Haiku-class downgrade safety:

| Surface | How it runs | Model today | Safe to downgrade? |
|---|---|---|---|
| `/babysit-pr` quiet ticks (T0–T7) | Inline in Monitor parent session | Parent session model | **No** — no per-tick model param |
| PMM quiet ticks (Steps 1–3) | Inline in Monitor parent session | Parent session model | **No** — same constraint |
| `escalate-review.sh` classify calls | Pure bash (`gh` + `jq`) | **None** (zero tokens) | **N/A** — already free |
| `pm-worker` data gathering | Agent spawn | `sonnet` | **Defer** — planning work, not pure classify |

**Core constraint:** The Monitor primitive has no `model`/`effort` parameter (parallel to `spawn_task` gap in Issue #735). babysit/PMM ticks run inline in the parent session — the per-tick tier is not configurable. A per-tick Haiku subagent spawn would cold-cache each tick, likely negating savings, and risks misrouting dispatch judgment (`merge-ready` → `/wrap`).

**Verdict: Defer/Advisory.** No surface today supports a clearly safe Haiku downgrade. No routing changes applied.

### Changes

1. **`.claude/reference/token-efficiency-audit-2026-07.md`** — FU-4 section appended with surfaces table, decision matrix, verdict, guardrails, re-check triggers, and note on FU-2 as the lower-risk adjacent lever.

2. **`.claude/rules/subagent-orchestration.md`** §Model Selection — one sentence added: set model at spawn, never mid-session (per-model caches are session-scoped; mid-session tier switch cold-restarts the cache).

Rule-lint: **OK** (11,459 / 11,749 word cap).

**CR plan deviation:** The plan recommended a new `.claude/reference/` file + README.md update. Per task scope constraints, the eval is recorded as a FU-4 section in the existing `token-efficiency-audit-2026-07.md` (same pattern FU-1 used), and `.claude/reference/README.md` is not touched (PR #1018 holds that surface).

## Test plan

- [x] FU-4 eval section appended to `token-efficiency-audit-2026-07.md` after FU-1
- [x] Evaluation covers all four poll/classify tick surfaces (babysit, PMM, escalate-review.sh, pm-worker)
- [x] Verdict is Defer/Advisory with concrete re-check triggers documented
- [x] No routing changes applied (eval concludes no clearly safe downgrade surface)
- [x] "Set model at spawn, never mid-session" note added to `subagent-orchestration.md` §Model Selection
- [x] Rule-lint passes (`rule-lint: OK`)
- [x] Word budget: 11,459 words vs 11,749 soft cap (290 headroom)
- [x] No new `.claude/reference/` files created; `README.md` untouched

**Local review coverage:** none — CodeRabbit rate-limited (OSS daily cap), CodeAnt 403 (daily cap). Both CLIs dropped after two errors each per `cr-local-review.md`. One careful self-review performed; no findings.
