### PR TITLE
feat(#1170): add doc-lint for prose references to deprecated frontmatter keys

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -6,7 +6,7 @@ This directory contains custom agent definitions for the Phase A/B/C subagent wo
 
 Claude Code's Agent tool supports a `subagent_type` parameter that references agent definition files in `.claude/agents/`. When spawning a subagent with `subagent_type: "phase-a-fixer"`, Claude Code loads the agent whose frontmatter `name:` field matches that string — identity comes from `name:`, not the filename. The `name:` field is **required**; without it the agent file is not resolvable by `subagent_type`.
 
-Claude Code scans `.claude/agents/` at session start. A session restart is required for a newly added or edited agent file to be registered. The `tools:` key in frontmatter restricts which tools the agent may use; the deprecated `allowed-tools:` key is not recognized by the current schema.
+Claude Code scans `.claude/agents/` at session start. A session restart is required for a newly added or edited agent file to be registered. The `tools:` key in frontmatter restricts which tools the agent may use; the deprecated `allowed-tools:` key is not recognized by the current schema. <!-- deprecated-key-ok: allowed-tools -->
 
 ## Placeholder Syntax
 
@@ -132,7 +132,7 @@ The agent definition provides role-specific workflow rules. The harness injects 
 ## Adding New Agents
 
 1. Create `<agent-name>.md` in this directory
-2. Include frontmatter with **`name:`** (required — must match the intended `subagent_type` string and the filename stem exactly), `description:` (required), and optionally `tools:` for tool restrictions (use `tools:`, not `allowed-tools:`)
+2. Include frontmatter with **`name:`** (required — must match the intended `subagent_type` string and the filename stem exactly), `description:` (required), and optionally `tools:` for tool restrictions (use `tools:`, not `allowed-tools:`) <!-- deprecated-key-ok: allowed-tools -->
 3. Embed only role-specific rules — global rules (skill-first, autonomy, etc.) are inherited automatically
 4. Always include the SAFETY and MINDSET blocks as safety-critical restatements
 5. Document any new placeholders in this README

--- a/.claude/reference/issue-1121-subagent-registration-verification.md
+++ b/.claude/reference/issue-1121-subagent-registration-verification.md
@@ -39,7 +39,7 @@ Additionally, two files (`phase-c-merger.md`, `researcher.md`) used an `allowed-
 
 2. Renamed `allowed-tools:` to `tools:` in `phase-c-merger.md` and `researcher.md` so tool restrictions actually take effect.
 
-3. Updated `.claude/agents/README.md` to state that identity comes from `name:`, that a session restart is needed after adding/editing files, and that `tools:` (not `allowed-tools:`) is the correct key.
+3. Updated `.claude/agents/README.md` to state that identity comes from `name:`, that a session restart is needed after adding/editing files, and that `tools:` (not `allowed-tools:`) is the correct key. <!-- deprecated-key-ok: allowed-tools -->
 
 4. Updated `.claude/rules/subagent-orchestration.md` to add `researcher` to the enumerated types, add a precondition note about `name:` and session restart, and add a fallback path for when a custom spawn fails.
 

--- a/.claude/reference/issue-852-browser-rung-verification.md
+++ b/.claude/reference/issue-852-browser-rung-verification.md
@@ -98,6 +98,7 @@ Read the two passes together: where they disagree, the 2026-08-12 result superse
 
 ```bash
 # Item 4 — tools audit (static, deterministic)
+# <!-- deprecated-key-ok: allowed-tools --> (deliberate migration note below)
 # NOTE: the key is `tools:` on agents. `allowed-tools:` is the SKILL key and is
 # silently ignored on an agent — grepping for it reports every agent unrestricted.
 for f in .claude/agents/*.md; do

--- a/.github/scripts/deprecated-frontmatter-key-lint.sh
+++ b/.github/scripts/deprecated-frontmatter-key-lint.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# doc-lint: flag prose references to deprecated frontmatter keys (issue #1170).
+#
+# Background: PR #1131 renamed the agent frontmatter key `allowed-tools:` to
+# `tools:` (the old key was silently ignored by the harness).  Docs can still
+# name the deprecated key in agent-scoped prose — e.g. in a code block that
+# loops over .claude/agents/*.md — and readers may mistake it for valid syntax.
+#
+# This lint flags such occurrences so they can be either corrected or
+# suppressed with an inline opt-out marker when a mention is deliberate.
+#
+# === Deprecated-key table ===
+#
+#   allowed-tools:  →  tools:  (scope: agents)
+#
+# Extension path: add a new "DEPRECATED|REPLACEMENT|SCOPE" entry to the
+# DEPRECATED_KEYS array below (one entry per deprecated key).  No other
+# change is needed; the detection logic is driven by the table.
+#
+# === Opt-out marker ===
+#
+#   <!-- deprecated-key-ok: allowed-tools -->
+#
+# Place on the same line as the mention, on the immediately preceding line,
+# or anywhere inside the same fenced code block as the mention.  This covers
+# historical references, migration guides, and audit commands that legitimately
+# name the old key.
+#
+# === Detection scope: "agent-scoped" ===
+#
+# An occurrence of `allowed-tools:` is agent-scoped when ANY of:
+#   1. The file lives under .claude/agents/
+#   2. The occurrence line itself contains ".claude/agents/"
+#   3. The occurrence is inside a fenced code block that contains ".claude/agents/"
+#
+# Non-agent-scoped occurrences are silent — this lets skill frontmatter
+# (.claude/skills/*/SKILL.md) keep using `allowed-tools:` where it is correct.
+#
+# === Canary ===
+#
+# Also asserts that the two known-restricted agents (phase-c-merger.md and
+# researcher.md) still declare a `tools:` restriction in their frontmatter.
+# If the key ever drifts back, any prose audit command that greps for
+# `^allowed-tools:` would silently report them as unrestricted (fail-open
+# defect from issue #864).
+#
+# === CI wiring ===
+#
+# Named to match .github/scripts/*-lint.sh — auto-discovered by
+# run-doc-lints.sh (PR #1147).  Runs under the `rule-lint` required CI check
+# without any change to rule-lint.sh or the workflow file.
+#
+# Companion: .github/scripts/tests/deprecated-frontmatter-key-lint.test.sh
+#
+# Usage: bash .github/scripts/deprecated-frontmatter-key-lint.sh
+# Exits 0 on clean pass, 1 on any findings, 2 on usage error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/lint-common.sh
+source "$SCRIPT_DIR/lib/lint-common.sh"
+
+errors=0
+
+usage() {
+  cat <<'EOF'
+Usage: .github/scripts/deprecated-frontmatter-key-lint.sh
+
+  Flags deprecated frontmatter key names (e.g. allowed-tools:) in
+  agent-scoped Markdown prose.  Suppressed by an inline opt-out marker:
+
+    <!-- deprecated-key-ok: allowed-tools -->
+
+  See script header for scope rules.  Run from the repo root.
+  Exits 1 on any finding, 2 on usage error.
+EOF
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "::error::deprecated-frontmatter-key-lint.sh: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# ---------------------------------------------------------------------------
+# Deprecated-key table (extensible).
+# Format: "DEPRECATED_KEY|REPLACEMENT_KEY|SCOPE"
+# Add one entry per deprecated key — the detection loop consumes the whole table.
+# ---------------------------------------------------------------------------
+DEPRECATED_KEYS=(
+  "allowed-tools:|tools:|agents"
+)
+
+# Opt-out marker prefix; the key name follows the colon.
+OPT_OUT_PREFIX="<!-- deprecated-key-ok:"
+
+# ---------------------------------------------------------------------------
+# Build the scan corpus: all git-tracked Markdown files.
+# Falls back to find when not in a git repo (test fixtures use git init).
+# ---------------------------------------------------------------------------
+md_files=()
+while IFS= read -r f; do
+  [[ -n "$f" ]] && md_files+=("$f")
+done < <(git ls-files '*.md' 2>/dev/null || find . -name '*.md' ! -path './.git/*')
+
+if (( ${#md_files[@]} == 0 )); then
+  echo "::error::deprecated-frontmatter-key-lint.sh: no Markdown files found — run from repo root"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Per-file stateful analysis using awk.
+#
+# For each file, awk tracks fenced code-block state (``` or ~~~) and decides
+# whether each allowed-tools: occurrence is "agent-scoped".  It emits
+# ::error:: lines for unprotected occurrences; bash counts them.
+#
+# Variables passed to awk:
+#   file     — path for annotations
+#   agent    — 1 if file lives under .claude/agents/, 0 otherwise
+#   AGENTS   — the path fragment that marks agent co-occurrence
+#   TARGET   — the deprecated key to detect
+#   MARKER   — the inline opt-out marker (full string)
+#   MSG      — error message text (avoids single-quote issues in awk)
+# ---------------------------------------------------------------------------
+
+for file in "${md_files[@]}"; do
+  [[ -f "$file" ]] || continue
+
+  is_agent_file=0
+  [[ "$file" == .claude/agents/* ]] && is_agent_file=1
+
+  # Extract the key and opt-out marker for the table entry.
+  # Currently one entry; loop is ready for additional deprecated keys.
+  for entry in "${DEPRECATED_KEYS[@]}"; do
+    dep_key="${entry%%|*}"
+    rest="${entry#*|}"
+    rep_key="${rest%%|*}"
+    # scope="${rest##*|}"  # informational only
+
+    marker="${OPT_OUT_PREFIX} ${dep_key%:} -->"
+    msg="Deprecated frontmatter key '${dep_key}' in agent-scoped context (use '${rep_key}' instead). For a deliberate migration mention add: ${marker}"
+
+    while IFS= read -r err_line; do
+      [[ -n "$err_line" ]] && echo "$err_line" && errors=$((errors + 1))
+    done < <(
+      awk -v file="$file" -v agent="$is_agent_file" \
+          -v AGENTS=".claude/agents/" \
+          -v TARGET="$dep_key" \
+          -v MARKER="$marker" \
+          -v MSG="$msg" \
+      'BEGIN { in_fence=0; fence_n=0; fence_agents=0; prev="" }
+
+       /^[`]{3}|^[~]{3}/ {
+         if (!in_fence) {
+           in_fence=1; fence_n=0; fence_agents=0
+           for (k in fl) delete fl[k]
+           for (k in fn) delete fn[k]
+         } else {
+           if (fence_agents) {
+             blk_m=0
+             for (i=1; i<=fence_n; i++) {
+               if (index(fl[i], MARKER) > 0) { blk_m=1; break }
+             }
+             if (!blk_m) {
+               for (i=1; i<=fence_n; i++) {
+                 if (index(fl[i], TARGET) > 0)
+                   printf "::error file=%s,line=%d::%s\n", file, fn[i], MSG
+               }
+             }
+           }
+           in_fence=0; fence_n=0; fence_agents=0
+           for (k in fl) delete fl[k]
+           for (k in fn) delete fn[k]
+         }
+         prev=$0; next
+       }
+
+       in_fence {
+         fence_n++; fl[fence_n]=$0; fn[fence_n]=NR
+         if (index($0, AGENTS) > 0) fence_agents=1
+         prev=$0; next
+       }
+
+       index($0, TARGET) > 0 {
+         scoped=agent
+         if (!scoped && index($0, AGENTS) > 0) scoped=1
+         if (scoped) {
+           has_m=(index($0, MARKER) > 0 || index(prev, MARKER) > 0) ? 1 : 0
+           if (!has_m)
+             printf "::error file=%s,line=%d::%s\n", file, NR, MSG
+         }
+         prev=$0; next
+       }
+
+       { prev=$0 }
+      ' "$file"
+    )
+  done
+done
+
+# ---------------------------------------------------------------------------
+# Canary: the two known-restricted agents must still carry a tools: key.
+# If this fails, any prose snippet that greps ^allowed-tools: in these agents
+# will report them as unrestricted — the fail-open defect from issue #864.
+# ---------------------------------------------------------------------------
+RESTRICTED_AGENTS=(
+  ".claude/agents/phase-c-merger.md"
+  ".claude/agents/researcher.md"
+)
+
+for agent_file in "${RESTRICTED_AGENTS[@]}"; do
+  require_file "$agent_file" || continue
+  fm="$(awk 'NR==1 && /^---/{in_fm=1; next} in_fm && /^---/{exit} in_fm{print}' "$agent_file")"
+  if ! printf '%s\n' "$fm" | grep -qE '^tools:'; then
+    echo "::error file=${agent_file}::Canary: ${agent_file} no longer declares a 'tools:' restriction in frontmatter. Any prose audit command greping '^allowed-tools:' would silently report this agent as unrestricted (fail-open defect, issue #864). Restore the 'tools:' key."
+    errors=$((errors + 1))
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+if (( errors > 0 )); then
+  echo "deprecated-frontmatter-key-lint: ${errors} error(s) found"
+  exit 1
+fi
+
+echo "deprecated-frontmatter-key-lint: OK (${#md_files[@]} files scanned)"

--- a/.github/scripts/deprecated-frontmatter-key-lint.sh
+++ b/.github/scripts/deprecated-frontmatter-key-lint.sh
@@ -164,7 +164,7 @@ for file in "${md_files[@]}"; do
            for (k in fl) delete fl[k]
            for (k in fn) delete fn[k]
          } else {
-           if (fence_agents) {
+           if (agent || fence_agents) {
              blk_m=0
              for (i=1; i<=fence_n; i++) {
                if (index(fl[i], MARKER) > 0) { blk_m=1; break }

--- a/.github/scripts/tests/deprecated-frontmatter-key-lint.test.sh
+++ b/.github/scripts/tests/deprecated-frontmatter-key-lint.test.sh
@@ -250,6 +250,34 @@ else
   failures=$((failures + 1))
 fi
 
+# 14. INVERSION — Fenced block inside an agent file (no .claude/agents/ path
+#     inside the fence) with allowed-tools: and no marker FAILS.
+#     Regression test for the fence_agents-only check that Greptile P2 caught.
+expect "fenced block in agent file without path reference fails" 1 \
+  "Deprecated frontmatter key 'allowed-tools:'" \
+  bash -c 'cat >> .claude/agents/phase-a-fixer.md <<'"'"'MDEOF'"'"'
+
+```yaml
+allowed-tools:
+  - Read
+  - Bash
+```
+MDEOF
+git add .'
+
+# 15. Fenced block inside an agent file with an opt-out marker PASSES.
+expect "fenced block in agent file with opt-out marker passes" 0 \
+  'deprecated-frontmatter-key-lint: OK' \
+  bash -c 'cat >> .claude/agents/phase-a-fixer.md <<'"'"'MDEOF'"'"'
+
+```yaml
+# <!-- deprecated-key-ok: allowed-tools -->
+allowed-tools:
+  - Read
+```
+MDEOF
+git add .'
+
 # ---------------------------------------------------------------------------
 # Revert-verify: plant a live-surface violation in the real repo and confirm
 # the lint catches it.  This proves the test is not trivially passing against

--- a/.github/scripts/tests/deprecated-frontmatter-key-lint.test.sh
+++ b/.github/scripts/tests/deprecated-frontmatter-key-lint.test.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# Unit tests for deprecated-frontmatter-key-lint.sh (issue #1170)
+#
+# Each case builds a hermetic git-tracked fixture tree and runs the lint.
+# Inversion tests cover both flag directions:
+#   - a case that should fail proves the lint fires on violations
+#   - a case that should pass proves the lint does NOT fire on correct usage
+#
+# Auto-discovered by run-hook-tests.sh — no workflow edit needed.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LINT="${REPO_ROOT}/.github/scripts/deprecated-frontmatter-key-lint.sh"
+
+TMP_ROOT=$(mktemp -d -t dep-fm-lint.XXXXXX)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+case_num=0
+
+# ---------------------------------------------------------------------------
+# make_fixture DIR
+#
+# Build a minimal well-formed fixture tree with:
+#   - one restricted agent (phase-c-merger.md with tools:)
+#   - one restricted agent (researcher.md with tools:)
+#   - one unrestricted agent (phase-a-fixer.md, no tools:)
+#   - one skill file (.claude/skills/my-skill/SKILL.md) with allowed-tools:
+#     frontmatter (correct for skills — must NOT be flagged)
+#
+# The fixture is initialized as a git repo so git ls-files works.
+# ---------------------------------------------------------------------------
+make_fixture() {
+  local dir="$1"
+  mkdir -p "${dir}/.claude/agents" \
+            "${dir}/.claude/skills/my-skill" \
+            "${dir}/.claude/reference"
+
+  # Restricted agent — must retain tools: for canary to pass
+  cat > "${dir}/.claude/agents/phase-c-merger.md" <<'EOF'
+---
+name: phase-c-merger
+description: Phase C merger agent.
+model: sonnet
+tools: Read, Glob, Grep, Bash
+---
+
+Phase C merger body.
+EOF
+
+  # Second restricted agent
+  cat > "${dir}/.claude/agents/researcher.md" <<'EOF'
+---
+name: researcher
+description: Read-only researcher agent.
+model: sonnet
+tools: Read, Glob, Grep
+---
+
+Researcher body.
+EOF
+
+  # Unrestricted agent (no tools:) — canary should not fire on this one
+  cat > "${dir}/.claude/agents/phase-a-fixer.md" <<'EOF'
+---
+name: phase-a-fixer
+description: Phase A fixer agent.
+model: opus
+---
+
+Phase A fixer body.
+EOF
+
+  # Skill file with allowed-tools: in frontmatter — correct and must NOT be flagged
+  cat > "${dir}/.claude/skills/my-skill/SKILL.md" <<'EOF'
+---
+name: my-skill
+description: Example skill.
+allowed-tools:
+  - Read
+  - Bash
+---
+
+Skill body text.
+EOF
+
+  # Reference file with allowed-tools: mention but NOT agent-scoped — must NOT be flagged
+  cat > "${dir}/.claude/reference/browser-cap.md" <<'EOF'
+## Subagent reachability
+
+The deprecated `allowed-tools:` key is the skill frontmatter key and is
+silently ignored on an agent definition.
+EOF
+
+  # Initialize git and stage all files
+  ( cd "$dir" && git init -q && git add . )
+}
+
+# ---------------------------------------------------------------------------
+# expect NAME WANT_EXIT WANT_REGEX [MUTATOR CMD...]
+#
+# Builds a fresh fixture, applies the optional mutator (run from inside the
+# fixture dir), runs the lint, and asserts exit code + output regex.
+# ---------------------------------------------------------------------------
+expect() {
+  local name="$1" want="$2" want_re="$3"; shift 3
+  case_num=$((case_num + 1))
+  local dir="${TMP_ROOT}/case${case_num}"
+  make_fixture "$dir"
+
+  if [[ "$#" -gt 0 ]] && [[ "$1" != "noop" ]]; then
+    ( cd "$dir" && "$@" )
+  fi
+
+  local out got
+  out=$(cd "$dir" && bash "$LINT" 2>&1) && got=0 || got=$?
+
+  if (( got != want )); then
+    echo "FAIL — ${name}: expected exit ${want}, got ${got}"
+    echo "$out" | sed 's/^/       /'
+    failures=$((failures + 1))
+    return
+  fi
+
+  if ! grep -qE "$want_re" <<< "$out"; then
+    echo "FAIL — ${name}: exit ${got} as expected, but output did not match /${want_re}/"
+    echo "$out" | sed 's/^/       /'
+    failures=$((failures + 1))
+    return
+  fi
+
+  echo "ok   — ${name}"
+}
+
+noop() { :; }
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+# 1. Clean fixture passes.
+expect "clean fixture passes" 0 \
+  'deprecated-frontmatter-key-lint: OK' \
+  noop
+
+# 2. INVERSION — Agent file (in .claude/agents/) with allowed-tools: and no
+#    marker FAILS. This is the core detection case.
+expect "agent file with allowed-tools: and no marker fails" 1 \
+  "Deprecated frontmatter key 'allowed-tools:'" \
+  bash -c 'printf "\nThe deprecated allowed-tools: key was renamed to tools:.\n" >> .claude/agents/phase-a-fixer.md && git add .'
+
+# 3. INVERSION — Prose line containing .claude/agents/ path AND allowed-tools:
+#    with no marker FAILS (agent-scoped via line co-occurrence).
+expect "prose co-occurrence of allowed-tools: and .claude/agents/ path fails" 1 \
+  "Deprecated frontmatter key 'allowed-tools:'" \
+  bash -c 'printf "\nUse tools: not allowed-tools: in .claude/agents/*.md frontmatter.\n" >> .claude/reference/browser-cap.md && git add .'
+
+# 4. INVERSION — Skill file with allowed-tools: in frontmatter PASSES
+#    (NOT agent-scoped — skill files are exempt).
+expect "skill file with allowed-tools: in frontmatter passes" 0 \
+  'deprecated-frontmatter-key-lint: OK' \
+  noop
+
+# 5. Opt-out marker on same line suppresses the error.
+expect "opt-out marker on same line suppresses error" 0 \
+  'deprecated-frontmatter-key-lint: OK' \
+  bash -c 'printf "\nThe allowed-tools: key was renamed to tools:. <!-- deprecated-key-ok: allowed-tools -->\n" >> .claude/agents/phase-a-fixer.md && git add .'
+
+# 6. Opt-out marker on immediately preceding line suppresses the error.
+expect "opt-out marker on preceding line suppresses error" 0 \
+  'deprecated-frontmatter-key-lint: OK' \
+  bash -c 'printf "\n<!-- deprecated-key-ok: allowed-tools -->\nThe allowed-tools: key was renamed to tools:.\n" >> .claude/agents/phase-a-fixer.md && git add .'
+
+# 7. Fenced code block with .claude/agents/ AND allowed-tools: with no marker
+#    FAILS (agent-scoped via fenced block).
+expect "fenced block with agents path and allowed-tools: fails" 1 \
+  "Deprecated frontmatter key 'allowed-tools:'" \
+  bash -c 'cat >> .claude/reference/browser-cap.md <<'"'"'MDEOF'"'"'
+
+```bash
+for f in .claude/agents/*.md; do
+  grep "^allowed-tools:" "$f" || echo "(none)"
+done
+```
+MDEOF
+git add .'
+
+# 8. Fenced code block with .claude/agents/ AND opt-out marker in block PASSES.
+expect "fenced block with agents path and opt-out marker in block passes" 0 \
+  'deprecated-frontmatter-key-lint: OK' \
+  bash -c 'cat >> .claude/reference/browser-cap.md <<'"'"'MDEOF'"'"'
+
+```bash
+# <!-- deprecated-key-ok: allowed-tools -->
+for f in .claude/agents/*.md; do
+  grep "^allowed-tools:" "$f" || echo "(none)"
+done
+```
+MDEOF
+git add .'
+
+# 9. CANARY — Restricted agent loses tools: key → FAILS.
+expect "canary fails when restricted agent loses tools: key" 1 \
+  "Canary:" \
+  bash -c 'sed -i.bak "/^tools: Read/d" .claude/agents/phase-c-merger.md && git add .'
+
+# 10. Reference file with allowed-tools: mention NOT in agent-scoped context
+#     PASSES (the non-scoped prose in .claude/reference/ is exempt).
+expect "non-agent-scoped allowed-tools: in reference file passes" 0 \
+  'deprecated-frontmatter-key-lint: OK' \
+  noop
+
+# 11. Both opt-out marker forms: fenced block marker covers all occurrences in block.
+expect "single marker in fenced block covers multiple occurrences" 0 \
+  'deprecated-frontmatter-key-lint: OK' \
+  bash -c 'cat >> .claude/reference/browser-cap.md <<'"'"'MDEOF'"'"'
+
+```bash
+# <!-- deprecated-key-ok: allowed-tools -->
+# allowed-tools: was used before, now tools: is correct
+for f in .claude/agents/*.md; do
+  grep "^allowed-tools:" "$f" || echo "(none)"
+done
+```
+MDEOF
+git add .'
+
+# 12. --help exits 0.
+case_num=$((case_num + 1))
+help_dir="${TMP_ROOT}/case${case_num}"
+make_fixture "$help_dir"
+if (cd "$help_dir" && bash "$LINT" --help >/dev/null 2>&1); then
+  echo "ok   — --help exits 0"
+else
+  echo "FAIL — --help should exit 0"
+  failures=$((failures + 1))
+fi
+
+# 13. Unknown argument exits 2.
+case_num=$((case_num + 1))
+bogus_dir="${TMP_ROOT}/case${case_num}"
+make_fixture "$bogus_dir"
+got_exit=0
+(cd "$bogus_dir" && bash "$LINT" --bogus >/dev/null 2>&1) || got_exit=$?
+if (( got_exit == 2 )); then
+  echo "ok   — unknown arg exits 2"
+else
+  echo "FAIL — unknown arg: expected exit 2, got ${got_exit}"
+  failures=$((failures + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Revert-verify: plant a live-surface violation in the real repo and confirm
+# the lint catches it.  This proves the test is not trivially passing against
+# a broken lint.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- revert-verify: lint must fail on planted violation in real repo ---"
+
+AGENTS_DIR="${REPO_ROOT}/.claude/agents"
+PLANTED_FILE="${AGENTS_DIR}/_dep-key-lint-revert-verify-$$.md"
+trap 'rm -f "$PLANTED_FILE"; rm -rf "$TMP_ROOT"' EXIT
+
+cat > "$PLANTED_FILE" <<'EOF'
+---
+name: _revert-verify-placeholder
+description: Temporary revert-verify fixture — must not survive the test.
+model: sonnet
+---
+
+This is a test fixture. The following line should be flagged by the lint:
+The deprecated allowed-tools: key was renamed to tools:.
+EOF
+( cd "$REPO_ROOT" && git add "$PLANTED_FILE" 2>/dev/null ) || true
+
+revert_verify_ok=0
+if ( cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1 ); then
+  echo "FAIL — revert-verify: lint passed on repo with planted violation (should have failed)"
+  failures=$((failures + 1))
+  revert_verify_ok=1
+else
+  echo "ok   — revert-verify: lint correctly failed on planted violation"
+fi
+
+rm -f "$PLANTED_FILE"
+( cd "$REPO_ROOT" && git rm --cached "$PLANTED_FILE" 2>/dev/null ) || true
+
+# Real-repo conformance: the actual repo should pass after fixture cleanup.
+if ! ( cd "$REPO_ROOT" && bash "$LINT" >/dev/null 2>&1 ); then
+  echo "FAIL — real-repo conformance: lint fails on the real repo (unexpected)"
+  ( cd "$REPO_ROOT" && bash "$LINT" 2>&1 | sed 's/^/       /') || true
+  failures=$((failures + 1))
+else
+  echo "ok   — real-repo conformance is intact"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+if (( failures > 0 )); then
+  echo ""
+  echo "deprecated-frontmatter-key-lint.test: ${failures} failure(s)"
+  exit 1
+fi
+
+echo ""
+echo "OK: deprecated-frontmatter-key-lint tests passed (${case_num} fixtures + revert-verify)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Skills live in `.claude/skills/<name>/SKILL.md`.
    - `description` (required — used by the model for discovery; be specific about when to trigger)
    - `model` (optional: `sonnet` or `opus` override)
    - `triggers` (optional: natural-language invocation phrases)
-   - `allowed-tools` (optional: restrict the skill to specific tools)
+   - `allowed-tools` (optional: restrict the skill to specific tools — **correct for skills only**; agent definitions under `.claude/agents/` use `tools:` instead)
    - `disable-model-invocation` (optional: prevents auto-trigger AND hides from slash-command autocomplete — avoid unless you really mean both)
 2. **Skill body:** step-by-step instructions, exact bash commands with absolute paths, and clear exit criteria. Subagents skip prose rules — prefer numbered checklists with explicit STOP conditions.
 


### PR DESCRIPTION
## Summary

Adds `deprecated-frontmatter-key-lint.sh` — a new auto-discovered doc-lint that flags agent-scoped prose references to the deprecated `allowed-tools:` frontmatter key (renamed to `tools:` by PR #1131; the old key was silently ignored by the harness, which is how the fail-open defect in issue #864 occurred).

Closes #1170

## Key design decisions

- **Deny-list, extensible**: `DEPRECATED_KEYS` array (currently one entry: `allowed-tools:` → `tools:`). Add one entry per future deprecated key — no other change needed.
- **Agent-scoped detection only**: fires when (1) file lives under `.claude/agents/`, (2) the `allowed-tools:` line co-occurs with `.claude/agents/` text, or (3) the line is inside a fenced code block that references `.claude/agents/`. Non-agent occurrences (skill frontmatter, plain reference prose) are silent.
- **Inline opt-out marker**: `<!-- deprecated-key-ok: allowed-tools -->` on the same line, the immediately preceding line, or anywhere in the same fenced block suppresses the error for deliberate migration mentions.
- **Canary**: asserts `phase-c-merger.md` and `researcher.md` still declare a `tools:` restriction; catches the fail-open defect from issue #864 if the key drifts back.
- **Auto-discovered**: named `deprecated-frontmatter-key-lint.sh` to match `run-doc-lints.sh`'s `*-lint.sh` glob. Runner now shows **7 lints, 0 failed** (was 6).

## Opt-out markers applied to 4 live-surface locations

| File | Reason |
|------|--------|
| `.claude/agents/README.md` lines 9, 134 | Agent docs explaining the rename — file is in `.claude/agents/` |
| `.claude/reference/issue-852-browser-rung-verification.md` line 101 | Inside a `bash` fence that loops over `.claude/agents/*.md` |
| `.claude/reference/issue-1121-subagent-registration-verification.md` line 42 | Records updating `.claude/agents/README.md` with the correct key name |

## Test plan

- [x] New lint `deprecated-frontmatter-key-lint.sh` is auto-discovered — runner shows exactly 7 lints
- [x] `bash .github/scripts/run-doc-lints.sh` exits 0 with 7 lints, 0 failed
- [x] `bash .github/scripts/rule-lint.sh` exits 0
- [x] Test suite covers both flag directions: agent reference without marker fails; skill frontmatter passes
- [x] Test suite covers opt-out marker on same line, preceding line, and inside fenced block
- [x] Test suite covers canary failure when restricted agent loses `tools:` key
- [x] Test suite covers fenced block with `.claude/agents/` AND `allowed-tools:` firing correctly
- [x] Revert-verify confirms test suite would catch an unguarded real-repo violation
- [x] Real-repo conformance: actual repo passes after all opt-out markers applied
- [x] All 4 live-surface hits classified and marked with inline opt-out markers
- [x] `browser-capability-rung.md` line 91 (non-agent-scoped prose) — correctly does NOT trigger the lint
- [x] Skill frontmatter (`allowed-tools:` in `.claude/skills/*/SKILL.md`) — correctly does NOT trigger
- [x] Extension path documented in script header (add one `DEPRECATED_KEYS` entry per future key)
- [x] Local review: both CR CLI and CodeAnt CLI failed after one retry each (CR: rate limit; CodeAnt: 403 daily cap). Coverage: **none**. Self-review applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)