### PR TITLE
fix(#1121): add required name frontmatter so custom agents register

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -4,7 +4,9 @@ This directory contains custom agent definitions for the Phase A/B/C subagent wo
 
 ## How It Works
 
-Claude Code's Agent tool supports a `subagent_type` parameter that references agent definition files in `.claude/agents/`. When spawning a subagent with `subagent_type: "phase-a-fixer"`, Claude Code loads `.claude/agents/phase-a-fixer.md` as the agent's system context — including its `allowed-tools` restrictions and embedded instructions.
+Claude Code's Agent tool supports a `subagent_type` parameter that references agent definition files in `.claude/agents/`. When spawning a subagent with `subagent_type: "phase-a-fixer"`, Claude Code loads the agent whose frontmatter `name:` field matches that string — identity comes from `name:`, not the filename. The `name:` field is **required**; without it the agent file is not resolvable by `subagent_type`.
+
+Claude Code scans `.claude/agents/` at session start. A session restart is required for a newly added or edited agent file to be registered. The `tools:` key in frontmatter restricts which tools the agent may use; the deprecated `allowed-tools:` key is not recognized by the current schema.
 
 ## Placeholder Syntax
 
@@ -36,7 +38,7 @@ Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the par
 | `pm-worker` | — | Issue management, repo bootstrap | Full access | Yes | `sonnet` |
 | `researcher` | — | Read-only exploration, audit, investigation — produces a findings report | Read, Glob, Grep, Bash (read-only `gh`/`git`/`cat`/`find`/etc.) | No — read-only by design | `sonnet` |
 
-**Browser MCP** (`mcp__Claude_Browser__*` / `mcp__claude-in-chrome__*`) is rung 4 of the capability ladder. An agent that declares no `allowed-tools` inherits the full tool set and can reach it; one that declares `allowed-tools` gets only what it lists, and no browser tool is on any current list. Evidence, the `phase-c-merger` decision, and the surface-selection rules: `.claude/reference/browser-capability-rung.md`.
+**Browser MCP** (`mcp__Claude_Browser__*` / `mcp__claude-in-chrome__*`) is rung 4 of the capability ladder. An agent that declares no `tools:` frontmatter inherits the full tool set and can reach it; one that declares `tools:` gets only what it lists, and no browser tool is on any current list. Evidence, the `phase-c-merger` decision, and the surface-selection rules: `.claude/reference/browser-capability-rung.md`.
 
 ### Model Selection
 
@@ -67,7 +69,7 @@ This reverses the version-pinning call made in #749. That change wanted the docs
 | `phase-b-reviewer` | `opus` | Evaluates review findings (many are false positives), decides when to dismiss vs. fix, handles multi-reviewer edge cases, judges severity. Needs strong judgment. |
 | `phase-c-merger` | `sonnet` | Lightweight verification plus canonical `/wrap` execution: reads PR body, checks boxes against code, runs `gh`/git commands, and reports blockers. Read-only tool restrictions (no Write/Edit) — the mechanical work does not need Opus-level reasoning. |
 | `pm-worker` | `sonnet` | Data gathering and formatting: issue creation, repo bootstrap checks. Each task follows a well-defined template. |
-| `researcher` | `sonnet` | Read-only exploration and summarization: reads files, runs `gh`/`git` queries, synthesizes findings. No code edits, no fixes — `sonnet` is sufficient for read-and-report work, and the restricted `allowed-tools` frontmatter prevents any write operations regardless of model. |
+| `researcher` | `sonnet` | Read-only exploration and summarization: reads files, runs `gh`/`git` queries, synthesizes findings. No code edits, no fixes — `sonnet` is sufficient for read-and-report work, and the `tools:` frontmatter restriction prevents any write operations regardless of model. |
 
 **Why Fable is not any agent's default:** Fable is the strongest model in the fleet, but no agent defaults to it — the same cost logic that puts `sonnet` on `phase-c-merger` applies in the other direction. Phase spawns run unattended, often several in parallel, and Opus already clears the reasoning bar for the heaviest phase (A/B) work; paying roughly double per spawn buys headroom these phases do not need. Fable is reserved for interactive hardest-work step-ups, where a human is watching the spend and can judge the trade. `/prompt`'s tier ladder is where it is actively recommended (see `.claude/skills/prompt/SKILL.md` "Model Lineup & Effort Levels"). Escalating a specific spawn to `fable` is a deliberate exception — document why, and do not make it a default.
 
@@ -128,8 +130,10 @@ The agent definition provides role-specific workflow rules. The harness injects 
 ## Adding New Agents
 
 1. Create `<agent-name>.md` in this directory
-2. Include frontmatter with `description` and optionally `allowed-tools`
+2. Include frontmatter with **`name:`** (required — must match the intended `subagent_type` string and the filename stem exactly), `description:` (required), and optionally `tools:` for tool restrictions (use `tools:`, not `allowed-tools:`)
 3. Embed only role-specific rules — global rules (skill-first, autonomy, etc.) are inherited automatically
 4. Always include the SAFETY and MINDSET blocks as safety-critical restatements
 5. Document any new placeholders in this README
 6. Update the Agent Inventory table above
+7. Restart Claude Code so the new file is scanned and registered
+8. Verify the agent spawns successfully with a smoke-test spawn before any workflow relies on it

--- a/.claude/agents/phase-a-fixer.md
+++ b/.claude/agents/phase-a-fixer.md
@@ -1,4 +1,5 @@
 ---
+name: phase-a-fixer
 description: "Phase A subagent: fix review findings, push code, write handoff file, print exit report. Used after a PR receives CR/BugBot/Greptile review findings."
 model: opus
 ---

--- a/.claude/agents/phase-b-reviewer.md
+++ b/.claude/agents/phase-b-reviewer.md
@@ -1,4 +1,5 @@
 ---
+name: phase-b-reviewer
 description: "Phase B subagent: poll for CR/BugBot/Greptile reviews, process findings, fix code, update handoff file, print exit report. Runs after Phase A pushes fixes."
 model: opus
 ---

--- a/.claude/agents/phase-c-merger.md
+++ b/.claude/agents/phase-c-merger.md
@@ -1,6 +1,7 @@
 ---
+name: phase-c-merger
 description: "Phase C subagent: verify merge gate and AC, then run the canonical /wrap merge flow when authorized."
-allowed-tools: Read, Glob, Grep, Bash
+tools: Read, Glob, Grep, Bash
 model: sonnet
 ---
 

--- a/.claude/agents/pm-worker.md
+++ b/.claude/agents/pm-worker.md
@@ -1,4 +1,5 @@
 ---
+name: pm-worker
 description: "PM task execution agent: issue management and repo bootstrap checks. Used for lightweight PM tasks that don't require the full Phase A/B/C pipeline."
 model: sonnet
 ---

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -1,6 +1,7 @@
 ---
+name: researcher
 description: "Read-only research subagent: explore, audit, or investigate the codebase and GitHub state without any risk of file modification. Use when you need findings, not fixes."
-allowed-tools: Read, Glob, Grep, Bash(gh api:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(gh pr diff:*), Bash(gh pr checks:*), Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh run list:*), Bash(gh run view:*), Bash(gh repo view:*), Bash(gh search:*), Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git show:*), Bash(git blame:*), Bash(git branch:*), Bash(git worktree list:*), Bash(cat:*), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(find:*), Bash(ls:*), Bash(pwd:*), Bash(echo:*), Bash(grep:*)
+tools: Read, Glob, Grep, Bash(gh api:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(gh pr diff:*), Bash(gh pr checks:*), Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh run list:*), Bash(gh run view:*), Bash(gh repo view:*), Bash(gh search:*), Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git show:*), Bash(git blame:*), Bash(git branch:*), Bash(git worktree list:*), Bash(cat:*), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(find:*), Bash(ls:*), Bash(pwd:*), Bash(echo:*), Bash(grep:*)
 model: sonnet
 ---
 

--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -176,3 +176,4 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 
 - `issue-162-phase-protocol-verification.md` — static verification log for exit reports, phase B/C protocols, and monitor loop ordering (issue #162)
 - `issue-852-browser-rung-verification.md` — live + static verification log for the browser capability rung: subagent reach, ask-once login, dead-end runbooks, `phase-c-merger` restriction, credential/confirm behavior (issues #852, #864)
+- `issue-1121-subagent-registration-verification.md` — diagnosis of missing `name:` frontmatter causing "Agent type not found" for all custom agents; root cause, fix applied, restart precondition, and fallback path (issue #1121)

--- a/.claude/reference/issue-1121-subagent-registration-verification.md
+++ b/.claude/reference/issue-1121-subagent-registration-verification.md
@@ -1,0 +1,68 @@
+# Issue #1121 — Custom Agent Registration: Diagnosis and Resolution
+
+**Date:** 2026-08-08
+**Scope:** Why custom `subagent_type` values fail with "Agent type not found", and how it was fixed.
+**Related:** Issue #864 (browser rung verification), PR for Issue #1121.
+
+## Observed Error
+
+```
+Agent type 'pm-worker' not found
+```
+
+Observed in session working Issue #864. The same error occurs for every custom type in `.claude/agents/`: `phase-a-fixer`, `phase-b-reviewer`, `phase-c-merger`, `pm-worker`, `researcher`.
+
+The built-in types available in that session (and documented in the system-reminder): `claude`, `claude-code-guide`, `Explore`, `general-purpose`, `Plan`, `statusline-setup`, `vercel:ai-architect`, `vercel:deployment-expert`, `vercel:performance-optimizer`.
+
+## Root Cause
+
+All five `.claude/agents/*.md` files were missing the required `name:` frontmatter field.
+
+The Claude Code sub-agents documentation states (verified 2026-08-08):
+
+> "The subdirectory path doesn't affect how a subagent is identified or invoked, because identity comes only from the **name frontmatter field**."
+
+> "Only **name** and **description** are required."
+
+Without `name:`, the agent file is loaded at session start but cannot be matched against the `subagent_type` string passed to the Agent tool. The prior `.claude/agents/README.md` incorrectly stated that identity came from the filename — that was never true per the product schema.
+
+Additionally, two files (`phase-c-merger.md`, `researcher.md`) used an `allowed-tools:` frontmatter key that is not part of the documented schema. The correct key is `tools:`. An unrecognized key is silently ignored, which means the read-only restrictions on those agents were never actually enforced.
+
+## Fix Applied
+
+1. Added `name:` as the first frontmatter key to all five agent files, with values matching the filename stem exactly:
+   - `phase-a-fixer.md` → `name: phase-a-fixer`
+   - `phase-b-reviewer.md` → `name: phase-b-reviewer`
+   - `phase-c-merger.md` → `name: phase-c-merger`
+   - `pm-worker.md` → `name: pm-worker`
+   - `researcher.md` → `name: researcher`
+
+2. Renamed `allowed-tools:` to `tools:` in `phase-c-merger.md` and `researcher.md` so tool restrictions actually take effect.
+
+3. Updated `.claude/agents/README.md` to state that identity comes from `name:`, that a session restart is needed after adding/editing files, and that `tools:` (not `allowed-tools:`) is the correct key.
+
+4. Updated `.claude/rules/subagent-orchestration.md` to add `researcher` to the enumerated types, add a precondition note about `name:` and session restart, and add a fallback path for when a custom spawn fails.
+
+5. Added `.github/scripts/agents-frontmatter-lint.sh` and wired it into `.github/workflows/rule-lint.yml` to prevent regression.
+
+## Restart Precondition
+
+Claude Code scans `.claude/agents/` at session start. The fix applies when the updated files exist AND a new session has been started. An existing session that predates the merge will still see "Agent type not found" for custom types. After session restart the agents register normally.
+
+## Fallback (Pre-Restart or Edge Cases)
+
+If a spawn returns `Agent type '<name>' not found`, use `general-purpose` and paste the verbatim SAFETY/MINDSET/SKILLS blocks plus the role-specific procedure. See `.claude/rules/subagent-orchestration.md` §Fallback for the full contract.
+
+## Doc Drift Resolved
+
+`.claude/agents/README.md` previously stated:
+
+> "When spawning a subagent with `subagent_type: "phase-a-fixer"`, Claude Code loads `.claude/agents/phase-a-fixer.md`..."
+
+This implied identity came from the filename. The authoritative mechanism is `name:` frontmatter. The README now states this correctly.
+
+## Evidence
+
+- Observed error and session context: `.claude/reference/issue-852-browser-rung-verification.md` §Doc drift item 1
+- Schema source: `https://docs.anthropic.com/en/docs/claude-code/sub-agents` §Supported frontmatter fields (fetched 2026-08-08)
+- Lint regression guard: `.github/scripts/agents-frontmatter-lint.sh`

--- a/.claude/rules/subagent-orchestration.md
+++ b/.claude/rules/subagent-orchestration.md
@@ -8,7 +8,7 @@
 
 Use `.claude/agents/` definitions. Custom `subagent_type` agents automatically inherit the project CLAUDE.md hierarchy + `.claude/rules/*.md` — no manual rule injection needed. Every Agent call must include:
 1. `mode: "bypassPermissions"`.
-2. `subagent_type`: `phase-a-fixer`, `phase-b-reviewer`, `phase-c-merger`, or `pm-worker`.
+2. `subagent_type`: `phase-a-fixer`, `phase-b-reviewer`, `phase-c-merger`, `pm-worker`, or `researcher`. **Precondition:** resolution requires the `name:` frontmatter field and a session started (or restarted) after the file exists — see `.claude/agents/README.md`.
 3. Explicit `model` (see "Model Selection").
 4. Runtime context: PR/issue/branch, repo, handoff path, HEAD SHA, reviewer, optional pre-fetched findings.
 5. The verbatim `SAFETY:` block from `safety.md` — kept as a deliberate safety-critical restatement even though it is inherited.
@@ -20,6 +20,8 @@ See `.claude/agents/README.md` for the full placeholder reference and spawning e
 ### Fallback: Explore/Plan and Non-Custom Spawns
 
 Built-in Explore/Plan agents omit the project hierarchy. For any spawn that does NOT use a `.claude/agents/` definition (e.g. a bare general-purpose Agent call), paste the verbatim SAFETY/MINDSET/SKILLS blocks manually. Do NOT paste the full CLAUDE.md + rules corpus — that double-pays the corpus for custom-agent spawns that already inherit it. Verification: `.claude/reference/token-efficiency-audit-2026-07.md` §FU-1.
+
+**Failed custom spawn fallback:** if a spawn returns `Agent type '<name>' not found`, the session has not yet registered the agent (pre-restart or `name:` missing). Spawn `general-purpose` instead and paste the verbatim SAFETY/MINDSET/SKILLS blocks plus the role-specific procedure from `.claude/reference/phase-decomposition.md`. Do NOT paste the full CLAUDE.md + rules corpus.
 
 ## Model Selection
 

--- a/.github/scripts/agents-frontmatter-lint.sh
+++ b/.github/scripts/agents-frontmatter-lint.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Lint the frontmatter of every .claude/agents/*.md agent definition file.
+#
+# Validates (per the Claude Code sub-agents schema and issue #1121):
+#   1. Each file has a `name:` field in frontmatter.
+#   2. Each file has a `description:` field in frontmatter.
+#   3. The `name:` value matches the filename stem exactly (identity source).
+#   4. No file uses the deprecated `allowed-tools:` key (use `tools:` instead).
+#
+# Output uses GitHub Actions annotations (::error::) so issues surface
+# directly on PR checks. Exits 1 on any error condition.
+#
+# Run from the repo root.
+
+set -euo pipefail
+shopt -s nullglob
+
+AGENTS_DIR=".claude/agents"
+errors=0
+
+usage() {
+  cat <<'EOF'
+Usage: .github/scripts/agents-frontmatter-lint.sh
+
+  Verifies all .claude/agents/*.md files carry required frontmatter.
+  No options. Run from the repo root. Exits 1 on any error.
+EOF
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "::error::Unknown argument: $1"
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ ! -d "$AGENTS_DIR" ]]; then
+  echo "::error::${AGENTS_DIR} directory not found — run from repo root"
+  exit 1
+fi
+
+# Extract the frontmatter block (between first --- and second ---) from a file.
+# Prints only the frontmatter lines (not the delimiters).
+extract_frontmatter() {
+  local file="$1"
+  awk 'NR==1 && /^---/ { in_fm=1; next }
+       in_fm && /^---/ { exit }
+       in_fm { print }' "$file"
+}
+
+checked=0
+
+for file in "${AGENTS_DIR}"/*.md; do
+  stem=$(basename "$file" .md)
+
+  # README.md is documentation, not an agent definition — skip it.
+  if [[ "$stem" == "README" ]]; then
+    continue
+  fi
+
+  fm=$(extract_frontmatter "$file")
+  checked=$((checked + 1))
+
+  # 1. name: present
+  if ! grep -qE '^name:' <<< "$fm"; then
+    echo "::error file=${file}::${file} is missing a 'name:' frontmatter field (required for subagent_type resolution)"
+    errors=$((errors + 1))
+  else
+    # 3. name: value matches filename stem
+    name_val=$(grep -E '^name:' <<< "$fm" | head -1 | sed 's/^name:[[:space:]]*//')
+    if [[ "$name_val" != "$stem" ]]; then
+      echo "::error file=${file}::${file}: name: '${name_val}' does not match filename stem '${stem}' — subagent_type must match name: exactly"
+      errors=$((errors + 1))
+    fi
+  fi
+
+  # 2. description: present
+  if ! grep -qE '^description:' <<< "$fm"; then
+    echo "::error file=${file}::${file} is missing a 'description:' frontmatter field (required)"
+    errors=$((errors + 1))
+  fi
+
+  # 4. deprecated allowed-tools: key
+  if grep -qE '^allowed-tools:' <<< "$fm"; then
+    echo "::error file=${file}::${file} uses deprecated 'allowed-tools:' key — rename to 'tools:' per the current schema"
+    errors=$((errors + 1))
+  fi
+done
+
+if (( checked == 0 )); then
+  echo "::error::No agent definition files found in ${AGENTS_DIR}/ (excluding README.md)"
+  exit 1
+fi
+
+if (( errors > 0 )); then
+  echo "agents-frontmatter-lint: ${errors} error(s) found across ${checked} files"
+  exit 1
+fi
+
+echo "agents-frontmatter-lint: OK (${checked} files)"

--- a/.github/scripts/agents-frontmatter-lint.sh
+++ b/.github/scripts/agents-frontmatter-lint.sh
@@ -49,11 +49,14 @@ fi
 
 # Extract the frontmatter block (between first --- and second ---) from a file.
 # Prints only the frontmatter lines (not the delimiters).
+# Exits 1 if the opening --- is present but the closing --- is never found
+# (unterminated frontmatter), so callers can detect malformed files.
 extract_frontmatter() {
   local file="$1"
   awk 'NR==1 && /^---/ { in_fm=1; next }
-       in_fm && /^---/ { exit }
-       in_fm { print }' "$file"
+       in_fm && /^---/ { terminated=1; exit }
+       in_fm { print }
+       END { if (in_fm && !terminated) exit 1 }' "$file"
 }
 
 checked=0
@@ -66,7 +69,11 @@ for file in "${AGENTS_DIR}"/*.md; do
     continue
   fi
 
-  fm=$(extract_frontmatter "$file")
+  if ! fm=$(extract_frontmatter "$file"); then
+    echo "::error file=${file}::${file} has unterminated frontmatter (missing closing '---')"
+    errors=$((errors + 1))
+    continue
+  fi
   checked=$((checked + 1))
 
   # 1. name: present

--- a/.github/scripts/tests/agents-frontmatter-lint.test.sh
+++ b/.github/scripts/tests/agents-frontmatter-lint.test.sh
@@ -91,6 +91,12 @@ expect "allowed-tools: key fails" 1 \
   "deprecated 'allowed-tools:'" \
   sed -i.bak 's/^model: sonnet/allowed-tools: Read, Bash\nmodel: sonnet/' .claude/agents/my-agent.md
 
+# --- unterminated frontmatter (missing closing ---) -------------------------
+# Replace the well-formed fixture with a file that opens --- but never closes it.
+expect "unterminated frontmatter fails" 1 \
+  "unterminated frontmatter" \
+  bash -c 'printf -- "---\nname: my-agent\ndescription: Test agent.\nmodel: sonnet\n" > .claude/agents/my-agent.md'
+
 # --- README.md is skipped (no agent fields) --------------------------------
 # Add a README.md that has none of the required fields; lint must still pass.
 expect "README.md is skipped" 0 \

--- a/.github/scripts/tests/agents-frontmatter-lint.test.sh
+++ b/.github/scripts/tests/agents-frontmatter-lint.test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Unit tests for agents-frontmatter-lint.sh (issue #1121)
+#
+# Each case builds a throwaway fixture dir and runs the lint from within it.
+# Every failure mode has an explicit inversion test: a guard that passes on
+# well-formed input but NOT on the broken variant proves the check fires.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LINT="${REPO_ROOT}/.github/scripts/agents-frontmatter-lint.sh"
+
+TMP_ROOT=$(mktemp -d -t agents-fm-lint.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+case_num=0
+
+# Build a minimal well-formed fixture: one agent file with all required fields.
+make_fixture() {
+  local dir="$1"
+  mkdir -p "${dir}/.claude/agents"
+  cat > "${dir}/.claude/agents/my-agent.md" <<'EOF'
+---
+name: my-agent
+description: "Test agent for linting."
+model: sonnet
+---
+
+# My Agent
+
+Body text.
+EOF
+}
+
+# expect <name> <expected-exit> <expected-output-regex> <mutator...>
+# Builds a fresh fixture, applies the mutator (runs it from within the
+# fixture dir), then asserts both exit status and matching output.
+expect() {
+  local name="$1" want="$2" want_re="$3"; shift 3
+  case_num=$((case_num + 1))
+  local dir="${TMP_ROOT}/case${case_num}"
+  make_fixture "$dir"
+  # Apply mutator (if any) inside fixture dir.
+  if [[ "$1" != "noop" ]]; then
+    ( cd "$dir" && "$@" )
+  fi
+
+  local out got
+  out=$(cd "$dir" && bash "$LINT" 2>&1) && got=0 || got=$?
+
+  if (( got != want )); then
+    echo "FAIL — ${name}: expected exit ${want}, got ${got}"
+    echo "$out" | sed 's/^/       /'
+    failures=$((failures + 1))
+    return
+  fi
+
+  if ! grep -qE "$want_re" <<< "$out"; then
+    echo "FAIL — ${name}: exit ${got} as expected, but output did not match /${want_re}/"
+    echo "$out" | sed 's/^/       /'
+    failures=$((failures + 1))
+    return
+  fi
+
+  echo "ok   — ${name}"
+}
+
+noop() { :; }
+
+# --- passing case -----------------------------------------------------------
+expect "well-formed agent passes" 0 'agents-frontmatter-lint: OK' noop
+
+# --- name: missing (inversion: passes before deletion, fails after) ---------
+expect "missing name: fails" 1 \
+  "missing a 'name:' frontmatter field" \
+  sed -i.bak '/^name:/d' .claude/agents/my-agent.md
+
+# --- name: mismatch with filename stem -------------------------------------
+expect "name: mismatch with stem fails" 1 \
+  "does not match filename stem" \
+  sed -i.bak 's/^name: my-agent/name: wrong-name/' .claude/agents/my-agent.md
+
+# --- description: missing --------------------------------------------------
+expect "missing description: fails" 1 \
+  "missing a 'description:' frontmatter field" \
+  sed -i.bak '/^description:/d' .claude/agents/my-agent.md
+
+# --- deprecated allowed-tools: key ----------------------------------------
+expect "allowed-tools: key fails" 1 \
+  "deprecated 'allowed-tools:'" \
+  sed -i.bak 's/^model: sonnet/allowed-tools: Read, Bash\nmodel: sonnet/' .claude/agents/my-agent.md
+
+# --- README.md is skipped (no agent fields) --------------------------------
+# Add a README.md that has none of the required fields; lint must still pass.
+expect "README.md is skipped" 0 \
+  'agents-frontmatter-lint: OK' \
+  bash -c 'printf "# README\n\nThis is documentation.\n" > .claude/agents/README.md'
+
+# --- no agents dir ---------------------------------------------------------
+case_num=$((case_num + 1))
+empty_dir="${TMP_ROOT}/case${case_num}"
+mkdir -p "$empty_dir"
+if out=$(cd "$empty_dir" && bash "$LINT" 2>&1); then
+  echo "FAIL — missing agents dir: expected non-zero exit, got 0"
+  failures=$((failures + 1))
+else
+  echo "ok   — missing agents dir exits non-zero"
+fi
+
+# --- CLI contract -----------------------------------------------------------
+case_num=$((case_num + 1))
+help_dir="${TMP_ROOT}/case${case_num}"
+make_fixture "$help_dir"
+if (cd "$help_dir" && bash "$LINT" --help >/dev/null 2>&1); then
+  echo "ok   — --help exits 0"
+else
+  echo "FAIL — --help should exit 0"
+  failures=$((failures + 1))
+fi
+
+case_num=$((case_num + 1))
+bogus_dir="${TMP_ROOT}/case${case_num}"
+make_fixture "$bogus_dir"
+got_exit=0
+(cd "$bogus_dir" && bash "$LINT" --bogus >/dev/null 2>&1) || got_exit=$?
+if (( got_exit == 2 )); then
+  echo "ok   — unknown arg exits 2"
+else
+  echo "FAIL — unknown arg: expected exit 2, got ${got_exit}"
+  failures=$((failures + 1))
+fi
+
+# --- real repo --------------------------------------------------------------
+if (cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1); then
+  echo "ok   — real repo agent files pass lint"
+else
+  echo "FAIL — lint does not pass against the real repo"
+  (cd "$REPO_ROOT" && bash "$LINT" 2>&1 | sed 's/^/       /') || true
+  failures=$((failures + 1))
+fi
+
+if (( failures > 0 )); then
+  echo "agents-frontmatter-lint.test: ${failures} failure(s)"
+  exit 1
+fi
+
+echo "OK: agents-frontmatter-lint tests passed (${case_num} fixtures)"

--- a/.github/workflows/rule-lint.yml
+++ b/.github/workflows/rule-lint.yml
@@ -31,3 +31,6 @@ jobs:
       # Unlike its siblings above, this lint lives under .claude/scripts/.
       - name: Run reference-catalog-lint
         run: bash .claude/scripts/reference-catalog-lint.sh
+
+      - name: Run agents-frontmatter-lint
+        run: bash .github/scripts/agents-frontmatter-lint.sh


### PR DESCRIPTION
## Summary

All five `.claude/agents/*.md` files were missing the required `name:` frontmatter field. Per the Claude Code sub-agents schema (verified against docs 2026-08-08), identity comes from `name:` — not the filename — and `name:` is the only way `subagent_type` resolves to an agent definition. Without it, every custom spawn fails with `Agent type '<name>' not found`.

Also fixes a secondary issue: `phase-c-merger.md` and `researcher.md` used `allowed-tools:` which is not in the documented schema (silently ignored). Renamed to `tools:` so tool restrictions now actually take effect.

Closes #1121

**Live spawn verification is deferred** — registration requires a session restart after the files exist. Tracked in Issue #1130. The Test Plan below covers everything verifiable without a restart.

**Local review coverage: none** — both CodeRabbit CLI (2x timeout) and CodeAnt (403 daily cap) were unavailable. GitHub App review proceeds normally.

## Changes

- **`.claude/agents/*.md` (all 5):** Add `name:` as first frontmatter key, value = filename stem exactly
- **`phase-c-merger.md`, `researcher.md`:** Rename `allowed-tools:` → `tools:` (schema alignment; restrictions now enforced)
- **`.claude/agents/README.md`:** Document that `name:` is required, identity from `name:`, session restart needed, `tools:` not `allowed-tools:`; update Adding New Agents checklist (steps 7–8 for restart + smoke test)
- **`.claude/rules/subagent-orchestration.md`:** Add `researcher` to enumerated types; precondition note (session restart); fallback contract for failed custom spawns
- **`.github/scripts/agents-frontmatter-lint.sh`:** New lint — asserts `name:`/`description:` present, `name:` matches stem, no `allowed-tools:` key
- **`.github/scripts/tests/agents-frontmatter-lint.test.sh`:** Inversion fixtures for every failure mode
- **`.github/workflows/rule-lint.yml`:** Wire new lint as a step
- **`.claude/reference/issue-1121-subagent-registration-verification.md`:** Diagnosis, root cause, fix applied, restart precondition, fallback path
- **`.claude/reference/README.md`:** Add entry for the new verification doc

## Test plan

- [x] Schema claim verified: docs state `name:` and `description:` are required; "identity comes only from the name frontmatter field" — fetched from `https://docs.anthropic.com/en/docs/claude-code/sub-agents` on 2026-08-08; also confirms `tools:` (not `allowed-tools:`) is the documented key
- [x] All five agent files carry exact-match `name:` as first frontmatter key (`phase-a-fixer`, `phase-b-reviewer`, `phase-c-merger`, `pm-worker`, `researcher`)
- [x] `phase-c-merger.md` and `researcher.md` frontmatter key renamed from `allowed-tools:` to `tools:`
- [x] `agents-frontmatter-lint.sh` passes against real repo: `agents-frontmatter-lint: OK (5 files)`
- [x] `agents-frontmatter-lint.test.sh` passes all 9 inversion fixtures (missing `name:`, `name:` mismatch, missing `description:`, `allowed-tools:` present, README skipped, no agents dir, --help, --bogus, real repo)
- [x] All existing lints pass: `rule-lint`, `skill-catalog-lint`, `verbatim-block-lint`, `chip-model-guard-lint`, `reference-catalog-lint`
- [x] Corpus word count: 11634 (soft cap 12000, ratchet cap 11749, hard cap 13000 — all green)
- [x] Load-condition docs added in `.claude/agents/README.md` (How It Works + Adding New Agents checklist steps 7–8)
- [x] `subagent-orchestration.md` updated: `researcher` in enumerated types, precondition note, fallback contract
- [x] Follow-up issue filed: Issue #1130 "Verify custom subagent_type registration after restart"
- [x] **PENDING — requires session restart:** Live spawn verification that `subagent_type: "phase-a-fixer"` (and others) resolves without "Agent type not found" — tracked in Issue #1130
