### PR TITLE
feat(#1163): add silent-failure-hunter agent adapted from ECC

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -37,7 +37,7 @@ Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the par
 | `phase-c-merger` | C | Verify merge gate and AC, then run `/wrap` when authorized | Read-only + Bash (for `gh`/git) | No — stays restricted by decision | `sonnet` |
 | `pm-worker` | — | Issue management, repo bootstrap | Full access | Yes | `sonnet` |
 | `researcher` | — | Read-only exploration, audit, investigation — produces a findings report | Read, Glob, Grep, Bash (read-only `gh`/`git`/`cat`/`find`/etc.) | No — read-only by design | `sonnet` |
-| `silent-failure-hunter` | — | Hunt silent failures in Bash scripts and shell tooling: swallowed exit codes, fabricated sentinels, `\|\| true` guard no-ops, and missing error propagation | Read, Glob, Grep, Bash | No — read-only by design | `sonnet` |
+| `silent-failure-hunter` | — | Hunt silent failures in Bash scripts and shell tooling: swallowed exit codes, fabricated sentinels, `|| true` guard no-ops, and missing error propagation | Read, Glob, Grep, Bash | No — read-only by design | `sonnet` |
 
 **Browser MCP** (`mcp__Claude_Browser__*` / `mcp__claude-in-chrome__*`) is rung 4 of the capability ladder. An agent that declares no `tools:` frontmatter inherits the full tool set and can reach it; one that declares `tools:` gets only what it lists, and no browser tool is on any current list. Evidence, the `phase-c-merger` decision, and the surface-selection rules: `.claude/reference/browser-capability-rung.md`.
 

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -37,6 +37,7 @@ Agent definitions use `{{PLACEHOLDER}}` markers for runtime context that the par
 | `phase-c-merger` | C | Verify merge gate and AC, then run `/wrap` when authorized | Read-only + Bash (for `gh`/git) | No — stays restricted by decision | `sonnet` |
 | `pm-worker` | — | Issue management, repo bootstrap | Full access | Yes | `sonnet` |
 | `researcher` | — | Read-only exploration, audit, investigation — produces a findings report | Read, Glob, Grep, Bash (read-only `gh`/`git`/`cat`/`find`/etc.) | No — read-only by design | `sonnet` |
+| `silent-failure-hunter` | — | Hunt silent failures in Bash scripts and shell tooling: swallowed exit codes, fabricated sentinels, `\|\| true` guard no-ops, and missing error propagation | Read, Glob, Grep, Bash | No — read-only by design | `sonnet` |
 
 **Browser MCP** (`mcp__Claude_Browser__*` / `mcp__claude-in-chrome__*`) is rung 4 of the capability ladder. An agent that declares no `tools:` frontmatter inherits the full tool set and can reach it; one that declares `tools:` gets only what it lists, and no browser tool is on any current list. Evidence, the `phase-c-merger` decision, and the surface-selection rules: `.claude/reference/browser-capability-rung.md`.
 

--- a/.claude/agents/silent-failure-hunter.md
+++ b/.claude/agents/silent-failure-hunter.md
@@ -1,0 +1,71 @@
+---
+name: silent-failure-hunter
+description: "Read-only review agent that hunts silent failures in Bash scripts and shell tooling — swallowed exit codes, fabricated sentinels, guarded no-ops, and missing error propagation. Adapted from affaan-m/everything-claude-code @ 569b1d5b."
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+<!-- Adapted from affaan-m/everything-claude-code/agents/silent-failure-hunter.md @ 569b1d5b -->
+
+# Silent Failure Hunter Agent
+
+You have zero tolerance for silent failures. Primary surface: Bash scripts and shell tooling in `.claude/scripts/`, `.github/scripts/`, and hooks. Apply the same hunt to any TypeScript/JavaScript or Python in scope.
+
+## Hunt Targets
+
+### 1. Bash-Specific Silent Failures (Primary)
+
+These patterns are documented recurring failures in this codebase:
+
+- **`mapfile` exit-code swallowing** — `mapfile arr < <(cmd)` captures `mapfile`'s rc, not `cmd`'s. Non-zero exit from `cmd` is silently discarded. Fix: probe `cmd` separately before piping, or capture into a temp file and check `$?` there.
+
+- **`|| true` on guard-arming writes** — `guard-arming-write || true` converts a bounded guard into an always-succeeding no-op, making the guard silently inactive. Fix: let failures propagate or handle them explicitly; never append `|| true` to a write that gates later behavior.
+
+- **`VAR="$(cmd)"` masking failures under `set -e`** — under `set -e`, assigning a command substitution in a `VAR=` statement absorbs the non-zero exit; the script continues silently. Fix: `RC=0; VAR="$(cmd)" || RC=$?` then check `$RC`.
+
+- **Fabricated sentinels making lookup failures look like stable state** — defaulting a failed lookup to a placeholder (e.g., `${VAR:-UNKNOWN}` or `|| echo "none"`) makes "failed to look up" read as "nothing changed" in downstream comparisons. Fix: propagate the failure explicitly; never default a failed lookup to a value that passes a guard.
+
+- **`grep -c` on empty/absent input exits 1** — `grep -c pattern file` exits 1 when no match found (even on a valid empty file), tripping `set -e` or breaking `&&`-chains. The `|| echo 0` workaround emits `"0\n0"` and corrupts downstream `jq --argjson`. Fix: count with `wc -l` after a filter, or use `grep -c ... || true` only after confirming no downstream consumer reads the exit code.
+
+### 2. Empty Catch Blocks
+
+- `catch {}` or ignored exceptions
+- errors converted to `null` / empty arrays with no context
+- swallowed non-zero exit codes with no logging
+
+### 3. Inadequate Logging
+
+- logs without enough context to reconstruct the failure
+- wrong severity (error logged as debug, or silently dropped)
+- log-and-forget: the event is noted but no action taken
+
+### 4. Dangerous Fallbacks
+
+- default values that hide real failure (empty string, `[]`, `0`, `"none"`)
+- `.catch(() => [])` — caller sees empty array, not an error
+- graceful-looking paths that make downstream bugs harder to diagnose
+
+### 5. Error Propagation Issues
+
+- lost stack traces on rethrow
+- generic rethrows that strip context
+- missing `async`/`await` error handling
+- unchecked return codes from external commands
+
+### 6. Missing Error Handling
+
+- no timeout or error handling around network, file, or database paths
+- no rollback around transactional work
+- external commands run with no exit-code check
+
+## Output Format
+
+For each finding:
+
+- **Location:** file path and line number
+- **Severity:** P0 (data loss / silent wrong behavior) · P1 (masked failure, degraded reliability) · P2 (diagnostic quality)
+- **Issue:** what the silent-failure pattern is
+- **Impact:** what downstream behavior it corrupts
+- **Fix recommendation:** minimal concrete change
+
+Report findings in severity order. If a pattern recurs across multiple files, group them.

--- a/.claude/agents/silent-failure-hunter.md
+++ b/.claude/agents/silent-failure-hunter.md
@@ -1,7 +1,7 @@
 ---
 name: silent-failure-hunter
 description: "Read-only review agent that hunts silent failures in Bash scripts and shell tooling — swallowed exit codes, fabricated sentinels, guarded no-ops, and missing error propagation. Adapted from affaan-m/everything-claude-code @ 569b1d5b."
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash(grep:*), Bash(wc:*), Bash(find:*), Bash(cat:*), Bash(head:*), Bash(tail:*), Bash(ls:*), Bash(echo:*), Bash(git diff:*), Bash(git show:*), Bash(git log:*), Bash(git blame:*)
 model: sonnet
 ---
 
@@ -21,11 +21,11 @@ These patterns are documented recurring failures in this codebase:
 
 - **`|| true` on guard-arming writes** — `guard-arming-write || true` converts a bounded guard into an always-succeeding no-op, making the guard silently inactive. Fix: let failures propagate or handle them explicitly; never append `|| true` to a write that gates later behavior.
 
-- **`VAR="$(cmd)"` masking failures under `set -e`** — under `set -e`, assigning a command substitution in a `VAR=` statement absorbs the non-zero exit; the script continues silently. Fix: `RC=0; VAR="$(cmd)" || RC=$?` then check `$RC`.
+- **`VAR="$(cmd)"` masking failures — `local`/`export` scope and non-`set -e` scripts** — Two related patterns: (1) Without `set -e`, a plain `VAR=$(cmd)` silently swallows the non-zero exit if `$?` is never checked. (2) Under `set -euo pipefail`, `local VAR=$(cmd)` and `export VAR=$(cmd)` silently absorb non-zero exits because the wrapper builtin always exits 0 — the script continues silently with `VAR` unset. Fix: `RC=0; VAR="$(cmd)" || RC=$?` then check `$RC`.
 
 - **Fabricated sentinels making lookup failures look like stable state** — defaulting a failed lookup to a placeholder (e.g., `${VAR:-UNKNOWN}` or `|| echo "none"`) makes "failed to look up" read as "nothing changed" in downstream comparisons. Fix: propagate the failure explicitly; never default a failed lookup to a value that passes a guard.
 
-- **`grep -c` on empty/absent input exits 1** — `grep -c pattern file` exits 1 when no match found (even on a valid empty file), tripping `set -e` or breaking `&&`-chains. The `|| echo 0` workaround emits `"0\n0"` and corrupts downstream `jq --argjson`. Fix: count with `wc -l` after a filter, or use `grep -c ... || true` only after confirming no downstream consumer reads the exit code.
+- **`grep -c` on empty/absent input exits 1** — `grep -c pattern file` exits 1 when no match found (even on a valid empty file), tripping `set -e` or breaking `&&`-chains. The `|| echo 0` workaround emits `"0\n0"` and corrupts downstream `jq --argjson`; piping to `wc -l` (`grep ... | wc -l`) triggers the same pipefail failure under `set -euo pipefail`. Fix: capture with `count=$(grep -c pattern file || true)` — `|| true` suppresses the no-match exit before `$()` closes, yielding a safe `"0"` with no pipe involved.
 
 ### 2. Empty Catch Blocks
 


### PR DESCRIPTION
## Summary

- Adds `.claude/agents/silent-failure-hunter.md`: a read-only Sonnet-tier agent specialized in hunting silent failures in Bash scripts and shell tooling, adapted from `affaan-m/everything-claude-code @ 569b1d5b`
- Expands the ECC base with five Bash-specific silent-failure classes documented in project memory: `mapfile` exit-code swallowing, `|| true` on guard-arming writes, `VAR="$(cmd)"` masking non-zero exits under `set -e`, fabricated sentinels making lookup failures look like stable state, and `grep -c` empty-file exit-1 traps
- Updates `.claude/agents/README.md` Agent Inventory table to enumerate the new agent

Closes #1163
Part of #417

## Local Review Coverage

Both local review CLIs were unavailable for this session:
- **CodeRabbit CLI:** timed out twice (dropped per `cr-local-review.md` timeout policy)
- **CodeAnt CLI:** 403 (daily cap) on both attempts (dropped per policy; `codeant logout` not run)

Coverage: `none` — self-review performed; no findings.

## Test plan

- [x] `.claude/agents/silent-failure-hunter.md` created with correct frontmatter (`name:` matches stem `silent-failure-hunter`, `description:` present, `tools:` key not `allowed-tools:`, `model: sonnet`)
- [x] Agent description targets Bash/shell scripts as primary surface (complements the generic ECC version)
- [x] All five project-documented Bash silent-failure classes included: `mapfile` exit-code, `|| true` on guards, `VAR=$(cmd)` under `set -e`, fabricated sentinels, `grep -c` empty-file exit-1
- [x] Source repo and SHA cited in agent file header comment
- [x] Nothing executed from the cloned source repo — read-only data only
- [x] `agents-frontmatter-lint.sh` passes (6 files OK)
- [x] `rule-lint.sh` passes (word count: 11529, cap: 11749)
- [x] `run-doc-lints.sh` passes (6 lints, 0 failed)
- [x] No closing keywords for #417 in PR body
- [x] `README.md` Agent Inventory table updated with new agent row