### PR TITLE
fix(#1161): strip trailing CR from jq read block on Windows Git Bash

### DIFF
--- a/.claude/scripts/pr-state.sh
+++ b/.claude/scripts/pr-state.sh
@@ -66,6 +66,18 @@
 #   Cannot be combined with --pr, --since, or --infer-candidates.
 #   Exit code 0 on success; 2 on usage error.
 #
+# Platform notes:
+#   Windows Git Bash quirk (issue #1161): process substitution (`< <(...)`) reads
+#   through a FIFO/temp path that appears to append a trailing `\r` to each line
+#   of jq output, so a plain `read` populates variables with the CR still attached
+#   (e.g. `PR_STATE="OPEN\r"` instead of `"OPEN"`). String comparisons like
+#   `[[ "$PR_STATE" != "OPEN" ]]` then fail spuriously, and any variable spliced
+#   into a URL or API path carries a stray CR. Every variable populated by the
+#   post-`gh pr view` read block below is stripped with `"${var%$'\r'}"` — a
+#   no-op on macOS/Linux, safe cross-platform. A blanket `tr -d '\r'` at the
+#   pipeline source was rejected because it would strip legitimate CRs from
+#   comment bodies flowing through the REST endpoints downstream.
+#
 # Exit codes:
 #   0  OK
 #   2  usage error (unknown flag, --since missing value, incompatible flag combo)
@@ -402,6 +414,18 @@ fi
   (.mergeStateStatus // ""),
   (.mergeable // ""),
   (.reviewDecision // "")')
+
+# Strip trailing CR that Windows Git Bash process substitution injects on each
+# line of jq output. Without this, comparisons like `[[ "$PR_STATE" != "OPEN" ]]`
+# fire spuriously and API path fragments (HEAD_SHA, etc.) carry a stray \r.
+# No-op on macOS/Linux. See "Platform notes" in the file header.
+PR_NUMBER="${PR_NUMBER%$'\r'}"
+PR_STATE="${PR_STATE%$'\r'}"
+HEAD_SHA="${HEAD_SHA%$'\r'}"
+PR_URL="${PR_URL%$'\r'}"
+MERGE_STATE="${MERGE_STATE%$'\r'}"
+MERGEABLE="${MERGEABLE%$'\r'}"
+REVIEW_DECISION="${REVIEW_DECISION%$'\r'}"
 
 if [[ "$PR_STATE" != "OPEN" ]]; then
   echo "ERROR: PR #$PR_NUMBER is $PR_STATE — nothing to audit" >&2


### PR DESCRIPTION
## **User description**
## Summary

- Fixes `pr-state.sh` exiting 4 with `ERROR: PR #N is OPEN — nothing to audit` against every actual OPEN PR on Windows Git Bash, which broke `/fixpr`, `/merge`, `/wrap`, `/continue`, `/status`, `phase-b-reviewer`, and `phase-c-merger` on Windows.
- Root cause: Windows Git Bash process substitution (`< <(...)`) appends `\r` to each line of `jq -r` output. The `read` block after `gh pr view` populates `PR_STATE="OPEN\r"`, so `[[ "$PR_STATE" != "OPEN" ]]` fires spuriously.
- Fix: strip `${var%$'\r'}` from all 7 variables populated by that read block. Added a "Platform notes" header section documenting the pattern (no-op on macOS/Linux).

## Scope decision

The repo-wide grep confirmed exactly one `read < <(jq …)` construct in the script. Other jq output flows through command substitution `$(…)`, which behaves differently for trailing `\r` and has not been reported broken; deferring those to a follow-up if reproduced.

Closes #1161

## Test plan
- [x] `pr-state.sh --pr <open-pr>` returns valid JSON on Windows Git Bash (previously exited 4)
- [x] All 7 read-block variables (PR_NUMBER, PR_STATE, HEAD_SHA, PR_URL, MERGE_STATE, MERGEABLE, REVIEW_DECISION) have the `${var%$'\r'}` strip applied
- [x] `${var%$'\r'}` is a no-op on macOS/Linux (nothing to strip when no CR is present)
- [x] Script header contains a Platform-notes section explaining that Windows Git Bash CRLF handling is the reason for the per-variable strip pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Prevent open pull requests from being misclassified on Windows Git Bash

### What Changed
- Pull request state and related details are cleaned up before comparison and API use, so open pull requests are recognized correctly on Windows Git Bash
- Commands such as `/fixpr`, `/merge`, `/wrap`, `/continue`, `/status`, and review or merge phases no longer fail because of hidden carriage-return characters
- Added platform guidance explaining the Windows-specific behavior and cross-platform handling

### Impact
`✅ Open PRs remain usable on Windows Git Bash`
`✅ Fewer false “PR is OPEN — nothing to audit” errors`
`✅ Reliable PR URLs and identifiers across supported platforms`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request status handling on Windows Git Bash by normalizing command output, preventing comparison and API-processing issues caused by trailing carriage returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
