### PR TITLE
docs(#1011): record chip-model-guard-decision.md hotspot adjudication

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -105,6 +105,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `pm-worker-hotspot-decision.md` — diagnosis and KEEP + safety-block fix decision for `pm-worker.md` churn (5 merged PRs, Issue #1023); verdict: KEEP + add capability-ladder MINDSET bullet (#1023)
 - `subagent-phase-guardrails-hotspot-decision.md` — diagnosis and no-operative-change decision for `subagent-phase-guardrails.md` churn (5 merged PRs, Issue #1033); verdict: KEEP as canonical verbatim-block home; all churn is required propagation from canonical rule files, byte-guarded by `verbatim-block-lint.sh`
 - `bugbot-rule-hotspot-decision.md` — diagnosis and no-operative-change decision for `bugbot.md` churn (5 merged PRs, Issue #1036); verdict: KEEP single canonical BugBot rule file; churn is mixed-cause (two corpus-compression sweeps, two by-design policy adds, one already-completed dedup); only identified duplication removed by PR #1013
+- `chip-model-guard-doc-hotspot-decision.md` — diagnosis and no-operative-change decision for `chip-model-guard-decision.md` churn (6 merged PRs, Issue #1011); verdict: KEEP as living decision record for the chip model-guard contract; churn is by-design amendment-record growth tracking guard evolution across PRs #736, #775, #799, #842, #857, #1008
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `harness-model-audit-2026-06.md` — harness components vs current model fleet (#49)
 - `script-extraction-audit.md` — deterministic script extraction inventory (#271)

--- a/.claude/reference/chip-model-guard-doc-hotspot-decision.md
+++ b/.claude/reference/chip-model-guard-doc-hotspot-decision.md
@@ -1,0 +1,76 @@
+<!-- churn-hotspot: .claude/reference/chip-model-guard-decision.md -->
+# Hotspot Decision — chip-model-guard-decision.md
+
+**Verdict:** KEEP (no operative change)
+**Decided:** 2026-08-06
+**Issue:** #1011
+**Reporter:** `/wrap` post-merge churn report (PR #1008)
+
+## Churn summary
+
+`churn-hotspots.sh` flagged `.claude/reference/chip-model-guard-decision.md` as touched by 6
+distinct merged PRs since 2026-07-23: PRs #736, #775, #799, #842, #857, #1008.
+
+| PR | Churn class | What changed |
+|----|-------------|--------------|
+| PR #736 | Amendment — guard enforcement | Recorded that the guard now covers all five canonical emitters (Issue #731) |
+| PR #775 | Amendment — sixth emitter + resolver class | Recorded the `/harness-audit` Amendment (#770): resolver class, `model-fleet.sh`, literal vs resolved distinction |
+| PR #799 | Amendment — versionless names + effort line | Recorded Amendment (#791): bare family name as the written form; effort line travels with the guard but is not itself guarded |
+| PR #842 | Amendment — family-level comparison | Recorded Amendment (#837): comparison axis is the family, not the full version string; scope limit and retired-family gap documented |
+| PR #857 | Amendment — stale-chip sweep outcome | Recorded #838 sweep result: 28 pre-#837 chips enumerated, all closed, none re-emittable; added issue-closed stale-chip trigger |
+| PR #1008 | Cross-reference accretion | Added upstream requirement note for the cross-session `dismiss_task` gap (#859); pointer to `chip-launching.md` §Upstream requirement |
+
+## Diagnosis
+
+The churn is uniform single-cause with no recorded merge conflicts across all 6 PRs.
+
+**Every touch is an amendment to the guard or a cross-reference to an amendment outcome.**
+`chip-model-guard-decision.md` is a living decision record: it tracks the full history of choices
+made about how the chip model guard behaves. The amendment pattern is structural — each change to
+the guard mechanism (enforced via `chip-model-guard-lint.sh`) generates a corresponding
+"Amendment (#N)" section in the decision record. The file's churn IS its design: an amendment log
+for an actively evolving contract.
+
+**The ownership boundary is already clear.** `chip-launching.md` is the sole owner of the
+mechanism — the guard preamble verbatim text, the six-emitter list with literal vs resolved
+classes, the model and effort line format. `chip-model-guard-decision.md` is the sole owner of the
+rationale — why the guard rides in both prompt and fallback, what was rejected, and the amendment
+history. The README already names both files in their respective sections without overlap.
+
+**No split is warranted.** The file has one clear responsibility: record the decisions and
+rationale for the chip model-guard contract. Its amendment sections map one-to-one to the Issues
+that changed the guard. No amendment section has grown beyond documenting a single decision
+context. The 6 touches are 5 by-design amendment records and 1 cross-reference addition — none of
+these motivate a split or restructuring.
+
+**A decision-record-about-a-decision-record adjudication is a lighter lift.** This file exists to
+document `chip-launching.md`'s guard. Its continued growth mirrors `chip-launching.md`'s continued
+evolution. When the guard is stable, this file will stabilize too. Re-filing is appropriate only
+when `conflict_rounds > 0`.
+
+## Decision
+
+**KEEP** `.claude/reference/chip-model-guard-decision.md` as the single living decision record for
+the chip model-guard contract. Make no operative change.
+
+The ownership boundary between this file (rationale) and `chip-launching.md` (mechanism) is
+already enforced — `chip-model-guard-lint.sh` checks `chip-launching.md`'s operative corpus, and
+this decision record is a non-auto-loaded reference that does not affect the rule corpus budget.
+The 6 reported touches are intentional amendment-record growth, not structural churn.
+
+Per `.claude/reference/churn-hotspots.md`, re-file this hotspot only when
+`conflict_rounds > 0` — rising PR count alone on a living decision record is not a re-filing
+trigger.
+
+## Expected impact
+
+None. No rule corpus files were changed. The corpus word count remains unchanged at the
+pre-adjudication baseline.
+
+## Related
+
+- Issue #1042 — `chip-model-guard-lint.sh` hotspot; separate queued issue (script, not doc)
+- `chip-model-guard-decision.md` — the adjudicated file; its `## References` section names all six amendment Issues
+- `chip-launching.md` — mechanism owner; `chip-model-guard-decision.md` rationale pointer in §Model-guard placement
+- `.github/scripts/chip-model-guard-lint.sh` — lint that enforces `chip-launching.md`'s guard across all canonical emitters
+- `.claude/reference/churn-hotspots.md` — hotspot mechanism, calibration, and re-open trigger logic


### PR DESCRIPTION
## Summary

Adjudicates the 6-PR churn hotspot on `.claude/reference/chip-model-guard-decision.md`
(Issue #1011, filed by `/wrap` after PR #1008 merged).

**Verdict: KEEP (no operative change)**

The file is a living decision record whose churn is by-design amendment-record growth — each of
the 6 reported PRs (#736, #775, #799, #842, #857, #1008) added an Amendment section or
cross-reference as the chip model guard evolved through Issues #731, #770, #791, #837, #838, #859.
No merge conflicts recorded. The ownership boundary between this file (rationale) and
`chip-launching.md` (mechanism) is already clear and enforced by `chip-model-guard-lint.sh`.

**Changes:**
- New: `.claude/reference/chip-model-guard-doc-hotspot-decision.md` — KEEP adjudication record
- Updated: `.claude/reference/README.md` — index entry added

**Local review coverage:** cr-only — CodeRabbit verified clean (0 findings); CodeAnt 403 daily
cap, dropped after two attempts.

Closes #1011

## Test plan

- [x] `chip-model-guard-doc-hotspot-decision.md` follows the `<stem>-hotspot-decision.md` naming convention used by all sibling adjudications
- [x] `reference-catalog-lint.sh` passes (100 files indexed, no errors)
- [x] No operative changes to rule corpus — corpus word count unchanged
- [x] README index entry added after `bugbot-rule-hotspot-decision.md`, consistent with chronological ordering of recent adjudications
- [x] Verdict (KEEP) consistent with issue context: living decision record, churn is amendment-record growth by design

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an audit and research tracker entry for the chip model guard documentation review.
  * Recorded the review findings, including prior updates, ownership boundaries, and the decision to retain the existing documentation structure.
  * No operational or user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->