### PR TITLE
refactor(#1003): extract polling-gate test fixtures + close scoped-path coverage gap

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -93,6 +93,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `scheduling-reliability-hotspot-decision.md` — diagnosis and dedup decision for `scheduling-reliability.md` churn (12 merged PRs in the #959 hotspot window, re-measured after #982); verdict: KEEP single rule file + remove downstream formula/enforcement restatements
 - `local-review-cli-failure-modes-hotspot-decision.md` — diagnosis and no-runtime-change decision for `local-review-cli-failure-modes.md` churn (6 merged PRs in the Issue #1005 window); verdict: KEEP the single multi-incident diagnostic reference
 - `scheduling-failure-modes-hotspot-decision.md` — diagnosis and no-runtime-change decision for `scheduling-failure-modes.md` churn (7 PRs in the Issue #1007 window, including PR #1009 merged same day); verdict: KEEP as intentional append-only incident log; Pattern 5 dedup already applied by PR #987
+- `polling-state-gate-test-hotspot-decision.md` — diagnosis and KEEP + extract decision for `polling-state-gate.test.sh` churn (7 merged PRs); verdict: coordinated shared-contract churn on the repo-scoping seam; extract shared helpers into `tests/lib/polling-state-gate-fixtures.sh` and close the scoped-path coverage gap in the multirepo suite
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `harness-model-audit-2026-06.md` — harness components vs current model fleet (#49)
 - `script-extraction-audit.md` — deterministic script extraction inventory (#271)

--- a/.claude/reference/polling-state-gate-test-hotspot-decision.md
+++ b/.claude/reference/polling-state-gate-test-hotspot-decision.md
@@ -1,0 +1,81 @@
+<!-- churn-hotspot: .claude/scripts/tests/polling-state-gate.test.sh -->
+# Hotspot Decision — polling-state-gate.test.sh
+
+**Verdict:** KEEP + extract shared fixtures  
+**Decided:** 2026-08-05  
+**Issue:** #1003  
+**Reporter:** `/wrap` post-merge churn report (PR #999)
+
+## Churn summary
+
+`churn-hotspots.sh` flagged `.claude/scripts/tests/polling-state-gate.test.sh` as
+touched by 7 distinct merged PRs:
+
+| PR | What changed |
+|----|-------------|
+| PR #653 | Introduced polling-state-gate.sh + primary test suite |
+| PR #659 | session-state.sh schema changed (PR-scope layout); test adapted |
+| PR #724 | --repo / $CLAUDE_SESSION_REPO scope selection tests added (issue #854) |
+| PR #728 | Colliding-PR-number and every-refusal-exits-nonzero tests added |
+| PR #739 | Stale-env-scope override tests added (issue #967) |
+| PR #747 | pr-authorship.sh gate wired into --ensure-session; tests 11–12 added |
+| PR #999 | pr-scope-resolver.sh extracted; stub signature updated |
+
+A companion file, `polling-state-gate-multirepo.test.sh`, was created separately
+(PR #856) and evolved in parallel, touching the same shared contracts at each step.
+
+## Diagnosis
+
+This is **coordinated shared-contract churn** on the repo-scoping seam, not
+scatter or instability. Every edit traces to a deliberate extension of the
+`polling-state-gate.sh` public interface (a new flag, a new exit code, a new
+scope-resolution rule). The test file tracks the gate faithfully; its edit
+frequency is a direct symptom of the gate itself being actively developed.
+
+Contributing factors:
+- Two test files (`*.test.sh` primary + `*-multirepo.test.sh`) both carry the
+  same local helper functions (`mk_repo`, `write_handoff`, `gh` stub), so every
+  stub-signature change requires two edits instead of one.
+- The multirepo suite's `write_handoff` wrote flat-path handoffs that relied on
+  the backward-compat fallback in the gate — silently not exercising the scoped
+  path introduced by PR #655 / issue #655.
+
+## Decision
+
+**KEEP** both test files in their current locations. The gate is a load-bearing
+offline check in the polling workflow; splitting it across more files buys
+nothing and multiplies the import surface.
+
+**EXTRACT** shared helpers into `tests/lib/polling-state-gate-fixtures.sh`:
+- `mk_repo <dir> <origin-url>` — throwaway git repo builder
+- `write_handoff <owner_repo_or_empty> <pr_number> <head_sha>` — scoped handoff
+  writer via `handoff-state.sh`; unified 3-arg signature replaces the two
+  diverged per-suite forms
+- `write_polling_gh_stub <bin_dir>` — env-var-driven `gh` stub; replaces both
+  the baked-at-write `write_ensure_session_gh_stub` in the primary suite and the
+  inline heredoc in the multirepo suite
+
+**CLOSE COVERAGE GAP**: multirepo suite previously wrote flat handoffs relying on
+the fallback. Switch to scoped `write_handoff` and add path-existence assertions
+for `~/.claude/handoffs/org/a/pr-84-handoff.json` and
+`~/.claude/handoffs/org/b/pr-84-handoff.json`.
+
+## Why not split the test file?
+
+The churn is caused by the gate's evolving interface, not by the test file's own
+structure. Splitting the primary suite into per-feature files would:
+1. Require N edits (one per sub-file) on every subsequent gate change
+2. Destroy the sequential setup context (REPO_A, STATE, HANDOFF) that several
+   later tests depend on
+3. Not reduce future churn — the driving factor is external
+
+The extraction already removes the main mechanical duplication (helpers). Future
+single-PR gate changes now require one helper update instead of two full stub
+rewrites.
+
+## Expected impact
+
+After this extraction, a stub-signature change requires one edit in
+`tests/lib/polling-state-gate-fixtures.sh` and zero edits in either suite.
+Gate-interface extensions still touch both suites (new test cases), but that is
+intentional co-evolution, not churn.

--- a/.claude/scripts/tests/lib/polling-state-gate-fixtures.sh
+++ b/.claude/scripts/tests/lib/polling-state-gate-fixtures.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Shared repo builder, handoff writer, and gh stub factory for the
+# polling-state-gate.sh test suites. This file intentionally does not end in
+# .test.sh, so run-hook-tests.sh will not execute it directly.
+#
+# Source this file from a *.test.sh suite; do NOT execute it directly:
+#   TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   # shellcheck source=lib/polling-state-gate-fixtures.sh
+#   source "$TEST_DIR/lib/polling-state-gate-fixtures.sh"
+#
+# WHAT THIS PROVIDES
+#   mk_repo <dir> <origin-url>
+#     Creates a throwaway git repo with one commit, needed for git worktree add.
+#
+#   write_handoff <owner_repo_or_empty> <pr_number> <head_sha>
+#     Writes a minimal handoff JSON via handoff-state.sh. When owner_repo is
+#     non-empty the handoff lands at the scoped path
+#     ~/.claude/handoffs/{owner}/{repo}/pr-{N}-handoff.json (issue #655).
+#     When empty it uses the legacy flat path.
+#
+#   write_polling_gh_stub <bin_dir>
+#     Writes an env-var-driven gh stub. Callers set these env vars when
+#     invoking the gate script (inline VAR=value before the command):
+#       STUB_OWNER_REPO   — `gh repo view` response and default PR JSON slug
+#                           (default: org/c)
+#       STUB_PR_JSON      — full JSON for `gh pr view` (optional; when absent
+#                           the stub builds it from STUB_HEAD_SHA /
+#                           STUB_OWNER_REPO / STUB_PR_NUMBER)
+#       STUB_HEAD_SHA     — headRefOid in the default PR JSON (default: ccc3333)
+#       STUB_PR_NUMBER    — PR number in the default PR JSON (default: 84)
+#       STUB_PR_AUTHOR    — login for the PR author authorship check
+#                           (default: testuser); `gh api user` always returns
+#                           "testuser" as the viewer login
+#
+# WHAT IS DELIBERATELY EXCLUDED
+#   check_eq / check_contains — kept per-file per the repo-wide convention.
+#   TMP / TMP_HOME / HOME setup — each suite manages its own temp dirs and
+#   cleanup traps to preserve independent isolation guarantees.
+
+# Guard against direct execution — this file only defines functions and does
+# nothing else, so running it would silently succeed and provide nothing.
+if [ "${BASH_SOURCE[0]:-}" = "${0:-}" ]; then
+  echo "polling-state-gate-fixtures.sh: source this file, do not execute it directly" >&2
+  exit 2
+fi
+
+_PSG_REPO_ROOT="$(git rev-parse --show-toplevel)"
+_PSG_HANDOFF_HELPER="$_PSG_REPO_ROOT/.claude/scripts/handoff-state.sh"
+
+# mk_repo <dir> <origin-url>
+# Creates a throwaway git repo with one commit (needed for git worktree add).
+# Uses -c flags for user config so no global git config is modified.
+mk_repo() {
+  local dir="$1" origin="$2"
+  mkdir -p "$dir"
+  git -C "$dir" init --quiet
+  git -C "$dir" remote add origin "$origin"
+  : > "$dir/README.md"
+  git -C "$dir" add README.md
+  git -C "$dir" -c user.email=test@example.com -c user.name=Test commit --quiet -m init
+}
+
+# write_handoff <owner_repo_or_empty> <pr_number> <head_sha>
+# Writes a minimal handoff JSON via handoff-state.sh. A non-empty owner_repo
+# routes to the scoped path ~/.claude/handoffs/{owner}/{repo}/pr-{N}-handoff.json
+# (issue #655); an empty owner_repo uses the legacy flat path.
+# Callers must have set HOME to a temp directory and created $HOME/.claude/handoffs.
+write_handoff() {
+  local owner_repo="${1:-}" pr="${2}" sha="${3}"
+  local json_body
+  json_body="$(jq -n --argjson pr "$pr" --arg sha "$sha" \
+    '{schema_version:"1.0", pr_number:$pr, head_sha:$sha, reviewer:"cr",
+      phase_completed:"B", created_at:"2026-07-21T00:00:00Z",
+      findings_fixed:[], threads_replied:[], threads_resolved:[],
+      files_changed:[], push_timestamp:"2026-07-21T00:00:00Z"}')"
+  if [[ -n "$owner_repo" ]]; then
+    "$_PSG_HANDOFF_HELPER" --owner-repo "$owner_repo" --create "$pr" "$json_body"
+  else
+    "$_PSG_HANDOFF_HELPER" --create "$pr" "$json_body"
+  fi
+}
+
+# write_polling_gh_stub <bin_dir>
+# Writes a gh stub script that reads from env vars at runtime (set inline on
+# each gate invocation). The stub covers all surface areas exercised by
+# polling-state-gate.sh, pr-authorship.sh, and the pr-state.sh calls made
+# during --ensure-session's poll-watermarks.sh --init step.
+write_polling_gh_stub() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+_owner_repo="${STUB_OWNER_REPO:-org/c}"
+_head_sha="${STUB_HEAD_SHA:-ccc3333}"
+_pr_num="${STUB_PR_NUMBER:-84}"
+_pr_author="${STUB_PR_AUTHOR:-testuser}"
+case "${1:-}" in
+  pr)
+    if [[ -n "${STUB_PR_JSON:-}" ]]; then
+      printf '%s\n' "$STUB_PR_JSON"
+    else
+      printf '{"headRefOid":"%s","state":"OPEN","number":%s,"headRefName":"feature","url":"https://github.com/%s/pull/%s","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","reviewDecision":""}\n' \
+        "$_head_sha" "$_pr_num" "$_owner_repo" "$_pr_num"
+    fi ;;
+  repo) printf '%s\n' "$_owner_repo" ;;
+  api)
+    shift
+    [[ "${1:-}" == "--paginate" ]] && shift
+    case "${1:-}" in
+      user) echo 'testuser' ;;
+      graphql)
+        echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
+        ;;
+      repos/*/pulls/*)
+        if [[ "$*" == *"/reviews"* || "$*" == *"/comments"* ]]; then
+          echo '[]'
+        else
+          printf '{"user":{"login":"%s","type":"User"}}\n' "$_pr_author"
+        fi ;;
+      repos/*/issues/*/comments*) echo '[]' ;;
+      repos/*/commits/*/check-runs*) echo '{"check_runs":[]}' ;;
+      repos/*/commits/*/statuses*) echo '[]' ;;
+      *) echo '[]' ;;
+    esac ;;
+  *) exit 1 ;;
+esac
+STUB
+  chmod +x "$bin_dir/gh"
+}

--- a/.claude/scripts/tests/lib/polling-state-gate-fixtures.sh
+++ b/.claude/scripts/tests/lib/polling-state-gate-fixtures.sh
@@ -44,7 +44,8 @@ if [ "${BASH_SOURCE[0]:-}" = "${0:-}" ]; then
   exit 2
 fi
 
-_PSG_REPO_ROOT="$(git rev-parse --show-toplevel)"
+_PSG_FIXTURE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_PSG_REPO_ROOT="$(git -C "$_PSG_FIXTURE_DIR" rev-parse --show-toplevel)"
 _PSG_HANDOFF_HELPER="$_PSG_REPO_ROOT/.claude/scripts/handoff-state.sh"
 
 # mk_repo <dir> <origin-url>

--- a/.claude/scripts/tests/polling-state-gate-multirepo.test.sh
+++ b/.claude/scripts/tests/polling-state-gate-multirepo.test.sh
@@ -35,6 +35,9 @@
 set -uo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/polling-state-gate-fixtures.sh
+source "$TEST_DIR/lib/polling-state-gate-fixtures.sh"
 GATE="$REPO_ROOT/.claude/scripts/polling-state-gate.sh"
 STATE_SH="$REPO_ROOT/.claude/scripts/session-state.sh"
 
@@ -56,24 +59,11 @@ check_eq() {
   fi
 }
 
-make_repo() { # $1 = dir, $2 = owner/name
-  mkdir -p "$1"
-  git -C "$1" init --quiet
-  git -C "$1" remote add origin "https://github.com/$2.git"
-  git -C "$1" -c user.email=t@e -c user.name=T commit --quiet --allow-empty -m init
-}
+# mk_repo and write_handoff are provided by lib/polling-state-gate-fixtures.sh.
+# write_handoff signature: write_handoff <owner_repo_or_empty> <pr_number> <head_sha>
 
-write_handoff() { # $1 = pr, $2 = sha
-  cat > "$HOME/.claude/handoffs/pr-$1-handoff.json" <<JSON
-{"schema_version":"1.0","pr_number":$1,"head_sha":"$2","reviewer":"cr",
- "phase_completed":"B","created_at":"2026-07-21T00:00:00Z","findings_fixed":[],
- "threads_replied":[],"threads_resolved":[],"files_changed":[],
- "push_timestamp":"2026-07-21T00:00:00Z"}
-JSON
-}
-
-REPO_A="$WORK/a"; make_repo "$REPO_A" "org/a"
-REPO_B="$WORK/b"; make_repo "$REPO_B" "org/b"
+REPO_A="$WORK/a"; mk_repo "$REPO_A" "https://github.com/org/a.git"
+REPO_B="$WORK/b"; mk_repo "$REPO_B" "https://github.com/org/b.git"
 
 # Both repos track a PR #84 — the collision case from the issue.
 ( cd "$REPO_A" && "$STATE_SH" --set '.prs["84"].root_repo='"$REPO_A" \
@@ -91,13 +81,17 @@ check_eq "repo B keeps its own head_sha" "bbb2222" "$( cd "$REPO_B" && "$STATE_S
 
 echo
 echo "== No false 'wrong checkout' refusal when another repo wrote last =="
-write_handoff 84 aaa1111
+write_handoff "org/a" 84 aaa1111
+check_eq "scoped handoff for org/a written to correct path" "1" \
+  "$(test -f "$HOME/.claude/handoffs/org/a/pr-84-handoff.json" && echo 1 || echo 0)"
 OUT="$( cd "$REPO_A" && bash "$GATE" 84 --verify-state 2>&1 )"; RC=$?
 check_eq "polling from repo A is allowed (exit 0)" "0" "$RC"
 check_eq "no 'refuse to poll from wrong checkout' message" "0" "$(grep -c 'wrong checkout' <<<"$OUT")"
 
 # And repo B still validates on its own terms, against ITS head_sha.
-write_handoff 84 bbb2222
+write_handoff "org/b" 84 bbb2222
+check_eq "scoped handoff for org/b written to correct path" "1" \
+  "$(test -f "$HOME/.claude/handoffs/org/b/pr-84-handoff.json" && echo 1 || echo 0)"
 RC=0; ( cd "$REPO_B" && bash "$GATE" 84 --verify-state >/dev/null 2>&1 ) || RC=$?
 check_eq "polling from repo B is allowed too" "0" "$RC"
 
@@ -105,7 +99,7 @@ echo
 echo "== A sibling worktree of the same repo is not a wrong checkout =="
 WT_A="$WORK/a-worktree"
 git -C "$REPO_A" worktree add --quiet -b feature "$WT_A" >/dev/null 2>&1
-write_handoff 84 aaa1111
+write_handoff "org/a" 84 aaa1111
 OUT="$( cd "$WT_A" && bash "$GATE" 84 --verify-state 2>&1 )"; RC=$?
 check_eq "polling from a worktree of repo A is allowed" "0" "$RC"
 check_eq "worktree poll emits no wrong-checkout refusal" "0" "$(grep -c 'wrong checkout' <<<"$OUT")"
@@ -122,7 +116,7 @@ echo "== A repo that never registered this PR is refused, not answered for =="
 # are per-repo, so "repo A also has an 84" is not a reason to accuse repo C of
 # polling the wrong repo — 84 is simply not registered for C, and
 # --ensure-session is the remedy. A/B's entries are named as diagnostics only.
-REPO_C="$WORK/c"; make_repo "$REPO_C" "org/c"
+REPO_C="$WORK/c"; mk_repo "$REPO_C" "https://github.com/org/c.git"
 RC=0; OUT="$( cd "$REPO_C" && bash "$GATE" 84 --verify-state 2>&1 )" || RC=$?
 check_eq "poll from an unregistered repo is refused (exit 4)" "4" "$RC"
 check_eq "refusal names the active repo" "1" "$(grep -c "not registered in session-state for 'org/c'" <<<"$OUT")"
@@ -137,29 +131,8 @@ echo "== A colliding PR number does not block registering our own (issue #854) =
 # every other repo's entry byte-identical.
 A_BEFORE="$(jq -Sc '.repos["org/a"].prs["84"]' "$HOME/.claude/session-state.json")"
 B_BEFORE="$(jq -Sc '.repos["org/b"].prs["84"]' "$HOME/.claude/session-state.json")"
-STUB_BIN="$WORK/bin"; mkdir -p "$STUB_BIN"
-cat > "$STUB_BIN/gh" <<'STUB'
-#!/usr/bin/env bash
-set -uo pipefail
-case "${1:-}" in
-  pr)   printf '{"headRefOid":"%s","state":"OPEN","number":84,"headRefName":"feature","url":"https://github.com/%s/pull/84","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","reviewDecision":""}\n' "${STUB_HEAD_SHA:-ccc3333}" "${STUB_OWNER_REPO:-org/c}" ;;
-  repo) printf '%s\n' "${STUB_OWNER_REPO:-org/c}" ;;
-  api)
-    shift
-    [[ "${1:-}" == "--paginate" ]] && shift
-    case "${1:-}" in
-      user) echo 'testuser' ;;
-      graphql) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' ;;
-      repos/*/pulls/*)
-        if [[ "$*" == *"/reviews"* || "$*" == *"/comments"* ]]; then echo '[]'
-        else echo '{"user":{"login":"testuser","type":"User"}}'; fi ;;
-      repos/*/commits/*/check-runs*) echo '{"check_runs":[]}' ;;
-      *) echo '[]' ;;
-    esac ;;
-  *) exit 1 ;;
-esac
-STUB
-chmod +x "$STUB_BIN/gh"
+STUB_BIN="$WORK/bin"
+write_polling_gh_stub "$STUB_BIN"
 RC=0; OUT="$( cd "$REPO_C" && PATH="$STUB_BIN:$PATH" bash "$GATE" 84 --ensure-session 2>&1 )" || RC=$?
 check_eq "--ensure-session succeeds despite a colliding PR number" "0" "$RC"
 check_eq "…and registers under our own scope" "ccc3333" \
@@ -172,7 +145,7 @@ check_eq "repo B's entry is untouched" "$B_BEFORE" \
   "$(jq -Sc '.repos["org/b"].prs["84"]' "$HOME/.claude/session-state.json")"
 
 # And a subsequent poll from C reads C's own head_sha, not A's or B's.
-write_handoff 84 ccc3333
+write_handoff "org/c" 84 ccc3333
 RC=0; OUT="$( cd "$REPO_C" && bash "$GATE" 84 --verify-state 2>&1 )" || RC=$?
 check_eq "a later tick from repo C validates against C's own state" "0" "$RC"
 
@@ -183,7 +156,7 @@ echo "== A self-identifying checkout overrides a stale inherited scope (issue #9
 # environment still names repo B. Both registration and verification must use A,
 # and B's existing entry must remain byte-identical.
 B_BEFORE_STALE_ENV="$(jq -Sc '.repos["org/b"].prs["84"]' "$HOME/.claude/session-state.json")"
-write_handoff 84 aaa1111
+write_handoff "org/a" 84 aaa1111
 RC=0; OUT="$( cd "$REPO_A" && CLAUDE_SESSION_REPO=org/b STUB_HEAD_SHA=aaa1111 STUB_OWNER_REPO=org/a PATH="$STUB_BIN:$PATH" bash "$GATE" 84 --ensure-session 2>&1 )" || RC=$?
 check_eq "stale inherited scope does not block --ensure-session" "0" "$RC"
 check_eq "--ensure-session remains scoped to the invoking repo" "org/a" \
@@ -204,7 +177,7 @@ NOREMOTE="$WORK/noremote"
 mkdir -p "$NOREMOTE"
 git -C "$NOREMOTE" init --quiet
 git -C "$NOREMOTE" -c user.email=t@e -c user.name=T commit --quiet --allow-empty -m init
-write_handoff 84 aaa1111
+write_handoff "org/a" 84 aaa1111
 RC=0; OUT="$( cd "$NOREMOTE" && bash "$GATE" 84 --verify-state --repo org/a 2>&1 )" || RC=$?
 check_eq "--repo selects the named scope from an origin-less checkout" "0" "$RC"
 RC=0; OUT="$( cd "$NOREMOTE" && CLAUDE_SESSION_REPO=org/a bash "$GATE" 84 --verify-state 2>&1 )" || RC=$?
@@ -238,7 +211,7 @@ echo "== a declared repo key may supply an identity, never override one (issue #
 # code validated every per-PR field against the DECLARED repo while gh,
 # merge-gate.sh and the session-state writes all ran against the checkout —
 # polling one repo's PR while acting on another (CodeAnt Major + BugBot, PR #856).
-write_handoff 84 aaa1111
+write_handoff "org/a" 84 aaa1111
 RC=0; OUT="$( cd "$REPO_B" && bash "$GATE" 84 --verify-state --repo org/a --root-repo "$REPO_B" 2>&1 )" || RC=$?
 check_eq "--repo contradicting --root-repo is refused" "4" "$RC"
 check_eq "…and the refusal names both sides" "1" "$(grep -c "contradicts the checkout being operated on" <<<"$OUT")"
@@ -246,7 +219,7 @@ check_eq "…and it did not operate on the declared repo" "0" "$(grep -c 'gate m
 # An inherited environment value is ambient rather than explicit. A
 # self-identifying checkout replaces it before scope resolution, whether or not
 # --root-repo pins that checkout.
-write_handoff 84 bbb2222
+write_handoff "org/b" 84 bbb2222
 RC=0; OUT="$( cd "$REPO_B" && CLAUDE_SESSION_REPO=org/a bash "$GATE" 84 --verify-state --root-repo "$REPO_B" 2>&1 )" || RC=$?
 check_eq "stale environment value yields to explicit checkout identity" "0" "$RC"
 RC=0; OUT="$( cd "$REPO_B" && CLAUDE_SESSION_REPO=org/a bash "$GATE" 84 --verify-state 2>&1 )" || RC=$?
@@ -260,7 +233,7 @@ check_eq "…and the explicit mismatch keeps the contradiction message" "1" \
   "$(grep -c "contradicts the checkout being operated on" <<<"$OUT")"
 # A key merely DERIVED from the checkout can never contradict it, so the ordinary
 # no-override path must stay clean — this is the regression guard for the fix.
-write_handoff 84 aaa1111
+write_handoff "org/a" 84 aaa1111
 RC=0; OUT="$( cd "$REPO_A" && bash "$GATE" 84 --verify-state 2>&1 )" || RC=$?
 check_eq "no declared key: ordinary poll is unaffected" "0" "$RC"
 check_eq "…and emits no contradiction message" "0" "$(grep -c 'contradicts the checkout' <<<"$OUT")"

--- a/.claude/scripts/tests/polling-state-gate.test.sh
+++ b/.claude/scripts/tests/polling-state-gate.test.sh
@@ -297,10 +297,10 @@ STUB_BIN2="$TMP/bin2"
 write_polling_gh_stub "$STUB_BIN2"
 
 rm -f "$STATE"
-out2="$(cd "$REPO_MIXED" && PATH="$STUB_BIN2:$PATH" \
+( cd "$REPO_MIXED" && PATH="$STUB_BIN2:$PATH" \
   STUB_PR_JSON='{"headRefOid":"c0ffee","state":"OPEN","number":99647,"headRefName":"feature","url":"https://github.com/AuerbachB/Skingod/pull/99647","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","reviewDecision":""}' \
   STUB_OWNER_REPO="AuerbachB/Skingod" \
-  "$SCRIPT" "$PR_NUM" --ensure-session 2>&1)"; rc2=$?
+  "$SCRIPT" "$PR_NUM" --ensure-session > /dev/null 2>&1 ); rc2=$?
 check_eq "--ensure-session with mixed-case remote exits 0" "0" "$rc2"
 
 # The key stored in session-state.json must be lowercase.

--- a/.claude/scripts/tests/polling-state-gate.test.sh
+++ b/.claude/scripts/tests/polling-state-gate.test.sh
@@ -15,8 +15,10 @@
 set -uo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/polling-state-gate-fixtures.sh
+source "$TEST_DIR/lib/polling-state-gate-fixtures.sh"
 SCRIPT="$REPO_ROOT/.claude/scripts/polling-state-gate.sh"
-HANDOFF_HELPER="$REPO_ROOT/.claude/scripts/handoff-state.sh"
 SCOPE_LIB="$REPO_ROOT/.claude/scripts/lib/pr-scope-resolver.sh"
 
 TMP="$(mktemp -d)"
@@ -129,59 +131,7 @@ check_eq "source-site matcher ignores source mentioned as an argument" "0" \
 check_eq "source-site matcher ignores source text inside an argument" "0" \
   "$(printf '%s\n' 'echo '\''x then source "$_SCOPE_RESOLVER_LIB"'\''' | grep -Ec "$SCOPE_SOURCE_OP_RE" || true)"
 
-# Shared gh stub for --ensure-session tests. poll-watermarks.sh (issue #741) calls
-# pr-state.sh during --ensure-session, so the stub must satisfy pr-state's gh
-# surface in addition to polling-state-gate / pr-authorship.
-write_ensure_session_gh_stub() {
-  local bin_dir="$1" pr_json="$2" repo_slug="$3" author_login="${4:-testuser}"
-  mkdir -p "$bin_dir"
-  cat > "$bin_dir/gh" <<STUB
-#!/usr/bin/env bash
-set -uo pipefail
-case "\${1:-}" in
-  pr)   echo '$pr_json' ;;
-  repo) echo '$repo_slug' ;;
-  api)
-    shift
-    [[ "\${1:-}" == "--paginate" ]] && shift
-    endpoint="\${1:-}"
-    case "\$endpoint" in
-      user) echo 'testuser' ;;
-      graphql)
-        echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
-        ;;
-      repos/*/pulls/*)
-        if [[ "\$*" == *"/reviews"* || "\$*" == *"/comments"* ]]; then
-          echo '[]'
-        else
-          echo '{"user":{"login":"$author_login","type":"User"}}'
-        fi
-        ;;
-      repos/*/issues/*/comments*) echo '[]' ;;
-      repos/*/commits/*/check-runs*) echo '{"check_runs":[]}' ;;
-      repos/*/commits/*/statuses*) echo '[]' ;;
-      *) echo '[]' ;;
-    esac
-    ;;
-  *) exit 1 ;;
-esac
-STUB
-  chmod +x "$bin_dir/gh"
-}
-
-# ---- throwaway repos --------------------------------------------------------
-# mk_repo <dir> <origin-url>
-mk_repo() {
-  local dir="$1" origin="$2"
-  mkdir -p "$dir"
-  git -C "$dir" init --quiet
-  git -C "$dir" remote add origin "$origin"
-  git -C "$dir" config user.email test@example.com
-  git -C "$dir" config user.name Test
-  : > "$dir/README.md"
-  git -C "$dir" add README.md
-  git -C "$dir" commit --quiet -m init
-}
+# ---- throwaway repos (mk_repo from lib) -------------------------------------
 
 # Resolve symlinks up front (macOS /var -> /private/var) so recorded paths compare
 # equal to what the script canonicalizes.
@@ -219,30 +169,8 @@ PR_NUM="99647"
 HANDOFF="$HOME/.claude/handoffs/pr-${PR_NUM}-handoff.json"
 STATE="$HOME/.claude/session-state.json"
 
-write_handoff() {
-  # Optional first arg: owner/repo slug (e.g. "org/a"). When supplied the
-  # handoff is written to the scoped path via handoff-state.sh so it lands
-  # in ~/.claude/handoffs/{owner}/{repo}/pr-{N}-handoff.json (issue #655).
-  # Using --create (not --init) ensures any stale handoff at that path is
-  # replaced, providing test-to-test isolation: --ensure-session (test 6)
-  # creates a scoped handoff for "org/a" that would otherwise shadow a
-  # fresh flat write in tests 8/9 (root cause of CI head_sha mismatch).
-  # Use if/else rather than "${arr[@]}" expansion to stay compatible with
-  # bash 3.2 (macOS system bash), which raises "unbound variable" for empty
-  # arrays under set -u.
-  local owner_repo="${1:-}"
-  local json_body
-  json_body="$(jq -n --argjson pr "$PR_NUM" --arg sha "deadbeef" \
-    '{schema_version:"1.0", pr_number:$pr, head_sha:$sha, reviewer:"cr",
-      phase_completed:"B", created_at:"2026-07-21T00:00:00Z",
-      findings_fixed:[], threads_replied:[], threads_resolved:[],
-      files_changed:[], push_timestamp:"2026-07-21T00:00:00Z"}')"
-  if [[ -n "$owner_repo" ]]; then
-    "$HANDOFF_HELPER" --owner-repo "$owner_repo" --create "$PR_NUM" "$json_body"
-  else
-    "$HANDOFF_HELPER" --create "$PR_NUM" "$json_body"
-  fi
-}
+# write_handoff is provided by lib/polling-state-gate-fixtures.sh.
+# Signature: write_handoff <owner_repo_or_empty> <pr_number> <head_sha>
 # write_state <global_root_repo> <per-pr fields as jq object or 'null'>
 write_state() {
   local global_root="$1" per_pr="$2"
@@ -253,7 +181,7 @@ write_state() {
 # ---- 1. false positive: foreign session owns the global .root_repo ----------
 # This is the exact PR #637 failure — repo B's session wrote .root_repo last while
 # we legitimately poll a repo A PR from repo A.
-write_handoff
+write_handoff "" "$PR_NUM" "deadbeef"
 write_state "$REPO_B" "$(jq -n --arg r "$REPO_A" '{root_repo:$r, owner_repo:"org/a", head_sha:"deadbeef", reviewer:"cr"}')"
 out="$(cd "$REPO_A" && "$SCRIPT" "$PR_NUM" --verify-state 2>&1)"; rc=$?
 check_eq "correct checkout passes while a foreign repo owns global .root_repo" "0" "$rc"
@@ -287,12 +215,13 @@ check_contains "unscoped state emits a notice recommending --ensure-session" "--
 
 # ---- 6. --ensure-session records per-PR scoping ----------------------------
 STUB_BIN="$TMP/bin"
-write_ensure_session_gh_stub "$STUB_BIN" \
-  '{"headRefOid":"cafebabe","state":"OPEN","number":99647,"headRefName":"feature","url":"https://github.com/org/a/pull/99647","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","reviewDecision":""}' \
-  "org/a"
+write_polling_gh_stub "$STUB_BIN"
 
 rm -f "$STATE" "$HANDOFF"
-out="$(cd "$REPO_A" && PATH="$STUB_BIN:$PATH" "$SCRIPT" "$PR_NUM" --ensure-session 2>&1)"; rc=$?
+out="$(cd "$REPO_A" && PATH="$STUB_BIN:$PATH" \
+  STUB_PR_JSON='{"headRefOid":"cafebabe","state":"OPEN","number":99647,"headRefName":"feature","url":"https://github.com/org/a/pull/99647","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","reviewDecision":""}' \
+  STUB_OWNER_REPO="org/a" \
+  "$SCRIPT" "$PR_NUM" --ensure-session 2>&1)"; rc=$?
 check_eq "--ensure-session succeeds on a fresh PR" "0" "$rc"
 # Per-PR state is stored under the repo's own scope since issue #638
 # (`.repos["<owner>/<name>"].prs["<N>"]`), so these read the scoped path. The
@@ -321,7 +250,7 @@ check_eq "owner_repo comparison ignores case" "0" "$rc"
 # ---- 8. owner and repo sharing a name is still a valid identity ------------
 REPO_SAME="$TMP/repo-same"
 mk_repo "$REPO_SAME" "git@github.com:foo/foo.git"
-write_handoff "foo/foo"
+write_handoff "foo/foo" "$PR_NUM" "deadbeef"
 write_state "$REPO_B" "$(jq -n --arg r "$REPO_SAME" '{root_repo:$r, owner_repo:"foo/foo", head_sha:"deadbeef", reviewer:"cr"}')"
 out="$(cd "$REPO_SAME" && "$SCRIPT" "$PR_NUM" --verify-state 2>&1)"; rc=$?
 check_eq "owner/repo with identical names resolves and passes" "0" "$rc"
@@ -338,7 +267,7 @@ git -C "$REPO_NOREMOTE" config user.name Test
 : > "$REPO_NOREMOTE/README.md"
 git -C "$REPO_NOREMOTE" add README.md
 git -C "$REPO_NOREMOTE" commit --quiet -m init
-write_handoff "org/a"
+write_handoff "org/a" "$PR_NUM" "deadbeef"
 write_state "$REPO_B" "$(jq -n '{root_repo:"/nonexistent/gone", owner_repo:"org/a", head_sha:"deadbeef", reviewer:"cr"}')"
 out="$(cd "$REPO_NOREMOTE" && "$SCRIPT" "$PR_NUM" --verify-state 2>&1)"; rc=$?
 check_eq "uncomparable identity with recorded scoping fails closed" "4" "$rc"
@@ -365,12 +294,13 @@ check_eq "session-state.sh --repo-key lowercases mixed-case remote" \
 # produced (already lowercase from test above), then --verify-state from the
 # same checkout should pass (not refuse as a cross-repo mismatch).
 STUB_BIN2="$TMP/bin2"
-write_ensure_session_gh_stub "$STUB_BIN2" \
-  '{"headRefOid":"c0ffee","state":"OPEN","number":99647,"headRefName":"feature","url":"https://github.com/AuerbachB/Skingod/pull/99647","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","reviewDecision":""}' \
-  "AuerbachB/Skingod"
+write_polling_gh_stub "$STUB_BIN2"
 
 rm -f "$STATE"
-out2="$(cd "$REPO_MIXED" && PATH="$STUB_BIN2:$PATH" "$SCRIPT" "$PR_NUM" --ensure-session 2>&1)"; rc2=$?
+out2="$(cd "$REPO_MIXED" && PATH="$STUB_BIN2:$PATH" \
+  STUB_PR_JSON='{"headRefOid":"c0ffee","state":"OPEN","number":99647,"headRefName":"feature","url":"https://github.com/AuerbachB/Skingod/pull/99647","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","reviewDecision":""}' \
+  STUB_OWNER_REPO="AuerbachB/Skingod" \
+  "$SCRIPT" "$PR_NUM" --ensure-session 2>&1)"; rc2=$?
 check_eq "--ensure-session with mixed-case remote exits 0" "0" "$rc2"
 
 # The key stored in session-state.json must be lowercase.
@@ -386,20 +316,23 @@ check_eq "--verify-state passes for mixed-case-remote checkout (no false cross-r
 # gh api user (viewer) and the PR author disagree, so pr-authorship.sh returns
 # not_mine and enrolment is refused. Enrolling a PR in polling is a "touch".
 STUB_BIN3="$TMP/bin3"
-write_ensure_session_gh_stub "$STUB_BIN3" \
-  '{"headRefOid":"feed1234","state":"OPEN","number":99647,"headRefName":"feature","url":"https://github.com/org/a/pull/99647","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","reviewDecision":""}' \
-  "org/a" \
-  "collab"
+write_polling_gh_stub "$STUB_BIN3"
+# Tests 11 and 12 use the same stub with collab as the PR author.
+_STUB3_PR_JSON='{"headRefOid":"feed1234","state":"OPEN","number":99647,"headRefName":"feature","url":"https://github.com/org/a/pull/99647","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","reviewDecision":""}'
 
 rm -f "$STATE" "$HANDOFF"
-out="$(cd "$REPO_A" && PATH="$STUB_BIN3:$PATH" "$SCRIPT" "$PR_NUM" --ensure-session 2>&1)"; rc=$?
+out="$(cd "$REPO_A" && PATH="$STUB_BIN3:$PATH" \
+  STUB_PR_JSON="$_STUB3_PR_JSON" STUB_OWNER_REPO="org/a" STUB_PR_AUTHOR="collab" \
+  "$SCRIPT" "$PR_NUM" --ensure-session 2>&1)"; rc=$?
 check_eq "--ensure-session refuses a collaborator-authored PR" "4" "$rc"
 check_contains "refusal names the authorship guard" "authorship guard" "$out"
 check_eq "no session-state written for the refused PR" "" \
   "$(jq -r --arg pr "$PR_NUM" '.repos["org/a"].prs[$pr] // ""' "$STATE" 2>/dev/null || echo "")"
 
 # ---- 12. --allow-nonauthor bypasses the guard (explicit user override) ------
-out="$(cd "$REPO_A" && PATH="$STUB_BIN3:$PATH" "$SCRIPT" "$PR_NUM" --ensure-session --allow-nonauthor 2>&1)"; rc=$?
+out="$(cd "$REPO_A" && PATH="$STUB_BIN3:$PATH" \
+  STUB_PR_JSON="$_STUB3_PR_JSON" STUB_OWNER_REPO="org/a" STUB_PR_AUTHOR="collab" \
+  "$SCRIPT" "$PR_NUM" --ensure-session --allow-nonauthor 2>&1)"; rc=$?
 check_eq "--allow-nonauthor lets --ensure-session enrol a non-author PR" "0" "$rc"
 check_eq "override records per-PR owner_repo" "org/a" \
   "$(jq -r --arg pr "$PR_NUM" '.repos["org/a"].prs[$pr].owner_repo // ""' "$STATE")"


### PR DESCRIPTION
## Summary

- Extracts shared helpers (`mk_repo`, `write_handoff`, `write_polling_gh_stub`) from both polling-state-gate test suites into a new `tests/lib/polling-state-gate-fixtures.sh`, eliminating duplicated function definitions that required two edits per stub-signature change.
- Unifies the diverged `write_handoff` signatures (primary suite used globals; multirepo suite used positional args; lib uses `<owner_repo_or_empty> <pr_number> <head_sha>`).
- Replaces the baked-at-write `write_ensure_session_gh_stub` in the primary suite and the inline heredoc stub in the multirepo suite with a single env-var-driven `write_polling_gh_stub`.
- Closes the scoped-path coverage gap: multirepo suite previously wrote flat handoffs relying on the backward-compat fallback; now writes to scoped paths via `handoff-state.sh --owner-repo` and asserts the paths exist.
- Adds decision record `polling-state-gate-test-hotspot-decision.md` and README catalog entry.

## Test plan

- [x] `polling-state-gate.test.sh` passes (71/71)
- [x] `polling-state-gate-multirepo.test.sh` passes (51/51, +2 new scoped-path assertions)
- [x] `tests/lib/polling-state-gate-fixtures.sh` exits 2 on direct execution (direct-execution guard)
- [x] `reference-catalog-lint.sh` passes (87 files indexed)
- [x] CodeRabbit local CLI: `verified_run=true, findings=0`
- [x] CodeAnt local CLI: 403 daily cap, dropped after one retry — noted here. CodeAnt GitHub App review unaffected and satisfies the merge gate independently.
- [x] Decision record verdict: KEEP + extract (coordinated shared-contract churn on repo-scoping seam, not instability)

**Coverage:** `cr-only` (CodeAnt CLI daily cap; GitHub App available for merge gate)

Closes #1003

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved polling-state test coverage for multiple repositories, including isolated handoffs, conflicting pull request numbers, stale scopes, and repository identity mismatches.
  * Added validation for scoped paths and unregistered repositories.
  * Expanded coverage for session enforcement, author restrictions, and the non-author override.

* **Documentation**
  * Added reference documentation describing polling-state test coverage decisions and shared fixture improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->