### PR TITLE
docs(#1171): define OUTCOME values for pm-worker and researcher exits

### DIFF
--- a/.claude/agents/pm-worker.md
+++ b/.claude/agents/pm-worker.md
@@ -54,9 +54,9 @@ fi
 
 Classify the top candidate per `.claude/reference/autofile-dedup.md`:
 
-- **Strong match** (open issue, same primary artifact, a quotable covering criterion, `coverage ≥ 0.6`) → **do not file**. Post the finding as a comment on the existing issue using the template in `autofile-dedup.md`. Record in your exit report: `"<title>" — appended to #<N> instead of filing`. Proceed to the exit report (Steps 3 and 4 are skipped).
+- **Strong match** (open issue, same primary artifact, a quotable covering criterion, `coverage ≥ 0.6`) → **do not file**. Post the finding as a comment on the existing issue using the template in `autofile-dedup.md`. In the prose body **above** the exit report, record: `"<title>" — appended to #<N> instead of filing`. Proceed to the exit report (Steps 3 and 4 are skipped).
 - **Weak / ambiguous match** → file as normal (Step 3), and include `Possibly duplicates #<N> — <one line on the overlap>` in the issue body.
-- **No match** or helper not found → file as normal (Step 3). If the helper was missing, note the degraded check once in your exit report.
+- **No match** or helper not found → file as normal (Step 3). If the helper was missing, note the degraded check once in the prose body above the exit report.
 
 ### 3. Create the issue
 
@@ -117,15 +117,17 @@ Skill-first rules are inherited from `.claude/rules/skill-first.md` via the harn
 
 ## Exit Report (MANDATORY — print as final output)
 
-Every pm-worker invocation MUST print a structured exit report as its final output, for consistency with the Phase A/B/C orchestration model. This lets the parent agent parse pm-worker results mechanically.
+Every pm-worker invocation MUST print a structured exit report as its final output, for consistency with the Phase A/B/C orchestration model. This lets the parent agent parse pm-worker results mechanically. Canonical field and OUTCOME contract: `.claude/reference/exit-report-format.md`.
+
+Include the task-specific result (issue number created or deferred, bootstrap outcome, blocker description) in the prose body **above** the EXIT_REPORT block — not in the OUTCOME value.
 
 ```text
 EXIT_REPORT
-PHASE_COMPLETE: pm
+PHASE_COMPLETE: pm-worker
 PR_NUMBER: <PR number if a PR was created or referenced, else "none">
 HEAD_SHA: <current HEAD SHA if applicable, else "none">
 REVIEWER: <cr, bugbot, greptile, or none>
-OUTCOME: <issue_created|issue_deferred|repo_bootstrapped|blocked|exhaustion>
+OUTCOME: <completed|blocked|exhaustion>
 FILES_CHANGED: <comma-separated paths, or empty>
 NEXT_PHASE: none
 HANDOFF_FILE: none
@@ -133,8 +135,6 @@ HANDOFF_FILE: none
 
 **Valid OUTCOME values for pm-worker:**
 
-- `issue_created` — a GitHub issue was created (include issue number in your output before the exit report)
-- `issue_deferred` — dedup check found a strong match; finding was commented on the existing issue instead of filing (include the target issue number and a one-line summary in your output before the exit report)
-- `repo_bootstrapped` — a required workflow file was added or branch-protection gap reported
-- `blocked` — a task requires user confirmation (e.g., branch protection changes) or cannot proceed autonomously
-- `exhaustion` — token budget low, partial work applied
+- `completed` — task finished; specific result (issue number, deferral target, bootstrap outcome) is in the prose body above
+- `blocked` — could not complete autonomously — reason above (e.g. branch protection change requires user confirmation)
+- `exhaustion` — token budget low, partial work applied, replacement needed

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -63,12 +63,12 @@ Example prompts the parent might send:
 
 ## Exit Report Format
 
-Print this as your FINAL output:
+Print this as your FINAL output. Canonical OUTCOME contract: `.claude/reference/exit-report-format.md`.
 
 ```text
 EXIT_REPORT
 AGENT: researcher
-OUTCOME: <complete|partial|blocked>
+OUTCOME: <findings|inconclusive|blocked>
 SCOPE: <one-line summary of what was searched>
 
 FINDINGS:
@@ -82,8 +82,8 @@ RECOMMENDATIONS (optional):
 ```
 
 **Valid `OUTCOME` values for researcher:**
-- `complete` — research question fully answered with evidence.
-- `partial` — some evidence gathered, but the question could not be fully resolved (note what's missing).
+- `findings` — research question fully answered with evidence.
+- `inconclusive` — investigated but could not reach a confident answer (note what's missing or ambiguous).
 - `blocked` — could not proceed (e.g., required file unreadable, GitHub API error, question out of scope for read-only access).
 
 ## When to Spawn This Agent Instead of `general-purpose`

--- a/.claude/reference/exit-report-format.md
+++ b/.claude/reference/exit-report-format.md
@@ -20,10 +20,10 @@ HANDOFF_FILE: ~/.claude/handoffs/pr-618-handoff.json
 
 | Field | Values | Description |
 |-------|--------|-------------|
-| `PHASE_COMPLETE` | `A`, `B`, `C` | Which phase just finished |
-| `PR_NUMBER` | integer | The PR number |
-| `HEAD_SHA` | string | HEAD SHA after last push (or current HEAD) |
-| `REVIEWER` | `cr`, `bugbot`, `greptile` | Which reviewer owns this PR |
+| `PHASE_COMPLETE` | `A`, `B`, `C`, or non-phase agent name (e.g. `pm-worker`) | Which phase or agent just finished. `researcher` uses a distinct reduced schema with an `AGENT:` field instead; it has no `PHASE_COMPLETE` field. |
+| `PR_NUMBER` | integer, or `none` for non-phase agents | The PR number |
+| `HEAD_SHA` | string, or `none` for non-phase agents | HEAD SHA after last push (or current HEAD) |
+| `REVIEWER` | `cr`, `bugbot`, `greptile`, or `none` for non-phase agents | Which reviewer owns this PR |
 | `OUTCOME` | see below | What happened |
 | `FILES_CHANGED` | comma-separated paths | Files modified (empty string if none) |
 | `NEXT_PHASE` | `B`, `C`, `none` | What parent should launch next |
@@ -48,6 +48,18 @@ The three `FIXPR_*` fields are required whenever the phase executed the `/fixpr`
 | B | `exhaustion` | Token budget low — replacement needed |
 | C | `merged` | All AC verified and checked off; `/wrap` completed the squash merge and follow-up flow |
 | C | `blocked` | Merge blocked (CI failure, missing approvals, unchecked AC) |
+| `pm-worker` | `completed` | Task finished — specific result (issue number, deferral target, etc.) is in the prose body above the report |
+| `pm-worker` | `blocked` | Could not complete autonomously — reason above (e.g. branch protection change requires user confirmation) |
+| `pm-worker` | `exhaustion` | Token budget low — partial work applied, replacement needed |
+| `researcher` | `findings` | Investigation complete — evidence and findings are in the body above |
+| `researcher` | `inconclusive` | Investigated but could not reach a confident answer — gaps noted above |
+| `researcher` | `blocked` | Could not investigate — reason above (e.g. required file unreadable, GitHub API error, out of scope for read-only access) |
+
+## Non-Phase Agent Handling
+
+`pm-worker` and `researcher` emit an exit report for consistency with the Phase A/B/C orchestration model. However, the parent has **no `OUTCOME` branch protocol** for these agents (the A/B/C completion protocols in `phase-protocols.md` do not apply to them) — the parent reads the prose result directly and acts on it. The OUTCOME field on non-phase exit reports is informational, not a branch key.
+
+`researcher` uses a distinct reduced schema: no `PHASE_COMPLETE` field; `AGENT: researcher` carries agent identity. See `.claude/agents/researcher.md` for the full reduced-schema template.
 
 ## Rules
 

--- a/.claude/reference/pm-worker-hotspot-decision.md
+++ b/.claude/reference/pm-worker-hotspot-decision.md
@@ -76,8 +76,8 @@ Extract if the same pattern is introduced elsewhere and then requires a coordina
 | Repo bootstrap flow | `.claude/agents/pm-worker.md` | `.claude/rules/repo-bootstrap.md` owns the policy; `repo-bootstrap.sh` implements checks |
 | Safety and capability posture | Embedded in the agent definition for spawn-time availability | `.claude/rules/safety.md` is canonical; `subagent-phase-guardrails.md` holds verbatim spawn-prompt blocks |
 | Skill-first reflex | Embedded prose in the agent definition | `.claude/rules/skill-first.md` is canonical |
-| EXIT_REPORT block format | Inline in the agent definition (OUTCOME vocabulary is pm-worker-specific) | `.claude/reference/exit-report-format.md` owns the cross-phase field schema |
-| OUTCOME vocabulary (`issue_created`, `issue_deferred`, `repo_bootstrapped`, `blocked`, `exhaustion`) | Inline in `pm-worker.md`, matching `researcher.md` precedent for non-phase agents | Not delegated to a separate reference file |
+| EXIT_REPORT block format | Inline in the agent definition | `.claude/reference/exit-report-format.md` owns the cross-phase field schema |
+| OUTCOME vocabulary (`completed`, `blocked`, `exhaustion`) | `pm-worker.md` references the canonical set | `.claude/reference/exit-report-format.md` now owns the non-phase OUTCOME vocabulary (amended: Issue #1171) |
 | Model pin (`sonnet`) and frontmatter | `pm-worker.md` YAML frontmatter | `.claude/rules/subagent-orchestration.md` sets the fleet default |
 
 ## 4. Preserved invariants
@@ -137,3 +137,12 @@ both tasks in a future PR.
   is an unstable substrate propagated through one owner, not accumulation of independent concerns.
 - `.claude/reference/churn-hotspots.md` — hotspot reports are observational and require
   adjudication.
+
+## Amendment — Issue #1171
+
+The §3 ownership row for "OUTCOME vocabulary" was updated to reflect that the canonical values
+(`completed`, `blocked`, `exhaustion` for pm-worker; `findings`, `inconclusive`, `blocked` for
+researcher) now live in `.claude/reference/exit-report-format.md`. `pm-worker.md` and
+`researcher.md` reference that set rather than defining a private vocabulary. This change was
+required by Issue #1171, which identified that non-phase agents were inventing undefined OUTCOME
+values because no canonical enumeration existed.


### PR DESCRIPTION
## Summary

Adds canonical OUTCOME enumerations for `pm-worker` and `researcher` non-phase agents to `.claude/reference/exit-report-format.md`, aligns both agent definitions to the documented set, and updates the pm-worker hotspot decision record.

**Problem:** `exit-report-format.md` §"Valid OUTCOME Values" only had rows for phases A/B/C. Both non-phase agents invented their own vocabulary (e.g., `issue_created` for a read-only task). No parent branch protocol exists for these agents, making undefined values unparseable by contract.

**Changes:**
- **`exit-report-format.md`** — Added pm-worker rows (`completed`, `blocked`, `exhaustion`) and researcher rows (`findings`, `inconclusive`, `blocked`); updated `PHASE_COMPLETE` field to allow agent names; added `none` as valid for non-applicable fields on non-phase reports; added Non-Phase Agent Handling section
- **`pm-worker.md`** — Changed `PHASE_COMPLETE: pm` → `pm-worker`; narrowed OUTCOME to `completed|blocked|exhaustion`; specific results (issue number, deferral target) now directed to prose body above the report; added canonical reference
- **`researcher.md`** — Changed OUTCOME `complete|partial|blocked` → `findings|inconclusive|blocked`; added canonical reference
- **`pm-worker-hotspot-decision.md`** — Updated §3 OUTCOME vocabulary ownership row; added amendment note

**`phase-protocols.md`:** zero-growth (no change) — the existing pointer `Fields + valid OUTCOME values: .claude/reference/exit-report-format.md` already covers non-phase vocabulary now that it's in that file.

## Local Review Coverage

**Coverage: `none`** (both CLIs unavailable)
- CodeRabbit CLI: rate-limited after first run — that run found 1 finding (PR_NUMBER/REVIEWER fields missing `none` as valid value for non-phase reports), which was fixed before commit
- CodeAnt CLI: 403 (daily cap) on both attempts — GitHub App is unaffected and satisfies the merge gate independently
- Self-review performed: no issues found beyond the CR finding already resolved

Closes #1171

## Test plan

- [x] `exit-report-format.md` defines valid `OUTCOME` values for `pm-worker` (`completed`, `blocked`, `exhaustion`) — derived from agent definition exit shapes; no task-specific values
- [x] `exit-report-format.md` defines valid `OUTCOME` values for `researcher` (`findings`, `inconclusive`, `blocked`) — derived from agent definition exit shapes (`.claude/agents/researcher.md` lines 84–87 before this change: `complete`, `partial`, `blocked`; changed to stable vocabulary)
- [x] `PHASE_COMPLETE` allowed values for non-phase agents documented (`pm-worker` uses agent name; `researcher` uses reduced schema with `AGENT:` field, no `PHASE_COMPLETE`)
- [x] `pm-worker.md` references `.claude/reference/exit-report-format.md` as canonical contract (line 120)
- [x] `researcher.md` references `.claude/reference/exit-report-format.md` as canonical contract (line 66)
- [x] Format matches sibling table conventions in `exit-report-format.md`
- [x] `phase-protocols.md` untouched (zero-growth: existing pointer already covers non-phase vocabulary)
- [x] All 6 doc lints green (`run-doc-lints.sh`, `rule-lint.sh`, `reference-catalog-lint.sh`)
_Post-merge smoke test tracked in Issue #1181: verify a live pm-worker emits OUTCOME from the documented set._