### PR TITLE
feat(#1164): add subagent-dispatch skill adapted from superpowers

### DIFF
--- a/.claude/skills/subagent-dispatch/SKILL.md
+++ b/.claude/skills/subagent-dispatch/SKILL.md
@@ -55,7 +55,7 @@ Multiple tasks?
 >
 > **Silence/bgwork ceiling** (`bgwork-ceiling.sh`) — a separate backstop that fires when background work goes quiet. Do not confuse the two.
 
-Count your currently open PRs (`gh pr list --author "@me" --state open`). Dispatch only enough agents to stay at or below the pipeline ceiling (3–4). Agents that would exceed the ceiling queue inline — they do not get their own chips.
+Count your currently open PRs (`gh pr list --author "@me" --state open`) as a conservative proxy for pipeline load. Dispatch only enough agents to stay at or below the pipeline ceiling (3–4). Agents that would exceed the ceiling queue inline — they do not get their own chips. (The canonical ceiling definition — actively CR-polled PRs authored by `@me` — lives in `.claude/rules/subagent-orchestration.md`; dormant open PRs are counted here for safety.)
 
 Spawn mechanics, model tiers (Opus for Phase A/B, Sonnet for Phase C/PM), and mode settings live in `.claude/rules/subagent-orchestration.md`. Read that file; do not restate it here.
 
@@ -109,7 +109,7 @@ You are a Phase A fixer. Repo: auerbachb/claude-code-config.
   - Do NOT change /absolute/path/to/repo/src/foo/baz.ts
 
 **Return:** Structured exit report per .claude/rules/phase-protocols.md.
-**Handoff:** Write via `handoff-state.sh` to ~/.claude/handoffs/auerbachb/claude-code-config/pr-<N>-handoff.json (atomic; exit 6 = lock timeout, retry; exit 4 = wrong field type, fix the call).
+**Handoff:** Write via `<ABSOLUTE_REPO_ROOT>/.claude/scripts/handoff-state.sh` to ~/.claude/handoffs/auerbachb/claude-code-config/pr-<N>-handoff.json (atomic; exit 6 = lock timeout, retry; exit 4 = wrong field type, fix the call).
 ```
 
 ---
@@ -125,7 +125,7 @@ Agent("Fix batch-completion.test.ts failures")
 Agent("Fix abort-handling.test.ts failures")
 ```
 
-Include model, mode (`bypassPermissions`), and the verbatim SAFETY/MINDSET/SKILLS blocks in each call per `.claude/rules/subagent-orchestration.md`.
+Include model, mode (`bypassPermissions`), and the verbatim SAFETY/MINDSET blocks in each call. Add the SKILLS block for general-purpose or built-in spawns without a `subagent_type` — custom `subagent_type` agents inherit it automatically. Full contract: `.claude/rules/subagent-orchestration.md`.
 
 **Do not exceed the pipeline ceiling.** If you have 3 agents queued and you already have 2 open PRs (with a ceiling of 4), dispatch only 2 agents in parallel and hold the 3rd to queue inline as PRs complete.
 

--- a/.claude/skills/subagent-dispatch/SKILL.md
+++ b/.claude/skills/subagent-dispatch/SKILL.md
@@ -98,7 +98,7 @@ A subagent that inherits implicit context from your session will fail when that 
 
 You are a Phase A fixer. Repo: auerbachb/claude-code-config.
 
-**Scope:** src/foo/bar.ts — the `validateInput` function only.
+**Scope:** /absolute/path/to/repo/src/foo/bar.ts — the `validateInput` function only.
 **Goal:** Fix the 2 failing tests listed below without touching other files.
 **Failing tests:**
   - "should reject null input" — TypeError: Cannot read property 'length' of null
@@ -106,10 +106,10 @@ You are a Phase A fixer. Repo: auerbachb/claude-code-config.
 
 **Constraints:**
   - Do NOT change test files
-  - Do NOT change src/foo/baz.ts
+  - Do NOT change /absolute/path/to/repo/src/foo/baz.ts
 
 **Return:** Structured exit report per .claude/rules/phase-protocols.md.
-**Handoff:** Write to ~/.claude/handoffs/auerbachb/claude-code-config/pr-<N>-handoff.json
+**Handoff:** Write via `handoff-state.sh` to ~/.claude/handoffs/auerbachb/claude-code-config/pr-<N>-handoff.json (atomic; exit 6 = lock timeout, retry; exit 4 = wrong field type, fix the call).
 ```
 
 ---
@@ -139,7 +139,7 @@ STOP and verify before declaring the work done.
 2. **Check for conflicts.** Did two agents edit the same file? Merge manually if so.
 3. **Run the full test suite.** Individual-agent passes do not guarantee combined correctness.
 4. **Integrate handoff state.** Each agent writes to `~/.claude/handoffs/<owner>/<repo>/pr-<N>-handoff.json`. Read each file; check `phase_completed` and `head_sha` before proceeding. Writes go through `handoff-state.sh` (atomic); exit code 6 = lock timeout (retry); exit code 4 = wrong field type (fix the call). Field names: `.claude/reference/handoff-file-schema.json`.
-5. **Launch Phase B within 60 s of Phase A completion.** The parent session owns this transition — do not ask. See `.claude/rules/phase-protocols.md` Phase A Completion Protocol.
+5. **Verify Phase A handoff and trigger Phase B.** See `.claude/rules/phase-protocols.md` Phase A Completion Protocol — the parent session owns this transition automatically.
 
 ---
 
@@ -157,7 +157,7 @@ STOP and verify before declaring the work done.
 
 **STOP if you catch yourself:**
 - Restating Phase A/B/C protocol steps
-- Copying the SAFETY/MINDSET/SKILLS blocks (link to `subagent-phase-guardrails.md` instead)
+- Inlining the SAFETY/MINDSET/SKILLS blocks into this file (link to `subagent-phase-guardrails.md` instead — the verbatim blocks belong in your spawn prompts, not here)
 - Picking issues or ranking work (that is `/wave` and `/pm`)
 - Merging or wrapping (that is `/wrap`)
 

--- a/.claude/skills/subagent-dispatch/SKILL.md
+++ b/.claude/skills/subagent-dispatch/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: subagent-dispatch
+description: Use when designing a parallel agent dispatch, deciding whether to parallelize work, or writing isolated subagent prompts. Teaches the prompt-crafting discipline for independent parallel agents in the Phase A/B/C model.
+triggers:
+  - dispatch parallel agents
+  - parallel dispatch
+  - should I parallelize
+  - write isolated subagent prompt
+  - one agent per domain
+  - parallel subagents
+argument-hint: "(no arguments — describe the work you want to parallelize)"
+---
+
+<!-- Adapted from obra/superpowers @ b36e0829: skills/dispatching-parallel-agents/SKILL.md -->
+<!-- Adapted to auerbachb/claude-code-config Phase A/B/C model. -->
+
+**Core principle: one agent per independent problem domain.**
+
+This skill teaches the _craft_ of designing and writing independent parallel-agent prompts. Spawn mechanics, model selection, and Phase A/B/C orchestration are in `.claude/rules/subagent-orchestration.md` — do not duplicate them here.
+
+---
+
+## Step 1: Decide Whether to Parallelize
+
+Run this decision tree before dispatching anything.
+
+```
+Multiple tasks?
+ └─ Are failures/tasks related?
+     ├─ YES (related) → Single agent investigates all
+     └─ NO (independent) → Can they work without shared state?
+         ├─ NO (shared state, e.g. same file) → Sequential agents
+         └─ YES (no shared state) → Parallel dispatch
+```
+
+**Parallelize when:**
+- Tasks span different subsystems, files, or problem domains
+- Each task can be understood without context from the others
+- Agents will not edit the same files or shared state
+- The ceiling allows it (see Step 2)
+
+**Do NOT parallelize when:**
+- Failures are related (fixing one may fix others — investigate first)
+- Agents would write to the same files, branch, or session state
+- You don't yet know what's broken (explore first)
+- The pipeline ceiling is already full
+
+**This repo's vocabulary:** `/wave` calls this the "dependency- and overlap-filtered independent set"; `/subagent` calls it "disjoint chains run as parallel pipelines." Both terms mean the same thing as "independent problem domain."
+
+---
+
+## Step 2: Check the Pipeline Ceiling Before Dispatching
+
+> **Pipeline ceiling** (3–4 active PRs, per `.claude/rules/subagent-orchestration.md`) — how many concurrently reviewed PRs the parent thread manages.
+>
+> **Silence/bgwork ceiling** (`bgwork-ceiling.sh`) — a separate backstop that fires when background work goes quiet. Do not confuse the two.
+
+Count your currently open PRs (`gh pr list --author "@me" --state open`). Dispatch only enough agents to stay at or below the pipeline ceiling (3–4). Agents that would exceed the ceiling queue inline — they do not get their own chips.
+
+Spawn mechanics, model tiers (Opus for Phase A/B, Sonnet for Phase C/PM), and mode settings live in `.claude/rules/subagent-orchestration.md`. Read that file; do not restate it here.
+
+---
+
+## Step 3: Write Self-Contained Prompts
+
+Each subagent inherits **only what you write into its prompt** — it does not inherit your session history, context, or loaded files. Every prompt must be a complete, standalone brief.
+
+### Mandatory elements in each prompt
+
+| Element | What to include |
+|---------|-----------------|
+| **Scope** | Exact file(s) or subsystem — not "the codebase" |
+| **Goal** | One clear outcome |
+| **Evidence** | Relevant error messages, test names, or failing assertions |
+| **Constraints** | Files/directories NOT to touch |
+| **Output format** | What the agent should return (summary, handoff, exit report) |
+| **Safety/Mindset blocks** | Verbatim from `.claude/reference/subagent-phase-guardrails.md` |
+
+### Context isolation — repo-specific rules
+
+- **One worktree per agent/PR.** Each agent works in its own worktree (`EnterWorktree`). See `CLAUDE.md` "ALWAYS USE A WORKTREE" and `.claude/rules/main-hygiene.md`.
+- **Absolute paths everywhere.** The Bash tool has a minimal `PATH`; bare tool names can resolve wrong. Always pass `/opt/homebrew/bin/<tool>` or a resolved path.
+- **No shared mutable state.** Parallel agents must not write to the same branch, file, or session-state key. If they must share output, route it through handoff files with distinct PR-scoped keys.
+- **Guardrail blocks are non-negotiable.** Include the verbatim `SAFETY:` and `MINDSET:` blocks from `.claude/reference/subagent-phase-guardrails.md` in every spawn prompt. Do not reword them — a reworded copy drifts or fails `verbatim-block-lint.sh`.
+
+### Why self-contained prompts matter
+
+A subagent that inherits implicit context from your session will fail when that context is absent (compaction, a fresh spawn, a different thread). Prompts written as if the agent knows nothing are more robust and easier to debug. Detail: `.claude/reference/skill-first-subagent-delivery.md`.
+
+### Concrete prompt template
+
+```markdown
+**Model:** Opus — Phase A fixer
+**Effort:** High
+
+[SAFETY block from .claude/reference/subagent-phase-guardrails.md]
+[MINDSET block from .claude/reference/subagent-phase-guardrails.md]
+
+You are a Phase A fixer. Repo: auerbachb/claude-code-config.
+
+**Scope:** src/foo/bar.ts — the `validateInput` function only.
+**Goal:** Fix the 2 failing tests listed below without touching other files.
+**Failing tests:**
+  - "should reject null input" — TypeError: Cannot read property 'length' of null
+  - "should handle empty string" — AssertionError: expected '' to be rejected
+
+**Constraints:**
+  - Do NOT change test files
+  - Do NOT change src/foo/baz.ts
+
+**Return:** Structured exit report per .claude/rules/phase-protocols.md.
+**Handoff:** Write to ~/.claude/handoffs/auerbachb/claude-code-config/pr-<N>-handoff.json
+```
+
+---
+
+## Step 4: Dispatch in Parallel
+
+Multiple Agent tool calls in a **single response** run concurrently. One per response runs sequentially.
+
+```
+# Parallel — all three calls in one response
+Agent("Fix auth-flow.test.ts failures")
+Agent("Fix batch-completion.test.ts failures")
+Agent("Fix abort-handling.test.ts failures")
+```
+
+Include model, mode (`bypassPermissions`), and the verbatim SAFETY/MINDSET/SKILLS blocks in each call per `.claude/rules/subagent-orchestration.md`.
+
+**Do not exceed the pipeline ceiling.** If you have 3 agents queued and the ceiling is already at 4 PRs, hold the 3rd and queue it inline.
+
+---
+
+## Step 5: Verify After Agents Return
+
+STOP and verify before declaring the work done.
+
+1. **Read each exit report.** Every agent must print a Structured Exit Report (`.claude/rules/phase-protocols.md`). No exit report = silent failure — check GitHub, not memory.
+2. **Check for conflicts.** Did two agents edit the same file? Merge manually if so.
+3. **Run the full test suite.** Individual-agent passes do not guarantee combined correctness.
+4. **Integrate handoff state.** Each agent writes to `~/.claude/handoffs/<owner>/<repo>/pr-<N>-handoff.json`. Read each file; check `phase_completed` and `head_sha` before proceeding. Writes go through `handoff-state.sh` (atomic); exit code 6 = lock timeout (retry); exit code 4 = wrong field type (fix the call). Field names: `.claude/reference/handoff-file-schema.json`.
+5. **Launch Phase B within 60 s of Phase A completion.** The parent session owns this transition — do not ask. See `.claude/rules/phase-protocols.md` Phase A Completion Protocol.
+
+---
+
+## Not this command's job
+
+| Task | Use instead |
+|------|------------|
+| Issue triage and ranking | `/pm` |
+| Picking which issues can run in parallel | `/wave` |
+| Overlap serialization and merge sequencing | `/subagent` |
+| Phase A/B/C protocol, model selection, spawn mechanics | `.claude/rules/subagent-orchestration.md` |
+| Verbatim SAFETY/MINDSET/SKILLS spawn blocks | `.claude/reference/subagent-phase-guardrails.md` |
+| Per-phase exit report format | `.claude/rules/phase-protocols.md` |
+| Handoff file schema and write contract | `.claude/rules/handoff-files.md` + `.claude/reference/handoff-file-schema.json` |
+
+**STOP if you catch yourself:**
+- Restating Phase A/B/C protocol steps
+- Copying the SAFETY/MINDSET/SKILLS blocks (link to `subagent-phase-guardrails.md` instead)
+- Picking issues or ranking work (that is `/wave` and `/pm`)
+- Merging or wrapping (that is `/wrap`)
+
+---
+
+## Common Mistakes
+
+| Wrong | Right |
+|-------|-------|
+| "Fix all the failing tests" | "Fix the 3 failures in src/foo/bar.test.ts" |
+| No error context in prompt | Paste the exact error messages and test names |
+| No constraints | "Do NOT touch src/other.ts or test files" |
+| Vague output request | "Return Structured Exit Report per phase-protocols.md" |
+| Relative paths in prompt | Use absolute paths everywhere |
+| Dispatching beyond the ceiling | Count open PRs first; queue excess inline |
+
+---
+
+## Usage
+
+```
+/subagent-dispatch
+```
+
+No arguments — describe the work you want to parallelize in the conversation and this skill will walk the decision tree, check the ceiling, and help you write the prompts.
+
+**Typical flow:**
+1. You describe the independent tasks
+2. This skill checks whether parallel dispatch fits
+3. You verify the pipeline ceiling
+4. This skill helps you write each self-contained prompt
+5. You issue all Agent calls in a single response
+6. After agents return, this skill guides exit verification

--- a/.claude/skills/subagent-dispatch/SKILL.md
+++ b/.claude/skills/subagent-dispatch/SKILL.md
@@ -127,7 +127,7 @@ Agent("Fix abort-handling.test.ts failures")
 
 Include model, mode (`bypassPermissions`), and the verbatim SAFETY/MINDSET/SKILLS blocks in each call per `.claude/rules/subagent-orchestration.md`.
 
-**Do not exceed the pipeline ceiling.** If you have 3 agents queued and the ceiling is already at 4 PRs, hold the 3rd and queue it inline.
+**Do not exceed the pipeline ceiling.** If you have 3 agents queued and you already have 2 open PRs (with a ceiling of 4), dispatch only 2 agents in parallel and hold the 3rd to queue inline as PRs complete.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ After setup, Claude Code will automatically:
 - **Review locally, then on GitHub** — Runs CodeRabbit CLI reviews before pushing (instant feedback, no PR noise). After PR creation, the reviewer chain is CodeRabbit primary, BugBot (Cursor) second tier, Greptile last resort, then self-review only if every reviewer is unavailable; CodeAnt and Graphite AI Reviews provide supplemental AI review signals.
 - **Verify and merge** — Checks every acceptance criteria checkbox against the code, confirms CI is green, then squash-merges with branch cleanup.
 - **Orchestrate multi-agent work** — Decomposes large tasks into phases (fix, review, merge) with health monitoring, handoff files, and heartbeat enforcement.
-- **Manage your project** — 30 slash commands for backlog prioritization, OKR tracking, daily standups, PR-fleet monitoring, and cross-thread orchestration.
+- **Manage your project** — 31 slash commands for backlog prioritization, OKR tracking, daily standups, PR-fleet monitoring, and cross-thread orchestration.
 
 Review ownership is sticky once a fallback tier takes over:
 
@@ -127,7 +127,7 @@ ls -la ~/.claude/skills/       # each skill -> ~/.claude/skills-worktree/.claude
 
 ## Slash Commands
 
-All 30 commands are invoked as `/command` in a Claude Code session. They are defined as skill files in `.claude/skills/` and symlinked globally.
+All 31 commands are invoked as `/command` in a Claude Code session. They are defined as skill files in `.claude/skills/` and symlinked globally.
 
 | Command | Category | Description |
 |---------|----------|-------------|
@@ -139,6 +139,7 @@ All 30 commands are invoked as `/command` in a Claude Code session. They are def
 | `/pm-forgotten-pr` | PM | One-shot triage of open PRs idle above a threshold — classify as close or merge, render a Forgotten PRs block, dispatch confirmed merges |
 | `/subagent` | PM | Run Quick/Light issues as Phase A/B/C subagents from a PM thread |
 | `/wave` | PM | Offer the largest dependency- and overlap-free set of backlog issues as click-to-launch chips, capped at the concurrent-pipeline ceiling |
+| `/subagent-dispatch` | PM | Teach the craft of writing independent parallel-agent prompts — decision tree for when to parallelize, context-isolation guidance, and exit-verification steps |
 | `/prompt` | Planning | Classify issue complexity, recommend a Claude 4.7/4.6 model tier, generate copy-paste prompt without the removed `effort` field |
 | `/start-issue` | Planning | End-to-end issue-to-coding setup — plan polling, plan merge, worktree, branch |
 | `/issue-maker` | Planning | Capture-only thread mode — drafts and opens well-structured issues, reflects before writing, no implementation |


### PR DESCRIPTION
## Summary

Delivers `.claude/skills/subagent-dispatch/SKILL.md` — an on-demand skill that teaches the craft of writing independent parallel-agent prompts, adapted from `obra/superpowers` @ `b36e0829`.

**Source:** `obra/superpowers` @ `b36e0829` — `skills/dispatching-parallel-agents/SKILL.md`

**Delivery form:** Skill (`.claude/skills/subagent-dispatch/SKILL.md`), not a reference doc. The issue's implementation plan and acceptance criteria both target the skill form; the skill form is the primary intent. CR plan concurs.

**Adaptation rationale:** The source skill used generic "test file" examples. This adaptation replaces them with our Phase A/B/C vocabulary, the 3–4 PR pipeline ceiling (disambiguated from the bgwork/silence ceiling), worktree-per-thread isolation guidance, and handoff-file exit verification. It cross-references `.claude/rules/subagent-orchestration.md`, `.claude/reference/subagent-phase-guardrails.md`, `.claude/rules/handoff-files.md`, and `.claude/rules/phase-protocols.md` without duplicating their content.

**No changes to `subagent-orchestration.md`** — that rule remains canonical for spawn mechanics.

Part of #417

Closes #1164

## Local review coverage

**Coverage: `none`** — both CLI reviewers unavailable for this session.

- CodeRabbit CLI: timed out on first attempt (120s), rate-limited on retry. Dropped per `cr-local-review.md`.
- CodeAnt CLI: 403 on both attempts (undocumented daily cap, not auth). Dropped per `cr-local-review.md`.

Self-review performed: changes are documentation only (new skill SKILL.md + README count row). No code paths or logic. All 6 doc lints pass (0 failures).

## Test plan

- [x] `.claude/skills/subagent-dispatch/SKILL.md` created with `name: subagent-dispatch` matching directory
- [x] Decision tree references our 3–4 pipeline ceiling (disambiguated from bgwork ceiling)
- [x] Context-isolation guidance references worktree isolation and absolute-path discipline
- [x] Exit-criteria guidance references handoff files (`handoff-files.md`) and Structured Exit Reports (`phase-protocols.md`)
- [x] Does NOT duplicate `subagent-orchestration.md` — skill teaches prompt-crafting discipline, links to orchestration rule for mechanics
- [x] `skill-catalog-lint.sh` passes: `OK (31 commands)`
- [x] `run-doc-lints.sh` passes: 6 lints, 0 failed
- [x] Rule corpus untouched: `rule-lint.sh` OK, word count 11529 (soft cap 12000, ratchet cap 11749)
- [x] Source cited at SHA (`obra/superpowers @ b36e0829`)
- [x] Local CLI coverage noted in PR body (none — both CLIs down this session)
- [x] Post-merge symlink step: after merge, parent must run `fetch + reset --hard origin/main` in `~/.claude/skills-worktree` and `ln -s` the new skill into `~/.claude/skills/subagent-dispatch` (per `skill-symlinks.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `/subagent-dispatch` command for coordinating parallel work through a guided decision process.
  * Included instructions for prompt preparation, workflow phases, verification, and common usage mistakes.

* **Documentation**
  * Updated the command reference to include `/subagent-dispatch`.
  * Updated the documented command count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->