### PR TITLE
feat(#781): token measurement baseline — ccusage wrapper, MCP prune inventory, junk-dir read denials

### DIFF
--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -72,6 +72,7 @@ Files here are NOT auto-loaded by Claude Code. Agents read them on demand when w
 ### Living trackers (updated each cycle — not point-in-time)
 
 - `skill-repo-diff.md` — cross-repo pattern-harvest tracker (#417): gap analysis vs superpowers / everything-claude-code, prioritized import backlog, and import log; re-surveyed and appended each cycle
+- `token-measurement-baseline-2026-08.md` — per-repo token baseline tracker (#781): `/context` floor procedure, ccusage spend baseline, MCP server inventory + prune list, `permissions.deny` junk-dir blocks; re-measured and appended each cycle
 
 ### Audits and research (point-in-time)
 

--- a/.claude/reference/token-measurement-baseline-2026-08.md
+++ b/.claude/reference/token-measurement-baseline-2026-08.md
@@ -1,0 +1,202 @@
+# Per-Repo Token Measurement Baseline — August 2026
+
+**Issue:** [#781](https://github.com/auerbachb/claude-code-config/issues/781) (FU-6: `/context` + ccusage baseline, MCP prune list, `permissions.deny`)
+
+**Date:** 2026-08-10
+
+**Related precedent:** [`token-efficiency-audit-2026-07.md`](token-efficiency-audit-2026-07.md) (FU-6 source, MCP schema cost figures, `permissions.deny` rationale), [Issue #710](https://github.com/auerbachb/claude-code-config/issues/710) (spend/thread-type telemetry pipeline — in-flight; data from there will supersede the manual figures here once available), [`harness-model-audit-2026-06.md`](harness-model-audit-2026-06.md) (static-evidence convention this doc follows)
+
+**Scope guard:** This document covers per-repo context-floor measurement, MCP prune inventory, and junk-dir read-denial. It is NOT Issue #710's spend/thread-type telemetry pipeline and does NOT build a new per-session settings-sync mechanism.
+
+---
+
+## Living-Tracker Instructions
+
+**Re-run and append each measurement cycle** (à la `skill-repo-diff.md`):
+1. Run the ccusage wrapper: `.claude/scripts/ccusage-baseline.sh --json`
+2. Capture `/context` output manually (see MANUAL CAPTURE below)
+3. Append a dated row to the [Baseline Table](#baseline-table)
+4. Re-classify MCP servers if the installed set changes
+
+**Gap acknowledgment:** Until Issue #710's telemetry pipeline ships, context-floor figures come from the manual `/context` procedure below. The `ccusage` figures are accurate at run time; the `/context` figures depend on the session configuration at capture time.
+
+---
+
+## Reproducible Measurement
+
+### MANUAL CAPTURE — `/context` Context Floor
+
+> **This section requires interactive capture.** `/context` is a Claude Code slash command that prints the current session's context breakdown. It cannot be scripted.
+
+**Procedure (run during an active Claude Code session):**
+
+1. Open a Claude Code session in this repo.
+2. Run `/context` in the chat.
+3. Record the following sections from the output:
+
+| Section | What to record |
+|---------|---------------|
+| **System prompt** | Token count shown |
+| **System tools** | Token count shown |
+| **MCP tools** | Token count per server + total |
+| **Memory / CLAUDE.md** | Token count shown |
+| **Agents** | Count and token footprint if shown |
+| **Messages (context window used)** | Token count + percentage |
+
+4. Paste the captured numbers into the [Baseline Table](#baseline-table) under a dated row.
+
+**Reference values from token-efficiency-audit-2026-07.md:**
+- Rule corpus: ~12K words (always-loaded CLAUDE.md + 18 unscoped rules)
+- Community-documented floor before "hi": 20–30K tokens
+- MCP schema cost estimate: ~1K+/tool; 10–20K tokens/server; 55K observed for 5 servers
+  (source: token-efficiency-audit-2026-07.md §Quantitative benchmarks, tier B)
+
+### Scripted Capture — ccusage Spend Baseline
+
+```bash
+# Human-readable summary (active block + window total)
+bash .claude/scripts/ccusage-baseline.sh
+
+# Machine-readable JSON (for the table below)
+bash .claude/scripts/ccusage-baseline.sh --json
+
+# Last 3 days only
+bash .claude/scripts/ccusage-baseline.sh --recent
+
+# Filter from a specific date
+bash .claude/scripts/ccusage-baseline.sh --since 20260801
+```
+
+Exit codes: `0` data found, `1` no blocks in window, `2` usage error, `3` ccusage not found, `4` invocation error.
+
+**Tip:** If `ccusage` is not installed, the script exits 3 with install instructions. Install via:
+```bash
+npm install -g ccusage
+# or: npx ccusage@latest --help
+```
+
+---
+
+## Baseline Table
+
+> **Dates are measurement timestamps, not averages.** Each row captures a snapshot at a specific session. Context floor varies by active MCP servers and loaded skills.
+
+| Date | Context floor (tokens) | MCP schema share (tokens) | Active block cost (USD) | Window cost (USD) | Window tokens | Notes |
+|------|----------------------|--------------------------|------------------------|-------------------|---------------|-------|
+| 2026-08-10 | PENDING MANUAL CAPTURE | See MCP Inventory below | run `ccusage-baseline.sh` | run `ccusage-baseline.sh` | run `ccusage-baseline.sh` | Initial baseline; Issue #710 telemetry not yet available |
+
+**How to fill in the context floor:** Run `/context` during a session in this repo, copy the token counts from the System prompt + System tools + MCP tools + Memory sections, sum them, and enter here.
+
+---
+
+## MCP Server Inventory and Prune List
+
+> **Classification method:** each server is checked against references in `.claude/rules/*.md` and `.claude/skills/*/SKILL.md` for actual tool invocations (`mcp__<server>__*`). Servers with no harness references are prune candidates for this repo.
+
+### Installed MCP Servers
+
+**Plugin-based servers** (global scope — configured in `~/.claude/settings.json` via `enabledPlugins`):
+
+| Server key | Plugin | Referenced in harness | Classification |
+|-----------|--------|----------------------|----------------|
+| `graphite@claude-code-graphite` | graphite CLI plugin | Graphite CLI (`graphite-app[bot]`) as supplemental reviewer in `cr-github-review.md` and `codeant-graphite-supplemental.md` | **KEEP** — used in review chain |
+| `graphite-mcp@claude-code-graphite` | graphite MCP plugin | No `mcp__graphite*` tool calls found in rules/skills | **PRUNE CANDIDATE** — MCP schema loaded but no tool calls; CLI path is sufficient |
+
+**User-configured MCP servers** (in `~/.claude.json`):
+
+| Server key | Referenced in harness | Classification |
+|-----------|----------------------|----------------|
+| `Neon` | No `mcp__Neon__*` calls in this repo's rules/skills | **PRUNE CANDIDATE for this repo** — may be used in other repos; project-level opt-out is the right mechanism |
+
+**Built-in / platform MCP servers** (loaded automatically by Claude Code):
+
+| Server | Tool prefix | Referenced in harness | Classification |
+|--------|------------|----------------------|----------------|
+| Claude Browser | `mcp__Claude_Browser__*` | `safety.md` capability-discovery rung 4; `cr-github-review.md` fallback | **KEEP** — used in browser capability ladder |
+| CCD Session | `mcp__ccd_session__*` | `monitor-mode.md`, `subagent-orchestration.md` (spawn_task, dismiss_task) | **KEEP** — orchestration primitive |
+| Claude-in-Chrome | `mcp__claude-in-chrome__*` | `safety.md` (logged-in-session browser rung) | **KEEP** — alternate browser rung |
+| Scheduled Tasks | `mcp__scheduled-tasks__*` | `scheduling-reliability.md` (not used — explicitly declined per #827) | **KEEP LISTED, NOT USED** — harness intentionally uses Monitor instead |
+
+### MCP Disable Paths
+
+**Path A — Global plugin opt-out** (for plugin-based servers like `graphite-mcp@claude-code-graphite`):
+
+Edit `~/.claude/settings.json` and set the plugin's `enabledPlugins` entry to `false`:
+```json
+"enabledPlugins": {
+  "graphite-mcp@claude-code-graphite": false
+}
+```
+This disables the plugin globally. `setup.sh` seeds the initial value from `global-settings.json`; changes to `enabledPlugins` persist in `~/.claude/settings.json`.
+
+**Path B — Project-scoped `.mcp.json`** (for future repo-defined MCP servers):
+
+For MCP servers defined at the project level (not plugin-based), use the project `.mcp.json` approval mechanism:
+- `disabledMcpjsonServers` — list of server names to disable for this project
+- `enabledMcpjsonServers` — allowlist (if set, only listed servers are enabled)
+
+No `.mcp.json` file exists in this repo currently. Current MCP servers are all plugin-based (global) and require Path A for per-server opt-out.
+
+**Recommendation:** Disable `graphite-mcp@claude-code-graphite` globally if the Graphite MCP adds no active tooling to sessions in this repo. The Graphite CLI (`graphite@claude-code-graphite`) is independent and should remain enabled.
+
+### MCP Schema Cost Estimate
+
+From `token-efficiency-audit-2026-07.md` §Quantitative benchmarks (tier B evidence):
+- ~1K+ tokens per tool definition
+- ~10–20K tokens per MCP server (all its tools combined)
+- ~55K tokens observed for a 5-server session
+
+**Tool Search Tool** (Claude Code built-in): defers MCP schemas until needed, cutting schema overhead by ~85% (77K→8.7K tokens observed). Already available in this harness — no additional setup required.
+
+---
+
+## `permissions.deny` Junk-Dir Blocks
+
+> **Note on syntax:** `permissions.deny` follows the same `"Tool(pattern)"` format as `permissions.allow` in `global-settings.json`, inferred from the existing allow array. The `A`-tier citation in `token-efficiency-audit-2026-07.md` points to Claude Code docs; the deny array below is consistent with that format. If Claude Code's actual runtime behaviour differs, adjust the patterns and update this doc.
+
+### Rationale
+
+`.claudeignore` is **advisory-only** — Claude Code respects it for file suggestions but does not enforce read boundaries. `permissions.deny` adds enforceable read restrictions that prevent reads from high-noise directories (node_modules, build outputs, caches) that bloat tool results and context window without adding useful content.
+
+### Propagation
+
+The `deny` array is added as a new sub-key under `permissions` in `global-settings.json`. Since `setup.sh` uses a seed-missing-only merge (one level deep), this brand-new sub-key seeds into `~/.claude/settings.json` on the next `bash ./setup.sh` re-run — without disturbing existing `allow` or `defaultMode` values.
+
+**SETUP CAVEAT:** The `deny` block does NOT propagate automatically. It reaches `~/.claude/settings.json` only on a manual `bash ./setup.sh` re-run. There is no per-session auto-sync for non-hook settings.
+
+### Deny Array (in `global-settings.json`)
+
+```json
+"deny": [
+  "Read(**/node_modules/**)",
+  "Glob(**/node_modules/**)",
+  "Grep(**/node_modules/**)",
+  "Read(**/.git/objects/**)",
+  "Glob(**/.git/objects/**)",
+  "Read(**/dist/**)",
+  "Glob(**/dist/**)",
+  "Read(**/build/**)",
+  "Glob(**/build/**)",
+  "Read(**/.venv/**)",
+  "Glob(**/.venv/**)",
+  "Read(**/__pycache__/**)",
+  "Glob(**/__pycache__/**)",
+  "Read(**/.tox/**)",
+  "Read(**/.mypy_cache/**)",
+  "Read(**/.pytest_cache/**)",
+  "Read(**/.ruff_cache/**)",
+  "Read(**/.next/**)",
+  "Glob(**/.next/**)"
+]
+```
+
+**Adjusting the deny list:** Users can remove entries from `~/.claude/settings.json` directly. To re-seed after removing, run `bash ./setup.sh` again — it will not re-add entries already present, but a removed entry will not reappear automatically.
+
+---
+
+## Follow-Up Items
+
+- [ ] **FU-6a (this issue):** Capture first manual `/context` reading and fill in the Baseline Table
+- [ ] **FU-6b:** Re-measure after disabling `graphite-mcp@claude-code-graphite` to quantify the schema savings
+- [ ] **FU-6c:** Once Issue #710 telemetry is live, replace manual context-floor rows with automated data and retire the manual procedure
+- [ ] **FU-6d:** Re-evaluate Tool Search Tool opt-in — check if the harness currently enables deferred MCP schemas and measure impact

--- a/.claude/scripts/README.md
+++ b/.claude/scripts/README.md
@@ -102,6 +102,14 @@ Scripts that surface stale issues, duplicate candidates, forgotten PRs, and back
 | `forgotten-pr-triage.sh` | Detect and classify open PRs that have gone quiet past a staleness threshold |
 | `pm-config-get.sh` | Extract a named section from `.claude/pm-config.md` |
 
+## Token Measurement
+
+Scripts that capture per-repo token spend and usage baselines.
+
+| Script | Purpose |
+|--------|---------|
+| `ccusage-baseline.sh` | Read-only per-session spend baseline via `ccusage`; exits 0 OK / 1 no data / 2 usage error / 3 ccusage missing / 4 invocation error; `--json` for machine output, `--recent` for last 3 days (#781) |
+
 ## Skills & Telemetry
 
 Scripts that audit, report, and sync skill and script usage telemetry.
@@ -164,6 +172,7 @@ All tests live in `tests/` and run offline (no network required). Run from the r
 
 | Test | What it covers |
 |------|----------------|
+| `ccusage-baseline.test.sh` | JSON shape, human-readable output, ccusage-absent exit 3, empty-blocks exit 1, usage errors, and --help for `ccusage-baseline.sh` (#781) |
 | `admin-merge.test.sh` | Tests for `admin-merge.sh` |
 | `backlog-health.test.sh` | Tests for `backlog-health.sh` |
 | `backlog-staleness.test.sh` | Tests for `backlog-staleness.sh` |

--- a/.claude/scripts/ccusage-baseline.sh
+++ b/.claude/scripts/ccusage-baseline.sh
@@ -12,8 +12,11 @@
 #   MANUAL CAPTURE section in the living-tracker doc for the `/context`
 #   procedure.
 #
-#   READ-ONLY: this script never writes files, creates issues, posts comments,
-#   or mutates any state. It is safe to run anywhere, including inside /wrap.
+#   READ-ONLY: this script never writes project files, creates issues, posts PR
+#   comments, or mutates repository state. The only side-effect is a best-effort
+#   append to ~/.claude/script-usage.log — the standard audit trail shared by
+#   all scripts in this library (|| true, non-blocking). Safe to run anywhere,
+#   including inside /wrap.
 #
 # USAGE:
 #   ccusage-baseline.sh [--json] [--recent] [--since YYYYMMDD] [--help]

--- a/.claude/scripts/ccusage-baseline.sh
+++ b/.claude/scripts/ccusage-baseline.sh
@@ -98,6 +98,12 @@ if [ "$RECENT" -eq 1 ] && [ -n "$SINCE" ]; then
   exit 2
 fi
 
+# Validate --since is a date (digits and hyphens only; prevents injection via eval)
+if [ -n "$SINCE" ] && ! [[ "$SINCE" =~ ^[0-9-]+$ ]]; then
+  err "--since must be a date in YYYYMMDD or YYYY-MM-DD format"
+  exit 2
+fi
+
 # ---- locate ccusage ----------------------------------------------------------
 # CCUSAGE_BIN env var: if explicitly set (even to ""), overrides detection.
 # Set to "" in tests to simulate ccusage-absent environments.
@@ -147,7 +153,7 @@ if [ "$RECENT" -eq 1 ]; then
 elif [ -n "$SINCE" ]; then
   # Normalise YYYY-MM-DD to YYYYMMDD (ccusage blocks uses YYYYMMDD format)
   SINCE_NORM="${SINCE//-/}"
-  BLOCKS_ARGS="$BLOCKS_ARGS --since $SINCE_NORM"
+  BLOCKS_ARGS="$BLOCKS_ARGS --since $(printf '%q' "$SINCE_NORM")"
 fi
 
 # ---- invoke ccusage ----------------------------------------------------------

--- a/.claude/scripts/ccusage-baseline.sh
+++ b/.claude/scripts/ccusage-baseline.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# ccusage-baseline.sh — Read-only per-repo/per-session spend and usage baseline (issue #781).
+#
+# PURPOSE:
+#   Provides a reproducible, read-only way to capture per-session token spend
+#   and 5-hour billing-block usage for the token-measurement baseline tracker
+#   (`token-measurement-baseline-2026-08.md`). Shells out to `ccusage` and
+#   normalises its output into a compact summary on stdout.
+#
+#   SCOPE: covers `ccusage blocks` (billing blocks) and `ccusage session` data
+#   only. `/context` is interactive-only and is NOT captured here — see the
+#   MANUAL CAPTURE section in the living-tracker doc for the `/context`
+#   procedure.
+#
+#   READ-ONLY: this script never writes files, creates issues, posts comments,
+#   or mutates any state. It is safe to run anywhere, including inside /wrap.
+#
+# USAGE:
+#   ccusage-baseline.sh [--json] [--recent] [--since YYYYMMDD] [--help]
+#
+#   --json         Emit a single compact JSON object on stdout (default: human-
+#                  readable text summary).
+#   --recent       Show only the last 3 days of billing blocks (default: all).
+#   --since <date> Filter blocks from date (YYYYMMDD). Mutually exclusive with
+#                  --recent.
+#   --help | -h    Print this help and exit 0.
+#
+# OUTPUT (human-readable default):
+#   A short text summary with the active block's spend / token counts and a
+#   recent-block rolling total. Safe to read in a terminal.
+#
+# OUTPUT (--json):
+#   A single JSON object:
+#   {
+#     "ccusage_version": "<string>",
+#     "generated_at": "<ISO-8601>",
+#     "active_block": { <block object from ccusage> | null },
+#     "recent_blocks": [ <block objects> ],
+#     "recent_total_cost_usd": <number>,
+#     "recent_total_tokens": <number>
+#   }
+#
+# EXIT CODES:
+#   0  Success — data captured and emitted
+#   1  Clean run with no billing-block data (ccusage returned empty blocks)
+#   2  Usage error (unknown flag or conflicting options)
+#   3  ccusage not found or environment error (PATH or npx unavailable)
+#   4  ccusage invocation failed (network, auth, or parse error)
+#
+# CCUSAGE DETECTION (in order):
+#   1. ccusage binary on PATH
+#   2. /opt/homebrew/bin/ccusage
+#   3. /opt/homebrew/bin/npx ccusage@latest  (installs on first run via npx cache)
+#   Graceful degradation: if none resolves, exits 3 with a clear error + doc note.
+#
+# EXAMPLES:
+#   .claude/scripts/ccusage-baseline.sh
+#   .claude/scripts/ccusage-baseline.sh --json
+#   .claude/scripts/ccusage-baseline.sh --recent --json
+#   .claude/scripts/ccusage-baseline.sh --since 20260801 --json \
+#     | jq '.recent_total_cost_usd'
+#
+# DEPENDENCIES:
+#   ccusage (via PATH, Homebrew, or npx); jq; bash 3.2+.
+
+set -uo pipefail
+printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$(basename "$0")" "${*//$'\n'/ }" \
+  >> "$HOME/.claude/script-usage.log" 2>/dev/null || true
+
+print_help() {
+  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
+}
+
+err() {
+  printf 'ccusage-baseline.sh: %s\n' "$1" >&2
+}
+
+# ---- defaults ----------------------------------------------------------------
+AS_JSON=0
+RECENT=0
+SINCE=""
+
+# ---- flag parsing ------------------------------------------------------------
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json)         AS_JSON=1 ;;
+    --recent)       RECENT=1 ;;
+    --since=*)      SINCE="${1#*=}" ;;
+    --since)        shift; [ $# -gt 0 ] || { err "--since requires a value"; exit 2; }; SINCE="$1" ;;
+    --help|-h)      print_help; exit 0 ;;
+    *)              err "unknown argument: $1"; exit 2 ;;
+  esac
+  shift
+done
+
+if [ "$RECENT" -eq 1 ] && [ -n "$SINCE" ]; then
+  err "--recent and --since are mutually exclusive"
+  exit 2
+fi
+
+# ---- locate ccusage ----------------------------------------------------------
+# CCUSAGE_BIN env var: if explicitly set (even to ""), overrides detection.
+# Set to "" in tests to simulate ccusage-absent environments.
+CCUSAGE_CMD=""
+if [ "${CCUSAGE_BIN+set}" = "set" ]; then
+  # Caller explicitly set it; may be empty string (= not found)
+  CCUSAGE_CMD="${CCUSAGE_BIN}"
+elif command -v ccusage >/dev/null 2>&1; then
+  CCUSAGE_CMD="ccusage"
+elif [ -x "/opt/homebrew/bin/ccusage" ]; then
+  CCUSAGE_CMD="/opt/homebrew/bin/ccusage"
+elif [ -x "/opt/homebrew/bin/npx" ]; then
+  CCUSAGE_CMD="/opt/homebrew/bin/npx ccusage@latest"
+elif command -v npx >/dev/null 2>&1; then
+  CCUSAGE_CMD="npx ccusage@latest"
+fi
+
+if [ -z "$CCUSAGE_CMD" ]; then
+  err "ccusage is not installed and npx is not available."
+  err "Install ccusage: npm install -g ccusage  OR  brew install ccusage"
+  err "Alternatively, run the manual /context capture procedure documented in"
+  err ".claude/reference/token-measurement-baseline-2026-08.md"
+  exit 3
+fi
+
+command -v jq >/dev/null 2>&1 || { err "jq is required but not installed"; exit 3; }
+
+# ---- capture ccusage version -------------------------------------------------
+CCUSAGE_VERSION=""
+RC=0
+CCUSAGE_VERSION=$(eval "$CCUSAGE_CMD" --version 2>/dev/null) || RC=$?
+case "$RC" in
+  0)
+    # Strip leading "ccusage " prefix if present ("ccusage 20.0.19" → "20.0.19")
+    CCUSAGE_VERSION=$(printf '%s' "$CCUSAGE_VERSION" | head -1 | tr -d '[:space:]')
+    CCUSAGE_VERSION="${CCUSAGE_VERSION#ccusage}"
+    # Strip any remaining leading whitespace or separator
+    CCUSAGE_VERSION="${CCUSAGE_VERSION# }"
+    ;;
+  *) CCUSAGE_VERSION="unknown" ;;
+esac
+
+# ---- build ccusage invocation ------------------------------------------------
+BLOCKS_ARGS="blocks --json --no-color"
+if [ "$RECENT" -eq 1 ]; then
+  BLOCKS_ARGS="$BLOCKS_ARGS --recent"
+elif [ -n "$SINCE" ]; then
+  # Normalise YYYY-MM-DD to YYYYMMDD (ccusage blocks uses YYYYMMDD format)
+  SINCE_NORM="${SINCE//-/}"
+  BLOCKS_ARGS="$BLOCKS_ARGS --since $SINCE_NORM"
+fi
+
+# ---- invoke ccusage ----------------------------------------------------------
+BLOCKS_RAW=""
+RC=0
+BLOCKS_RAW=$(eval "$CCUSAGE_CMD" $BLOCKS_ARGS 2>&1) || RC=$?
+
+if [ "$RC" -ne 0 ]; then
+  err "ccusage invocation failed (exit $RC): $BLOCKS_RAW"
+  if [ "$AS_JSON" -eq 1 ]; then
+    printf '{"error":"ccusage invocation failed","exit_code":%d}\n' "$RC"
+  fi
+  exit 4
+fi
+
+# Validate JSON
+if ! printf '%s' "$BLOCKS_RAW" | jq -e . >/dev/null 2>&1; then
+  err "ccusage returned non-JSON output: $(printf '%s' "$BLOCKS_RAW" | head -3)"
+  if [ "$AS_JSON" -eq 1 ]; then
+    printf '{"error":"ccusage non-JSON output"}\n'
+  fi
+  exit 4
+fi
+
+# ---- extract summary fields --------------------------------------------------
+BLOCKS_JSON=$(printf '%s' "$BLOCKS_RAW" | jq -c '.blocks // []' 2>/dev/null) || BLOCKS_JSON='[]'
+BLOCK_COUNT=$(printf '%s' "$BLOCKS_JSON" | jq 'length' 2>/dev/null) || BLOCK_COUNT=0
+
+if [ "$BLOCK_COUNT" -eq 0 ]; then
+  if [ "$AS_JSON" -eq 1 ]; then
+    jq -cn \
+      --arg ver "$CCUSAGE_VERSION" \
+      --arg ts "$(date -u +%FT%TZ)" \
+      '{ccusage_version:$ver,generated_at:$ts,active_block:null,recent_blocks:[],recent_total_cost_usd:0,recent_total_tokens:0}'
+  else
+    printf 'ccusage-baseline: no billing blocks found in the requested window.\n'
+    printf 'Run: %s blocks --help  for filtering options.\n' "$CCUSAGE_CMD"
+  fi
+  exit 1
+fi
+
+ACTIVE_BLOCK=$(printf '%s' "$BLOCKS_JSON" | jq -c '[.[] | select(.isActive == true)] | first // null' 2>/dev/null) || ACTIVE_BLOCK='null'
+RECENT_BLOCKS=$(printf '%s' "$BLOCKS_JSON" | jq -c '[.[] | select(.isActive != true)]' 2>/dev/null) || RECENT_BLOCKS='[]'
+
+TOTAL_COST=$(printf '%s' "$BLOCKS_JSON" | \
+  jq '[.[] | .costUSD // 0] | add // 0' 2>/dev/null) || TOTAL_COST=0
+TOTAL_TOKENS=$(printf '%s' "$BLOCKS_JSON" | \
+  jq '[.[] | .totalTokens // 0] | add // 0' 2>/dev/null) || TOTAL_TOKENS=0
+
+# ---- emit output -------------------------------------------------------------
+GENERATED_AT=$(date -u +%FT%TZ)
+
+if [ "$AS_JSON" -eq 1 ]; then
+  jq -cn \
+    --arg ver "$CCUSAGE_VERSION" \
+    --arg ts "$GENERATED_AT" \
+    --argjson active "$ACTIVE_BLOCK" \
+    --argjson recent "$RECENT_BLOCKS" \
+    --argjson total_cost "$TOTAL_COST" \
+    --argjson total_tokens "$TOTAL_TOKENS" \
+    '{
+      ccusage_version: $ver,
+      generated_at: $ts,
+      active_block: $active,
+      recent_blocks: $recent,
+      recent_total_cost_usd: $total_cost,
+      recent_total_tokens: $total_tokens
+    }'
+else
+  # Human-readable summary
+  printf '=== ccusage baseline (%s) ===\n' "$GENERATED_AT"
+  printf 'ccusage version: %s\n' "$CCUSAGE_VERSION"
+  printf 'Billing blocks found: %d\n' "$BLOCK_COUNT"
+  printf '\n'
+
+  if [ "$ACTIVE_BLOCK" != 'null' ] && [ -n "$ACTIVE_BLOCK" ]; then
+    ACTIVE_COST=$(printf '%s' "$ACTIVE_BLOCK" | jq -r '.costUSD // 0' 2>/dev/null) || ACTIVE_COST=0
+    ACTIVE_TOKENS=$(printf '%s' "$ACTIVE_BLOCK" | jq -r '.totalTokens // 0' 2>/dev/null) || ACTIVE_TOKENS=0
+    ACTIVE_START=$(printf '%s' "$ACTIVE_BLOCK" | jq -r '.startTime // "unknown"' 2>/dev/null) || ACTIVE_START="unknown"
+    printf 'Active block (started %s):\n' "$ACTIVE_START"
+    printf '  Cost:    $%.4f USD\n' "$ACTIVE_COST"
+    printf '  Tokens:  %s\n' "$ACTIVE_TOKENS"
+    printf '\n'
+  fi
+
+  printf 'Window total:\n'
+  printf '  Cost:    $%.4f USD\n' "$TOTAL_COST"
+  printf '  Tokens:  %s\n' "$TOTAL_TOKENS"
+  printf '\n'
+  printf 'For detailed breakdown: %s blocks --breakdown\n' "$CCUSAGE_CMD"
+  printf 'For JSON output:        .claude/scripts/ccusage-baseline.sh --json\n'
+  printf '\nNote: /context floor (system prompt + rules + MCP schemas) requires\n'
+  printf 'manual capture — see .claude/reference/token-measurement-baseline-2026-08.md\n'
+fi
+
+exit 0

--- a/.claude/scripts/tests/ccusage-baseline.test.sh
+++ b/.claude/scripts/tests/ccusage-baseline.test.sh
@@ -212,6 +212,10 @@ check_eq "6a: unknown flag exits 2" "2" "$RC_ERR"
 OUT_CONFLICT=$(bash "$SCRIPT" --recent --since 20260801 2>&1); RC_CONFLICT=$?
 check_eq "6b: --recent + --since exits 2 (mutually exclusive)" "2" "$RC_CONFLICT"
 
+OUT_INJECT=$(bash "$SCRIPT" --since '20260801; rm -rf /' 2>&1); RC_INJECT=$?
+check_eq "6c: --since with shell metacharacters exits 2 (injection guard)" "2" "$RC_INJECT"
+check_contains "6d: injection guard error mentions YYYYMMDD format" "$OUT_INJECT" "YYYYMMDD"
+
 # =============================================================================
 # Scenario 7 — --help exits 0
 # =============================================================================

--- a/.claude/scripts/tests/ccusage-baseline.test.sh
+++ b/.claude/scripts/tests/ccusage-baseline.test.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Offline tests for ccusage-baseline.sh (issue #781).
+#
+# Fully hermetic: stubs the `ccusage` binary on PATH; no network access, no
+# real ccusage install required. Follows the *.test.sh stubbing pattern used
+# by churn-hotspots.test.sh and companion tests in this directory.
+#
+# Run from repo root: bash .claude/scripts/tests/ccusage-baseline.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/.claude/scripts/ccusage-baseline.sh"
+
+TMP="$(mktemp -d)"
+TMP_HOME="$(mktemp -d)"
+cleanup() { rm -rf "$TMP" "$TMP_HOME"; }
+trap cleanup EXIT
+export HOME="$TMP_HOME"
+mkdir -p "$HOME/.claude"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "ok   — $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL — $1"; }
+
+check_eq() {  # desc, expected, actual
+  if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (expected '$2', got '$3')"; fi
+}
+
+check_jq() {  # desc, json, jq boolean expr
+  if printf '%s' "$2" | jq -e "$3" >/dev/null 2>&1; then pass "$1"; else fail "$1 (jq: $3)"; fi
+}
+
+check_contains() {  # desc, haystack, needle
+  if printf '%s' "$2" | grep -qF "$3"; then pass "$1"; else fail "$1 (missing '$3' in output)"; fi
+}
+
+# ---- ccusage stub -------------------------------------------------------------
+# Minimal stub that honours:
+#   --version              → print version line
+#   blocks --json          → print BLOCKS_JSON fixture
+#   blocks --json --recent → same fixture (recent flag is transparent in stub)
+# Any other invocation exits 1 loudly.
+STUB_BIN="$TMP/bin"
+mkdir -p "$STUB_BIN"
+
+# Shared fixture: one active block + one completed block
+FIXTURE_BLOCKS="$TMP/blocks.json"
+cat > "$FIXTURE_BLOCKS" <<'EOF'
+{
+  "blocks": [
+    {
+      "id": "2026-08-09T21:00:00.000Z",
+      "startTime": "2026-08-09T21:00:00.000Z",
+      "endTime": "2026-08-10T02:00:00.000Z",
+      "actualEndTime": "2026-08-10T01:45:00.000Z",
+      "isActive": false,
+      "isGap": false,
+      "costUSD": 42.5,
+      "totalTokens": 5000000,
+      "entries": 120,
+      "burnRate": null,
+      "projection": null,
+      "models": ["claude-sonnet-4-6", "claude-opus-5"],
+      "tokenCounts": {
+        "cacheCreationInputTokens": 100000,
+        "cacheReadInputTokens": 4800000,
+        "inputTokens": 1000,
+        "outputTokens": 99000
+      }
+    },
+    {
+      "id": "2026-08-10T14:00:00.000Z",
+      "startTime": "2026-08-10T14:00:00.000Z",
+      "endTime": "2026-08-10T19:00:00.000Z",
+      "actualEndTime": null,
+      "isActive": true,
+      "isGap": false,
+      "costUSD": 18.25,
+      "totalTokens": 2000000,
+      "entries": 55,
+      "burnRate": 12.5,
+      "projection": 65.0,
+      "models": ["claude-opus-5"],
+      "tokenCounts": {
+        "cacheCreationInputTokens": 50000,
+        "cacheReadInputTokens": 1900000,
+        "inputTokens": 500,
+        "outputTokens": 49500
+      }
+    }
+  ]
+}
+EOF
+
+cat > "$STUB_BIN/ccusage" <<STUB
+#!/usr/bin/env bash
+args="\$*"
+case "\$args" in
+  *"--version"*)
+    printf 'ccusage 20.0.19\n'
+    ;;
+  *"blocks --json"*)
+    cat "$FIXTURE_BLOCKS"
+    ;;
+  *)
+    printf 'ccusage stub: unhandled args: %s\n' "\$args" >&2
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$STUB_BIN/ccusage"
+export PATH="$STUB_BIN:$PATH"
+
+# Helper: run the script with given args; sets OUT and RC
+run() {
+  OUT=$(bash "$SCRIPT" "$@" 2>/dev/null)
+  RC=$?
+}
+
+# =============================================================================
+# Scenario 1 — JSON output: shape, fields, and values
+# =============================================================================
+run --json
+check_eq "1a: exits 0 on success" "0" "$RC"
+check_jq "1b: top-level key ccusage_version present" "$OUT" 'has("ccusage_version")'
+check_jq "1c: generated_at is present" "$OUT" 'has("generated_at")'
+check_jq "1d: active_block is present and non-null" "$OUT" '.active_block != null'
+check_jq "1e: active_block.isActive is true" "$OUT" '.active_block.isActive == true'
+check_jq "1f: recent_blocks is an array" "$OUT" '.recent_blocks | type == "array"'
+check_jq "1g: recent_total_cost_usd is a number" "$OUT" '.recent_total_cost_usd | type == "number"'
+check_jq "1h: recent_total_tokens is a number" "$OUT" '.recent_total_tokens | type == "number"'
+check_jq "1i: total cost == sum of both blocks (42.5 + 18.25 = 60.75)" "$OUT" \
+  '.recent_total_cost_usd == 60.75'
+check_jq "1j: total tokens == sum (5000000 + 2000000 = 7000000)" "$OUT" \
+  '.recent_total_tokens == 7000000'
+check_jq "1k: recent_blocks contains the non-active block" "$OUT" \
+  '[.recent_blocks[] | select(.isActive == false)] | length == 1'
+check_jq "1l: ccusage_version is non-empty string" "$OUT" \
+  '(.ccusage_version | type) == "string" and (.ccusage_version | length) > 0'
+
+# =============================================================================
+# Scenario 2 — Human-readable default output
+# =============================================================================
+run
+check_eq "2a: exits 0 in human-readable mode" "0" "$RC"
+check_contains "2b: output contains 'ccusage baseline' header" "$OUT" "ccusage baseline"
+check_contains "2c: output contains billing block count" "$OUT" "Billing blocks found: 2"
+check_contains "2d: output shows Active block section" "$OUT" "Active block"
+check_contains "2e: output shows Window total section" "$OUT" "Window total"
+check_contains "2f: output references the /context manual capture doc" "$OUT" "token-measurement-baseline-2026-08.md"
+
+# =============================================================================
+# Scenario 3 — --recent flag passes through without error
+# =============================================================================
+run --json --recent
+check_eq "3a: --recent exits 0" "0" "$RC"
+check_jq "3b: JSON shape is intact with --recent" "$OUT" 'has("ccusage_version") and has("active_block")'
+
+# =============================================================================
+# Scenario 4 — ccusage missing: graceful degradation with exit 3
+# =============================================================================
+# CCUSAGE_BIN="" explicitly marks ccusage as absent (bypasses all detection
+# paths including hardcoded /opt/homebrew/bin/npx checks). This is the
+# testability hook documented in the script header.
+OUT_MISSING=$(CCUSAGE_BIN="" bash "$SCRIPT" --json 2>&1)
+RC_MISSING=$?
+
+check_eq "4a: exits 3 when CCUSAGE_BIN='' (absent)" "3" "$RC_MISSING"
+check_contains "4b: error message mentions ccusage not installed" "$OUT_MISSING" "ccusage is not installed"
+check_contains "4c: error message mentions manual capture doc" "$OUT_MISSING" "token-measurement-baseline-2026-08.md"
+
+# =============================================================================
+# Scenario 5 — empty blocks response: exit 1 (no data)
+# =============================================================================
+EMPTY_FIXTURE="$TMP/empty_blocks.json"
+cat > "$EMPTY_FIXTURE" <<'EOF'
+{"blocks":[]}
+EOF
+cat > "$STUB_BIN/ccusage" <<STUB
+#!/usr/bin/env bash
+args="\$*"
+case "\$args" in
+  *"--version"*) printf 'ccusage 20.0.19\n' ;;
+  *"blocks --json"*) cat "$EMPTY_FIXTURE" ;;
+  *) printf 'stub: unhandled: %s\n' "\$args" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$STUB_BIN/ccusage"
+
+run --json
+check_eq "5a: exits 1 when blocks array is empty" "1" "$RC"
+
+# Restore full stub
+cat > "$STUB_BIN/ccusage" <<STUB
+#!/usr/bin/env bash
+args="\$*"
+case "\$args" in
+  *"--version"*)     printf 'ccusage 20.0.19\n' ;;
+  *"blocks --json"*) cat "$FIXTURE_BLOCKS" ;;
+  *) printf 'stub: unhandled: %s\n' "\$args" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$STUB_BIN/ccusage"
+
+# =============================================================================
+# Scenario 6 — usage errors
+# =============================================================================
+OUT_ERR=$(bash "$SCRIPT" --bogus 2>&1); RC_ERR=$?
+check_eq "6a: unknown flag exits 2" "2" "$RC_ERR"
+
+OUT_CONFLICT=$(bash "$SCRIPT" --recent --since 20260801 2>&1); RC_CONFLICT=$?
+check_eq "6b: --recent + --since exits 2 (mutually exclusive)" "2" "$RC_CONFLICT"
+
+# =============================================================================
+# Scenario 7 — --help exits 0
+# =============================================================================
+OUT_HELP=$(bash "$SCRIPT" --help 2>&1); RC_HELP=$?
+check_eq "7a: --help exits 0" "0" "$RC_HELP"
+check_contains "7b: --help output contains USAGE" "$OUT_HELP" "USAGE"
+
+# =============================================================================
+echo
+echo "ccusage-baseline.test.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/SETUP.md
+++ b/SETUP.md
@@ -54,7 +54,7 @@ Default locations (may vary with your setup):
 > Steps below are the logical workflow — see `setup.sh` for exact step numbering in script output.
 
 1. Creates the `~/.claude/skills/` directory
-2. Merges non-hook settings from `global-settings.json` into `~/.claude/settings.json` (existing keys like `permissions`, `model`, `env` are preserved — only missing keys are seeded), including optional Graphite plugin marketplace and `enabledPlugins` when absent. `statusLine` is skipped here alongside `hooks`: both carry path placeholders that only the skills-worktree registration in step 5 can resolve
+2. Merges non-hook settings from `global-settings.json` into `~/.claude/settings.json` (existing keys like `permissions`, `model`, `env` are preserved — only missing keys are seeded), including optional Graphite plugin marketplace and `enabledPlugins` when absent. **New sub-keys** (like `permissions.deny`) are seeded on first encounter — they do NOT propagate automatically on subsequent runs, only on a fresh re-run of `bash ./setup.sh` when the sub-key is absent. `statusLine` is skipped here alongside `hooks`: both carry path placeholders that only the skills-worktree registration in step 5 can resolve
 3. Optionally runs `gt repo init` for this checkout when Graphite CLI is installed (creates `.git/.graphite_repo_config`; setup fails if `gt repo init` fails when `gt` is installed)
 4. Verifies all hook scripts exist and are executable
 5. Runs `setup-skills-worktree.sh` which:

--- a/global-settings.json
+++ b/global-settings.json
@@ -23,6 +23,27 @@
       "WebFetch(*)",
       "WebSearch(*)",
       "mcp__*"
+    ],
+    "deny": [
+      "Read(**/node_modules/**)",
+      "Glob(**/node_modules/**)",
+      "Grep(**/node_modules/**)",
+      "Read(**/.git/objects/**)",
+      "Glob(**/.git/objects/**)",
+      "Read(**/dist/**)",
+      "Glob(**/dist/**)",
+      "Read(**/build/**)",
+      "Glob(**/build/**)",
+      "Read(**/.venv/**)",
+      "Glob(**/.venv/**)",
+      "Read(**/__pycache__/**)",
+      "Glob(**/__pycache__/**)",
+      "Read(**/.tox/**)",
+      "Read(**/.mypy_cache/**)",
+      "Read(**/.pytest_cache/**)",
+      "Read(**/.ruff_cache/**)",
+      "Read(**/.next/**)",
+      "Glob(**/.next/**)"
     ]
   },
   "model": "opus",


### PR DESCRIPTION
## Summary

- Add `ccusage-baseline.sh`: read-only wrapper around the ccusage CLI with JSON/human-readable output, `--recent`/`--since` filters, and `CCUSAGE_BIN` env override for test isolation (exits 0/1/2/3/4)
- Add `ccusage-baseline.test.sh`: 28 offline stub-based tests (all green)
- Add `.claude/reference/token-measurement-baseline-2026-08.md`: living tracker with manual `/context` capture procedure, ccusage invocation guide, MCP server inventory + prune recommendations, and `permissions.deny` junk-dir blocks
- Add `permissions.deny` array to `global-settings.json` (node_modules, dist, build, .venv, __pycache__, cache dirs, .next, .git/objects)
- Update `SETUP.md` with `permissions.deny` propagation caveat (seeds only on manual `bash ./setup.sh` re-run)
- Catalog new living tracker in `.claude/reference/README.md` and `ccusage-baseline.sh` in `.claude/scripts/README.md`

Implements FU-6 from `token-efficiency-audit-2026-07.md`. Scope guard: this is NOT Issue #710's telemetry pipeline; no new per-session settings-sync mechanism.

Closes #781

## Test plan

- [x] `bash .claude/scripts/tests/ccusage-baseline.test.sh` — 28 tests pass (JSON shape, human-readable, --recent/--since, absent binary via `CCUSAGE_BIN=""`, empty blocks, usage errors, --help)
- [x] All doc lints pass (`run-doc-lints.sh` — 6 scripts, 0 failed; `reference-catalog-lint.sh` — 162 files indexed, OK)
- [x] `permissions.deny` array present in `global-settings.json` under `permissions`
- [x] `.claude/reference/token-measurement-baseline-2026-08.md` exists with all required sections (Living-Tracker Instructions, Reproducible Measurement, Baseline Table, MCP Server Inventory, permissions.deny Junk-Dir Blocks, Follow-Up Items)
- [x] Issue #781 body contains `## Implementation Plan`
- [x] SETUP.md mentions `permissions.deny` propagation caveat
- [x] `.claude/reference/README.md` lists new living tracker under "Living trackers"
- [x] `.claude/scripts/README.md` has Token Measurement section with `ccusage-baseline.sh` row and test table row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Local CLI review coverage:** `none` — CodeRabbit timed out (>120s); CodeAnt returned no-files-reviewed (worktree diff scope). Self-review completed; no issues found. GitHub App reviewers are independent and unaffected.
