### PR TITLE
docs(#994): adjudicate admin-merge.sh hotspot

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -14,6 +14,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 ### Runbooks and long command forms
 
 - `admin-merge-auto-plain.md` — mechanism and contracts for the one `admin-merge.sh --auto-plain` shape Claude may execute itself; plain vs protection-modifying shape distinction (#754)
+- `admin-merge-hotspot-decision.md` — KEEP adjudication for the `admin-merge.sh` churn hotspot; per-section attribution for 7 PRs, dedup search result (no restatements found), and verdict rationale (#994)
 - `cli-tool-defaults.md` — installed service CLIs (vercel, neonctl, railway, cloudinary) and common commands; CLI-first over web dashboards
 - `churn-hotspots.md` — mechanism, calibration, and threshold rationale for `churn-hotspots.sh`; exclusion list for by-design catalog files (#755)
 - `cr-polling-commands.md` — full multi-line `gh api` commands for CR review polling and CI verification

--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -14,7 +14,6 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 ### Runbooks and long command forms
 
 - `admin-merge-auto-plain.md` — mechanism and contracts for the one `admin-merge.sh --auto-plain` shape Claude may execute itself; plain vs protection-modifying shape distinction (#754)
-- `admin-merge-hotspot-decision.md` — KEEP adjudication for the `admin-merge.sh` churn hotspot; per-section attribution for 7 PRs, dedup search result (no restatements found), and verdict rationale (#994)
 - `cli-tool-defaults.md` — installed service CLIs (vercel, neonctl, railway, cloudinary) and common commands; CLI-first over web dashboards
 - `churn-hotspots.md` — mechanism, calibration, and threshold rationale for `churn-hotspots.sh`; exclusion list for by-design catalog files (#755)
 - `cr-polling-commands.md` — full multi-line `gh api` commands for CR review polling and CI verification
@@ -119,6 +118,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `root-readme-hotspot-decision.md` — diagnosis and dedup decision for `README.md` churn (9 merged PRs in the Issue #988 hotspot window); verdict: KEEP single file + point Rule Files / Hook Scripts / Scripts Library catalog content to canonical owners; Slash Commands table (enforced by `skill-catalog-lint.sh`) unchanged
 - `pm-monitoring-decision-hotspot-decision.md` — diagnosis and KEEP decision for `pm-monitoring-decision.md` churn (7 merged PRs, Issue #990); verdict: KEEP single-topic hub; churn is scheduling-substrate corrections (CronCreate durability, Monitor migration, repo-scoping precision) + one confirmed dedup already applied by PR #985; no new duplication found
 - `cr-local-review-hotspot-decision.md` — diagnosis and no-operative-change decision for `cr-local-review.md` rule churn (7 merged PRs in the Issue #992 hotspot window); verdict: KEEP single cohesive local-review-loop policy file; all churn is legitimate (false-clean policy tightening, corpus compression, new coverage-visibility mandate, CLI abstraction refactor); no concrete duplication confirmed
+- `admin-merge-hotspot-decision.md` — KEEP adjudication for the `admin-merge.sh` churn hotspot; per-section attribution for 7 PRs, dedup search result (no restatements found), and verdict rationale (#994)
 - `repo-audit-2026-05.md` — bundled org + efficiency + best-practices audit (#413–#415)
 - `harness-model-audit-2026-06.md` — harness components vs current model fleet (#49)
 - `script-extraction-audit.md` — deterministic script extraction inventory (#271)

--- a/.claude/reference/admin-merge-hotspot-decision.md
+++ b/.claude/reference/admin-merge-hotspot-decision.md
@@ -1,0 +1,233 @@
+# `admin-merge.sh` hotspot — diagnosis and KEEP decision
+
+Reference for Issue #994 (`.claude/scripts/admin-merge.sh` churn hotspot). Not auto-loaded.
+
+## The problem being read
+
+`.claude/scripts/admin-merge.sh` was touched by 7 distinct merged PRs since
+2026-07-21: #616, #658, #726, #739, #761, #878, and #968.
+
+The script is the single entry point for the branch-protection bypass workflow:
+it verifies merge-readiness, confirms solo ownership, diagnoses the bypass shape
+(toggle vs plain), and either prints or executes the appropriate merge command.
+Every new bypass capability in the 2026-07 window required a corresponding change
+here because the script owns the boundary between "Claude may act" and "human must
+act." The churn signal reflects a series of feature and correctness additions to
+that boundary, not maintainability problems.
+
+## Functional sections
+
+The 877-line script divides into seven functional sections:
+
+| Section | Lines (approx) | Purpose |
+|---------|----------------|---------|
+| A — Header / docs | 1–101 | Modes, options, exit codes |
+| B — Bootstrap / arg parsing | 102–230 | `set_mode`, arg parsing, PR state check |
+| C — Authorship guard | 231–256 | `pr-authorship.sh` delegation (issue #733) |
+| D — Merge-gate pre-flight | 290–420 | `merge-gate.sh` check, clean-BEHIND allowance, hard-blocker filter |
+| E — Solo-owner heuristic | 420–480 | CODEOWNERS parsing, admin count check |
+| F — Shape detection | 480–570 | `enforce_admins`, `STRICT`, `BYPASS_MODE`, bypass command builder |
+| G — Mode implementations | 563–877 | `print`, `launch-terminal`, `auto-plain`, `execute` |
+
+## Churn attribution — per-section evidence
+
+### PR #616 — Sections B, G
+
+Removed the `.merged` field from `gh pr view` JSON and replaced `'.merged //
+false'` with `'(.state == "MERGED")'` throughout. Added a 3-attempt
+read-after-write retry loop in the `--execute` mode's post-verify block, with a
+2-second sleep between attempts and an explicit exit 7 when all attempts exhaust.
+
+**Driver:** API reliability. The `.merged` boolean was less reliable than
+inferring state from `.state`; the read-after-write retry handles eventual
+consistency on repos with queued/deferred merges — `gh pr merge --admin` can
+return before GitHub's state API reflects the merge. This was a correctness fix
+independent of any other change.
+
+### PR #658 — Sections D, G
+
+Added `CLEAN_BEHIND_OK`, `BEHIND_PRESENT`, `CBC` (clean-behind-check.sh path
+discovery), and `CBC_ARGS` variables. Updated the hard-blocker filter to allow a
+clean `BEHIND` past the guard. Added `clean-behind-check.sh` invocation (exit 0
+= safe). Added re-validation of the clean-BEHIND state in `--execute` mode before
+touching branch protection. Updated the bypass-mode detection to set
+`BYPASS_MODE=plain` when `enforce_admins==false && strict==true &&
+CLEAN_BEHIND_OK==true`.
+
+**Driver:** Issue #631 — the "clean BEHIND, safe to bypass" allowance. A PR
+BEHIND base with no file overlap between main's new commits and the PR's changed
+files does not need a rebase; an admin merge is safe. This required programmatic
+detection of the "safe" subset of BEHIND states so the guard could distinguish
+mechanical staleness from content conflict.
+
+### PR #726 — Sections A, F, G
+
+Added `BYPASS_MODE` variable (toggle vs plain), `STRICT` reading from the
+branch-protection API, conditional bypass-command builder (plain omits protection
+toggle calls), conditional `print_warning_block()` output (plain vs toggle), and
+a new execute-mode branch for the plain shape that runs `gh pr merge --squash
+--admin` without touching protection settings. Updated exit code 6 documentation
+to name the new condition (`enforce_admins==false` and the strict+clean-BEHIND
+plain bypass does not apply).
+
+**Driver:** Issue #720 — when `enforce_admins` is already off but
+`required_status_checks.strict` blocks a clean-BEHIND branch, a bare `--admin`
+merge bypasses the staleness constraint without modifying any protection
+setting. The distinction between "toggle shape" and "plain shape" was needed to
+give Claude a structurally safe auto-execute path (plain) while keeping the
+protection-modifying toggle print-only.
+
+### PR #739 — Sections A, B, C
+
+Added `--allow-nonauthor` flag and `ALLOW_NONAUTHOR=false` variable to arg
+parsing. Added the authorship guard block (Section C): discovers `pr-authorship.sh`
+from three candidate paths, runs it, and refuses exit 1 on any non-zero result
+(fail-closed). Updated the header docs for `--allow-nonauthor` and updated exit
+codes 0/1 in the header to include the authorship guard refusal.
+
+**Driver:** Issue #733 — authorship guard. A bypass merge is the most
+consequential PR write; restricting it to the authenticated user's own PRs
+prevents accidental writes to collaborators' PRs. `pr-authorship.sh` is the
+single source of truth; `admin-merge.sh` delegates to it rather than duplicating
+the detection logic.
+
+### PR #761 — Sections A, B, G
+
+Added `--auto-plain` mode and `--ac-verified` option to arg parsing and to the
+header. Added `AC_VERIFIED=false` variable. Added the full `--auto-plain`
+implementation in Section G: hard shape gate (exit 8 on non-plain `BYPASS_MODE`),
+AC gate (exit 8 without `--ac-verified`), repeat guard (read/write marker in
+`~/.claude/admin-merge-auto/`), mandatory TOCTOU re-validation of
+`clean-behind-check.sh`, `gh pr merge --squash --admin` execution, 3-attempt
+read-after-write retry, and an evidence report on stdout. Updated exit code
+documentation (added exit 8).
+
+**Driver:** Issue #754 — the plain shape is structurally safe for Claude to
+auto-execute: it contains no protection-modifying call, and a non-plain
+`BYPASS_MODE` refuses before any write. `--execute` was originally the only
+entry point for execution, but it is user-only *because* it can also run the
+toggle dance. A separate `--auto-plain` mode that is structurally incapable of
+the toggle dance was required so the boundary is enforced by structure, not
+prose.
+
+### PR #878 — Section G
+
+Added `release_issue_claim()` helper function (best-effort, never changes exit
+status). Called it in three places: after the `FINAL_MERGED == true` check in
+`--auto-plain`, after the same check in `--execute`'s plain-shape branch, and
+after the same check in `--execute`'s toggle-shape branch.
+
+**Driver:** Issue #873 — issue claim release on merge. When a PR merges, the
+issue it closes should become startable again immediately. The function looks up
+the linked issue via `pr-issue-ref.sh` and calls `issue-claim.sh --release`;
+failures are warnings only, since the merge has already completed.
+
+### PR #968 — Sections D, G
+
+Added `REVIEW_DECISION_BLOCKER_RE` regex constant (the full branch-protection
+`reviewDecision` failure message pattern). Added `clean_behind_evidence_allows_admin()`
+function that accepts the helper's JSON and exit code, allowing exit 0 directly
+and additionally accepting exit 1 when JSON evidence shows the only residual
+blockers are reviewDecision notes `admin-merge.sh` is independently allowed to
+bypass. Added `CBC_JSON` and `CBC_RC` state variables to capture the helper's
+output for re-use. Added `NON_BEHIND_HARD_BLOCKERS` filter. Updated the
+`HARD_BLOCKERS` jq filter to use the regex rather than a substring match.
+Improved error messaging to distinguish "BEHIND but unsafe" from "other
+blockers."
+
+**Driver:** Issue #947 — gate-filter asymmetry. `clean-behind-check.sh` runs
+its own internal `merge-gate.sh` call, which can exit 1 solely because the
+branch-protection `reviewDecision` note is present — the same note
+`admin-merge.sh` is already allowed to step over. Before this PR, exit 1 from
+the helper was treated uniformly as "unsafe," making `--auto-plain` unreachable
+on exactly the PRs where it was most needed. The structured JSON evidence path
+lets `admin-merge.sh` distinguish the known asymmetry (safe to proceed) from
+genuine mechanical unsafety (rebase required).
+
+## Churn classification
+
+| Section | PRs | Driver category |
+|---------|-----|-----------------|
+| A: Header / docs | #726, #739, #761 | New mode and option documentation |
+| B: Arg parsing | #616, #739, #761 | New flag + mode wiring |
+| C: Authorship guard | #739 | New enforcement surface (issue #733) |
+| D: Merge-gate pre-flight | #658, #968 | New bypass allowance + asymmetry fix |
+| E: Solo-owner heuristic | — | Unchanged across all 7 PRs |
+| F: Shape detection | #726 | New bypass shape (plain) |
+| G: Mode implementations | #616, #658, #726, #761, #878, #968 | New shapes, correctness fixes, post-merge cleanup |
+
+**Churn driver summary:** All 7 PRs were additive expansions or correctness fixes
+for the script's role as the Claude ↔ human boundary for bypass merges. Four PRs
+added new capabilities to that boundary (#658 clean-BEHIND allowance, #726 plain
+shape, #739 authorship guard, #761 auto-plain mode). Two were correctness fixes
+for edge cases discovered after initial implementation (#616 API reliability and
+read-after-write, #968 gate-filter asymmetry). One was cross-cutting cleanup
+added alongside a sibling feature (#878 issue claim release). None arose from
+code-maintainability problems.
+
+## Dedup search — restatements in `.claude/reference/` and `.claude/rules/`
+
+Searched for downstream restatements of:
+- Exit-code table (codes 0–8)
+- Shape table (toggle vs plain)
+- Solo-owner heuristic (CODEOWNERS parsing, admin count logic)
+
+**Candidates examined:**
+
+- **`admin-merge-auto-plain.md`** — the existing reference file for `--auto-plain`.
+  Contains a focused exit-code table for the auto-plain caller contract, not a
+  restatement of the full 9-exit-code header table. It is the _intended pointer
+  target_ already registered in the catalog; it predates and motivates its own
+  entries rather than restating the script. **Not a restatement.**
+
+- **`cr-merge-gate.md` Step 1d** — invokes
+  `admin-merge.sh <N> --auto-plain --ac-verified` as an operative instruction.
+  This is policy the rule corpus owns, not a description of what the script does.
+  **Not a restatement — operative instruction must stay in the corpus.**
+
+- **`safety.md` §Authorship** — lists `admin-merge.sh` as one of three scripts
+  enforcing the authorship guard. Descriptive pointer to the enforcement surface;
+  does not restate exit codes, shapes, or heuristic logic.
+  **Not a restatement.**
+
+- **`authorship-guard.md`** — references `admin-merge.sh` as one of three
+  shared-script fail-safes. Does not restate the script's contract beyond a
+  single-line description. **Not a restatement.**
+
+**Conclusion: no downstream restatements found. No dedup edits warranted.**
+
+## Decision: KEEP — no extraction, no split, no dedup
+
+The churn is legitimate: every PR was reactive to a new feature requirement,
+a correctness gap, or an upstream behavior that the script's sole-boundary role
+demanded it handle. The script has no independent, separately-evolving concerns
+to split, no duplicated logic to extract (the solo-owner heuristic and the
+clean-BEHIND check both delegate to sibling scripts already), and no downstream
+restatements to replace with pointers.
+
+The `admin-merge-auto-plain.md` reference file serves its intended purpose as
+the detailed caller reference for `--auto-plain`, and `cr-merge-gate.md` Step 1d
+correctly remains as an operative instruction in the auto-loaded corpus.
+
+### What would change this verdict
+
+A future PR that adds a second script implementing the same solo-owner heuristic,
+or that restates the exit-code table in a rule file without pointing to the
+script, would reopen the dedup case. A split might become warranted if the
+`--execute` toggle path grew independent test coverage requirements that conflicted
+with the `--auto-plain` path's strict no-protection-modification guarantee —
+those share a single script today by design (the structural guarantee depends on
+`auto-plain` being a separate branch in the same file).
+
+## Related
+
+- Issue #631 — clean-behind-check.sh introduction; the BEHIND allowance
+- Issue #720 — plain vs toggle shape split
+- Issue #733 — authorship guard (`pr-authorship.sh`)
+- Issue #754 — `--auto-plain` mode; `.claude/reference/admin-merge-auto-plain.md`
+- Issue #873 — issue claim release on merge
+- Issue #947 — gate-filter asymmetry fix
+- `.claude/scripts/clean-behind-check.sh` — the mechanical BEHIND-safety evaluator
+- `.claude/scripts/pr-authorship.sh` — authorship gate delegated by this script
+- `.claude/reference/admin-merge-auto-plain.md` — auto-plain caller contract
+- `.claude/reference/authorship-guard.md` — authorship guard enforcement surface

--- a/.claude/reference/admin-merge-hotspot-decision.md
+++ b/.claude/reference/admin-merge-hotspot-decision.md
@@ -205,8 +205,9 @@ Searched for downstream restatements of:
 The churn is legitimate: every PR was reactive to a new feature requirement,
 a correctness gap, or an upstream behavior that the script's sole-boundary role
 demanded it handle. The script has no independent, separately-evolving concerns
-to split, no duplicated logic to extract (the solo-owner heuristic and the
-clean-BEHIND check both delegate to sibling scripts already), and no downstream
+to split, no duplicated logic to extract (the solo-owner heuristic is implemented
+inline in admin-merge.sh; the clean-BEHIND check delegates to `clean-behind-check.sh`),
+and no downstream
 restatements to replace with pointers.
 
 The `admin-merge-auto-plain.md` reference file serves its intended purpose as

--- a/.claude/reference/admin-merge-hotspot-decision.md
+++ b/.claude/reference/admin-merge-hotspot-decision.md
@@ -17,10 +17,9 @@ that boundary, not maintainability problems.
 
 ## Functional sections
 
-The 877-line script divides into seven functional sections:
-
-Ranges below are approximate hotspot anchors; the sections share boundary lines
-(helper functions and declarations between blocks) and may overlap slightly.
+The 877-line script is organized around seven approximate functional anchors;
+sections share boundary lines (helper functions, declarations between blocks)
+and some ranges overlap slightly.
 
 | Section | Lines (approx) | Purpose |
 |---------|----------------|---------|
@@ -69,9 +68,11 @@ Added `BYPASS_MODE` variable (toggle vs plain), `STRICT` reading from the
 branch-protection API, conditional bypass-command builder (plain omits protection
 toggle calls), conditional `print_warning_block()` output (plain vs toggle), and
 a new execute-mode branch for the plain shape that runs `gh pr merge --squash
---admin` without touching protection settings. Updated exit code 6 documentation
-to name the new condition (`enforce_admins==false` and the strict+clean-BEHIND
-plain bypass does not apply).
+--admin` without touching protection settings. Updated exit code 6 to fire
+precisely when `enforce_admins==false` AND NOT (`strict==true` AND
+`CLEAN_BEHIND_OK==true`) — i.e., `enforce_admins` is off but neither the plain
+bypass conditions (`strict` up-to-date + clean-BEHIND) nor the toggle conditions
+apply, so no bypass path can be identified.
 
 **Driver:** Issue #720 — when `enforce_admins` is already off but
 `required_status_checks.strict` blocks a clean-BEHIND branch, a bare `--admin`

--- a/.claude/reference/admin-merge-hotspot-decision.md
+++ b/.claude/reference/admin-merge-hotspot-decision.md
@@ -19,15 +19,18 @@ that boundary, not maintainability problems.
 
 The 877-line script divides into seven functional sections:
 
+Ranges below are approximate hotspot anchors; the sections share boundary lines
+(helper functions and declarations between blocks) and may overlap slightly.
+
 | Section | Lines (approx) | Purpose |
 |---------|----------------|---------|
 | A — Header / docs | 1–101 | Modes, options, exit codes |
-| B — Bootstrap / arg parsing | 102–230 | `set_mode`, arg parsing, PR state check |
+| B — Bootstrap / arg parsing | 102–256 | `set_mode`, arg parsing, PR state check, authorship guard |
 | C — Authorship guard | 231–256 | `pr-authorship.sh` delegation (issue #733) |
 | D — Merge-gate pre-flight | 290–420 | `merge-gate.sh` check, clean-BEHIND allowance, hard-blocker filter |
 | E — Solo-owner heuristic | 420–480 | CODEOWNERS parsing, admin count check |
-| F — Shape detection | 480–570 | `enforce_admins`, `STRICT`, `BYPASS_MODE`, bypass command builder |
-| G — Mode implementations | 563–877 | `print`, `launch-terminal`, `auto-plain`, `execute` |
+| F — Shape detection | 482–570 | `enforce_admins`, `STRICT`, `BYPASS_MODE`, bypass command builder |
+| G — Mode implementations | 564–877 | `print`, `launch-terminal`, `auto-plain`, `execute` |
 
 ## Churn attribution — per-section evidence
 
@@ -47,18 +50,18 @@ independent of any other change.
 ### PR #658 — Sections D, G
 
 Added `CLEAN_BEHIND_OK`, `BEHIND_PRESENT`, `CBC` (clean-behind-check.sh path
-discovery), and `CBC_ARGS` variables. Updated the hard-blocker filter to allow a
-clean `BEHIND` past the guard. Added `clean-behind-check.sh` invocation (exit 0
-= safe). Added re-validation of the clean-BEHIND state in `--execute` mode before
-touching branch protection. Updated the bypass-mode detection to set
-`BYPASS_MODE=plain` when `enforce_admins==false && strict==true &&
-CLEAN_BEHIND_OK==true`.
+discovery), and `CBC_ARGS` variables. Updated the hard-blocker filter to pass a
+clean `BEHIND` (using `--argjson cbo` and a BEHIND-aware jq filter). Added
+`clean-behind-check.sh` invocation (exit 0 = safe). Added re-validation of the
+clean-BEHIND state in `--execute` mode before touching branch protection.
 
 **Driver:** Issue #631 — the "clean BEHIND, safe to bypass" allowance. A PR
 BEHIND base with no file overlap between main's new commits and the PR's changed
 files does not need a rebase; an admin merge is safe. This required programmatic
 detection of the "safe" subset of BEHIND states so the guard could distinguish
-mechanical staleness from content conflict.
+mechanical staleness from content conflict. The `BYPASS_MODE` variable and the
+plain-shape execution branch were introduced in the subsequent PR #726; PR #658
+only established the `CLEAN_BEHIND_OK` verdict that #726 would act on.
 
 ### PR #726 — Sections A, F, G
 


### PR DESCRIPTION
## Summary

- Creates `.claude/reference/admin-merge-hotspot-decision.md` with per-section churn attribution for the 7 PRs that touched `admin-merge.sh` since 2026-07-21
- Adds the decision record to the `.claude/reference/README.md` catalog (in "Audits and research")
- Verdict: **KEEP — no extraction, split, or dedup warranted**

## Churn attribution (evidence summary)

| PR | Section(s) | Driver |
|----|-----------|--------|
| #616 | B, G | API reliability: `.merged` field → `(.state == "MERGED")`; read-after-write retry |
| #658 | D, G | Issue #631: clean-BEHIND allowance via `clean-behind-check.sh`; established `CLEAN_BEHIND_OK` |
| #726 | A, F, G | Issue #720: `BYPASS_MODE` + plain shape (no protection change) when `enforce_admins==false` + `strict==true` + `CLEAN_BEHIND_OK` |
| #739 | A, B, C | Issue #733: authorship guard (`pr-authorship.sh` delegation, fail-closed) |
| #761 | A, B, G | Issue #754: `--auto-plain` mode (structurally safe Claude-invocable path) |
| #878 | G | Issue #873: `release_issue_claim()` post-merge cleanup |
| #968 | D, G | Issue #947: gate-filter asymmetry fix (`clean_behind_evidence_allows_admin()`) |

All 7 PRs were additive expansions or correctness fixes reactive to upstream requirements. No maintainability-driven churn.

## Dedup verdict

Searched `.claude/reference/` and `.claude/rules/` for restatements of the exit-code table (0–8), shape table (toggle/plain), and solo-owner heuristic. **No restatements found.** `admin-merge-auto-plain.md` is the intended pointer target already in the catalog; `cr-merge-gate.md` Step 1d is an operative instruction that must stay in the corpus. No edits to downstream files.

## Test plan

- [x] Decision record `.claude/reference/admin-merge-hotspot-decision.md` created with per-section churn attribution (evidence-backed per PR, not a flat list) and per-section/driver table
- [x] `README.md` catalog entry added to "Audits and research" section; `reference-catalog-lint.sh` passes (113 files indexed)
- [x] `rule-lint.sh` passes (no rules corpus changes)
- [x] `verbatim-block-lint.sh` passes (6 copy surfaces)
- [x] `admin-merge.sh` is byte-identical (`git diff --stat` shows no change)
- [x] `admin-merge.test.sh` passes: 92 passed, 0 failed
- [x] No operative instructions moved out of the rules corpus (no rules files touched)
- [x] No inline semantic qualifiers dropped (no rules files touched)
- [x] Corpus word count unchanged (only `.claude/reference/` files added)
- [x] Local review coverage: **none** — CR rate-limited after 3 runs (OSS free-tier cap); CodeAnt reviewed 0 files (failed run). Both CLIs degraded; self-review applied. GitHub App reviewers are unaffected.

Closes #994


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference document catalog entry for the administrative merge review.
  * Documented the review of merge-script changes, including functional areas, change drivers, deduplication findings, and the decision to retain the current approach.
  * Recorded conditions that could prompt future reassessment, along with related work and reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->