### PR TITLE
feat(#752): add generational model-drift lint to doc-lint discovery

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -55,6 +55,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 - `continuous-work-posture.md` — why free capacity (not a finish) triggers refill, fill-vs-ramp, queue vs backlog refill, the human-in-chat stop, and the idle-reason taxonomy (`CLAUDE.md` "KEEP THE PIPELINE FULL"; #823)
 - `pm-handoff-chips-decision.md` — decision record: `/pm-handoff` intentionally does not offer task chips; its portable prompt text is the deliverable (#562)
 - `chip-model-guard-decision.md` — decision record: the chip model-guard preamble rides in both the chip `prompt` and the fallback block, redefining the fallback baseline (#601)
+- `model-fleet-drift-guard-decision.md` — decision record: build a generational deny-list lint (`model-drift-lint.sh`) that flags enumerated legacy model versions in live surfaces; fails open; auto-discovered by `run-doc-lints.sh` (#752)
 - `scheduling-failure-modes.md` — recurring poll failure analysis
 - `bgwork-ceiling.md` — why background work arms a turn-independent silence ceiling, why `Monitor` over `ScheduleWakeup`/`CronCreate`, and why the number stays unpublished (#803)
 - `skill-sync-hooks.md` — skills worktree sync and hook registration narrative

--- a/.claude/reference/model-fleet-drift-guard-decision.md
+++ b/.claude/reference/model-fleet-drift-guard-decision.md
@@ -1,0 +1,39 @@
+# Model-Fleet Drift Guard Decision (#752)
+
+## Decision
+
+**Build a generational deny-list lint that auto-runs under the existing `rule-lint` required check.**
+
+The guard flags enumerated legacy model versions matching `(Opus|Sonnet) 4.<digit>` (e.g. `Opus 4.8`, `Sonnet 4.6`) in live surfaces only — `.claude/rules/`, `.claude/skills/`, `.claude/agents/`, and `CLAUDE.md` — exempting the entire `.claude/reference/` tree. It fails **open**: a stale deny-list misses future drift rather than blocking unrelated PRs. No per-release editing is required for within-generation bumps.
+
+**CI wiring — auto-discovery substitution (override of CR plan):** The CodeRabbit implementation plan said "wire into `rule-lint.sh` as a delegated sub-check." That approach is overridden: `.github/scripts/rule-lint.sh` is agent-unwritable. Instead, the script is named to match the `.github/scripts/*-lint.sh` glob auto-discovered by `run-doc-lints.sh` (PR #1147). Outcome is identical — the guard runs under the same `rule-lint` required CI check — with no protected-file edits.
+
+## Rationale
+
+The drift has recurred twice: Issue #547 (generation N) and Issue #749 (generation N+1). Both times it was noticed **weeks later**, by a human spotting a stale model name in a chip. The chip model guard (Issue #731) compares strings, so a stale recommendation does not degrade quietly — it **blocks the launched thread outright**. That makes drift expensive, which makes the case for catching it at PR time instead.
+
+**Why generational, not per-version:**
+Issue #749's reconciliation itself set the precedent: it moved `/prompt`'s Legacy list from enumerated versions (`Opus 4.8 / 4.7 / 4.6`) to a generation token (`Opus 4.x`). A deny-list built on the same idea — flag `(Opus|Sonnet) 4.<digit>` — catches every 4.x enumerated version without ever needing to know which specific sub-version existed. The `4.x` generational prose in `/prompt` correctly passes (x is not a digit). `Haiku 4.5` correctly passes (Haiku is not in the pattern; it is the current fleet member, not a legacy one). Dated `.claude/reference/` records correctly pass (entire directory excluded by design).
+
+**Fails-open trade-off:** If a future generation drifts but the deny-list is not yet extended, the guard misses it — the same outcome as today's manual process. It never blocks an unrelated PR. An allow-list would invert this: a stale list fails closed, blocking unrelated PRs until hand-edited at each fleet bump, which relocates the maintenance burden rather than removing it.
+
+**One bounded maintenance cost:** At the next cross-generation fleet bump (e.g. when 5.x becomes legacy), the deny-list pattern is extended by one line. This is explicitly accepted per the acceptance criteria ("maintenance cost is explicitly accepted and documented"). The cost is O(1) per generation, not per version.
+
+## Explicitly Rejected
+
+**Allow-list approach** — enumerate the current fleet; flag anything outside it. Rejected because it fails *closed*: a stale list blocks unrelated PRs until someone hand-edits it at every fleet bump. It relocates the maintenance burden rather than removing it, and it is strictly harder to maintain than the deny-list for the same drift-detection coverage.
+
+**Won't-fix outcome** — record the reasoning and close, accepting continued hand-catching. Rejected because the recurrence rate (two occurrences, Issue #547 and #749), the multi-week detection lag both times, and the hard-blocking failure mode via the chip model guard (Issue #731) together clear the bar for small machinery.
+
+**Wiring into `rule-lint.sh` directly** — the CR plan's preferred approach. Overridden: `.github/scripts/rule-lint.sh` is agent-unwritable (config-protection hard-deny on the `.github/scripts/` path). The auto-discovery substitution via PR #1147's `run-doc-lints.sh` delivers the same outcome with no protected-file edits.
+
+## References
+
+- Issue [#752](https://github.com/auerbachb/claude-code-config/issues/752) — this decision
+- Issue [#749](https://github.com/auerbachb/claude-code-config/issues/749) — the fleet reconciliation this was deferred from; established the generational-prose precedent
+- Issue [#547](https://github.com/auerbachb/claude-code-config/issues/547) — the previous generation's drift, fixed the same way
+- Issue [#731](https://github.com/auerbachb/claude-code-config/issues/731) — the chip model guard that makes stale names hard-blocking rather than silent
+- PR [#1147](https://github.com/auerbachb/claude-code-config/pull/1147) — introduced `run-doc-lints.sh` auto-discovery, enabling this wiring substitution
+- `.github/scripts/model-drift-lint.sh` — the guard implementation
+- `.github/scripts/tests/model-drift-lint.test.sh` — test coverage
+- `chip-model-guard-decision.md` — house style this record follows (`## Decision / ## Rationale / ## Explicitly Rejected / ## References`)

--- a/.github/scripts/model-drift-lint.sh
+++ b/.github/scripts/model-drift-lint.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Generational model-fleet drift guard (issue #752).
+#
+# Flags enumerated legacy model versions matching `(Opus|Sonnet) 4.<digit>`
+# (e.g. "Opus 4.8", "Sonnet 4.6") in live surfaces only.
+#
+# Scan targets (live operative corpus):
+#   CLAUDE.md
+#   .claude/rules/
+#   .claude/skills/
+#   .claude/agents/
+#
+# EXEMPTED (intentionally stale by design):
+#   .claude/reference/  — dated audit records legitimately name old model
+#                         versions and must not be rewritten (#791).
+#
+# Why deny-list, not allow-list:
+#   An allow-list fails closed — a stale list blocks unrelated PRs until
+#   hand-edited at each fleet bump.  A deny-list fails open — a stale list
+#   simply misses future drift rather than blocking unrelated PRs.
+#   See .claude/reference/model-fleet-drift-guard-decision.md.
+#
+# Why these families only:
+#   The pattern targets Opus and Sonnet because those are the families that
+#   have had enumerated 4.x versions in live surfaces.  Haiku 4.5 is the
+#   current fleet member, not a legacy one, and Haiku is deliberately excluded
+#   from the pattern.  Fable has never carried a 4.x enumeration.
+#
+# Why digit, not 'x':
+#   `Opus 4.x` is the generational prose that /prompt uses for its Legacy
+#   list — a legitimate reference that must not be flagged.  The deny-list
+#   matches only a literal digit after the dot, so `4.8` matches but `4.x`
+#   does not.
+#
+# Extension cost:
+#   When the next cross-generation fleet bump makes 5.x legacy, extend the
+#   pattern from `4` to `(4|5)`.  One-line edit, explicitly accepted per #752.
+#
+# CI wiring:
+#   Named to match .github/scripts/*-lint.sh — auto-discovered by
+#   run-doc-lints.sh (PR #1147).  Runs under the same `rule-lint` required
+#   CI check without any change to rule-lint.sh or the workflow file.
+#
+# Companion: .github/scripts/tests/model-drift-lint.test.sh
+#
+# Usage: bash .github/scripts/model-drift-lint.sh
+# Exits 0 on clean pass, 1 on any findings.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/lint-common.sh
+source "$SCRIPT_DIR/lib/lint-common.sh"
+
+# Legacy enumerated-version pattern.
+# Matches: "Opus 4.8", "Opus 4.7", "Sonnet 4.6", etc.
+# Does NOT match: "Haiku 4.5" (Haiku excluded), "Opus 4.x" (x is not a digit),
+#   "claude-opus-4-5" (lowercase/hyphenated API ids).
+LEGACY_RE='(Opus|Sonnet) 4\.[0-9]'
+
+errors=0
+
+usage() {
+  cat <<'EOF'
+Usage: .github/scripts/model-drift-lint.sh
+
+  Flags legacy enumerated model versions (Opus/Sonnet 4.<digit>) in live
+  surfaces.  Exempts .claude/reference/ (dated records are stale by design).
+  See .claude/reference/model-fleet-drift-guard-decision.md.
+
+  No options.  Run from the repo root.  Exits 1 on any finding.
+EOF
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "::error::model-drift-lint.sh: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# Collect scan targets that exist.
+scan_targets=()
+for target in CLAUDE.md .claude/rules .claude/skills .claude/agents; do
+  [[ -e "$target" ]] && scan_targets+=("$target")
+done
+
+if (( ${#scan_targets[@]} == 0 )); then
+  echo "::warning::model-drift-lint.sh: no scan targets found — run from repo root"
+  exit 0
+fi
+
+while IFS= read -r hit; do
+  [[ -n "$hit" ]] || continue
+  hit_file="${hit%%:*}"
+  hit_rest="${hit#*:}"
+  hit_line="${hit_rest%%:*}"
+  hit_match="${hit_rest#*:}"
+  echo "::error file=${hit_file},line=${hit_line}::Legacy model version in live surface: '${hit_match}' — update to the current fleet family name. See .claude/reference/model-fleet-drift-guard-decision.md and .claude/agents/README.md \"Model naming\"."
+  errors=$((errors + 1))
+done < <(grep -rnE "$LEGACY_RE" --include='*.md' "${scan_targets[@]}" 2>/dev/null || true)
+
+if (( errors > 0 )); then
+  echo "model-drift-lint: ${errors} legacy model version(s) found in live surfaces"
+  exit 1
+fi
+
+echo "model-drift-lint: OK"

--- a/.github/scripts/tests/model-drift-lint.test.sh
+++ b/.github/scripts/tests/model-drift-lint.test.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Unit tests for model-drift-lint.sh (issue #752)
+#
+# Auto-discovered by run-hook-tests.sh — no workflow edit needed.
+# Follows the hermetic fixture pattern from chip-model-guard-lint.test.sh.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LINT="${REPO_ROOT}/.github/scripts/model-drift-lint.sh"
+
+TMP_ROOT=$(mktemp -d -t model-drift-lint.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+case_num=0
+
+# Build a minimal hermetic fixture tree that mirrors the live-surface layout.
+# Only the paths the lint actually scans are needed:
+#   CLAUDE.md, .claude/rules/, .claude/skills/, .claude/agents/
+# .claude/reference/ is intentionally NOT in the scan set — the exemption test
+# plants drift there and verifies the lint stays silent.
+make_fixture() {
+  local dir="$1"
+  mkdir -p "$dir/.claude/rules" \
+            "$dir/.claude/skills/example-skill" \
+            "$dir/.claude/agents" \
+            "$dir/.claude/reference"
+  # Minimal clean CLAUDE.md — no legacy model references.
+  cat > "$dir/CLAUDE.md" <<'CLAUDE'
+# Claude configuration
+Fleet: Fable, Opus, Sonnet, Haiku 4.5
+CLAUDE
+  # Minimal clean rule file.
+  cat > "$dir/.claude/rules/subagent-orchestration.md" <<'RULE'
+# Subagent Model Selection
+Use Opus for Phase A, Sonnet for Phase C.
+RULE
+  # Minimal clean skill file — contains generational prose that must NOT fire.
+  cat > "$dir/.claude/skills/example-skill/SKILL.md" <<'SKILL'
+# Example skill
+Legacy models (Opus 4.x, Sonnet 4.x) are no longer recommended.
+Use the bare family name instead.
+SKILL
+  # Minimal clean agent file.
+  cat > "$dir/.claude/agents/phase-a-fixer.md" <<'AGENT'
+---
+model: opus
+---
+Phase A fixer agent. Uses Opus for heavy lifting.
+AGENT
+  # Reference file — this is intentionally exempt even when it has legacy names.
+  cat > "$dir/.claude/reference/harness-model-audit-2026-06.md" <<'REF'
+Current fleet (assumed authoritative for this audit): Opus 4.8, Sonnet 4.6, Haiku 4.5.
+REF
+}
+
+# expect NAME WANT_EXIT WANT_REGEX MUTATION_CMD [MUTATION_ARGS...]
+#
+# Builds a fixture, applies the mutation, runs the lint, and checks:
+#   - exit code matches WANT_EXIT
+#   - combined stdout+stderr matches WANT_REGEX (ERE)
+expect() {
+  local name="$1" want="$2" want_re="$3"; shift 3
+  case_num=$((case_num + 1))
+  local dir="${TMP_ROOT}/case${case_num}"
+  make_fixture "$dir"
+
+  # Apply mutation in the fixture directory.
+  if ! ( cd "$dir" && "$@" ); then
+    echo "FAIL — ${name}: fixture mutation failed"
+    failures=$((failures + 1))
+    return
+  fi
+
+  local out got
+  out=$(cd "$dir" && bash "$LINT" 2>&1) && got=0 || got=$?
+
+  if (( got != want )); then
+    echo "FAIL — ${name}: expected exit ${want}, got ${got}"
+    echo "$out" | sed 's/^/       /'
+    failures=$((failures + 1))
+    return
+  fi
+
+  if ! grep -qE "$want_re" <<< "$out"; then
+    echo "FAIL — ${name}: exit ${got} as expected, but output did not match /${want_re}/"
+    echo "$out" | sed 's/^/       /'
+    failures=$((failures + 1))
+    return
+  fi
+
+  echo "ok   — ${name}"
+}
+
+noop() { :; }
+
+# mutate FILE SED_EXPR — apply a sed in-place mutation and verify it took effect.
+# A no-op mutation (pattern not found) fails loudly so the test proves nothing.
+mutate() {
+  local file="$1" expr="$2" before after
+  before=$(cksum < "$file")
+  sed -i.bak "$expr" "$file"
+  after=$(cksum < "$file")
+  if [[ "$before" == "$after" ]]; then
+    echo "       FIXTURE ERROR — no-op mutation on ${file}: ${expr}" >&2
+    return 90
+  fi
+}
+
+append_line() { printf '\n%s\n' "$2" >> "$1"; }
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+# 1. Clean fixture passes.
+expect "clean fixture passes" 0 'model-drift-lint: OK' noop
+
+# 2. Opus 4.8 in a live rules file fails.
+expect "Opus 4.8 in rules file fails" 1 \
+  'Legacy model version in live surface' \
+  append_line .claude/rules/subagent-orchestration.md \
+    'Historical note: Opus 4.8 was previously used for Phase A.'
+
+# 3. Sonnet 4.6 in a live rules file fails.
+expect "Sonnet 4.6 in rules file fails" 1 \
+  'Legacy model version in live surface' \
+  append_line .claude/rules/subagent-orchestration.md \
+    'Historical note: Sonnet 4.6 was previously used for Phase C.'
+
+# 4. Opus 4.8 in CLAUDE.md fails.
+expect "Opus 4.8 in CLAUDE.md fails" 1 \
+  'Legacy model version in live surface' \
+  append_line CLAUDE.md 'Phase A default: Opus 4.8'
+
+# 5. Opus 4.8 in a skills file fails.
+expect "Opus 4.8 in skills file fails" 1 \
+  'Legacy model version in live surface' \
+  append_line .claude/skills/example-skill/SKILL.md \
+    'Step up to Opus 4.8 for heavy analysis.'
+
+# 6. Opus 4.8 in an agents file fails.
+expect "Opus 4.8 in agents file fails" 1 \
+  'Legacy model version in live surface' \
+  append_line .claude/agents/phase-a-fixer.md \
+    'Previous generation used Opus 4.8.'
+
+# 7. Reference dir is EXEMPT — Opus 4.8 there does NOT fail.
+# (The reference file already contains legacy names — see make_fixture.)
+expect "Opus 4.8 in reference dir is exempt (passes)" 0 \
+  'model-drift-lint: OK' \
+  noop
+
+# 8. Haiku 4.5 in a live file does NOT fire (Haiku excluded by design).
+expect "Haiku 4.5 in live surface passes (Haiku excluded)" 0 \
+  'model-drift-lint: OK' \
+  append_line CLAUDE.md 'Light tier: Haiku 4.5'
+
+# 9. Generational prose "Opus 4.x" does NOT fire (x is not a digit).
+# The base fixture already has "Opus 4.x" in the skills file — verify clean.
+expect "Opus 4.x generational prose passes (not a digit)" 0 \
+  'model-drift-lint: OK' \
+  noop
+
+# 10. Sonnet 4.x generational prose passes.
+expect "Sonnet 4.x generational prose passes" 0 \
+  'model-drift-lint: OK' \
+  append_line .claude/rules/subagent-orchestration.md \
+    'Legacy tier includes Sonnet 4.x models.'
+
+# 11. Error output names the offending file for actionability.
+expect "error output names the offending file" 1 \
+  'subagent-orchestration\.md' \
+  append_line .claude/rules/subagent-orchestration.md \
+    'Was: Opus 4.8 for Phase A.'
+
+# 12. Multiple hits produce multiple errors.
+plant_two_hits() {
+  append_line .claude/rules/subagent-orchestration.md 'Was: Opus 4.8.'
+  append_line CLAUDE.md 'Was: Sonnet 4.6.'
+}
+expect "multiple hits produce multiple error lines" 1 \
+  'model-drift-lint: 2 legacy' \
+  plant_two_hits
+
+# ---------------------------------------------------------------------------
+# Revert-verify: confirm the test suite itself would catch an unguarded repo.
+# Plant drift into the real repo tree and assert the lint fails there too.
+# This ensures the test is not trivially passing against a misbuilt lint.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- revert-verify: lint must fail on planted drift in real repo ---"
+
+REAL_PLANTED=$(mktemp "${TMPDIR:-/tmp}/model-drift-revert-verify-XXXXXX.md")
+trap 'rm -f "$REAL_PLANTED"; rm -rf "$TMP_ROOT"' EXIT
+
+# Write a planted-drift file into a live-surface directory of the real repo.
+# We use a temp file in .claude/rules/ so the lint scans it, then clean up.
+REAL_RULES_DIR="${REPO_ROOT}/.claude/rules"
+PLANTED_FILE="${REAL_RULES_DIR}/_model-drift-lint-revert-verify-$$.md"
+printf 'Legacy tier: Opus 4.8 was used for Phase A.\n' > "$PLANTED_FILE"
+
+revert_verify_ok=0
+if ( cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1 ); then
+  echo "FAIL — revert-verify: lint passed on repo with planted drift (should have failed)"
+  failures=$((failures + 1))
+  revert_verify_ok=1
+else
+  echo "ok   — revert-verify: lint correctly failed on planted drift"
+fi
+
+rm -f "$PLANTED_FILE"
+
+# Clean repo should pass.
+if ! ( cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1 ); then
+  echo "FAIL — real repo conformance: lint fails on the real repo (unexpected)"
+  ( cd "$REPO_ROOT" && bash "$LINT" 2>&1 | sed 's/^/       /') || true
+  failures=$((failures + 1))
+else
+  echo "ok   — real repo conformance is intact"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+if (( failures > 0 )); then
+  echo ""
+  echo "model-drift-lint.test: ${failures} failure(s)"
+  exit 1
+fi
+
+echo ""
+echo "OK: model-drift-lint tests passed (${case_num} fixtures + revert-verify)"

--- a/.github/scripts/tests/model-drift-lint.test.sh
+++ b/.github/scripts/tests/model-drift-lint.test.sh
@@ -193,12 +193,12 @@ echo ""
 echo "--- revert-verify: lint must fail on planted drift in real repo ---"
 
 REAL_PLANTED=$(mktemp "${TMPDIR:-/tmp}/model-drift-revert-verify-XXXXXX.md")
-trap 'rm -f "$REAL_PLANTED"; rm -rf "$TMP_ROOT"' EXIT
-
 # Write a planted-drift file into a live-surface directory of the real repo.
 # We use a temp file in .claude/rules/ so the lint scans it, then clean up.
+# Declare PLANTED_FILE before the trap so the trap covers it on interruption.
 REAL_RULES_DIR="${REPO_ROOT}/.claude/rules"
 PLANTED_FILE="${REAL_RULES_DIR}/_model-drift-lint-revert-verify-$$.md"
+trap 'rm -f "$REAL_PLANTED" "$PLANTED_FILE"; rm -rf "$TMP_ROOT"' EXIT
 printf 'Legacy tier: Opus 4.8 was used for Phase A.\n' > "$PLANTED_FILE"
 
 revert_verify_ok=0


### PR DESCRIPTION
Closes #752

## Summary

Implements a generational deny-list guard that flags enumerated legacy model versions (`(Opus|Sonnet) 4.<digit>`) in live surfaces, converting a weeks-later manual discovery into a red check on the PR that ships drift.

**Design:**
- Pattern matches `Opus 4.8`, `Sonnet 4.6`, etc. — NOT `Haiku 4.5` (current fleet), NOT `Opus 4.x` (generational prose), NOT `.claude/reference/` (dated records exempt by design)
- Fails **open**: a stale deny-list misses future drift rather than blocking unrelated PRs
- Auto-discovered by `run-doc-lints.sh` via `*-lint.sh` glob (PR #1147) — zero edits to `rule-lint.sh` (config-protection hard-deny)
- One bounded maintenance cost at next cross-generation fleet bump: extend deny-list pattern by one generation (explicitly accepted per AC)

**Local review coverage:** `none` — CodeRabbit rate-limited (2 attempts), CodeAnt 403 daily cap (2 attempts). Self-reviewed: lint parses grep output correctly, scan targets exclude reference/, fixtures are hermetic with proper cleanup.

## Test plan

- [x] Pattern matches planted legacy names (`Opus 4.8`, `Sonnet 4.6`) in live surfaces (rules, skills, agents, CLAUDE.md) — lint exits 1
- [x] `Haiku 4.5` in live surface passes (Haiku excluded by pattern)
- [x] `Opus 4.x` generational prose passes (x is not a digit)
- [x] `.claude/reference/` mentions pass (entire dir excluded)
- [x] Current repo scan clean — zero findings in live corpus today
- [x] Auto-discovered by `run-doc-lints.sh` — runner shows 6 lints (was 5), 0 failed
- [x] Test suite revert-verified: lint correctly fails when drift planted in real repo, passes after removal
- [x] Decision record + catalog line — `reference-catalog-lint.sh` green (159 files indexed)
- [x] `rule-lint.sh` untouched and still passes
- [x] Local review: none (both CLIs down, noted above)