### PR TITLE
docs(#1033): record subagent-phase-guardrails hotspot decision

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -103,6 +103,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `pmm-lifecycle-hotspot-decision.md` — diagnosis and KEEP + dedup decision for `pmm-lifecycle.md` churn (6 merged PRs, Issue #1017); verdict: KEEP the PMM state-machine reference; churn driven by legitimate scheduling-substrate evolution; canonical-source marker added to `SKILL.md` pause-marker write block; mirror note added in `pmm-lifecycle.md`
 - `token-efficiency-audit-hotspot-decision.md` — diagnosis and no-runtime-change decision for `token-efficiency-audit-2026-07.md` churn (5 merged PRs, Issue #1021); verdict: KEEP as intentional append-per-FU-resolution audit record; all 5 PRs were non-conflicting initial authoring, inline FU closure notes, or appended FU evaluation sections
 - `pm-worker-hotspot-decision.md` — diagnosis and KEEP + safety-block fix decision for `pm-worker.md` churn (5 merged PRs, Issue #1023); verdict: KEEP + add capability-ladder MINDSET bullet (#1023)
+- `subagent-phase-guardrails-hotspot-decision.md` — diagnosis and no-operative-change decision for `subagent-phase-guardrails.md` churn (5 merged PRs, Issue #1033); verdict: KEEP as canonical verbatim-block home; all churn is required propagation from canonical rule files, byte-guarded by `verbatim-block-lint.sh`
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `harness-model-audit-2026-06.md` — harness components vs current model fleet (#49)
 - `script-extraction-audit.md` — deterministic script extraction inventory (#271)

--- a/.claude/reference/subagent-phase-guardrails-hotspot-decision.md
+++ b/.claude/reference/subagent-phase-guardrails-hotspot-decision.md
@@ -1,0 +1,131 @@
+# Subagent Phase Guardrails Hotspot Decision
+
+Reference for Issue #1033 (`.claude/reference/subagent-phase-guardrails.md` churn hotspot). Not auto-loaded.
+
+## Executive summary
+
+### Verdict: **KEEP** the file as the canonical verbatim-block home; make **no operative content change**
+
+`.claude/reference/subagent-phase-guardrails.md` is the single byte-verified home for the
+SAFETY, MINDSET, and SKILLS verbatim blocks inserted into Phase A/B/C subagent spawn prompts.
+Its churn across 5 PRs is structurally required: every edit originated in the canonical rule
+files (`.claude/rules/safety.md`, `.claude/rules/skill-first.md`) and propagated here to keep the
+byte-guarded copies current. A structural split or pointer replacement would not remove the churn
+source — it would scatter what the CI lint currently holds in one verified location.
+
+This decision is intentionally reference-only. The subject file, the canonical rule files,
+`verbatim-block-lint.sh`, and the auto-loaded rule corpus remain byte-for-byte unchanged.
+
+## 1. Trigger and current evidence
+
+Issue #1033 was filed by `/wrap` churn detection after PR #1032 merged. It recorded 5 distinct
+merged PRs touching the file since 2026-07-30: PRs #787, #839, #858, #870, #920.
+
+Measured at `main` after PR #1032, the file is 60 lines and ~480 words — single-topic, well
+below the 2,000-word per-file warning.
+
+| Churn class | PRs | What changed |
+|-------------|-----|--------------|
+| File creation — extraction from `subagent/SKILL.md` | PR #839 | New canonical home created; SAFETY/MINDSET/SKILLS blocks moved from duplicated inline positions in Phase A/B/C templates |
+| Capability-ladder evolution (MINDSET) | PRs #858, #870 | Browser added as rung 4 (#858); gated on rungs 1–3 actually failing (#870) |
+| Untracked-rm permission propagation (SAFETY) | PRs #787, #920 | Non-recursive `rm` permitted on verified-untracked root-repo paths (#787); untracked selector pinned to root-repo scope (#920) |
+
+Git history confirms the shallow checkout covers these 5 commits, consistent with the issue report.
+
+The file has two functional consumers: Phase A and Phase B spawn-prompt templates in
+`.claude/skills/subagent/SKILL.md` (which read the full file verbatim via an inline instruction),
+and Phase C's SAFETY-only injection from the same skill. A reference note in
+`.claude/reference/browser-capability-rung.md` also cites the MINDSET block propagation path.
+One CI guard, `.github/scripts/verbatim-block-lint.sh`, byte-compares all three blocks against
+their canonical rule-file sources on every PR. Because the lint enforces byte identity, every
+change to a canonical block must propagate here or CI fails.
+
+## 2. Options considered
+
+### Option 1: Split into separate SAFETY, MINDSET, and SKILLS files
+
+**Rejected.** The three blocks are injected together in Phase A and Phase B spawn prompts —
+splitting them into separate files would require the injection instruction to name three targets
+instead of one. Phase C uses SAFETY alone, which already works with the single-file layout via a
+specific per-block instruction. A split would add coordination surface without removing a single
+upstream edit obligation.
+
+### Option 2: Replace verbatim copies with pointers to the canonical rule files
+
+**Rejected.** Subagents do not auto-load `.claude/rules/` files at spawn time. The spawn-prompt
+blocks must be present verbatim at the time the agent is launched. A pointer instruction such as
+"read safety.md" requires a file read during prompt construction — the `/subagent` skill already
+does exactly this, reading `subagent-phase-guardrails.md` and injecting its full text. Moving back
+to per-rule-file reads would undo the consolidation and the CI guard that PR #839 introduced.
+
+### Option 3: Merge into `phase-decomposition.md` or `subagent-orchestration.md`
+
+**Rejected.** The verbatim blocks would still need byte-compare linting against their canonical
+sources, but those host files carry a wide range of other content. `verbatim-block-lint.sh` locates
+blocks by marker lines; merging would require the lint to search across a larger file with unrelated
+content and would couple the block integrity check to a broader edit surface.
+
+### Option 4: KEEP + record the decision (this option)
+
+**Chosen.** The file is the correct and intentional single home for the verbatim spawn-prompt
+blocks. Its churn is required propagation from canonical rule files — not an accumulation of
+independent concerns. No structural change is warranted.
+
+## 3. Canonical ownership boundaries
+
+| Content | Runtime owner | Canonical source |
+|---------|---------------|-----------------|
+| SAFETY block text | `.claude/reference/subagent-phase-guardrails.md` (verbatim copy) | `.claude/rules/safety.md` |
+| MINDSET block text | `.claude/reference/subagent-phase-guardrails.md` (verbatim copy) | `.claude/rules/safety.md` |
+| SKILLS block text | `.claude/reference/subagent-phase-guardrails.md` (verbatim copy) | `.claude/rules/skill-first.md` |
+| Byte-identity enforcement | `.github/scripts/verbatim-block-lint.sh` | CI check on every PR |
+| Spawn-prompt injection instruction | `.claude/skills/subagent/SKILL.md` Phase A/B (full) and Phase C (SAFETY only) | `subagent-orchestration.md` owns the spawn requirements |
+
+## 4. Preserved invariants
+
+- The three verbatim blocks in this file remain byte-identical to their respective canonical rule
+  files on every commit; `verbatim-block-lint.sh` CI-enforces this requirement.
+- Phase A and Phase B spawn prompts continue to receive all three blocks (SAFETY, MINDSET, SKILLS)
+  via the full-file verbatim injection instruction in `subagent/SKILL.md`.
+- Phase C (`phase-c-merger`) continues to receive only the SAFETY block — no MINDSET, no SKILLS —
+  per the constraint in `subagent-orchestration.md`.
+- The injection instruction in `subagent/SKILL.md` remains the single caller; no additional
+  consumers are introduced.
+- `verbatim-block-lint.sh`'s `VERBATIM_COPIES` array continues to list this file as a declared
+  copy surface for all three blocks.
+
+## 5. Remediation and verification
+
+The remediation adds only this decision record and its catalog entry in
+`.claude/reference/README.md`. Verification must confirm:
+
+- no diff in `subagent-phase-guardrails.md`, the canonical rule files (`.claude/rules/safety.md`,
+  `.claude/rules/skill-first.md`), or any auto-loaded rule corpus file;
+- exactly one catalog entry for this file in `README.md`;
+- `reference-catalog-lint.sh` exits clean;
+- `verbatim-block-lint.sh` exits clean (the blocks remain byte-identical); and
+- the full Bash and Python test suites remain green.
+
+## 6. Future edits and reconsideration
+
+Edit `subagent-phase-guardrails.md` only when one of its canonical rule files changes — the
+change must propagate here to keep the CI lint green. No other edit is warranted; all policy
+intent lives upstream.
+
+Reconsider the file's role if the harness gains native verbatim-block injection that does not
+require a separate reference file, or if `verbatim-block-lint.sh` is extended to support inline
+rule-file sources instead of declared copy surfaces. In either case, the change should simplify
+the injection path, not add a new one.
+
+## 7. Related precedent
+
+- `.claude/reference/phase-a-fixer-hotspot-decision.md` — KEEP when churn is required propagation
+  of safety/capability policy into a self-contained agent contract (Issue #975).
+- `.claude/reference/agents-readme-hotspot-decision.md` — KEEP when churn is coordinated policy
+  propagation into the authoritative documentation surface; PR #1016 context included (Issue #973).
+- `.claude/reference/pm-worker-hotspot-decision.md` — KEEP when dominant driver is safety-block
+  propagation, not accumulation of independent concerns (Issue #1023).
+- `.claude/reference/phase-b-reviewer-hotspot-decision.md` — KEEP when churn follows the
+  embedded safety posture rather than independent runtime concerns (Issue #942).
+- `.claude/reference/churn-hotspots.md` — hotspot reports are observational and require
+  adjudication before any operative change is made.

--- a/.claude/reference/subagent-phase-guardrails-hotspot-decision.md
+++ b/.claude/reference/subagent-phase-guardrails-hotspot-decision.md
@@ -7,7 +7,7 @@ Reference for Issue #1033 (`.claude/reference/subagent-phase-guardrails.md` chur
 ### Verdict: **KEEP** the file as the canonical verbatim-block home; make **no operative content change**
 
 `.claude/reference/subagent-phase-guardrails.md` is the single byte-verified home for the
-SAFETY, MINDSET, and SKILLS verbatim blocks inserted into Phase A/B/C subagent spawn prompts.
+SAFETY, MINDSET, and SKILLS verbatim blocks inserted into Phase A/B prompts; Phase C receives SAFETY only.
 Its churn across 5 PRs is structurally required: every edit originated in the canonical rule
 files (`.claude/rules/safety.md`, `.claude/rules/skill-first.md`) and propagated here to keep the
 byte-guarded copies current. A structural split or pointer replacement would not remove the churn


### PR DESCRIPTION
## Summary

Closes #1033

Adjudicates the 5-PR churn hotspot on `.claude/reference/subagent-phase-guardrails.md` (PRs #787, #839, #858, #870, #920). **Verdict: KEEP** with no operative content change.

- **Churn cause**: all 5 PRs are required propagation from canonical rule files (`.claude/rules/safety.md`, `.claude/rules/skill-first.md`) into the byte-guarded verbatim-block copy surface — not independent concerns that a split would decouple
- **PR #839** created the file by extracting SAFETY/MINDSET/SKILLS blocks from `subagent/SKILL.md` to a single linted home
- **PRs #858, #870** propagated capability-ladder MINDSET updates (browser rung addition and gating)
- **PRs #787, #920** propagated untracked-rm permission updates to the SAFETY block
- Pointer extraction rejected: subagents cannot auto-load rule files at spawn time; the verbatim blocks must be present in the spawned prompt
- Split rejected: blocks are injected as a unit for Phase A/B; Phase C's SAFETY-only injection already works with the single-file layout

**Deliverables:**
- `.claude/reference/subagent-phase-guardrails-hotspot-decision.md` — full 7-section diagnosis and KEEP decision record
- `.claude/reference/README.md` — one catalog entry added after `pm-worker-hotspot-decision.md`

**Local review coverage:** none — CodeRabbit and CodeAnt CLIs not available (rate-limited/daily cap); one careful self-review applied per policy.

## Test plan

- [x] `subagent-phase-guardrails.md` is unchanged — no operative content change
- [x] `.claude/rules/safety.md` and `.claude/rules/skill-first.md` are unchanged
- [x] `verbatim-block-lint.sh` exits clean (6 copy surfaces verified byte-identical)
- [x] `reference-catalog-lint.sh` exits clean (98 files indexed)
- [x] `rule-lint.sh` exits clean
- [x] Python test suite passes (142 tests, 0 failures)
- [x] Exactly one catalog entry for `subagent-phase-guardrails-hotspot-decision.md` in `README.md`
- [x] No other files modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a decision record documenting the canonical location and handling guidelines for subagent phase guardrails.
  * Updated the reference index to include the new audit and research document.
  * Recorded verification requirements, ownership boundaries, preserved invariants, and criteria for future reconsideration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->