### PR TITLE
feat(#813): evaluate newer hook events; wire PostCompact reconciliation trigger

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -172,6 +172,32 @@ Each record carries `recorded_at`, `session_id`, `cwd`, `transcript_path`, a tru
 
 ---
 
+## post-compact-reconcile.sh
+
+Emits a deterministic post-compaction reconciliation prompt after every context compaction (issue #813, follow-up from PR #811).
+
+Registered on **`PostCompact`** with a 10 s timeout.
+
+**Why it exists.** `monitor-mode.md` §"Post-Compaction Recovery" requires the agent to reconcile session state after compaction, but today that trigger depends on model judgment: the agent must notice an unfamiliar summary block and decide to run the recovery sequence. A missed or delayed judgment means stale state goes undetected. `PostCompact` fires deterministically after every compaction; this hook guarantees the reconciliation prompt reaches the agent regardless of how clearly the compact summary signals the prior state.
+
+**What it does.** Drains stdin (the `PostCompact` payload, including `compact_summary`), and emits `hookSpecificOutput.additionalContext` with the full Post-Compaction Recovery sequence from `monitor-mode.md`:
+
+1. Timestamp and rerun session-start checks.
+2. Read `session-state.json` + handoffs; reconcile each open PR on GitHub.
+3. Per polled PR: `polling-state-gate.sh <N> --verify-state`, then `polling-state-gate.sh <N>`.
+4. Reconcile state; verify stale agents and stalled transitions; launch as needed.
+5. Resume monitoring — one heartbeat line, no report.
+
+When `compact_summary` is present in the payload and `jq` is available, it is appended to the context so the agent has immediate visibility into what the compaction covered.
+
+**It does not replace existing backstops.** On-disk `session-state.json`, per-PR handoff files in `~/.claude/handoffs/`, and `checkpoint-handoff.sh` on `SubagentStop` remain intact. This hook makes the model-judgment trigger in `monitor-mode.md` redundant rather than necessary.
+
+**Evaluation:** `.claude/reference/hook-events-evaluation-2026-08.md` — full analysis of all candidate newer events and their adopt/defer verdicts.
+
+**Tests:** `.claude/hooks/tests/post-compact-reconcile.test.sh`
+
+---
+
 ## checkpoint-handoff.sh
 
 Writes a portable handoff document automatically while work is in progress, so `usage-limit-record.sh` has something real to point at when a turn dies without warning (issue #941).

--- a/.claude/hooks/post-compact-reconcile.sh
+++ b/.claude/hooks/post-compact-reconcile.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# post-compact-reconcile.sh — deterministic post-compaction reconciliation
+#                             trigger (issue #813)
+#
+# PURPOSE
+#   `monitor-mode.md` §"Post-Compaction Recovery" requires the agent to run a
+#   reconciliation sequence after context compaction — re-reading session-state
+#   and handoff files, reconciling open PRs against GitHub, and verifying stale
+#   agents and stalled transitions. Today that trigger depends on model judgment:
+#   the agent must notice an unfamiliar summary block and decide to run recovery.
+#
+#   This hook closes the gap. `PostCompact` fires deterministically after every
+#   compaction; by emitting `hookSpecificOutput.additionalContext`, the hook
+#   guarantees the reconciliation prompt reaches the agent regardless of how
+#   clearly the compact summary signals the prior state.
+#
+# WHAT THIS IS NOT
+#   It does not replace the backstops that already exist: on-disk
+#   `session-state.json`, per-PR handoff files in `~/.claude/handoffs/`, and
+#   `checkpoint-handoff.sh` on `SubagentStop`. Those remain intact. This hook
+#   makes the model-judgment trigger *redundant* rather than necessary — the
+#   recovery is now guaranteed to be prompted whether or not the agent would
+#   have noticed the need.
+#
+# PAYLOAD
+#   `PostCompact` extends the shared hook payload base with `compact_summary`
+#   (the text the runtime produced as the compaction summary). This script reads
+#   it for informational context but emits the same context regardless of its
+#   content — compaction always warrants a reconciliation pass.
+#
+# REGISTRATION
+#   Registered under `PostCompact` in `global-settings.json` with a 10 s timeout.
+#   `register-hooks.py` auto-registers it from that template on every session start.
+#
+# EXIT STATUS
+#   Always 0. A hook that becomes a new failure mode is worse than no hook.
+#   Diagnostics go to stderr.
+
+set -uo pipefail
+
+# Consume stdin. The hook protocol requires draining stdin; PostCompact carries
+# compact_summary and the shared base fields. Reading into a variable lets us
+# optionally surface the summary in the context message.
+INPUT=$(cat 2>/dev/null || true)
+
+# Extract compact_summary from the payload if jq is available. This is used only
+# for the context message — the reconciliation prompt is emitted regardless.
+COMPACT_SUMMARY=""
+if command -v jq >/dev/null 2>&1 && [[ -n "$INPUT" ]]; then
+  COMPACT_SUMMARY=$(jq -r '.compact_summary // empty' <<<"$INPUT" 2>/dev/null || true)
+fi
+
+# Build the additionalContext message. The core instruction is the Post-Compaction
+# Recovery sequence from monitor-mode.md. Including the compact_summary (when
+# available) gives the agent immediate context about what the compaction covered,
+# so it can calibrate how much state to re-verify.
+if [[ -n "$COMPACT_SUMMARY" ]]; then
+  CONTEXT="POST-COMPACTION RECOVERY REQUIRED
+
+Context compaction just completed. Run the Post-Compaction Recovery sequence from
+.claude/rules/monitor-mode.md §\"Post-Compaction Recovery\" now:
+
+1. Timestamp and rerun session-start checks.
+2. Read session-state.json + handoffs; reconcile each open PR on GitHub (all 3
+   endpoints per cr-github-review.md).
+3. Per polled PR: polling-state-gate.sh <N> --verify-state, then
+   polling-state-gate.sh <N> (shells merge-gate.sh).
+4. Reconcile state (PR, HEAD, reviewer, pending); verify stale agents and stalled
+   transitions; launch as needed.
+5. Resume monitoring — one heartbeat line, no report.
+
+Compact summary from the runtime:
+${COMPACT_SUMMARY}"
+else
+  CONTEXT="POST-COMPACTION RECOVERY REQUIRED
+
+Context compaction just completed. Run the Post-Compaction Recovery sequence from
+.claude/rules/monitor-mode.md §\"Post-Compaction Recovery\" now:
+
+1. Timestamp and rerun session-start checks.
+2. Read session-state.json + handoffs; reconcile each open PR on GitHub (all 3
+   endpoints per cr-github-review.md).
+3. Per polled PR: polling-state-gate.sh <N> --verify-state, then
+   polling-state-gate.sh <N> (shells merge-gate.sh).
+4. Reconcile state (PR, HEAD, reviewer, pending); verify stale agents and stalled
+   transitions; launch as needed.
+5. Resume monitoring — one heartbeat line, no report."
+fi
+
+# Emit the additionalContext. jq is preferred for correct JSON encoding; plain
+# printf is a reliable fallback for environments where jq is not installed.
+if command -v jq >/dev/null 2>&1; then
+  jq -n --arg ctx "$CONTEXT" '{
+    hookSpecificOutput: {
+      hookEventName: "PostCompact",
+      additionalContext: $ctx
+    }
+  }'
+else
+  # Minimal safe fallback: the context message contains no characters that would
+  # break this simple substitution (no backslashes, no control characters), but
+  # we escape double-quotes to be safe.
+  CONTEXT_ESCAPED="${CONTEXT//\\/\\\\}"
+  CONTEXT_ESCAPED="${CONTEXT_ESCAPED//\"/\\\"}"
+  printf '{"hookSpecificOutput":{"hookEventName":"PostCompact","additionalContext":"%s"}}\n' \
+    "${CONTEXT_ESCAPED//$'\n'/\\n}"
+fi
+
+exit 0

--- a/.claude/hooks/post-compact-reconcile.sh
+++ b/.claude/hooks/post-compact-reconcile.sh
@@ -63,8 +63,8 @@ Context compaction just completed. Run the Post-Compaction Recovery sequence fro
 1. Timestamp and rerun session-start checks.
 2. Read session-state.json + handoffs; reconcile each open PR on GitHub (all 3
    endpoints per cr-github-review.md).
-3. Per polled PR: polling-state-gate.sh <N> --verify-state, then
-   polling-state-gate.sh <N> (shells merge-gate.sh).
+3. Per polled PR: polling-state-gate.sh <N> --verify-state (optional --root-repo <path>),
+   then polling-state-gate.sh <N> (shells merge-gate.sh).
 4. Reconcile state (PR, HEAD, reviewer, pending); verify stale agents and stalled
    transitions; launch as needed.
 5. Resume monitoring — one heartbeat line, no report.
@@ -80,8 +80,8 @@ Context compaction just completed. Run the Post-Compaction Recovery sequence fro
 1. Timestamp and rerun session-start checks.
 2. Read session-state.json + handoffs; reconcile each open PR on GitHub (all 3
    endpoints per cr-github-review.md).
-3. Per polled PR: polling-state-gate.sh <N> --verify-state, then
-   polling-state-gate.sh <N> (shells merge-gate.sh).
+3. Per polled PR: polling-state-gate.sh <N> --verify-state (optional --root-repo <path>),
+   then polling-state-gate.sh <N> (shells merge-gate.sh).
 4. Reconcile state (PR, HEAD, reviewer, pending); verify stale agents and stalled
    transitions; launch as needed.
 5. Resume monitoring — one heartbeat line, no report."

--- a/.claude/hooks/tests/post-compact-reconcile.test.sh
+++ b/.claude/hooks/tests/post-compact-reconcile.test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Regression tests for post-compact-reconcile.sh (issue #813).
+# Asserts correct event registration wiring in global-settings.json,
+# correct hookEventName in emitted JSON, stdin fully consumed, and exit 0
+# behavior.
+#
+# Follows the same conventions as session-start-sync.test.sh.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK="$REPO_ROOT/.claude/hooks/post-compact-reconcile.sh"
+SETTINGS="$REPO_ROOT/global-settings.json"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# --- 1. Registration: must be under PostCompact in global-settings.json ---
+python3 - "$SETTINGS" <<'PY' || fail "post-compact-reconcile.sh not found under PostCompact in global-settings.json"
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+hooks = data.get("hooks", {})
+post_compact = hooks.get("PostCompact", [])
+found = any(
+    h.get("command", "").endswith("post-compact-reconcile.sh")
+    for group in post_compact
+    for h in group.get("hooks", [])
+)
+sys.exit(0 if found else 1)
+PY
+
+# --- 2. PostCompact registration must have timeout 10 ---
+python3 - "$SETTINGS" <<'PY' || fail "post-compact-reconcile.sh PostCompact registration does not have timeout 10"
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+hooks = data.get("hooks", {})
+post_compact = hooks.get("PostCompact", [])
+for group in post_compact:
+    for h in group.get("hooks", []):
+        if h.get("command", "").endswith("post-compact-reconcile.sh"):
+            sys.exit(0 if h.get("timeout") == 10 else 1)
+sys.exit(1)
+PY
+
+# --- 3. Must NOT be registered under any other event ---
+python3 - "$SETTINGS" <<'PY' || fail "post-compact-reconcile.sh appears under an event other than PostCompact"
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+hooks = data.get("hooks", {})
+for event, groups in hooks.items():
+    if event == "PostCompact":
+        continue
+    if not isinstance(groups, list):
+        continue
+    for group in groups:
+        for h in (group.get("hooks") or []):
+            if h.get("command", "").endswith("post-compact-reconcile.sh"):
+                print(f"found under {event}", file=sys.stderr)
+                sys.exit(1)
+sys.exit(0)
+PY
+
+# --- 4. Hook script exits 0 on empty input ---
+out=$(echo '{}' | bash "$HOOK" 2>/dev/null)
+[[ $? -eq 0 ]] || fail "hook must exit 0"
+[[ -n "$out" ]] || fail "hook must produce output on empty input"
+
+# --- 5. Output must be valid JSON containing hookEventName: "PostCompact" ---
+HOOK_OUT="$out" python3 - <<'PY' || fail "hook output is not valid JSON with hookEventName PostCompact; got: $out"
+import json, os, sys
+text = os.environ.get("HOOK_OUT", "").strip()
+if not text or text == '{}':
+    # Empty output is acceptable only if there's nothing to report — but this
+    # hook always has something to say (the reconciliation prompt). Flag it.
+    print("hook produced empty or bare-{} output", file=sys.stderr)
+    sys.exit(1)
+try:
+    obj = json.loads(text)
+except json.JSONDecodeError as e:
+    print(f"not valid JSON: {e}", file=sys.stderr)
+    sys.exit(1)
+hso = obj.get("hookSpecificOutput", {})
+event_name = hso.get("hookEventName", "")
+if event_name != "PostCompact":
+    print(f"hookEventName is '{event_name}', expected 'PostCompact'", file=sys.stderr)
+    sys.exit(1)
+ctx = hso.get("additionalContext", "")
+if not ctx:
+    print("additionalContext is empty", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+
+# --- 6. additionalContext must mention Post-Compaction Recovery ---
+HOOK_OUT="$out" python3 - <<'PY' || fail "additionalContext does not mention Post-Compaction Recovery"
+import json, os, sys
+text = os.environ.get("HOOK_OUT", "").strip()
+try:
+    obj = json.loads(text)
+except json.JSONDecodeError:
+    sys.exit(1)
+ctx = obj.get("hookSpecificOutput", {}).get("additionalContext", "")
+# The context must reference the recovery sequence so the agent knows what to do.
+if "Post-Compaction Recovery" not in ctx:
+    print(f"context missing 'Post-Compaction Recovery'; got: {ctx[:120]!r}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+
+# --- 7. compact_summary in payload is surfaced in additionalContext ---
+PAYLOAD='{"compact_summary":"Compacted 3 PRs in flight","session_id":"test-123"}'
+OUT_WITH_SUMMARY=$(echo "$PAYLOAD" | bash "$HOOK" 2>/dev/null)
+HOOK_OUT="$OUT_WITH_SUMMARY" python3 - <<'PY' || fail "compact_summary from payload not surfaced in additionalContext"
+import json, os, sys
+text = os.environ.get("HOOK_OUT", "").strip()
+try:
+    obj = json.loads(text)
+except json.JSONDecodeError as e:
+    print(f"not valid JSON: {e}", file=sys.stderr)
+    sys.exit(1)
+ctx = obj.get("hookSpecificOutput", {}).get("additionalContext", "")
+if "Compacted 3 PRs in flight" not in ctx:
+    print(f"compact_summary not in context; got: {ctx[:240]!r}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+
+# --- 8. Stdin fully consumed (no EPIPE on large input) ---
+# Generate >64 KB of input to exceed any pipe buffer; hook must drain it all
+# without producing a broken-pipe error or hanging.
+python3 -c "import sys; sys.stdout.write('{\"compact_summary\":\"x\"' + ',\"pad\":\"' + 'A'*65536 + '\"}')" \
+  | bash "$HOOK" >/dev/null 2>&1 \
+  || fail "hook failed or hung on large stdin input"
+
+echo "ok   — post-compact-reconcile.sh: all tests passed"

--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -112,6 +112,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `skill-prune-audit-2026-07.md` — skill-usage telemetry audit; keep/prune verdicts based on 62-day usage data (#431)
 - `subagent-orchestration-churn-audit-2026-07.md` — churn hotspot analysis for `subagent-orchestration.md` (13 PRs in 14 days); verdict: KEEP single file + dedup Phase A/B/C bullet descriptions toward canonical owners; ownership decisions recorded (#814)
 - `usage-limit-signal-audit-2026-07.md` — audit finding: no trustworthy approaching-limit signal exists for hooks/skills/sessions; the status-line signal has no path into model context (#824)
+- `hook-events-evaluation-2026-08.md` — evaluation of newer Claude Code hook events (WorktreeCreate/Remove, CwdChanged, SubagentStart/Stop, PreCompact/PostCompact, InstructionsLoaded) against indirect-detection mechanisms; PostCompact adopted, rest deferred with rationale (#813)
 
 ### Diagrams (mermaid stubs and indexes)
 

--- a/.claude/reference/diagrams/hook-lifecycle.md
+++ b/.claude/reference/diagrams/hook-lifecycle.md
@@ -1,7 +1,5 @@
 # Diagram: Hook lifecycle (this repo)
 
-<!-- STUB: map UserPromptSubmit / PreToolUse / PostToolUse / Stop to our scripts; compare to upstream event list -->
-
 ```mermaid
 sequenceDiagram
   participant U as User
@@ -16,8 +14,14 @@ sequenceDiagram
   Note over H: worktree-guard.sh, env-guard.py, script-bypass-detector.sh
   CC->>H: PostToolUse
   Note over H: post-merge-pull.sh, polling-backoff-warn.sh, skill-usage-tracker.sh, silence-detector.sh, bgwork-ceiling-arm.sh
+  CC->>H: SubagentStop
+  Note over H: checkpoint-handoff.sh
+  CC->>H: PostCompact
+  Note over H: post-compact-reconcile.sh
   CC->>H: Stop
-  Note over H: silence-detector-ack.sh, bgwork-ceiling-guard.sh, trust-flag-repair.sh, dirty-main-warn.sh
+  Note over H: silence-detector-ack.sh, bgwork-ceiling-guard.sh, trust-flag-repair.sh, dirty-main-warn.sh, skill-usage-snapshot-hook.sh
+  CC->>H: StopFailure (matcher: rate_limit)
+  Note over H: usage-limit-record.sh
 ```
 
 **`statusLine` is deliberately absent from this diagram.** It is a settings surface, not a hook event — Claude Code runs it from the interactive render loop on a timer, not from the event dispatcher — so it has no place in an event sequence. It is nonetheless *deployed* like a hook (same placeholder path, same `register-hooks.py` resolution). Give it its own box if this stub ever grows a config-surface diagram; do not add it as an event here. See ARCHITECTURE.md "Status Line" (#779).

--- a/.claude/reference/hook-events-evaluation-2026-08.md
+++ b/.claude/reference/hook-events-evaluation-2026-08.md
@@ -1,0 +1,221 @@
+# Hook Events Evaluation — 2026-08
+
+**Question (issue #813, follow-up from PR #811):** Which of the newer Claude Code hook events map precisely onto things we currently detect indirectly, and which should be wired now versus deferred?
+
+**Verdict summary:**
+
+| Event | Verdict | Action |
+|---|---|---|
+| `PostCompact` | **Adopt** | New hook `post-compact-reconcile.sh` (this PR) |
+| `SubagentStop` | **Partially adopted** | `checkpoint-handoff.sh` already wired (PR #941); bookkeeping aspect deferred |
+| `SubagentStart` | **Defer** | `bgwork-ceiling-arm.sh` covers this more broadly |
+| `PreCompact` | **Defer** | No meaningful pre-compaction action available |
+| `CwdChanged` | **Defer** | No cached state to update; per-call re-derivation is correct |
+| `WorktreeCreate` | **Defer** | Wrong semantics for our use case |
+| `WorktreeRemove` | **Defer** | Observability-only; low ROI |
+| `InstructionsLoaded` | **Defer** | Double-loading already solved statically |
+
+---
+
+## Audit record
+
+| | |
+|---|---|
+| Runtime | **Claude Code 2.1.221** |
+| Event catalog source | Binary strings audit, re-audit 2026-08-05 (`usage-limit-signal-audit-2026-07.md`) |
+| Events confirmed | All 32 events on 2.1.221 (see §Event catalog) |
+| Audited | 2026-08-05 |
+| Linked PR | #1028 (re-audit confirming catalog), #811 (SessionStart migration), #941 (SubagentStop wiring) |
+
+---
+
+## Event catalog (confirmed on 2.1.221)
+
+The binary audit in `.claude/reference/usage-limit-signal-audit-2026-07.md` enumerated all 32 hook events. The full set is:
+
+`ConfigChange`, `CwdChanged`, `DirectoryAdded`, `Elicitation`, `ElicitationResult`, `FileChanged`, `InstructionsLoaded`, `MessageDisplay`, `Notification`, `PermissionDenied`, `PermissionRequest`, `PostCompact`, `PostToolBatch`, `PostToolUse`, `PostToolUseFailure`, `PreCompact`, `PreToolUse`, `SessionEnd`, `SessionStart`, `Setup`, `Stop`, `StopFailure`, `SubagentStart`, `SubagentStop`, `TaskCompleted`, `TaskCreated`, `TeammateIdle`, `UserPromptExpansion`, `UserPromptSubmit`, `WorktreeCreate`, `WorktreeRemove`, `terminal`.
+
+All eight candidate events (`WorktreeCreate`, `WorktreeRemove`, `CwdChanged`, `SubagentStart`, `SubagentStop`, `PreCompact`, `PostCompact`, `InstructionsLoaded`) are confirmed present in the catalog. No candidate is wired against an event that doesn't exist.
+
+**Shared hook payload base** (confirmed on 2.1.221 via `Hm()` — identifier changes each build):
+```js
+{ session_id, transcript_path, cwd, prompt_id, permission_mode, agent_id, agent_type, effort }
+```
+Per-event payloads extend this with event-specific fields documented below.
+
+---
+
+## Per-event analysis
+
+### PostCompact — ADOPT
+
+**What it replaces:** The "notice an unfamiliar summary block" heuristic in `monitor-mode.md` §"Post-Compaction Recovery". Today's recovery trigger is entirely model-judgment: the agent must notice that a summary block references prior work it doesn't remember and then decide to run the reconciliation sequence. This is a judgment call that can be missed, delayed, or executed incompletely.
+
+**Payload:** Extends the shared base with `compact_summary` (the summary text produced by compaction). No blocking control — the hook cannot prevent compaction or change the summary. Output via `hookSpecificOutput.additionalContext` is the correct channel.
+
+**Firing semantics:** Fires deterministically after every compaction. Unlike `SessionStart` (which fires on compact events too, per its `source` field), `PostCompact` is specific to compaction and carries the compact summary — it is the right event for exactly this trigger.
+
+**What we build:** `post-compact-reconcile.sh` — a `PostCompact` hook that emits `additionalContext` instructing the agent to run the Post-Compaction Recovery sequence from `monitor-mode.md`. The existing compaction-agnostic backstops (`checkpoint-handoff.sh` on SubagentStop, on-disk session-state, handoff files) remain intact as backstops; this hook only makes the reconciliation trigger deterministic.
+
+**Why now:** Direct, low-risk, clearly better than the status quo. The current model-judgment trigger can silently fail; a deterministic event cannot.
+
+---
+
+### SubagentStop — PARTIALLY ADOPTED
+
+**Current wiring:** `checkpoint-handoff.sh` registered on `SubagentStop` since PR #941. This hook writes a portable handoff document automatically after every subagent completion, ensuring the breadcrumb `usage-limit-record.sh` points to is on disk when the recorder looks.
+
+**What the CR plan also suggested:** Pruning/annotating `active_agents[]` in `session-state.json` to replace text-based exit-report parsing in the monitor loop.
+
+**Why the bookkeeping aspect is deferred:**
+
+1. **Race condition risk.** The parent monitor loop manages `active_agents[]` directly via `session-state.sh`. A SubagentStop hook running concurrently with the parent's own state updates creates a write-lock race that `session-state.sh` mitigates with advisory locking but does not fully prevent at the per-field level. The current model — parent owns `active_agents[]` exclusively — is architecturally cleaner.
+
+2. **agent_id matching is not reliable across all spawn shapes.** The hook payload carries `agent_id` for the completed subagent, but the parent's `active_agents[]` entries may have been indexed by task id or other identifiers depending on the spawn path. Wiring a removal on `agent_id` alone risks stale entries.
+
+3. **The primary gap was already filled.** The usage-limit breadcrumb-pointing problem that motivated issue #941 is solved. The remaining bookkeeping use case is incremental improvement to the monitor loop, not a reliability fix.
+
+**Re-check trigger:** Wire the bookkeeping aspect when (a) the parent explicitly annotates spawned agents with a stable id that matches `agent_id` in the hook payload, and (b) `session-state.sh` gains per-key conditional-update support to avoid write-lock pressure from hook executions.
+
+---
+
+### SubagentStart — DEFER
+
+**What it could replace:** The spawn detection in `bgwork-ceiling-arm.sh`, which identifies background work by matching tool names (`Agent`, `Workflow`, `Monitor`) and payload shape (`run_in_background: true` on Bash) in `PostToolUse`.
+
+**Why defer:**
+
+1. **bgwork-ceiling-arm.sh is more complete.** It handles `Monitor` and backgrounded `Bash` — neither of which fires `SubagentStart`. A SubagentStart hook would require the ceiling arm hook to persist anyway for non-subagent background work.
+
+2. **Double-firing risk.** If we register on SubagentStart AND keep arm on PostToolUse for non-subagent cases, an Agent spawn fires both. Removing the Agent case from PostToolUse would require careful arm-hook surgery.
+
+3. **Nested subagent ambiguity.** SubagentStart fires inside the subagent's own session context for its own sub-subagents — not only in the parent. A hook registered globally would trigger for both, requiring session-id filtering that introduces complexity and fragility.
+
+**Re-check trigger:** Wire if (a) bgwork-ceiling-arm.sh is refactored to use SubagentStart for the Agent case specifically, and (b) non-subagent background work (Monitor, backgrounded Bash) gets its own event or remains on PostToolUse.
+
+---
+
+### PreCompact — DEFER
+
+**What it could do:** Run a script immediately before compaction starts.
+
+**Why defer:**
+
+1. **No meaningful action available.** Compaction is not blocking — a PreCompact hook cannot prevent it, choose a different compact strategy, or inject content that survives compaction. The only real option is to write something to disk before the compaction truncates context.
+
+2. **checkpoint-handoff.sh already covers this.** It writes a portable handoff document on every SubagentStop. Since compaction typically happens during active orchestration sessions (when subagents are completing work), the checkpoint is nearly always fresh. A PreCompact hook would duplicate this effort.
+
+3. **No payload advantage.** PreCompact carries no context that PostCompact doesn't — and PostCompact additionally carries `compact_summary`, which is what we actually need for the reconciliation reminder.
+
+**Re-check trigger:** Wire if a specific pre-compaction action that cannot be done post-compaction is identified.
+
+---
+
+### CwdChanged — DEFER
+
+**What it could replace:** Per-call `git rev-parse`/`branch --show-current` re-derivation in `worktree-guard.sh` and `stale-worktree-warn.sh`.
+
+**Why defer:**
+
+1. **No cached cwd state to update.** Both hooks re-derive the current branch on every call because they need the *current* state of the worktree at the time of the tool call or prompt. A CwdChanged hook that updates a cached value would add a race condition (hook fires → cached value written → guard reads stale cached value before the write).
+
+2. **stale-worktree-warn.sh fires on UserPromptSubmit.** This is the correct time — before the agent acts on a prompt about an issue. A CwdChanged hook would fire on directory changes that happen mid-turn (e.g., during a Bash `cd`), which is neither necessary nor useful for stale-worktree detection.
+
+3. **Payload is `old_cwd`/`new_cwd` only.** This tells us where we moved but not whether the new directory is a worktree, which branch it's on, or whether it matches the task issue. The hooks still need git calls — CwdChanged would add a trigger without reducing the work.
+
+**Re-check trigger:** Wire if we build an explicit cwd-state cache that hooks can reliably update and guards can safely read.
+
+---
+
+### WorktreeCreate — DEFER
+
+**What it could replace:** `repair-worktrees.sh` git polling and manual worktree bookkeeping.
+
+**Why defer:**
+
+1. **Wrong semantics for our use case.** `WorktreeCreate` is documented as an event where the hook *creates* the worktree and *returns the created path* — it is a creation-delegation hook, not a creation-observation hook. Our worktrees are created via `EnterWorktree` (the SDK tool) or by git directly; intercepting creation to return a path we didn't choose would conflict with that flow.
+
+2. **repair-worktrees.sh is a maintenance utility, not an automation.** It is run explicitly when worktree bookkeeping is suspected stale. An event-driven replacement would need to handle the full worktree lifecycle (create → track → remove), which is a substantially larger scope change.
+
+3. **CLAUDE.md already governs worktree creation.** The instructions there (EnterWorktree + branch naming + worktree removal after merge) are model-carried. A hook that intercepts creation would need to be harmonized with those instructions without making the two incoherent.
+
+**Re-check trigger:** Wire if we want to enforce branch-naming conventions or automatic session-state registration at worktree creation time.
+
+---
+
+### WorktreeRemove — DEFER
+
+**What it could replace:** Manual `git worktree remove` step after PR merge (CLAUDE.md §"Worktree cleanup").
+
+**Why defer:**
+
+1. **Observability-only event.** `WorktreeRemove` fires after a worktree is removed. It cannot prevent the removal or restore anything. The only action it could take is cleanup of state bookkeeping after the fact.
+
+2. **Low ROI.** Worktree cleanup is already well-handled: merge → `/wrap` Phase 5 → `git worktree remove`. The cleanup step is model-driven and not a reliability problem.
+
+3. **The hook would fire in the removed worktree's context.** By the time it fires, the worktree directory is gone. Any state cleanup (session-state entries, handoff files) would need to operate on paths that may no longer exist, requiring careful dead-path handling.
+
+**Re-check trigger:** Wire if worktree removal triggers a specific cleanup action that the current model-driven approach misses (e.g., automatic handoff file deletion at worktree removal time).
+
+---
+
+### InstructionsLoaded — DEFER
+
+**What it could replace:** The static `claudeMdExcludes` in `.claude/settings.json` that prevents double-loading of `CLAUDE.md` and `.claude/rules/*.md` when working inside this repo (`.claude/reference/double-loading-fix.md`).
+
+**Why defer:**
+
+1. **Double-loading is already solved statically.** The `claudeMdExcludes` approach prevents the loading entirely rather than detecting it after the fact. An `InstructionsLoaded` hook could detect double-loading and warn, but it cannot undo an already-loaded instruction set.
+
+2. **Telemetry-only value.** The main use case is observability: knowing which rule files actually loaded per project session. This is useful for data-driven corpus cuts but not a correctness concern — and the information could be obtained more directly from the existing session state.
+
+3. **P3 priority.** The repo-audit-2026-05.md (Section B, item #9) already classified this as "dev-only, P3." Nothing has changed to raise its priority.
+
+**Re-check trigger:** Wire if we build a per-project instruction-loading telemetry system, or if double-loading resumes as a correctness problem.
+
+---
+
+## What was built
+
+### post-compact-reconcile.sh (new)
+
+Registered on `PostCompact` with a 10 s timeout. Drains stdin, optionally reads `compact_summary` from the payload, and emits `hookSpecificOutput.additionalContext` directing the agent to run the Post-Compaction Recovery sequence in `monitor-mode.md`.
+
+The hook does not replace existing backstops (on-disk `session-state.json`, handoff files, `checkpoint-handoff.sh` on SubagentStop). It makes the model-judgment trigger in `monitor-mode.md` redundant for the case where compaction actually fired.
+
+**Tests:** `.claude/hooks/tests/post-compact-reconcile.test.sh`
+
+---
+
+## What NOT to change
+
+- `bgwork-ceiling-arm.sh` / `bgwork-ceiling-guard.sh` — the ceiling apparatus handles non-subagent background work that SubagentStart would miss. Do not refactor these in pursuit of SubagentStart parity without covering Monitor and backgrounded Bash.
+- `claudeMdExcludes` in `.claude/settings.json` — do not remove this static fix in anticipation of an InstructionsLoaded hook. The static fix is reliable and zero-cost; a hook-based detection is not an improvement.
+- `stale-worktree-warn.sh` — do not rewire this to CwdChanged. UserPromptSubmit is the correct firing time for stale-worktree detection.
+
+---
+
+## Re-check triggers
+
+| Event | Re-check when |
+|---|---|
+| `SubagentStop` (bookkeeping) | Parent annotates agents with stable id matching hook `agent_id`; `session-state.sh` gains conditional-update |
+| `SubagentStart` | `bgwork-ceiling-arm.sh` refactored to SubagentStart for Agent case; non-Agent bg work gets own event |
+| `PreCompact` | Specific pre-compaction action identified that PostCompact cannot cover |
+| `CwdChanged` | Explicit cwd-state cache built for guards to read |
+| `WorktreeCreate` | Branch-naming enforcement or auto session-state registration at creation time needed |
+| `WorktreeRemove` | Specific cleanup action identified that model-driven path misses |
+| `InstructionsLoaded` | Per-project instruction telemetry system built, or double-loading recurs as correctness problem |
+
+---
+
+## Related
+
+- Issue #813 — this evaluation
+- PR #811 — SessionStart migration (the predecessor that prompted this follow-up)
+- PR #941 — SubagentStop / checkpoint-handoff.sh (already wired before this evaluation)
+- PR #1028 — binary re-audit confirming 32-event catalog on 2.1.221
+- `.claude/reference/usage-limit-signal-audit-2026-07.md` — event catalog and binary audit methodology
+- `.claude/reference/double-loading-fix.md` — InstructionsLoaded static fix background
+- `.claude/reference/bgwork-ceiling.md` — SubagentStart/Stop ceiling rationale
+- `.claude/rules/monitor-mode.md` §"Post-Compaction Recovery" — the sequence PostCompact hook now triggers deterministically

--- a/global-settings.json
+++ b/global-settings.json
@@ -215,6 +215,17 @@
           }
         ]
       }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/claude-code-config/.claude/hooks/post-compact-reconcile.sh",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

- **Evaluation doc** (`.claude/reference/hook-events-evaluation-2026-08.md`): maps all 8 candidate newer hook events (WorktreeCreate/Remove, CwdChanged, SubagentStart/Stop, PreCompact/PostCompact, InstructionsLoaded) to their current indirect-detection mechanisms, with adopt/defer verdicts and re-check triggers grounded in the 2.1.221 binary event catalog.
- **PostCompact hook** (`.claude/hooks/post-compact-reconcile.sh`): replaces the model-judgment "notice an unfamiliar summary block" heuristic in `monitor-mode.md` with a deterministic reconciliation trigger. Fires after every compaction; emits `additionalContext` with the five-step Post-Compaction Recovery sequence.
- **Registration** in `global-settings.json`; `register-hooks.py` auto-installs on next session start.
- **Tests** (`.claude/hooks/tests/post-compact-reconcile.test.sh`): 8 assertions covering registration, timeout, `hookEventName`, `additionalContext` content, `compact_summary` surfacing, large-stdin drain.
- **Diagram updated**: `hook-lifecycle.md` STUB removed; SubagentStop, PostCompact, StopFailure added to sequence.

## Verdicts summary

| Event | Verdict |
|---|---|
| `PostCompact` | **Adopt** — this PR |
| `SubagentStop` | **Partially adopted** — `checkpoint-handoff.sh` already wired (PR #941); bookkeeping aspect deferred |
| `SubagentStart` | **Defer** — `bgwork-ceiling-arm.sh` covers this more broadly |
| `PreCompact` | **Defer** — no meaningful pre-compaction action; PostCompact + backstops cover the gap |
| `CwdChanged` | **Defer** — no cached state to update; per-call re-derivation is correct |
| `WorktreeCreate` | **Defer** — wrong semantics (creation-delegation, not observation) |
| `WorktreeRemove` | **Defer** — observability-only, low ROI |
| `InstructionsLoaded` | **Defer** — double-loading already solved statically |

## Notes on CR plan vs current main

The CR plan (fetched via `cr-plan.sh 813`) predates PR #1027, which retired `HOOKS_MANIFEST` and extended `register-hooks.py` with argv0 matching and decommissioned-hook pruning. Implementation uses the current `global-settings.json`-only approach — no `HOOKS_MANIFEST` entries, no `setup-skills-worktree.sh` edits.

`SubagentStop` was already wired (PR #941, `checkpoint-handoff.sh`) before this evaluation, so only `PostCompact` is newly wired here.

**Local review coverage:** none — CodeRabbit CLI not installed in this environment; CodeAnt returned 403 on both attempts (daily cap). Self-review performed; no issues found.

## Test plan

- [x] `post-compact-reconcile.sh` is registered under `PostCompact` in `global-settings.json` with timeout 10
- [x] Hook exits 0 on empty input and on payload with `compact_summary`
- [x] `hookEventName` in output is `"PostCompact"`
- [x] `additionalContext` contains the Post-Compaction Recovery steps
- [x] `compact_summary` from payload is surfaced in `additionalContext` when jq is available
- [x] Hook drains stdin without EPIPE on >64 KB input
- [x] `reference-catalog-lint.sh` passes (92 files indexed)
- [x] `session-start-sync.test.sh` still passes (no regression)
- [x] Rule corpus word count: 11,459 — under 11,749 cap and 12,000 soft warning
- [x] All 8 candidate events documented in evaluation doc with adopt/defer verdicts

Closes #813