### PR TITLE
docs(#863): codify blended provider-CLI secrets policy

### DIFF
--- a/.claude/reference/capability-discovery-examples.md
+++ b/.claude/reference/capability-discovery-examples.md
@@ -20,7 +20,7 @@ The ladder is not a GitHub rule. Every provider below is a one-liner, not a dash
 
 | "I can't…" | Actual command |
 |------------|----------------|
-| set a Railway env var (**the motivating case, issue #759**) | `railway variables --set "{KEY}={value}"` on the linked service |
+| set a Railway env var (**the motivating case, issue #759**) | `echo "$VALUE" \| railway variable set {KEY} --stdin` on the linked service |
 | read which Railway env vars already exist | `railway variables` |
 | redeploy or read logs on Railway | `railway redeploy` · `railway logs` |
 | add a Vercel env var | `vercel env add {NAME} {environment}` (value on stdin — never inline it) |
@@ -54,18 +54,18 @@ railway variables            # rung 1: which of the three are already set?
 
 NEW_KEY=$(openssl rand -base64 32)                   # generated, never printed
 [ -n "$NEW_KEY" ] || { echo "key generation failed" >&2; exit 1; }
-railway variables --set "S2S_SIGNING_KEY=$NEW_KEY"   # provisioned, value stays out of output
+echo "$NEW_KEY" | railway variable set S2S_SIGNING_KEY --stdin  # provisioned via stdin, value stays out of output
 ```
 
 That is one of the three. Repeat it for the second key, and set the third — `S2S_ISSUER`, not a secret — directly. Validating before provisioning matters: an unchecked `openssl` failure would quietly install an empty signing key, which is worse than the unset variable you started with.
 
 **Secrets are not pre-refused.** The deferred work was generating and provisioning signing keys, and `safety.md`'s credential prohibitions read at a glance like "don't touch keys at all." They are narrower than that: generating a key and setting it through a provider CLI is the allowed path. What's prohibited is letting the *value* land anywhere durable — a commit, an issue or PR body, a subagent prompt, a review comment, or a log. Reference credentials by name in all of those. A credential-shaped task earns the same ladder walk as any other.
 
-The interfaces differ — `vercel env add` reads the value from stdin, `railway variables --set` takes it as an argument — but the boundary does not: the value never reaches your output, a commit, or a PR body. Where a CLI offers a stdin path, prefer it.
+Both `vercel env add` and `railway variable set KEY --stdin` read the generated value from stdin — the boundary holds in both cases: the value never reaches your output, a commit, or a PR body.
 
 ### Decision: secrets on stdin vs argument (Issue #863)
 
-**Decided 2026-08-07.** Blended policy: prefer stdin where the CLI offers it; pass a generated secret as an argument only when the CLI has no stdin path. `railway variables --set` is the canonical example — it has no stdin path; the residual `ps`/shell-history exposure is deliberately accepted in exchange for the capability. A stdin-only rule would make the Issue #759 Railway signing-key case a rung-5 handoff, defeating the ladder's purpose. When using the argument form, reference a shell variable rather than the literal value; never echo, commit, paste, or log it. CodeRabbit's stdin-only proposal from PR #858 was considered and declined per user decision on Issue #863.
+**Decided 2026-08-07; corrected 2026-08-07.** Blended policy: prefer stdin where the CLI offers it; pass a generated secret as an argument only when the CLI has no stdin path. Railway CLI v4.30.5 and later ship `railway variable set KEY --stdin` — the modern form reads the value from stdin, so it is preferred (see updated example above). The `railway variables --set KEY=VALUE` flag form is legacy and passes the value as a process argument, which is visible in `ps` and shell history; avoid it. A stdin-only rule would still be wrong — it would incorrectly label every provider without a stdin path as a rung-5 handoff; the policy is blended, not absolute. When using any argument form (as a deliberate fallback for no-stdin CLIs), reference a shell variable rather than the literal value; never echo, commit, paste, or log it. CodeRabbit's stdin-only proposal from PR #858 was considered and declined per user decision on Issue #863 — this correction is distinct: it fixes a factual error in the Railway command, not the policy.
 
 ## Rungs 1–3 in practice — the not-installed case (rung 4 is the browser, below)
 

--- a/.claude/reference/capability-discovery-examples.md
+++ b/.claude/reference/capability-discovery-examples.md
@@ -20,7 +20,7 @@ The ladder is not a GitHub rule. Every provider below is a one-liner, not a dash
 
 | "I can't…" | Actual command |
 |------------|----------------|
-| set a Railway env var (**the motivating case, issue #759**) | `echo "$VALUE" \| railway variable set {KEY} --stdin` on the linked service |
+| set a Railway env var (**the motivating case, issue #759**) | `printf '%s\n' "$VALUE" \| railway variable set {KEY} --stdin` on the linked service |
 | read which Railway env vars already exist | `railway variables` |
 | redeploy or read logs on Railway | `railway redeploy` · `railway logs` |
 | add a Vercel env var | `vercel env add {NAME} {environment}` (value on stdin — never inline it) |
@@ -54,14 +54,14 @@ railway variables            # rung 1: which of the three are already set?
 
 NEW_KEY=$(openssl rand -base64 32)                   # generated, never printed
 [ -n "$NEW_KEY" ] || { echo "key generation failed" >&2; exit 1; }
-echo "$NEW_KEY" | railway variable set S2S_SIGNING_KEY --stdin  # provisioned via stdin, value stays out of output
+printf '%s\n' "$NEW_KEY" | railway variable set S2S_SIGNING_KEY --stdin  # provisioned via stdin; printf is verbatim, value stays out of output
 ```
 
 That is one of the three. Repeat it for the second key, and set the third — `S2S_ISSUER`, not a secret — directly. Validating before provisioning matters: an unchecked `openssl` failure would quietly install an empty signing key, which is worse than the unset variable you started with.
 
 **Secrets are not pre-refused.** The deferred work was generating and provisioning signing keys, and `safety.md`'s credential prohibitions read at a glance like "don't touch keys at all." They are narrower than that: generating a key and setting it through a provider CLI is the allowed path. What's prohibited is letting the *value* land anywhere durable — a commit, an issue or PR body, a subagent prompt, a review comment, or a log. Reference credentials by name in all of those. A credential-shaped task earns the same ladder walk as any other.
 
-Both `vercel env add` and `railway variable set KEY --stdin` read the generated value from stdin — the boundary holds in both cases: the value never reaches your output, a commit, or a PR body.
+Both `vercel env add` and `railway variable set KEY --stdin` read the generated value from stdin — the boundary holds in both cases: the value never reaches your output, a commit, or a PR body. Use `printf '%s\n'` to pipe the value; `echo` may interpret option-like values (e.g. `-n`) non-verbatim.
 
 ### Decision: secrets on stdin vs argument (Issue #863)
 

--- a/.claude/reference/capability-discovery-examples.md
+++ b/.claude/reference/capability-discovery-examples.md
@@ -63,6 +63,10 @@ That is one of the three. Repeat it for the second key, and set the third — `S
 
 The interfaces differ — `vercel env add` reads the value from stdin, `railway variables --set` takes it as an argument — but the boundary does not: the value never reaches your output, a commit, or a PR body. Where a CLI offers a stdin path, prefer it.
 
+### Decision: secrets on stdin vs argument (Issue #863)
+
+**Decided 2026-08-07.** Blended policy: prefer stdin where the CLI offers it; pass a generated secret as an argument only when the CLI has no stdin path. `railway variables --set` is the canonical example — it has no stdin path; the residual `ps`/shell-history exposure is deliberately accepted in exchange for the capability. A stdin-only rule would make the Issue #759 Railway signing-key case a rung-5 handoff, defeating the ladder's purpose. When using the argument form, reference a shell variable rather than the literal value; never echo, commit, paste, or log it. CodeRabbit's stdin-only proposal from PR #858 was considered and declined per user decision on Issue #863.
+
 ## Rungs 1–3 in practice — the not-installed case (rung 4 is the browser, below)
 
 **Rung 1 — look at what you already have.** MCP tools and custom skills count here too: a connected MCP server or an existing skill may already cover the task, in which case no CLI is needed at all. For the CLI itself, check by absolute path — the Bash tool runs with a minimal PATH, so a bare `which railway` can report nothing for a tool that is in fact installed:

--- a/.claude/reference/cli-tool-defaults.md
+++ b/.claude/reference/cli-tool-defaults.md
@@ -82,7 +82,8 @@ railway logs
 
 ```bash
 railway variables              # list for linked service
-railway variables --set "{KEY}={value}"   # takes value as argument (no stdin path) — use a shell var, never inline the literal secret
+echo "$VALUE" | railway variable set {KEY} --stdin   # preferred: reads value from stdin (Railway CLI v4.30.5+)
+railway variables --set "{KEY}={value}"              # legacy arg form — avoided; exposes value in ps/history
 railway link                   # link cwd to project/environment/service
 railway run {command}          # run a local command with service env injected
 ```

--- a/.claude/reference/cli-tool-defaults.md
+++ b/.claude/reference/cli-tool-defaults.md
@@ -82,7 +82,7 @@ railway logs
 
 ```bash
 railway variables              # list for linked service
-railway variables --set "{KEY}={value}"   # use shell vars, not literal secrets
+railway variables --set "{KEY}={value}"   # takes value as argument (no stdin path) — use a shell var, never inline the literal secret
 railway link                   # link cwd to project/environment/service
 railway run {command}          # run a local command with service env injected
 ```

--- a/.claude/reference/cli-tool-defaults.md
+++ b/.claude/reference/cli-tool-defaults.md
@@ -82,7 +82,7 @@ railway logs
 
 ```bash
 railway variables              # list for linked service
-echo "$VALUE" | railway variable set {KEY} --stdin   # preferred: reads value from stdin (Railway CLI v4.30.5+)
+printf '%s\n' "$VALUE" | railway variable set {KEY} --stdin  # preferred: verbatim stdin (Railway CLI v4.30.5+; printf avoids echo flag-interpretation)
 railway variables --set "{KEY}={value}"              # legacy arg form — avoided; exposes value in ps/history
 railway link                   # link cwd to project/environment/service
 railway run {command}          # run a local command with service env injected

--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -19,7 +19,7 @@
 2. **NEVER paste raw credentials into subagent prompts, issue/PR bodies, comments, commits, or logs.** Reference by name — never inline the value.
 3. **NEVER weaken `.gitignore` to commit a "just-this-once" config.** Move the secret to `.env` and commit a `.env.example` instead.
 
-**Provisioning is not committing.** Setting a generated secret through a provider CLI is ordinary work; prefer stdin where the CLI offers it (`vercel env add`), and pass the value as an argument only when the CLI has no stdin path (`railway variables --set` — residual `ps`/history exposure is deliberately accepted). The ban is on committing, pasting, echoing, or logging the value. Credential-shaped tasks are not pre-refused: they walk the capability ladder below like anything else. Rationale: `.claude/reference/capability-discovery-examples.md` §Decision.
+**Provisioning is not committing.** Setting a generated secret through a provider CLI is ordinary work; prefer stdin where the CLI offers it (`vercel env add`; `railway variable set KEY --stdin`), and pass the value as a shell-variable argument only when the CLI has no stdin path. The ban is on committing, pasting, echoing, or logging the value. Credential-shaped tasks are not pre-refused: they walk the capability ladder below like anything else. Rationale: `.claude/reference/capability-discovery-examples.md` §Decision.
 
 ## Untrusted Code & Network
 

--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -19,7 +19,7 @@
 2. **NEVER paste raw credentials into subagent prompts, issue/PR bodies, comments, commits, or logs.** Reference by name — never inline the value.
 3. **NEVER weaken `.gitignore` to commit a "just-this-once" config.** Move the secret to `.env` and commit a `.env.example` instead.
 
-**Provisioning is not committing.** Setting a generated secret through a provider CLI (`railway variables --set`, `vercel env add` — value on stdin where accepted) is ordinary work; the ban is on committing, pasting, echoing, or logging the value. Credential-shaped tasks are not pre-refused: they walk the capability ladder below like anything else.
+**Provisioning is not committing.** Setting a generated secret through a provider CLI is ordinary work; prefer stdin where the CLI offers it (`vercel env add`), and pass the value as an argument only when the CLI has no stdin path (`railway variables --set` — residual `ps`/history exposure is deliberately accepted). The ban is on committing, pasting, echoing, or logging the value. Credential-shaped tasks are not pre-refused: they walk the capability ladder below like anything else. Rationale: `.claude/reference/capability-discovery-examples.md` §Decision.
 
 ## Untrusted Code & Network
 


### PR DESCRIPTION
## Summary

- **Decision (user, 2026-08-07):** Blended — prefer stdin for provider-CLI secrets; arguments allowed when a CLI has no stdin path; residual `ps`/history exposure deliberately accepted. Stdin-only (CodeRabbit's PR #858 proposal) rejected because it would make argument-only CLIs a rung-5 handoff and defeat the ladder's purpose for the motivating Issue #759 Railway case.
- Corrects the inaccurate implication in `safety.md` that `railway variables --set` uses stdin.
- Adds an explicit named decision record in `capability-discovery-examples.md`.
- Updates the Railway CLI comment in `cli-tool-defaults.md` to note the no-stdin-path constraint.

## Changes

| File | Change |
|------|--------|
| `.claude/rules/safety.md` | §Provisioning: removed incorrect stdin parenthetical; stated blended policy tersely; added cross-reference to decision record |
| `.claude/reference/capability-discovery-examples.md` | Added `### Decision: secrets on stdin vs argument (Issue #863)` subsection with rationale and provenance |
| `.claude/reference/cli-tool-defaults.md` | Updated Railway `--set` comment to note no-stdin-path |

## Corpus word count

Before: **11542** · After: **11568** (+26 words) · Ratchet cap: **11749** · Headroom: 181 words.

## Local review coverage

**none** — both CLIs unavailable this session (CodeRabbit: rate-limited after 2 attempts; CodeAnt: 403 daily cap). Self-review performed; no issues found.

## Test plan

- [x] `safety.md` §"Provisioning is not committing" explicitly states: prefer stdin where available, arguments allowed only when no stdin path exists, residual exposure deliberately accepted
- [x] `safety.md` SAFETY/MINDSET verbatim blocks untouched (`verbatim-block-lint.sh` passes)
- [x] `capability-discovery-examples.md` decision subsection added, consistent with `capability-discovery-examples-hotspot-decision.md` (additive edit, no structural change)
- [x] Corpus words before/after stated and within ratchet cap (11568 ≤ 11749)
- [x] `rule-lint.sh` passes (11568 words, well within soft=12000 hard=13000)
- [x] `verbatim-block-lint.sh` passes (6 copy surfaces, all byte-identical)
- [x] `reference-catalog-lint.sh` passes (143 files indexed, no new files added)
- [x] Local review coverage noted (none — both CLIs down; self-review performed)
- [x] PR body cites user's decision comment (Issue #863, 2026-08-07)

Closes #863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified secure handling of secrets when using provider command-line tools.
  * Added guidance to prefer stdin where supported and use shell variables when argument passing is required.
  * Reinforced that secret values must not be exposed, logged, committed, or pasted.
  * Documented the canonical Railway environment-variable command example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->